### PR TITLE
Make state-core lazy group empty

### DIFF
--- a/js/runtime/lazyLoader.js
+++ b/js/runtime/lazyLoader.js
@@ -11,12 +11,8 @@
             'assets/scripts/complete-exam-data.js'
         ];
 
-        manifest['state-core'] = [
-            'js/core/practiceCore.js',
-            'js/core/resourceCore.js',
-            'js/app/state-service.js',
-            'js/services/libraryManager.js'
-        ];
+        // state-core is intentionally empty because core foundation is provided by js/bundles/core-foundation.bundle.js.
+        manifest['state-core'] = [];
 
         manifest['practice-suite'] = [
             // 练习记录功能与存储相关，需按用户行为加载


### PR DESCRIPTION
### Motivation
- 避免 lazy loader 与 `index.html` 直接加载的 `js/bundles/core-foundation.bundle.js` 出现双入口和重复加载，同时保持对旧调用的兼容性。

### Description
- 在 `js/runtime/lazyLoader.js` 的 `registerDefaultManifest()` 中将 `manifest['state-core']` 改为 `[]` 并添加注释 `state-core is intentionally empty because core foundation is provided by js/bundles/core-foundation.bundle.js`，保留 `dependencies['state-core'] = [];`，未删除 `ensureStateCoreGroup()` 或修改 `js/app/main-entry.js` 的调用路径以保证行为不变。

### Testing
- 运行 `python developer/tests/ci/run_static_suite.py`：静态检查和大量单元/集成测试通过，但报告中出现若干 Playwright 相关失败及一项阅读解析完整性不匹配，均由测试环境或数据问题（Playwright 未安装 / 测试数据差异）引起，与本次改动无关；
- 运行 `python developer/tests/e2e/suite_practice_flow.py`：执行失败，原因是本地缺少 Node 包 `playwright`，因此 E2E 流程在当前环境未能完成。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a45f7de48331be76aabdaec058f7)