### PR TITLE
修复 Scented Plants 解析与题干不匹配

### DIFF
--- a/assets/generated/reading-explanations/p1-low-67.js
+++ b/assets/generated/reading-explanations/p1-low-67.js
@@ -33,96 +33,119 @@
     },
     {
       "label": "Paragraph E",
-      "text": "植物中的挥发性化合物也可以在一些非常间接的防御系统中用作一种货币。例如，在雨林树 Leonardoxa africana 中，Petalomyrmex phylax 蚂蚁被幼叶吸引，因为它们释放高水平的挥发性化合物水杨酸甲酯，这是一种蚂蚁需要用作巢穴中防腐剂的物质；作为回报，蚂蚁保护树免受食草动物的侵害。这种互利共生关系展示了植物和昆虫之间复杂的化学通讯网络。"
+      "text": "植物中的挥发性化合物也可以在一些非常间接的防御系统中用作一种货币。例如，在雨林树 Leonardoxa africana 中，Petalomyrmex phylax 蚂蚁被幼叶吸引，因为它们释放高水平的挥发性化合物水杨酸甲酯，这是一种蚂蚁需要用作巢穴中防腐剂的物质；巧合的是，蚂蚁会攻击它们遇到的任何食草昆虫。看起来水杨酸甲酯既吸引蚂蚁，又奖励它们执行抵御食草动物的宝贵角色。植物与动物之间的相互作用网络可能变得如此复杂，以至于难以检测释放挥发性化合物的结果。但很明显，该系统可以具有防御目的，因为许多实验表明，植物挥发性释放系统的失活使其更容易受到食草动物的攻击。"
+    },
+    {
+      "label": "Paragraph F",
+      "text": "花香对许多依赖昆虫传粉的农作物的经济成功有强烈影响，包括蜜蜂授粉的樱桃、苹果、杏和桃等果树，以及木瓜等蔬菜和热带植物。由于为了果实大小或其他特征而进行杂交育种，香气排放减少，降低了植物吸引传粉者的能力，并可能给种植者带来相当大的损失。在美国，最近的流行病感染并杀死了许多蜜蜂（主要的昆虫传粉者），使这个问题更加严重。"
+    },
+    {
+      "label": "Paragraph G",
+      "text": "一些植物育种者试图通过在果园树上喷洒香气化合物来增强蜜蜂觅食来解决这个授粉问题，但这种方法成本高昂，最终被证明效率低下。其无效的原因之一是，对作物的普遍喷洒无法告诉昆虫花朵的确切位置。显然，需要更精细的策略；例如，对香气进行基因操作将允许种植者调节昆虫传粉者的类型和它们访问的频率。"
+    },
+    {
+      "label": "Paragraph H",
+      "text": "这种香气的操作也将有利于商业种植花卉的人。切花和盆栽植物在人类生活中发挥着重要的审美作用。不幸的是，传统育种产生了花瓶寿命、颜色和形状得到改善的品种，而香气却被牺牲了。观赏花卉（全球年产值超过300亿美元）香气的丧失，使它们成为花卉香气基因操作的重要目标。已经进行了一些初步实验，但由于技术原因，香气存在于植物的每个部分，而不是集中在花中，而且香气的强度水平低于人鼻的检测阈值。已经在进行中的下一代实验将包括更复杂的方案，将香气的表达专门针对花朵或其他器官，例如可以储存抗菌或驱虫化合物的特殊腺体。"
     }
   ],
   "questionExplanations": [
     {
-      "sectionTitle": "1. 判断正误（Questions 1–7）",
+      "sectionTitle": "1. 段落信息匹配题（Questions 1–4）",
       "mode": "group",
       "items": [
         {
           "questionNumber": 1,
-          "text": "（1）题目 1：Plant fragrances are used to attract pollinators.\n题目翻译：植物香气用于吸引传粉者。\n答案：F\n解析：定位 Paragraph A 中 \"a tool used by plants to entice pollinators\"。植物使用香气吸引传粉者，与题干一致，因此答案为 TRUE。",
+          "text": "（1）题目 1：a list of food plants which need insects to make them productive\n题目翻译：列举需要昆虫才能高产的食用植物。\n答案：F\n解析：定位 Paragraph F 中 \"many agricultural crops that rely on insect pollinators, including fruit trees such as the bee-pollinated cherry, apple, apricot, and peach, as well as vegetables and tropical plants such as the papaya\"。F 段列举了依赖昆虫传粉的果树（樱桃、苹果、杏、桃）和蔬菜、木瓜等食用植物，与题干吻合，因此答案为 F。",
           "questionId": "q1"
         },
         {
           "questionNumber": 2,
-          "text": "（2）题目 2：Many volatile compounds in plants are toxic when eaten.\n题目翻译：植物中的许多挥发性化合物在被食用时是有毒的。\n答案：G\n解析：定位 Paragraph B 中 \"many volatile compounds in plants are toxic when eaten.\"。与题干一致，因此答案为 TRUE。",
+          "text": "（2）题目 2：an explanation of why a genetic experiment may assist plant reproduction\n题目翻译：解释基因实验为何可能有助于植物繁殖。\n答案：G\n解析：定位 Paragraph G 中 \"Clearly, a more refined strategy is needed; genetic manipulation of scents, for example, would allow growers to regulate the types of insect pollinators and the frequency of their visits\"。G 段说明基因操作香气可以调节传粉昆虫的类型和访问频率，从而帮助植物授粉繁殖，因此答案为 G。",
           "questionId": "q2"
         },
         {
           "questionNumber": 3,
-          "text": "（3）题目 3：Cloves were used to speed up the growth of mould.\n题目翻译：丁香被用来加速霉菌生长。\n答案：H\n解析：定位 Paragraph B 中 \"the spice clove could be used in baked goods and prepared meats to slow the growth of mould and bacteria.\"。丁香用于减缓霉菌生长，与题干矛盾，因此答案为 FALSE。",
+          "text": "（3）题目 3：a description of current research with advantages for the flower industry\n题目翻译：描述对花卉产业有好处的研究现状。\n答案：H\n解析：定位 Paragraph H 中 \"The next generation of experiments, already in progress, will include more sophisticated schemes that target the expression of scent specifically to flowers\"。H 段描述了正在进行中的下一代实验，针对花卉产业改良香气，因此答案为 H。",
           "questionId": "q3"
         },
         {
           "questionNumber": 4,
-          "text": "（4）题目 4：Most insects detect volatile compounds through their antennae.\n题目翻译：大多数昆虫通过触角检测挥发性化合物。\n答案：C\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads.\"。与题干一致，因此答案为 TRUE。",
+          "text": "（4）题目 4：an explanation of how insects perceive volatile compounds in plants\n题目翻译：解释昆虫如何感知植物中的挥发性化合物。\n答案：C\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads\"。C 段说明了昆虫通过极其敏感的触角检测挥发性化合物，因此答案为 C。",
           "questionId": "q4"
-        },
-        {
-          "questionNumber": 5,
-          "text": "（5）题目 5：Some plants emit volatile compounds when they have been injured.\n题目翻译：一些植物在受伤时释放挥发性化合物。\n答案：C\n解析：定位 Paragraph D 中 \"still others emit such compounds when they have been injured.\"。与题干一致，因此答案为 TRUE。",
-          "questionId": "q5"
-        },
-        {
-          "questionNumber": 6,
-          "text": "（6）题目 6：Volatile compounds released by plants can attract parasites of herbivore eggs.\n题目翻译：植物释放的挥发性化合物可以吸引食草动物卵的寄生虫。\n答案：D\n解析：定位 Paragraph D 中 \"Volatile compounds released by plants in response to herbivore egg-laying, for example, can attract parasites of the eggs.\"。与题干一致，因此答案为 TRUE。",
-          "questionId": "q6"
-        },
-        {
-          "questionNumber": 7,
-          "text": "（7）题目 7：Ants are attracted to young leaves because they emit methyl salicylate.\n题目翻译：蚂蚁被幼叶吸引，因为它们释放水杨酸甲酯。\n答案：B\n解析：定位 Paragraph E 中 \"ants of the species Petalomyrmex phylax are attracted to young leaves because they emit high levels of the volatile compound methyl salicylate.\"。与题干一致，因此答案为 TRUE。",
-          "questionId": "q7"
         }
       ],
       "questionRange": {
         "start": 1,
-        "end": 7
+        "end": 4
       },
-      "text": "（1）题目 1：Plant fragrances are used to attract pollinators.\n题目翻译：植物香气用于吸引传粉者。\n答案：F\n解析：定位 Paragraph A 中 \"a tool used by plants to entice pollinators\"。植物使用香气吸引传粉者，与题干一致，因此答案为 TRUE。\n（2）题目 2：Many volatile compounds in plants are toxic when eaten.\n题目翻译：植物中的许多挥发性化合物在被食用时是有毒的。\n答案：G\n解析：定位 Paragraph B 中 \"many volatile compounds in plants are toxic when eaten.\"。与题干一致，因此答案为 TRUE。\n（3）题目 3：Cloves were used to speed up the growth of mould.\n题目翻译：丁香被用来加速霉菌生长。\n答案：H\n解析：定位 Paragraph B 中 \"the spice clove could be used in baked goods and prepared meats to slow the growth of mould and bacteria.\"。丁香用于减缓霉菌生长，与题干矛盾，因此答案为 FALSE。\n（4）题目 4：Most insects detect volatile compounds through their antennae.\n题目翻译：大多数昆虫通过触角检测挥发性化合物。\n答案：C\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads.\"。与题干一致，因此答案为 TRUE。\n（5）题目 5：Some plants emit volatile compounds when they have been injured.\n题目翻译：一些植物在受伤时释放挥发性化合物。\n答案：C\n解析：定位 Paragraph D 中 \"still others emit such compounds when they have been injured.\"。与题干一致，因此答案为 TRUE。\n（6）题目 6：Volatile compounds released by plants can attract parasites of herbivore eggs.\n题目翻译：植物释放的挥发性化合物可以吸引食草动物卵的寄生虫。\n答案：D\n解析：定位 Paragraph D 中 \"Volatile compounds released by plants in response to herbivore egg-laying, for example, can attract parasites of the eggs.\"。与题干一致，因此答案为 TRUE。\n（7）题目 7：Ants are attracted to young leaves because they emit methyl salicylate.\n题目翻译：蚂蚁被幼叶吸引，因为它们释放水杨酸甲酯。\n答案：B\n解析：定位 Paragraph E 中 \"ants of the species Petalomyrmex phylax are attracted to young leaves because they emit high levels of the volatile compound methyl salicylate.\"。与题干一致，因此答案为 TRUE。"
+      "text": "（1）题目 1：a list of food plants which need insects to make them productive\n题目翻译：列举需要昆虫才能高产的食用植物。\n答案：F\n解析：定位 Paragraph F 中 \"many agricultural crops that rely on insect pollinators, including fruit trees such as the bee-pollinated cherry, apple, apricot, and peach, as well as vegetables and tropical plants such as the papaya\"。F 段列举了依赖昆虫传粉的果树（樱桃、苹果、杏、桃）和蔬菜、木瓜等食用植物，与题干吻合，因此答案为 F。\n（2）题目 2：an explanation of why a genetic experiment may assist plant reproduction\n题目翻译：解释基因实验为何可能有助于植物繁殖。\n答案：G\n解析：定位 Paragraph G 中 \"Clearly, a more refined strategy is needed; genetic manipulation of scents, for example, would allow growers to regulate the types of insect pollinators and the frequency of their visits\"。G 段说明基因操作香气可以调节传粉昆虫的类型和访问频率，从而帮助植物授粉繁殖，因此答案为 G。\n（3）题目 3：a description of current research with advantages for the flower industry\n题目翻译：描述对花卉产业有好处的研究现状。\n答案：H\n解析：定位 Paragraph H 中 \"The next generation of experiments, already in progress, will include more sophisticated schemes that target the expression of scent specifically to flowers\"。H 段描述了正在进行中的下一代实验，针对花卉产业改良香气，因此答案为 H。\n（4）题目 4：an explanation of how insects perceive volatile compounds in plants\n题目翻译：解释昆虫如何感知植物中的挥发性化合物。\n答案：C\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads\"。C 段说明了昆虫通过极其敏感的触角检测挥发性化合物，因此答案为 C。"
     },
     {
-      "sectionTitle": "2. 笔记填空（Questions 8–13）",
+      "sectionTitle": "2. 单选题（Questions 5–9）",
       "mode": "group",
       "items": [
         {
+          "questionNumber": 5,
+          "text": "（1）题目 5：According to the passage, spices were used in the past to\n题目翻译：根据文章，香料过去被用来做什么？\n答案：C（prevent the decay of food）\n解析：定位 Paragraph B 中 \"when they were used to slow the spoilage of food\" 及 \"the spice clove could be used in baked goods and prepared meats to slow the growth of mould and bacteria\"。香料被用于减缓食物变质和霉菌、细菌的生长，即防止食物腐烂，因此答案为 C。",
+          "questionId": "q5"
+        },
+        {
+          "questionNumber": 6,
+          "text": "（2）题目 6：The Leonardoxa africana tree protects itself by\n题目翻译：Leonardoxa africana 树通过什么保护自己？\n答案：D（attracting an enemy of herbivorous insects）\n解析：定位 Paragraph E 中 \"ants attack any herbivorous insects that they encounter\"。树释放水杨酸甲酯吸引蚂蚁，蚂蚁攻击食草昆虫，即吸引食草昆虫的天敌，因此答案为 D。",
+          "questionId": "q6"
+        },
+        {
+          "questionNumber": 7,
+          "text": "（3）题目 7：Which of the following statements about methyl salicylate is NOT true according to the passage?\n题目翻译：根据文章，关于水杨酸甲酯的下列陈述哪一项是不正确的？\n答案：B（It helps herbivorous insects to find food）\n解析：定位 Paragraph E 中 \"ants need to use as an antiseptic in their nests\"（蚂蚁用作巢穴防腐剂，A 正确）、\"attracted to young leaves because they emit high levels of the volatile compound methyl salicylate\"（吸引蚂蚁，C 正确）、\"the system can have a defensive purpose\"（防御食草动物，D 正确）。文中说水杨酸甲酯吸引的是蚂蚁（食草昆虫的天敌），并未说帮助食草昆虫找食物，因此 B 不正确，答案为 B。",
+          "questionId": "q7"
+        },
+        {
           "questionNumber": 8,
-          "text": "（1）题目 8：Fragrances consist of small organic particles with high ______ pressures.\n题目翻译：香气由具有高 ______ 压的小型有机颗粒组成。\n答案：D\n解析：定位 Paragraph A 中 \"Fragrances consist of small organic particles with high vapor pressures.\"。香气由具有高蒸气压的颗粒组成，因此答案为 vapor。",
+          "text": "（4）题目 8：Which factor has made the problems of US fruit growers more serious?\n题目翻译：哪个因素使美国果农的问题更加严重？\n答案：D（Bees have had their numbers reduced by disease）\n解析：定位 Paragraph F 中 \"This problem has been made worse in the United States by recent epidemics that have infected and killed many honeybees, the major insect pollinator\"。美国的流行病感染并杀死了许多蜜蜂，即疾病导致蜜蜂数量减少，因此答案为 D。",
           "questionId": "q8"
         },
         {
           "questionNumber": 9,
-          "text": "（2）题目 9：European civilization was heavily dependent on ______ and other tropical spices.\n题目翻译：欧洲文明严重依赖 ______ 和其他热带香料。\n答案：C\n解析：定位 Paragraph B 中 \"European civilization was heavily dependent on cloves and other tropical spices.\"。欧洲文明严重依赖丁香，因此答案为 cloves。",
+          "text": "（5）题目 9：Experiments in genetically manipulating the fragrance of ornamental flowers have\n题目翻译：基因操作观赏花卉香气的实验已经……\n答案：C（failed to produce a strong enough scent）\n解析：定位 Paragraph H 中 \"the level of intensity of fragrance was below the threshold of detection for the human nose\"。实验产出的香气强度低于人鼻检测阈值，即未能产生足够强的香气，因此答案为 C。",
           "questionId": "q9"
-        },
+        }
+      ],
+      "questionRange": {
+        "start": 5,
+        "end": 9
+      },
+      "text": "（1）题目 5：According to the passage, spices were used in the past to\n题目翻译：根据文章，香料过去被用来做什么？\n答案：C（prevent the decay of food）\n解析：定位 Paragraph B 中 \"when they were used to slow the spoilage of food\" 及 \"the spice clove could be used in baked goods and prepared meats to slow the growth of mould and bacteria\"。香料被用于减缓食物变质和霉菌、细菌的生长，即防止食物腐烂，因此答案为 C。\n（2）题目 6：The Leonardoxa africana tree protects itself by\n题目翻译：Leonardoxa africana 树通过什么保护自己？\n答案：D（attracting an enemy of herbivorous insects）\n解析：定位 Paragraph E 中 \"ants attack any herbivorous insects that they encounter\"。树释放水杨酸甲酯吸引蚂蚁，蚂蚁攻击食草昆虫，即吸引食草昆虫的天敌，因此答案为 D。\n（3）题目 7：Which of the following statements about methyl salicylate is NOT true according to the passage?\n题目翻译：根据文章，关于水杨酸甲酯的下列陈述哪一项是不正确的？\n答案：B（It helps herbivorous insects to find food）\n解析：定位 Paragraph E 中 \"ants need to use as an antiseptic in their nests\"（蚂蚁用作巢穴防腐剂，A 正确）、\"attracted to young leaves because they emit high levels of the volatile compound methyl salicylate\"（吸引蚂蚁，C 正确）、\"the system can have a defensive purpose\"（防御食草动物，D 正确）。文中说水杨酸甲酯吸引的是蚂蚁（食草昆虫的天敌），并未说帮助食草昆虫找食物，因此 B 不正确，答案为 B。\n（4）题目 8：Which factor has made the problems of US fruit growers more serious?\n题目翻译：哪个因素使美国果农的问题更加严重？\n答案：D（Bees have had their numbers reduced by disease）\n解析：定位 Paragraph F 中 \"This problem has been made worse in the United States by recent epidemics that have infected and killed many honeybees, the major insect pollinator\"。美国的流行病感染并杀死了许多蜜蜂，即疾病导致蜜蜂数量减少，因此答案为 D。\n（5）题目 9：Experiments in genetically manipulating the fragrance of ornamental flowers have\n题目翻译：基因操作观赏花卉香气的实验已经……\n答案：C（failed to produce a strong enough scent）\n解析：定位 Paragraph H 中 \"the level of intensity of fragrance was below the threshold of detection for the human nose\"。实验产出的香气强度低于人鼻检测阈值，即未能产生足够强的香气，因此答案为 C。"
+    },
+    {
+      "sectionTitle": "3. 判断题（Questions 10–13）",
+      "mode": "group",
+      "items": [
         {
           "questionNumber": 10,
-          "text": "（3）题目 10：Most insects detect volatile compounds through their ______.\n题目翻译：大多数昆虫通过它们的 ______ 检测挥发性化合物。\n答案：FALSE\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads.\"。通过触角检测，因此答案为 antennae。",
+          "text": "（1）题目 10：The theory that plants defend themselves with smells is untested.\n题目翻译：植物用气味保护自己的理论未经测试。\n答案：FALSE\n解析：定位 Paragraph E 中 \"many experiments have shown that the deactivation of a plant's volatile emission system makes it more vulnerable to herbivores\"。许多实验已经证明该理论，题干说\"未经测试\"与原文矛盾，因此答案为 FALSE。",
           "questionId": "q10"
         },
         {
           "questionNumber": 11,
-          "text": "（4）题目 11：Some plants emit compounds to deter insects from laying ______ on them.\n题目翻译：一些植物释放化合物以阻止昆虫在其上产 ______。\n答案：TRUE\n解析：定位 Paragraph D 中 \"in order to deter insects from laying eggs on them.\"。阻止昆虫产卵，因此答案为 eggs。",
+          "text": "（2）题目 11：The smell from fruit-tree flowers is important to farmers.\n题目翻译：果树花朵的气味对农民很重要。\n答案：TRUE\n解析：定位 Paragraph F 中 \"Floral scent has a strong impact on the economic success of many agricultural crops\"。花香对农作物经济成功有强烈影响，即对农民很重要，因此答案为 TRUE。",
           "questionId": "q11"
         },
         {
           "questionNumber": 12,
-          "text": "（5）题目 12：Volatile compounds can attract ______ of the eggs, preventing them from hatching.\n题目翻译：挥发性化合物可以吸引卵的 ______，防止它们孵化。\n答案：NOT GIVEN\n解析：定位 Paragraph D 中 \"can attract parasites of the eggs, thereby preventing them from hatching.\"。吸引卵的寄生虫，因此答案为 parasites。",
+          "text": "（3）题目 12：The population of honeybees in Europe has declined.\n题目翻译：欧洲的蜜蜂数量已经下降。\n答案：NOT GIVEN\n解析：定位 Paragraph F 中 \"in the United States by recent epidemics that have infected and killed many honeybees\"。文中只提到美国蜜蜂数量因流行病减少，未提及欧洲蜜蜂数量，因此答案为 NOT GIVEN。",
           "questionId": "q12"
         },
         {
           "questionNumber": 13,
-          "text": "（6）题目 13：Ants use methyl salicylate as an ______ in their nests.\n题目翻译：蚂蚁在其巢穴中使用水杨酸甲酯作为 ______。\n答案：FALSE\n解析：定位 Paragraph E 中 \"a substance that ants need to use as an antiseptic in their nests.\"。蚂蚁需要将其用作防腐剂，因此答案为 antiseptic。",
+          "text": "（4）题目 13：Applying perfume to orchard trees is accepted as a good method of increasing pollination.\n题目翻译：向果园树喷洒香水被公认是增加授粉的好方法。\n答案：FALSE\n解析：定位 Paragraph G 中 \"this approach was costly and, in the end, proved to be inefficient\"。文中明确说喷洒香气的方法成本高且最终被证明效率低下，不是好方法，因此答案为 FALSE。",
           "questionId": "q13"
         }
       ],
       "questionRange": {
-        "start": 8,
+        "start": 10,
         "end": 13
       },
-      "text": "（1）题目 8：Fragrances consist of small organic particles with high ______ pressures.\n题目翻译：香气由具有高 ______ 压的小型有机颗粒组成。\n答案：D\n解析：定位 Paragraph A 中 \"Fragrances consist of small organic particles with high vapor pressures.\"。香气由具有高蒸气压的颗粒组成，因此答案为 vapor。\n（2）题目 9：European civilization was heavily dependent on ______ and other tropical spices.\n题目翻译：欧洲文明严重依赖 ______ 和其他热带香料。\n答案：C\n解析：定位 Paragraph B 中 \"European civilization was heavily dependent on cloves and other tropical spices.\"。欧洲文明严重依赖丁香，因此答案为 cloves。\n（3）题目 10：Most insects detect volatile compounds through their ______.\n题目翻译：大多数昆虫通过它们的 ______ 检测挥发性化合物。\n答案：FALSE\n解析：定位 Paragraph C 中 \"most insects detect volatile compounds through the extremely sensitive antennae on their heads.\"。通过触角检测，因此答案为 antennae。\n（4）题目 11：Some plants emit compounds to deter insects from laying ______ on them.\n题目翻译：一些植物释放化合物以阻止昆虫在其上产 ______。\n答案：TRUE\n解析：定位 Paragraph D 中 \"in order to deter insects from laying eggs on them.\"。阻止昆虫产卵，因此答案为 eggs。\n（5）题目 12：Volatile compounds can attract ______ of the eggs, preventing them from hatching.\n题目翻译：挥发性化合物可以吸引卵的 ______，防止它们孵化。\n答案：NOT GIVEN\n解析：定位 Paragraph D 中 \"can attract parasites of the eggs, thereby preventing them from hatching.\"。吸引卵的寄生虫，因此答案为 parasites。\n（6）题目 13：Ants use methyl salicylate as an ______ in their nests.\n题目翻译：蚂蚁在其巢穴中使用水杨酸甲酯作为 ______。\n答案：FALSE\n解析：定位 Paragraph E 中 \"a substance that ants need to use as an antiseptic in their nests.\"。蚂蚁需要将其用作防腐剂，因此答案为 antiseptic。"
+      "text": "（1）题目 10：The theory that plants defend themselves with smells is untested.\n题目翻译：植物用气味保护自己的理论未经测试。\n答案：FALSE\n解析：定位 Paragraph E 中 \"many experiments have shown that the deactivation of a plant's volatile emission system makes it more vulnerable to herbivores\"。许多实验已经证明该理论，题干说\"未经测试\"与原文矛盾，因此答案为 FALSE。\n（2）题目 11：The smell from fruit-tree flowers is important to farmers.\n题目翻译：果树花朵的气味对农民很重要。\n答案：TRUE\n解析：定位 Paragraph F 中 \"Floral scent has a strong impact on the economic success of many agricultural crops\"。花香对农作物经济成功有强烈影响，即对农民很重要，因此答案为 TRUE。\n（3）题目 12：The population of honeybees in Europe has declined.\n题目翻译：欧洲的蜜蜂数量已经下降。\n答案：NOT GIVEN\n解析：定位 Paragraph F 中 \"in the United States by recent epidemics that have infected and killed many honeybees\"。文中只提到美国蜜蜂数量因流行病减少，未提及欧洲蜜蜂数量，因此答案为 NOT GIVEN。\n（4）题目 13：Applying perfume to orchard trees is accepted as a good method of increasing pollination.\n题目翻译：向果园树喷洒香水被公认是增加授粉的好方法。\n答案：FALSE\n解析：定位 Paragraph G 中 \"this approach was costly and, in the end, proved to be inefficient\"。文中明确说喷洒香气的方法成本高且最终被证明效率低下，不是好方法，因此答案为 FALSE。"
     }
   ]
 });


### PR DESCRIPTION
## Summary

教学部反馈：P1 Scented Plants（p1-low-67）解析和题干匹配不上。

## Root cause

原解析文件（reading-explanations/p1-low-67.js）的 questionExplanations 使用错误数据生成：
- Q1-Q4 真实为段落匹配题（Which paragraph contains...），解析却写成判断题
- Q5-Q7 解析答案与解析内容自相矛盾（如"答案：C"却写"因此答案为 TRUE"）
- Q8-Q13 题型标注错误（真实为单选/判断，解析标注为笔记填空）

## Fix

重写整个 questionExplanations，基于：
- 教学部官方题干（docx 提取）
- 题库 answerKey 真实答案（q1=F, q2=G, q3=H, q4=C, q5=C, q6=D, q7=B, q8=D, q9=C, q10=FALSE, q11=TRUE, q12=NOT GIVEN, q13=FALSE）
- 文章原文逐段定位（每道解析含段落引用和推理过程）

## Validation

- 13 题解析答案与题库 answerKey 全部一致
- JS 语法验证通过
- 解析包含：题目原文、翻译、答案、定位段落、原文引用