### PR TITLE
Fix reading practice page layout and add countdown timer warnings

### DIFF
--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -34,8 +34,7 @@
             color: var(--text);
             height: 100vh;
             overflow: hidden;
-            display: flex;
-            flex-direction: column;
+            padding-bottom: 72px;
         }
 
         .header {
@@ -451,7 +450,7 @@
         @media (max-width: 980px) {
             body {
                 overflow: auto;
-                padding-bottom: 0 !important;
+                padding-bottom: 112px;
             }
 
             .shell {
@@ -543,7 +542,72 @@
             animation: endless-pulse-dark 1s ease-in-out infinite;
         }
 
-        @keyframes endless-pulse-dark {
+                /* Countdown warning styles */
+        #timer.countdown-warn-10 {
+            background: rgba(239, 68, 68, 0.15);
+            color: #dc2626;
+            animation: countdown-pulse-10 1.2s ease-in-out infinite;
+            font-weight: 700;
+        }
+
+        @keyframes countdown-pulse-10 {
+            0%, 100% { background: rgba(239, 68, 68, 0.12); color: #dc2626; }
+            50% { background: rgba(239, 68, 68, 0.24); color: #b91c1c; }
+        }
+
+        #timer.countdown-warn-5 {
+            background: rgba(185, 28, 28, 0.22);
+            color: #991b1b;
+            animation: countdown-pulse-5 0.7s ease-in-out infinite;
+            font-weight: 700;
+        }
+
+        @keyframes countdown-pulse-5 {
+            0%, 100% { background: rgba(185, 28, 28, 0.18); color: #991b1b; }
+            50% { background: rgba(185, 28, 28, 0.36); color: #7f1d1d; }
+        }
+
+        #timer.countdown-expired {
+            background: rgba(185, 28, 28, 0.30);
+            color: #7f1d1d;
+            font-weight: 700;
+            animation: none;
+        }
+
+        body.dark-mode #timer.countdown-warn-10 {
+            background: rgba(239, 68, 68, 0.25);
+            color: #fca5a5;
+        }
+
+        @keyframes countdown-pulse-10-dark {
+            0%, 100% { background: rgba(239, 68, 68, 0.25); }
+            50% { background: rgba(239, 68, 68, 0.38); }
+        }
+
+        body.dark-mode #timer.countdown-warn-10 {
+            animation: countdown-pulse-10-dark 1.2s ease-in-out infinite;
+        }
+
+        body.dark-mode #timer.countdown-warn-5 {
+            background: rgba(185, 28, 28, 0.32);
+            color: #fca5a5;
+        }
+
+        @keyframes countdown-pulse-5-dark {
+            0%, 100% { background: rgba(185, 28, 28, 0.30); }
+            50% { background: rgba(185, 28, 28, 0.46); }
+        }
+
+        body.dark-mode #timer.countdown-warn-5 {
+            animation: countdown-pulse-5-dark 0.7s ease-in-out infinite;
+        }
+
+        body.dark-mode #timer.countdown-expired {
+            background: rgba(185, 28, 28, 0.38);
+            color: #fca5a5;
+        }
+
+@keyframes endless-pulse-dark {
             0%, 100% { background: rgba(239, 68, 68, 0.25); }
             50% { background: rgba(239, 68, 68, 0.35); }
         }
@@ -970,17 +1034,11 @@
 
         /* ================= IELTS Redesign Custom Styles ================= */
         body {
-            display: flex;
-            flex-direction: column;
-            height: 100vh;
-            overflow: hidden;
-            padding-bottom: 0 !important;
-            background: #f8fafc;
+            padding-bottom: 72px;
         }
 
         .shell {
-            flex: 1;
-            height: auto !important;
+            height: calc(100vh - 67px - 72px);
         }
 
         /* Top Header */

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -81,6 +81,7 @@
         simulationMode: false,
         simulationCtx: null,
         simulationContextReady: false,
+        countdownExpiredAutoSubmit: false,
         suite: {
             inline: false,
             flowMode: '',
@@ -220,6 +221,9 @@
         };
     }
 
+    var COUNTDOWN_WARN_10_MIN = 600;
+    var COUNTDOWN_WARN_5_MIN = 300;
+
     function formatTimerSeconds(totalSeconds) {
         const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
         const minutes = String(Math.floor(safeSeconds / 60)).padStart(2, '0');
@@ -254,6 +258,25 @@
         var hasEndlessCountdown = state.endlessCountdownEndTime && Number.isFinite(state.endlessCountdownEndTime);
         timer.classList.toggle('paused', !interaction.timerRunning && !hasEndlessCountdown);
         timer.style.opacity = (interaction.timerRunning || hasEndlessCountdown) ? '1' : '0.5';
+        var _warnRemaining = state.suiteTimerMode === 'countdown' && state.suiteTimerLimitSeconds !== null && state.suiteTimerLimitSeconds > 0
+            ? Math.max(0, state.suiteTimerLimitSeconds - getPageElapsedSeconds())
+            : null;
+        if (_warnRemaining !== null) {
+            timer.classList.remove('countdown-warn-10', 'countdown-warn-5', 'countdown-expired');
+            if (_warnRemaining <= 0) {
+                timer.classList.add('countdown-expired');
+                if (!state.countdownExpiredAutoSubmit && !state.submitted) {
+                    state.countdownExpiredAutoSubmit = true;
+                    handleCountdownExpired();
+                }
+            } else if (_warnRemaining <= COUNTDOWN_WARN_5_MIN) {
+                timer.classList.add('countdown-warn-5');
+            } else if (_warnRemaining <= COUNTDOWN_WARN_10_MIN) {
+                timer.classList.add('countdown-warn-10');
+            }
+        } else {
+            timer.classList.remove('countdown-warn-10', 'countdown-warn-5', 'countdown-expired');
+        }
     }
 
     function setTimerRunning(nextRunning) {
@@ -266,6 +289,13 @@
             }));
         } catch (_) {
             // ignore timer bridge event failures
+        }
+    }
+
+    function handleCountdownExpired() {
+        setTimerRunning(false);
+        if (typeof handleSubmit === 'function' && !state.submitted) {
+            handleSubmit().catch(function () {});
         }
     }
 
@@ -644,9 +674,12 @@
         if (suiteTimerMode === 'countdown' || suiteTimerMode === 'elapsed') {
             state.suiteTimerMode = suiteTimerMode;
         }
-        const suiteTimerLimitSeconds = Number(params.get('suiteTimerLimitSeconds'));
-        if (Number.isFinite(suiteTimerLimitSeconds) && suiteTimerLimitSeconds >= 0) {
-            state.suiteTimerLimitSeconds = Math.floor(suiteTimerLimitSeconds);
+        const rawSuiteTimerLimit = params.get('suiteTimerLimitSeconds');
+        if (rawSuiteTimerLimit !== null && rawSuiteTimerLimit !== '') {
+            const suiteTimerLimitSeconds = Number(rawSuiteTimerLimit);
+            if (Number.isFinite(suiteTimerLimitSeconds) && suiteTimerLimitSeconds >= 0) {
+                state.suiteTimerLimitSeconds = Math.floor(suiteTimerLimitSeconds);
+            }
         }
         const queryFlowMode = decodeParam(params.get('suiteFlowMode')).trim().toLowerCase();
         if (queryFlowMode === 'simulation') {


### PR DESCRIPTION
## Summary

Fix the reading practice unified page's layout issue and add countdown timer warning styles.

## Changes

### Layout fix (CSS only)
- Change body from `display:flex/flex-direction:column` to `padding-bottom:72px` to fix page overflow
- Adjust responsive padding for narrow viewports (`112px`)
- Simplify redesign block body/shell overrides for consistent layout
- All existing HTML elements and IDs preserved — no DOM removal

### Countdown timer warnings
- Add CSS classes for countdown state: `countdown-warn-10` (10 min), `countdown-warn-5` (5 min), `countdown-expired`
- Auto-submit reading when countdown reaches zero
- Dark mode support for all warning states
- More robust URL parameter parsing for `suiteTimerLimitSeconds`

### JS changes (minimal)
- Only countdown-specific logic added: `handleCountdownExpired()`, warning class management
- Suite mode functionality fully preserved
- Other runtime logic (highlight detection, question navigation) unchanged

## Files changed
- `assets/generated/reading-exams/reading-practice-unified.html` — CSS layout fix + countdown styles
- `js/runtime/unifiedReadingPage.js` — countdown warning + auto-submit logic