### PR TITLE
Add virtual lazy-loader script registration

### DIFF
--- a/js/runtime/lazyLoader.js
+++ b/js/runtime/lazyLoader.js
@@ -5,6 +5,7 @@
     var scriptStatus = Object.create(null);
     var groupStatus = Object.create(null);
     var dependencies = Object.create(null);
+    var providedScripts = new Set();
 
     function registerDefaultManifest() {
         manifest['exam-data'] = [
@@ -102,6 +103,23 @@
         }
     }
 
+    function markProvided(files) {
+        if (!Array.isArray(files)) {
+            return;
+        }
+        files.forEach(function markFile(file) {
+            if (!file) {
+                return;
+            }
+            providedScripts.add(normalizeScriptUrl(file));
+            scriptStatus[file] = 'loaded';
+        });
+    }
+
+    function isProvided(url) {
+        return providedScripts.has(normalizeScriptUrl(url)) || scriptStatus[url] === 'loaded';
+    }
+
     function findExistingScriptTag(url) {
         if (typeof document === 'undefined') {
             return null;
@@ -128,7 +146,8 @@
         if (!url) {
             return Promise.resolve();
         }
-        if (scriptStatus[url] === 'loaded') {
+        if (isProvided(url)) {
+            scriptStatus[url] = 'loaded';
             return Promise.resolve();
         }
         if (scriptStatus[url] && scriptStatus[url].then) {
@@ -303,4 +322,5 @@
     global.AppLazyLoader.ensureGroup = ensureGroup;
     global.AppLazyLoader.registerGroup = registerGroup;
     global.AppLazyLoader.getStatus = getStatus;
+    global.AppLazyLoader.markProvided = markProvided;
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
### Motivation
- 允许将已由打包或页面预先加载的脚本标记为“已加载”，以避免 LazyLoader 再次创建真实 `<script>` 标签导致重复加载或副作用。

### Description
- 在 `lazyLoader` 中靠近 `scriptStatus` / `groupStatus` / `dependencies` 新增 `providedScripts = new Set()`。
- 新增 `markProvided(files)`，复用已有 `normalizeScriptUrl(url)` 遍历文件数组、跳过空值、将规范化后的 URL 加入 `providedScripts` 并将对应 `scriptStatus[file] = 'loaded'`。 
- 新增 `isProvided(url)`，通过 `providedScripts.has(normalizeScriptUrl(url))` 并兼容 `scriptStatus[url] === 'loaded'` 判定。 
- 在 `loadScript(url)` 顶部、真实 `<script src>` 查找前加入 `isProvided` 检查以短路返回并设置 `scriptStatus[url] = 'loaded'`，保持与 `file://` 的兼容性且未引入 `fetch`/`import`/module script 假设。 
- 将 `markProvided` 暴露为 `global.AppLazyLoader.markProvided`，并保持 `ensureGroup`、`registerGroup`、`getStatus` 的既有行为不变。 

### Testing
- 运行一个针对 `lazyLoader` 的 Node/VM smoke 脚本（在无 DOM 环境下用假的 `document`）验证 `markProvided` 后 `ensureGroup` 未注入真实 `<script>`，该 smoke 检查通过。 
- 运行 `python developer/tests/ci/run_static_suite.py`，静态套件产生报告且大部分检查通过，但总体任务失败，若干 E2E/回归项无法执行因为环境缺少 Playwright Python（环境依赖问题）；报告里也包含一个阅读数据一致性项的真实数据差异。 
- 运行 `python developer/tests/e2e/suite_practice_flow.py` 失败，因运行环境缺少 Node `playwright` 包（`ERR_MODULE_NOT_FOUND`），属于环境依赖缺失而非功能回归。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a43905c88331805836124d245d8c)