### PR TITLE
🎨 Palette: Add aria-label to delete button

### DIFF
--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -513,6 +513,7 @@
                     type: 'button',
                     className: 'delete-record-btn',
                     title: '删除此记录',
+                    'aria-label': '删除练习记录: ' + (record && record.title ? record.title : '无标题'),
                     dataset: { recordAction: 'delete', recordId: recordId }
                 }, '🗑️')
             ]);


### PR DESCRIPTION
Added an `aria-label` to the delete button in `js/views/legacyViewBundle.js` to improve accessibility. This ensures that screen readers announce "Delete practice record: [Title]" instead of just "Delete".

---
*PR created automatically by Jules for task [7760136174492420919](https://jules.google.com/task/7760136174492420919) started by @githubSINGLE*