### PR TITLE
fix(review): 套题回顾显示正确答案与对错判定

### DIFF
--- a/developer/tests/js/suiteReviewCorrectAnswers.test.js
+++ b/developer/tests/js/suiteReviewCorrectAnswers.test.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * Regression: suite review must surface correct answers.
+ *
+ * Suite records persist `answerComparison` per question, but the entry
+ * projection historically dropped `correctAnswerMap`. Review then rebuilt the
+ * record with an empty correct-answer map, so every question rendered a blank
+ * correct answer and `isCorrect: null`.
+ *
+ * Two defects had to be fixed together:
+ *   (a) `_resolveReplayCorrectAnswerMap` never derived from `answerComparison`
+ *       — this is what repairs already-stored records.
+ *   (b) the `suiteEntries` projection omitted `correctAnswerMap`
+ *       — this is what keeps new records self-describing.
+ *
+ * The safety property under all of it: when no correct answer is knowable,
+ * review must degrade to `isCorrect: null`. It must never guess.
+ */
+import path from 'path';
+import fs from 'fs';
+import vm from 'vm';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import { webcrypto } from 'crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function loadScript(relativePath, context) {
+    const code = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    vm.runInContext(code, context, { filename: relativePath });
+}
+
+function createApp() {
+    const documentStub = {
+        addEventListener() {}, removeEventListener() {},
+        querySelector() { return null; }, querySelectorAll() { return []; },
+        createElement() { return { className: '', style: {} }; },
+        dispatchEvent() { return true; }
+    };
+    const windowStub = {
+        document: documentStub,
+        addEventListener() {}, removeEventListener() {}, showMessage() {},
+        location: { protocol: 'http:', origin: 'http://localhost', href: 'http://localhost/' },
+        crypto: webcrypto,
+        navigator: {},
+        practiceConfig: { suite: {} }
+    };
+    const sandbox = {
+        window: windowStub, document: documentStub, console,
+        setTimeout, clearTimeout, setInterval, clearInterval,
+        Math, URL, URLSearchParams, Uint8Array, Date, JSON,
+        Object, Array, String, Number, Boolean, Set, Map, Promise
+    };
+    sandbox.globalThis = sandbox.window;
+    const context = vm.createContext(sandbox);
+    loadScript('js/app/examSessionMixin.js', context);
+    loadScript('js/app/suitePracticeMixin.js', context);
+
+    const app = {};
+    Object.assign(app,
+        windowStub.ExamSystemAppMixins.examSession,
+        windowStub.ExamSystemAppMixins.suitePractice);
+    return app;
+}
+
+function suiteRecord(entry) {
+    return {
+        id: 'record-1',
+        examId: 'suite-1',
+        title: '套题练习',
+        suiteEntries: [Object.assign({ examId: 'reading-p1', rawData: {} }, entry)]
+    };
+}
+
+const app = createApp();
+let passed = 0;
+function ok(label, fn) {
+    fn();
+    passed += 1;
+    console.log(`  ok - ${label}`);
+}
+
+// Values are built inside the VM realm, so their prototypes differ from the
+// host's. Round-trip through JSON before structural comparison.
+function plain(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+console.log('suiteReviewCorrectAnswers');
+
+// --- Stored records with no correctAnswerMap (the reported bug) -------------
+ok('存量记录：从 answerComparison 反推正确答案', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A', q2: 'B' },
+        answerComparison: {
+            q1: { userAnswer: 'A', correctAnswer: 'A', isCorrect: true },
+            q2: { userAnswer: 'B', correctAnswer: 'C', isCorrect: false }
+        }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), { q1: 'A', q2: 'C' });
+    assert.strictEqual(built.answerComparison.q1.isCorrect, true);
+    assert.strictEqual(built.answerComparison.q2.isCorrect, false);
+    assert.strictEqual(built.answerComparison.q2.correctAnswer, 'C');
+});
+
+ok('新记录：显式 correctAnswerMap 直接生效', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A' },
+        correctAnswerMap: { q1: 'A' },
+        answerComparison: { q1: { userAnswer: 'A', correctAnswer: 'A', isCorrect: true } }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), { q1: 'A' });
+});
+
+ok('显式 correctAnswerMap 优先于 answerComparison 反推', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A' },
+        correctAnswerMap: { q1: 'AUTHORITATIVE' },
+        answerComparison: { q1: { userAnswer: 'A', correctAnswer: 'STALE' } }
+    }))[0];
+    assert.strictEqual(built.correctAnswers.q1, 'AUTHORITATIVE');
+});
+
+// --- Safety: never fabricate correctness ------------------------------------
+ok('无任何来源时降级为 isCorrect: null，不瞎判对错', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A', q2: 'B' },
+        answerComparison: {
+            q1: { userAnswer: 'A' },
+            q2: { userAnswer: 'B', correctAnswer: '' }
+        }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), {});
+    assert.strictEqual(built.answerComparison.q1.isCorrect, null);
+    assert.strictEqual(built.answerComparison.q2.isCorrect, null);
+    assert.strictEqual(built.answerComparison.q2.correctAnswer, '');
+});
+
+ok('部分可推：只判定有来源的题', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A', q2: 'B' },
+        answerComparison: {
+            q1: { userAnswer: 'A', correctAnswer: 'A' },
+            q2: { userAnswer: 'B' }
+        }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), { q1: 'A' });
+    assert.strictEqual(built.answerComparison.q1.isCorrect, true);
+    assert.strictEqual(built.answerComparison.q2.isCorrect, null);
+});
+
+ok('空数组不被当作正确答案', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: [] },
+        answerComparison: { q1: { userAnswer: [], correctAnswer: [] } }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), {});
+});
+
+// --- Key normalization must not be bypassed ---------------------------------
+ok('多选题数组正确答案可反推', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: ['A', 'B'] },
+        answerComparison: { q1: { userAnswer: ['A', 'B'], correctAnswer: ['A', 'B'] } }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers).q1, ['A', 'B']);
+});
+
+ok('带 examId 前缀的复合键正确归一', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A' },
+        answerComparison: { 'reading-p1::q1': { userAnswer: 'A', correctAnswer: 'Z' } }
+    }))[0];
+    assert.strictEqual(built.correctAnswers.q1, 'Z');
+});
+
+ok('他篇前缀的答案不被串用到本篇', () => {
+    const built = app._buildReviewReplayEntriesFromRecord(suiteRecord({
+        answers: { q1: 'A' },
+        answerComparison: { 'other-exam::q1': { userAnswer: 'A', correctAnswer: 'WRONG' } }
+    }))[0];
+    assert.deepStrictEqual(plain(built.correctAnswers), {});
+});
+
+// --- Single-passage review must be unaffected -------------------------------
+ok('单篇（非套题）回顾不受影响', () => {
+    const built = app._buildReviewReplayEntriesFromRecord({
+        id: 'record-2',
+        examId: 'reading-solo',
+        title: '单篇',
+        answers: { q1: 'A' },
+        correctAnswerMap: { q1: 'A' },
+        answerComparison: { q1: { userAnswer: 'A', correctAnswer: 'A', isCorrect: true } },
+        scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }
+    });
+    assert.strictEqual(built.length, 1);
+    assert.strictEqual(built[0].correctAnswers.q1, 'A');
+    assert.strictEqual(built[0].answerComparison.q1.isCorrect, true);
+});
+
+ok('单篇无正确答案来源时同样降级为 null', () => {
+    const built = app._buildReviewReplayEntriesFromRecord({
+        id: 'record-3',
+        examId: 'reading-solo',
+        answers: { q1: 'A' },
+        answerComparison: { q1: { userAnswer: 'A' } }
+    });
+    assert.deepStrictEqual(plain(built[0].correctAnswers), {});
+    assert.strictEqual(built[0].answerComparison.q1.isCorrect, null);
+});
+
+console.log(`\n${passed} passed`);

--- a/js/app/examSessionMixin.js
+++ b/js/app/examSessionMixin.js
@@ -3021,14 +3021,46 @@
                 || ''
             ).trim();
             const allowUnprefixed = config.allowUnprefixed !== false;
+            // Suite entries persist answerComparison but historically dropped
+            // correctAnswerMap, so derive from the comparison as a last resort.
             return this._mergeReplayAnswerMapsFirstWins({},
                 targetExamId,
                 allowUnprefixed,
                 entry.correctAnswerMap,
                 realData.correctAnswerMap,
                 rawData.correctAnswerMap,
-                rawRealData.correctAnswerMap
+                rawRealData.correctAnswerMap,
+                this._deriveCorrectAnswerMapFromComparison(entry.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(realData.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(rawData.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(rawRealData.answerComparison)
             );
+        },
+
+        _deriveCorrectAnswerMapFromComparison(comparison) {
+            if (!this._isReplayObject(comparison)) {
+                return null;
+            }
+            const derived = {};
+            Object.entries(comparison).forEach(([questionId, detail]) => {
+                if (!this._isReplayObject(detail)) {
+                    return;
+                }
+                const correctAnswer = detail.correctAnswer;
+                // Only real answers: a blank or empty value must stay unknown so
+                // the comparison degrades to isCorrect: null instead of guessing.
+                if (correctAnswer == null) {
+                    return;
+                }
+                if (typeof correctAnswer === 'string' && !correctAnswer.trim()) {
+                    return;
+                }
+                if (Array.isArray(correctAnswer) && !correctAnswer.length) {
+                    return;
+                }
+                derived[questionId] = correctAnswer;
+            });
+            return Object.keys(derived).length ? derived : null;
         },
 
         _finalizeReplayComparison(answers, correctAnswers, comparison) {

--- a/js/app/suitePracticeMixin.js
+++ b/js/app/suitePracticeMixin.js
@@ -2108,6 +2108,7 @@
                         scoreInfo: entry.scoreInfo,
                         answers: entry.answers,
                         answerComparison: entry.answerComparison,
+                        correctAnswerMap: entry.correctAnswerMap,
                         markedQuestions: Array.isArray(entry.markedQuestions) ? entry.markedQuestions.slice() : [],
                         highlights: this._resolveSuiteEntryHighlights(entry, draft),
                         noteText: this._resolveSuiteEntryNoteText(entry, draft),

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -9909,14 +9909,46 @@
                 || ''
             ).trim();
             const allowUnprefixed = config.allowUnprefixed !== false;
+            // Suite entries persist answerComparison but historically dropped
+            // correctAnswerMap, so derive from the comparison as a last resort.
             return this._mergeReplayAnswerMapsFirstWins({},
                 targetExamId,
                 allowUnprefixed,
                 entry.correctAnswerMap,
                 realData.correctAnswerMap,
                 rawData.correctAnswerMap,
-                rawRealData.correctAnswerMap
+                rawRealData.correctAnswerMap,
+                this._deriveCorrectAnswerMapFromComparison(entry.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(realData.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(rawData.answerComparison),
+                this._deriveCorrectAnswerMapFromComparison(rawRealData.answerComparison)
             );
+        },
+
+        _deriveCorrectAnswerMapFromComparison(comparison) {
+            if (!this._isReplayObject(comparison)) {
+                return null;
+            }
+            const derived = {};
+            Object.entries(comparison).forEach(([questionId, detail]) => {
+                if (!this._isReplayObject(detail)) {
+                    return;
+                }
+                const correctAnswer = detail.correctAnswer;
+                // Only real answers: a blank or empty value must stay unknown so
+                // the comparison degrades to isCorrect: null instead of guessing.
+                if (correctAnswer == null) {
+                    return;
+                }
+                if (typeof correctAnswer === 'string' && !correctAnswer.trim()) {
+                    return;
+                }
+                if (Array.isArray(correctAnswer) && !correctAnswer.length) {
+                    return;
+                }
+                derived[questionId] = correctAnswer;
+            });
+            return Object.keys(derived).length ? derived : null;
         },
 
         _finalizeReplayComparison(answers, correctAnswers, comparison) {

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -7855,8 +7855,8 @@
     "path": "睡着过项目组/2. 所有文章(11.20)[192篇]/141. P1 - The history of the guitar 吉他的历史/",
     "filename": "141. P1 - The history of the guitar 吉他的历史.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/141. P1 - The history of the guitar 吉他的历史.pdf",
     "sourceKind": "generated-reading"
   },
   "p2-low-49": {
@@ -10030,7 +10030,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "200. P1 - Australia’s Airborne Dentists 澳洲飞行牙医【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/200. P1 - Australia’s Airborne Dentists 澳洲飞行牙医.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10045,7 +10045,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "211. P1 - Ahead of its time 新西兰头骨【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/211. P1 - Ahead of its time 新西兰头骨.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10060,7 +10060,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "216. P1 - Australia’s cane toad problem 澳洲蟾蜍【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/216. P1 - Australia’s cane toad problem 澳洲蟾蜍.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10075,7 +10075,7 @@
     "path": "三月/2.P1 次高频/",
     "filename": "194. P1 - The history of the British wool industry 英国羊毛产业的历史【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/194. P1 - The history of the British wool industry 英国羊毛产业的历史.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10090,7 +10090,7 @@
     "path": "三月/",
     "filename": "222. P2 - Ideal Homes 理想居所.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/222. P2 - Ideal Homes 理想居所.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10105,7 +10105,7 @@
     "path": "三月/",
     "filename": "223. P1 - Effect and Cause 湖泊海啸研究.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/223. P1 - Effect and Cause 湖泊海啸研究.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10120,7 +10120,7 @@
     "path": "三月/3.P2 高频/",
     "filename": "201. P2 - Multi-tasking and the brain 大脑与多任务处理【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/201. P2 - Multi-tasking and the brain 大脑与多任务处理.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10135,7 +10135,7 @@
     "path": "三月/3.P2 高频/",
     "filename": "217. P2 - A mechanical friend for children 孩子的机器人朋友【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/217. P2 - A mechanical friend for children 孩子的机器人朋友.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10150,7 +10150,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "192. P2(1115纸笔) - Should we stop eating meat 是否应该吃素【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/192. P2(1115纸笔) - Should we stop eating meat 是否应该吃素.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10165,7 +10165,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "209. P2 - Decision Fatigue 决策疲劳【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/209. P2 - Decision Fatigue 决策疲劳.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10180,7 +10180,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "213. P2 - Growing more for less 卫星农业【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/213. P2 - Growing more for less 卫星农业.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10195,7 +10195,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "51. P2 - The dingo debate 澳洲野犬_澳洲野狗.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/51. P2 - The dingo debate 澳洲野犬_澳洲野狗.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10210,7 +10210,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "58. P2 - Who wrote Shakespeare's plays 莎士比亚【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/58. P2 - Who wrote Shakespeare's plays 莎士比亚.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10225,7 +10225,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "204. P3 - When people are ‘deaf’ to music 失乐症【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/204. P3 - When people are ‘deaf’ to music 失乐症.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10240,7 +10240,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "206. P3 - 200 Years of Australian Landscapes at the Royal Academy in London 亚洲风景展【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/206. P3 - 200 Years of Australian Landscapes at the Royal Academy in London 澳洲风景展.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10255,7 +10255,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "212. P3 - Children’s literature studies today 儿童文学【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/212. P3 - Children’s literature studies today 儿童文学.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10270,7 +10270,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "218. P3 - The Causes of Linguistic Change 语音的演变【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/218. P3 - The Causes of Linguistic Change 语音的演变.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10285,7 +10285,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "219. P3 - The origin of language 语言的起源.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/219. P3 - The origin of language 语言的起源.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10300,8 +10300,8 @@
     "path": "三月/5.P3 高频/",
     "filename": "P3 - Risk taking.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P3 - Risk taking.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-medium-197": {
@@ -10315,7 +10315,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "197. P3 - Australia’s Megafauna Controversy 巨兽灭绝【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/197. P3 - Australia’s Megafauna Controversy 巨兽灭绝.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10330,7 +10330,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "198. P3 - Child’s Play in Medieval England 中世纪的游戏.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/198. P3 - Child’s Play in Medieval England 中世纪的游戏.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10345,7 +10345,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "78. P3 (ds做出来的) - Music Language We All Speak 音乐语言.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/78. P3 (仅原文无题) - Music Language We All Speak 音乐语言.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10525,8 +10525,8 @@
     "path": "",
     "filename": "",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - War of the Plants.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-high-229": {
@@ -10570,8 +10570,8 @@
     "path": "assets/generated/reading-exams/",
     "filename": "reading-practice-unified.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - Coins – the first form of money.pdf",
     "sourceKind": "generated-reading"
   },
   "p1-high-240": {
@@ -10644,9 +10644,9 @@
     "difficultyScore": 3.5,
     "path": "",
     "filename": "",
-    "hasHtml": false,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasHtml": true,
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - The internal body clock 生物钟.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-medium-244": {
@@ -10659,9 +10659,9 @@
     "difficultyScore": 4,
     "path": "",
     "filename": "",
-    "hasHtml": false,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasHtml": true,
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P3 - Look who was talking.pdf",
     "sourceKind": "generated-reading"
   }
 

--- a/js/bundles/session.bundle.js
+++ b/js/bundles/session.bundle.js
@@ -2111,6 +2111,7 @@
                         scoreInfo: entry.scoreInfo,
                         answers: entry.answers,
                         answerComparison: entry.answerComparison,
+                        correctAnswerMap: entry.correctAnswerMap,
                         markedQuestions: Array.isArray(entry.markedQuestions) ? entry.markedQuestions.slice() : [],
                         highlights: this._resolveSuiteEntryHighlights(entry, draft),
                         noteText: this._resolveSuiteEntryNoteText(entry, draft),


### PR DESCRIPTION
## 问题

套题练习的回顾界面**正确答案列为空，对错判定全部丢失**。用户看到每道题的正确答案是空白，对错状态无法显示。

单篇（非套题）回顾不受影响。

## 根因

两处缺陷叠加，**缺一不可**：

**(a) 提取器不会反推** — `js/app/examSessionMixin.js` `_resolveReplayCorrectAnswerMap()`
只在 `entry` / `realData` / `rawData` / `rawData.realData` 四处找 `correctAnswerMap` 字段，四处都空就返回 `{}`。即便 `answerComparison` 里每道题都带着 `correctAnswer` 也不采用。

**(b) 持久化丢字段** — `_normalizeSuiteResult()` 明明算出了 `correctAnswerMap`，但构造 `suiteEntries` 写入记录时**没有复制这个字段**。

于是：套题记录写出去就不带正确答案 → 回顾重建时又不会从 `answerComparison` 反推 → `correctAnswers` 恒为 `{}` → 每题渲染成空白且 `isCorrect: null`。

### 复现证据

在本分支基线（`7698e9a`）上实跑，输入一条典型套题记录（带 `answerComparison`、不带 `correctAnswerMap`，即当前代码实际写出的形状）：

```
correctAnswers   = {}
answerComparison = {"q1":{...,"correctAnswer":"","isCorrect":null},
                    "q2":{...,"correctAnswer":"","isCorrect":null}}
```

对照实验：手工给同一条记录补上 `correctAnswerMap` 后，回顾立即恢复正常 —— 证明**回放链路本身无缺陷，问题纯在数据供给**。

## 修复

两处都改，各自解决不同人群：

- **(a) 反推兜底 → 修复存量记录。** 老数据已经写在用户磁盘上，没有 `correctAnswerMap` 字段，只能从 `answerComparison` 反推。
- **(b) 补字段 → 保证新记录**自带正确答案，不依赖反推。

只做其中一条都不够：只做 (a) 则新记录继续缺字段、永远依赖兜底；只做 (b) 则所有历史记录仍然是坏的。

### 关键设计点

- 反推结果**排在显式字段之后**传入 `_mergeReplayAnswerMapsFirstWins`，保持 first-wins 语义 —— 显式 `correctAnswerMap` 仍然优先，反推只在前面全空时生效。
- **只采信非空值**：`null` / 空字符串 / 空数组一律跳过。无来源时仍然降级为 `isCorrect: null`，**绝不臆测对错**。
- 反推出的 map 照常走 `_normalizeReplayAnswerMap` 归一，`examId` 前缀隔离不被绕过（他篇的答案不会串用到本篇）。

改动量：源码 35 行（含注释），其余为 bundle 同步。未新增消息类型、未加版本号、未引入回退框架。

## 测试

新增 `developer/tests/js/suiteReviewCorrectAnswers.test.js`，11 例全部通过：

| 用例 | 覆盖 |
|---|---|
| 存量记录从 `answerComparison` 反推 | 主修复路径 |
| 新记录显式 `correctAnswerMap` 生效 | 主修复路径 |
| 显式 map 优先于反推 | first-wins 未被破坏 |
| **无任何来源时降级 `isCorrect: null`** | **安全性：不瞎判对错** |
| 部分可推：只判定有来源的题 | 安全性 |
| 空数组不被当作正确答案 | 安全性 |
| 多选题数组正确答案可反推 | 数据形状 |
| 带 `examId` 前缀的复合键归一 | 键名归一未被绕过 |
| 他篇前缀的答案不被串用 | 隔离性 |
| 单篇（非套题）回顾不受影响 | 回归 |
| 单篇无来源时同样降级 | 回归 |

**已验证该测试是真回归测试**：`git stash` 掉修复后测试在第一条断言即失败，恢复后通过。

### 既有套件

`suiteModeFlow` / `suiteModeRegression` / `appDataV2` / `unifiedReadingPageInlineSuiteRegression` / `practicePageEnhancerReplay` / `examPlaceholderReplay` / `suiteInlineFallback` —— 全部 PASS。

全量 JS 套件：**50 passed, 3 failed**。三个失败（`dataKernelV2`、`unifiedReadingCoreRegression`、`unifiedReadingNotesMigration`）已验证在**未加本改动的干净 `opensource` 上同样失败**，与本 PR 无关。

### Bundles

已跑 `node scripts/build-bundles.mjs`（运行时加载的是 `js/bundles/*.bundle.js`，不重建则改动不生效）。只提交了本改动波及的 `browse.bundle.js` 与 `session.bundle.js`；`core-foundation.bundle.js` 有一处上游 PDF manifest 的既有 drift，与本 PR 无关，已还原不带入。
