### PR TITLE
🎨 Palette: Add CTA to Practice History empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-23 - [Actionable Empty States]
+**Learning:** The "Practice History" empty state was a dead end, providing information but no clear next step for new users. Adding a direct CTA ("Go to Practice") bridges the gap between intent and action.
+**Action:** Always audit empty states for "dead ends" and provide a primary action button to guide the user to the core value of the feature.

--- a/index.html
+++ b/index.html
@@ -137,8 +137,8 @@
                     <div class="practice-history-empty">
                         <div class="practice-history-empty-icon" aria-hidden="true">📋</div>
                         <p class="practice-history-empty-text">暂无练习记录</p>
-                        <p style="font-size: 0.9em; margin-top: 10px;">开始练习后，记录将自动保存在这里</p>
-                        <button class="btn btn-primary" type="button" onclick="if(window.browseCategory) window.browseCategory('all')" style="margin-top: 15px;" aria-label="前往题库开始练习">去题库练习</button>
+                        <p style="font-size: 0.9em;">开始练习后，记录将自动保存在这里</p>
+                        <button class="btn btn-primary" type="button" onclick="if(window.browseCategory) window.browseCategory('all')" aria-label="前往题库开始练习">去题库练习</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -134,10 +134,11 @@
                 </div>
 
                 <div id="history-list" class="practice-history-list">
-                    <div style="text-align: center; padding: 40px; opacity: 0.7;">
-                        <div style="font-size: 3em; margin-bottom: 15px;">📋</div>
-                        <p>暂无练习记录</p>
+                    <div class="practice-history-empty">
+                        <div class="practice-history-empty-icon" aria-hidden="true">📋</div>
+                        <p class="practice-history-empty-text">暂无练习记录</p>
                         <p style="font-size: 0.9em; margin-top: 10px;">开始练习后，记录将自动保存在这里</p>
+                        <button class="btn btn-primary" type="button" onclick="if(window.browseCategory) window.browseCategory('all')" style="margin-top: 15px;" aria-label="前往题库开始练习">去题库练习</button>
                     </div>
                 </div>
             </div>

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -529,8 +529,15 @@
     historyRenderer.renderEmptyState = function (container) {
         if (!container) return;
         replaceContent(container, createNode('div', { className: 'practice-history-empty' }, [
-            createNode('div', { className: 'practice-history-empty-icon' }, '📂'),
-            createNode('p', { className: 'practice-history-empty-text' }, '暂无任何练习记录')
+            createNode('div', { className: 'practice-history-empty-icon', ariaHidden: 'true' }, '📂'),
+            createNode('p', { className: 'practice-history-empty-text' }, '暂无任何练习记录'),
+            createNode('button', {
+                className: 'btn btn-primary',
+                type: 'button',
+                onclick: "if(window.browseCategory) window.browseCategory('all')",
+                style: { marginTop: '15px' },
+                ariaLabel: '前往题库开始练习'
+            }, '去题库练习')
         ]));
     };
 

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -531,11 +531,11 @@
         replaceContent(container, createNode('div', { className: 'practice-history-empty' }, [
             createNode('div', { className: 'practice-history-empty-icon', ariaHidden: 'true' }, '📂'),
             createNode('p', { className: 'practice-history-empty-text' }, '暂无任何练习记录'),
+            createNode('p', { style: { fontSize: '0.9em' } }, '开始练习后，记录将自动保存在这里'),
             createNode('button', {
                 className: 'btn btn-primary',
                 type: 'button',
                 onclick: "if(window.browseCategory) window.browseCategory('all')",
-                style: { marginTop: '15px' },
                 ariaLabel: '前往题库开始练习'
             }, '去题库练习')
         ]));


### PR DESCRIPTION
💡 What: Added a "Go to practice" (去题库练习) button to the empty state of the Practice History view.
🎯 Why: To guide new users or users with no history to the question bank instead of showing a dead-end message.
📸 Before/After: The empty state now includes a primary action button.
♿ Accessibility: Added `aria-hidden="true"` to the decorative icon and `aria-label` to the new button.

---
*PR created automatically by Jules for task [13479368069251229945](https://jules.google.com/task/13479368069251229945) started by @githubSINGLE*