### PR TITLE
🎨 Palette: Enhance accessibility of 'More Tools' cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - [Card Button Accessibility]
+**Learning:** Complex buttons containing headings and descriptions are often read as a single text blob by screen readers. Using `aria-labelledby` and `aria-describedby` allows for a structured and semantic announcement, while `aria-hidden="true"` on decorative icons reduces noise.
+**Action:** Apply this pattern to all "card-like" interactive elements to ensure clear separation of label and description.

--- a/index.html
+++ b/index.html
@@ -207,37 +207,37 @@
             </div>
             <p class="more-view-subtitle">探索额外的学习辅助功能，助你高效备考。</p>
             <div class="more-tools-grid">
-                <button class="tool-card tool-card--featured" type="button" id="writing-entry-btn">
-                    <div class="tool-card-icon">✍️</div>
+                <button class="tool-card tool-card--featured" type="button" id="writing-entry-btn" aria-labelledby="writing-title" aria-describedby="writing-desc">
+                    <div class="tool-card-icon" aria-hidden="true">✍️</div>
                     <div class="tool-card-content">
-                        <h3>写作评分</h3>
-                        <p>AI驱动的雅思写作评分系统，获取专业四维度评分与详细反馈。</p>
+                        <h3 id="writing-title">写作评分</h3>
+                        <p id="writing-desc">AI驱动的雅思写作评分系统，获取专业四维度评分与详细反馈。</p>
                     </div>
-                    <div class="tool-card-arrow">进入</div>
+                    <div class="tool-card-arrow" aria-hidden="true">进入</div>
                 </button>
-                <button class="tool-card" type="button" data-action="open-clock">
-                    <div class="tool-card-icon">🕒</div>
+                <button class="tool-card" type="button" data-action="open-clock" aria-labelledby="clock-title" aria-describedby="clock-desc">
+                    <div class="tool-card-icon" aria-hidden="true">🕒</div>
                     <div class="tool-card-content">
-                        <h3>全屏时钟</h3>
-                        <p>沉浸式模拟指针时钟，实时同步系统时间，陪伴你的专注时刻。</p>
+                        <h3 id="clock-title">全屏时钟</h3>
+                        <p id="clock-desc">沉浸式模拟指针时钟，实时同步系统时间，陪伴你的专注时刻。</p>
                     </div>
-                    <div class="tool-card-arrow">进入</div>
+                    <div class="tool-card-arrow" aria-hidden="true">进入</div>
                 </button>
-                <button class="tool-card" type="button" data-action="open-vocab">
-                    <div class="tool-card-icon">🧠</div>
+                <button class="tool-card" type="button" data-action="open-vocab" aria-labelledby="vocab-title" aria-describedby="vocab-desc">
+                    <div class="tool-card-icon" aria-hidden="true">🧠</div>
                     <div class="tool-card-content">
-                        <h3>单词背诵</h3>
-                        <p>本地 Leitner 分箱 + 艾宾浩斯复习节奏，随时继续你的词汇任务。</p>
+                        <h3 id="vocab-title">单词背诵</h3>
+                        <p id="vocab-desc">本地 Leitner 分箱 + 艾宾浩斯复习节奏，随时继续你的词汇任务。</p>
                     </div>
-                    <div class="tool-card-arrow">进入</div>
+                    <div class="tool-card-arrow" aria-hidden="true">进入</div>
                 </button>
-                <button class="tool-card" type="button" onclick="showAchievements()">
-                    <div class="tool-card-icon">🏆</div>
+                <button class="tool-card" type="button" onclick="showAchievements()" aria-labelledby="achievements-title" aria-describedby="achievements-desc">
+                    <div class="tool-card-icon" aria-hidden="true">🏆</div>
                     <div class="tool-card-content">
-                        <h3>成就</h3>
-                        <p>查看你解锁的徽章和荣誉。</p>
+                        <h3 id="achievements-title">成就</h3>
+                        <p id="achievements-desc">查看你解锁的徽章和荣誉。</p>
                     </div>
-                    <div class="tool-card-arrow">查看</div>
+                    <div class="tool-card-arrow" aria-hidden="true">查看</div>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the "More Tools" section in the dashboard by linking card buttons to their headings and descriptions using ARIA attributes.

🎯 Why: Screen readers often announce complex buttons as unstructured text blobs. Explicitly associating the button with its title and description via `aria-labelledby` and `aria-describedby` provides a clearer, more semantic experience. Hiding decorative elements reduces noise.

📸 Before/After: Visuals remain identical. The improvement is purely in the accessibility tree and screen reader announcement.

♿ Accessibility:
- Added `aria-labelledby` and `aria-describedby` to 4 tool cards.
- Added `aria-hidden="true"` to decorative icons and "Enter/View" labels.
- Verified with static analysis suite.

---
*PR created automatically by Jules for task [7961270834887976259](https://jules.google.com/task/7961270834887976259) started by @githubSINGLE*