### PR TITLE
🎨 Palette: Add clear button to exam search input

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2753,11 +2753,13 @@ body.no-scroll {
 
 .search-box {
     margin-bottom: var(--space-xl);
+    position: relative;
 }
 
 .search-input {
     width: 100%;
     padding: var(--space-md) var(--space-lg);
+    padding-right: 40px;
     border: 1px solid var(--color-gray-300);
     border-radius: var(--border-radius-lg);
     background: var(--color-white);
@@ -2766,6 +2768,32 @@ body.no-scroll {
     font-family: var(--font-family-primary);
     transition: all var(--transition-normal);
     outline: none;
+}
+
+.search-clear-btn {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-gray-400);
+    padding: 4px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s, background-color 0.2s;
+}
+
+.search-clear-btn:hover {
+    color: var(--color-gray-600);
+    background-color: var(--color-gray-100);
+}
+
+.search-clear-btn[hidden] {
+    display: none;
 }
 
 .search-input:focus {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,13 @@
             </div>
 
             <div class="search-box hero-surface">
-                <input type="text" class="search-input" placeholder="搜索题目..." aria-label="搜索题目" onkeyup="searchExams(this.value)">
+                <input type="text" class="search-input" id="exam-search-input" placeholder="搜索题目..." aria-label="搜索题目" onkeyup="searchExams(this.value)">
+                <button type="button" class="search-clear-btn" id="search-clear-btn" aria-label="清除搜索" hidden onclick="clearSearch()">
+                    <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
             </div>
 
             <div id="exam-list-container"></div>

--- a/js/app/browseController.js
+++ b/js/app/browseController.js
@@ -206,22 +206,8 @@
             buttons.forEach(button => {
                 const filterId = button.dataset.filterId;
                 const isActive = filterId === this.activeFilter;
-<<<<<<< palette-a11y-filter-buttons-11327431714844324793
                 button.classList.toggle('active', isActive);
                 button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-=======
-
-                if (isActive) {
-                    button.classList.add('active');
-                    button.setAttribute('aria-pressed', 'true');
-                } else {
-                    button.classList.remove('active');
-                    button.setAttribute('aria-pressed', 'false');
-                }
-
-                // Palette: Update aria-pressed
-                button.setAttribute('aria-pressed', isActive);
->>>>>>> IELTS-WRITING-FEAT
             });
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -2651,6 +2651,16 @@ function handleFolderSelection(event) { /* legacy stub - replaced by modal-speci
 
 
 function searchExams(query) {
+    // Toggle clear button visibility
+    const clearBtn = document.getElementById('search-clear-btn');
+    if (clearBtn) {
+        if (query && query.length > 0) {
+            clearBtn.removeAttribute('hidden');
+        } else {
+            clearBtn.setAttribute('hidden', '');
+        }
+    }
+
     if (window.performanceOptimizer && typeof window.performanceOptimizer.debounce === 'function') {
         const debouncedSearch = window.performanceOptimizer.debounce(performSearch, 300, 'exam_search');
         debouncedSearch(query);
@@ -2658,6 +2668,19 @@ function searchExams(query) {
         // Fallback: direct call if optimizer not available
         performSearch(query);
     }
+}
+
+function clearSearch() {
+    const input = document.getElementById('exam-search-input');
+    if (input) {
+        input.value = '';
+        input.focus();
+        searchExams('');
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.clearSearch = clearSearch;
 }
 
 function performSearch(query) {


### PR DESCRIPTION
Added a "Clear" button to the exam search input.

This micro-UX improvement allows users to quickly clear their search query without manually deleting text.

**Changes:**
- `index.html`: Added button markup to `.search-box`.
- `css/main.css`: Added styles for positioning the button and ensuring it hides correctly.
- `js/main.js`: Added logic to toggle visibility and handle the clear action.
- `js/app/browseController.js`: Fixed a syntax error (merge conflict markers) discovered during testing.

**Verification:**
- Verified using a Playwright script that the button appears when typing and clears the input when clicked.
- Ran existing E2E tests (`python3 developer/tests/run_all_tests.py`) to ensure no regressions.

---
*PR created automatically by Jules for task [3524155571190485997](https://jules.google.com/task/3524155571190485997) started by @githubSINGLE*