### PR TITLE
fix: harden single-window suite recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
           node developer/tests/js/readingAnnotationHostProtocol.test.js
           node developer/tests/js/reviewHighlightDictionaryProtocol.test.js
           node developer/tests/js/legacyViewReadStatus.test.js
+          node developer/tests/js/onDemandEntrypoints.test.js
           node developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
           node developer/tests/js/suiteInlineFallback.test.js
           node developer/tests/js/suiteModeRegression.test.js
+          node developer/tests/js/suiteSessionRecoveryV2.test.js
 
       - name: Run Python tests (listening asset quality)
         run: python -m unittest developer.tests.py.test_listening_generate_assets_quality

--- a/developer/tests/ci/run_static_suite.py
+++ b/developer/tests/ci/run_static_suite.py
@@ -2221,6 +2221,25 @@ def run_checks() -> Tuple[List[dict], bool]:
         results.append(_format_result("套题模式状态机回归测试", False, "测试脚本缺失"))
         all_passed = False
 
+    suite_recovery_test = REPO_ROOT / "developer" / "tests" / "js" / "suiteSessionRecoveryV2.test.js"
+    if suite_recovery_test.exists():
+        suite_recovery_ok, suite_recovery_payload = _run_json_subprocess(
+            ["node", str(suite_recovery_test)],
+            timeout=60,
+            parse_mode="last-line",
+        )
+        if not suite_recovery_ok:
+            suite_recovery_passed = False
+            suite_recovery_detail = suite_recovery_payload
+        else:
+            suite_recovery_passed = suite_recovery_payload.get("status") == "pass"
+            suite_recovery_detail = suite_recovery_payload.get("detail", suite_recovery_payload)
+        results.append(_format_result("Suite recovery regression", suite_recovery_passed, suite_recovery_detail))
+        all_passed &= suite_recovery_passed
+    else:
+        results.append(_format_result("Suite recovery regression", False, "Test script missing"))
+        all_passed = False
+
     simulation_nb_drag_test = REPO_ROOT / "developer" / "tests" / "e2e" / "simulation_nb_drag_regression.py"
     if simulation_nb_drag_test.exists():
         try:

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -22,8 +22,25 @@ function recordResult(name, passed, detail) {
 }
 
 function createDocumentStub(inputState, buttonState) {
+    const elementsById = new Map();
+    const body = {
+        appendChild(element) {
+            element.parentNode = body;
+            if (element.id) elementsById.set(element.id, element);
+            return element;
+        },
+        removeChild(element) {
+            if (element && element.id && elementsById.get(element.id) === element) {
+                elementsById.delete(element.id);
+            }
+            if (element) element.parentNode = null;
+            return element;
+        }
+    };
+
     return {
         readyState: 'complete',
+        body,
         addEventListener() {},
         querySelector(selector) {
             if (selector === '.main-nav [data-view="practice"]' || selector === '.main-nav [data-view="browse"]' || selector === '.main-nav [data-view="more"]') {
@@ -41,6 +58,9 @@ function createDocumentStub(inputState, buttonState) {
             return [];
         },
         getElementById(id) {
+            if (elementsById.has(id)) {
+                return elementsById.get(id);
+            }
             if (id === 'exam-search-input') {
                 return inputState;
             }
@@ -48,6 +68,44 @@ function createDocumentStub(inputState, buttonState) {
                 return buttonState;
             }
             return null;
+        },
+        createElement(tagName) {
+            const listeners = new Map();
+            return {
+                tagName: String(tagName || '').toUpperCase(),
+                id: '',
+                parentNode: null,
+                style: {},
+                innerHTML: '',
+                addEventListener(type, listener) {
+                    listeners.set(type, listener);
+                },
+                querySelector() {
+                    return null;
+                },
+                querySelectorAll() {
+                    return [];
+                },
+                __click(attribute, value) {
+                    const listener = listeners.get('click');
+                    assert(listener, `element ${this.id || tagName} should have a click listener`);
+                    const target = {
+                        closest(selector) {
+                            if (selector === 'button' || selector.includes(`[${attribute}]`)) {
+                                return this;
+                            }
+                            return null;
+                        },
+                        getAttribute(name) {
+                            return name === attribute ? value : null;
+                        },
+                        hasAttribute(name) {
+                            return name === attribute;
+                        }
+                    };
+                    listener({ target });
+                }
+            };
         }
     };
 }
@@ -156,10 +214,124 @@ async function testClearSearchProxyLoadsBrowseRuntime(harness) {
     });
 }
 
+async function waitForElement(document, id) {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        const element = document.getElementById(id);
+        if (element) return element;
+        await Promise.resolve();
+    }
+    assert.fail(`timed out waiting for #${id}`);
+}
+
+function createSuiteRecoveryHarness(candidate, options = {}) {
+    const harness = createHarness();
+    const events = [];
+    harness.windowStub.app = {
+        async getSuiteRecoveryCandidate() {
+            events.push({ type: 'candidate' });
+            return candidate;
+        },
+        async abandonSuiteRecovery(sessionId) {
+            events.push({ type: 'abandon', sessionId });
+            return options.abandonResult !== false;
+        },
+        async startSuitePractice(startOptions) {
+            events.push({ type: 'start', options: { ...startOptions } });
+            return 'started';
+        }
+    };
+    loadScript('js/presentation/app-actions.js', harness.context);
+    return { ...harness, events };
+}
+
+async function testSuiteRecoveryRequiresExplicitContinueChoice() {
+    const candidate = {
+        id: 'suite-recovery-1',
+        title: '<img src=x onerror=alert(1)>',
+        completedCount: 1,
+        total: 3
+    };
+    const harness = createSuiteRecoveryHarness(candidate);
+
+    const firstLaunch = harness.windowStub.AppActions.startSuitePractice();
+    const duplicateLaunch = harness.windowStub.AppActions.startSuitePractice();
+    const modal = await waitForElement(harness.windowStub.document, 'suite-recovery-choice-modal');
+
+    assert(modal.innerHTML.includes('&lt;img src=x onerror=alert(1)&gt;'), '恢复标题应转义后再写入 modal');
+    assert(!modal.innerHTML.includes('<img src=x onerror=alert(1)>'), '恢复标题不得作为 HTML 注入');
+    assert.strictEqual(harness.events.filter((event) => event.type === 'candidate').length, 1, '重复点击只能读取一次恢复候选');
+    assert.strictEqual(harness.events.filter((event) => event.type === 'start').length, 0, '用户选择前不得隐式恢复');
+
+    modal.__click('data-suite-recovery-choice', 'continue');
+    await Promise.all([firstLaunch, duplicateLaunch]);
+
+    const starts = harness.events.filter((event) => event.type === 'start');
+    assert.strictEqual(starts.length, 1, 'Continue 只能启动一次恢复');
+    assert.strictEqual(starts[0].options.recoveryAction, 'continue');
+    assert.strictEqual(starts[0].options.recoverySessionId, candidate.id);
+    assert.strictEqual(harness.events.filter((event) => event.type === 'abandon').length, 0);
+    recordResult('套题恢复必须显式选择 Continue', true, { events: harness.events });
+}
+
+async function testSuiteRecoveryAbandonThenStartsFreshSuite() {
+    const candidate = {
+        id: 'suite-recovery-2',
+        title: 'Reading Passage 2',
+        completedCount: 2,
+        total: 3
+    };
+    const harness = createSuiteRecoveryHarness(candidate);
+
+    const launch = harness.windowStub.AppActions.startSuitePractice();
+    const recoveryModal = await waitForElement(harness.windowStub.document, 'suite-recovery-choice-modal');
+    recoveryModal.__click('data-suite-recovery-choice', 'discard');
+
+    const modeModal = await waitForElement(harness.windowStub.document, 'suite-mode-selector-modal');
+    assert.deepStrictEqual(
+        harness.events.filter((event) => event.type === 'abandon').map((event) => event.sessionId),
+        [candidate.id],
+        'Abandon 应先删除指定恢复候选'
+    );
+    assert.strictEqual(harness.events.filter((event) => event.type === 'start').length, 0, '放弃完成前不得启动新套题');
+
+    modeModal.__click('data-suite-flow-mode', 'classic');
+    await launch;
+
+    const starts = harness.events.filter((event) => event.type === 'start');
+    assert.strictEqual(starts.length, 1, '放弃后应仅启动一套新题');
+    assert.strictEqual(starts[0].options.flowMode, 'classic');
+    assert.strictEqual(starts[0].options.frequencyScope, 'all');
+    assert.strictEqual(starts[0].options.recoveryAction, undefined, '新套题不得携带恢复动作');
+    assert.strictEqual(harness.events[1].type, 'abandon');
+    assert.strictEqual(harness.events[2].type, 'start');
+    recordResult('套题恢复可显式 Abandon 后新建', true, { events: harness.events });
+}
+
+async function testSuiteRecoveryCancelDoesNotMutateSession() {
+    const harness = createSuiteRecoveryHarness({
+        id: 'suite-recovery-3',
+        title: 'Reading Passage 3',
+        completedCount: 0,
+        total: 3
+    });
+
+    const launch = harness.windowStub.AppActions.startSuitePractice();
+    const modal = await waitForElement(harness.windowStub.document, 'suite-recovery-choice-modal');
+    modal.__click('data-suite-recovery-choice', 'cancel');
+    await launch;
+
+    assert.strictEqual(harness.events.filter((event) => event.type === 'start').length, 0, 'Cancel 不得启动或恢复套题');
+    assert.strictEqual(harness.events.filter((event) => event.type === 'abandon').length, 0, 'Cancel 不得删除恢复候选');
+    recordResult('套题恢复取消不改变会话', true, { events: harness.events });
+}
+
 async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
+        await testSuiteRecoveryRequiresExplicitContinueChoice();
+        await testSuiteRecoveryAbandonThenStartsFreshSuite();
+        await testSuiteRecoveryCancelDoesNotMutateSession();
         console.log(JSON.stringify({
             status: 'pass',
             detail: `${results.length}/${results.length} 测试通过`,

--- a/developer/tests/js/practiceRecorder.test.js
+++ b/developer/tests/js/practiceRecorder.test.js
@@ -158,7 +158,7 @@ function createHarness() {
     loadScript('js/core/practiceRecorder.js', context);
     const recorder = Object.create(windowStub.PracticeRecorder.prototype);
     recorder.wait = async () => {};
-    return { recorder, state };
+    return { recorder, state, windowStub };
 }
 
 function makeRecord(id = 'record-v2') {
@@ -236,6 +236,47 @@ async function main() {
                 }
             });
             assert.strictEqual(completionCalls, 0, 'host-owned completion must not be saved through the recorder global listener');
+        });
+
+        await record('restore and autosave isolate recorder sessions from suite recovery', async () => {
+            const { recorder, windowStub } = createHarness();
+            const savedSessions = [];
+            windowStub.AppData.recovery.listActiveSessions = async () => clone([
+                {
+                    schema: 'suite-session-v2',
+                    id: 'suite-owner',
+                    sessionId: 'suite-owner',
+                    examId: 'reading-suite-host'
+                },
+                {
+                    id: 'active-session:ordinary-session',
+                    sessionId: 'ordinary-session',
+                    examId: 'reading-p1',
+                    updatedAt: '2026-08-09T00:01:00.000Z'
+                }
+            ]);
+            windowStub.AppData.recovery.saveActiveSession = async (session) => {
+                savedSessions.push(clone(session));
+                return { committed: true };
+            };
+            recorder.activeSessions = new Map();
+
+            await recorder.restoreActiveSessions();
+
+            assert.deepStrictEqual(
+                Array.from(recorder.activeSessions.keys()),
+                ['reading-p1']
+            );
+            assert.strictEqual(recorder.activeSessions.get('reading-p1').status, 'restored');
+
+            await recorder.saveActiveSessions();
+
+            assert.deepStrictEqual(
+                savedSessions.map((session) => session.id),
+                ['active-session:ordinary-session']
+            );
+            assert(savedSessions.every((session) => session.schema !== 'suite-session-v2'),
+                'autosave must not clone suite recovery entities');
         });
 
         await record('temporary recovery draft does not overwrite reading drafts', async () => {

--- a/developer/tests/js/suiteModeFlow.test.js
+++ b/developer/tests/js/suiteModeFlow.test.js
@@ -117,7 +117,8 @@ async function main() {
             },
             async listDrafts() { return []; },
             async listActiveSessions() { return []; },
-            async saveActiveSession() { return { committed: true }; }
+            async saveActiveSession() { return { committed: true }; },
+            async discardActiveSession() { return { committed: true }; }
         }
     };
     windowStub.CustomEvent = function CustomEvent(type, init = {}) {
@@ -332,13 +333,37 @@ async function main() {
     const failureMessage = windowStub._messages.find(msg => typeof msg.text === 'string' && msg.text.includes('无法继续套题练习'));
     assert.strictEqual(failureMessage, undefined, '不应出现无法继续的警告');
 
-    const handledP3 = await app.handleSuitePracticeComplete(thirdExam.examId, practicePayload);
-    assert.strictEqual(handledP3, true, 'P3 完成后应顺利收尾');
-    assert.strictEqual(app.currentSuiteSession, null, '套题会话应在完成后被清理');
+    const finalWindow = app.currentSuiteSession.windowRef;
+    const finalPayload = {
+        ...practicePayload,
+        submissionId: 'submission-p3',
+        sessionId: 'session-reading-p3',
+        suiteSessionId: session.id
+    };
+    const handledP3 = await app.handleSuitePracticeComplete(thirdExam.examId, finalPayload, finalWindow);
+    assert.strictEqual(handledP3.handled, true, 'P3 完成后应进入提交收尾');
+    assert.strictEqual(handledP3.committed, true, 'P3 结果应在 ACK 前完成持久化');
+    assert.strictEqual(app.currentSuiteSession, session, 'ACK 前应保留套题会话以支持回执重放');
+    assert.strictEqual(finalWindow.closed, false, 'ACK 前不应关闭子窗口');
 
     const savedPracticeRecords = await windowStub.AppData.practice.list();
     assert.strictEqual(savedPracticeRecords.length, 1, '应只生成一条套题练习记录');
     assert.strictEqual(savedPracticeRecords[0].suiteEntries.length, 3, '套题记录应包含三篇文章');
+
+    assert.strictEqual(
+        app._announcePracticeSubmitOutcome(thirdExam.examId, finalPayload, finalWindow, true),
+        true,
+        '持久化完成后应向子窗口发送 ACK'
+    );
+    const submitAck = finalWindow._messages.find(msg => msg && msg.type === 'PRACTICE_SUBMIT_ACK');
+    assert(submitAck, '子窗口应收到最终提交 ACK');
+    assert.strictEqual(app.currentSuiteSession, session, 'ACK 后、延迟清理前仍应保留套题会话');
+    assert.strictEqual(finalWindow.closed, false, 'ACK 后由子页自行退出，宿主不应立即强制关闭');
+    assert.strictEqual(app._scheduleSuiteSubmitTeardown(handledP3.teardownSession), true, '应调度延迟清理兜底');
+    assert(session.submitReceiptTeardownTimer, '延迟清理计时器应已注册');
+    assert.strictEqual(await app._teardownSuiteSession(session), true, '执行延迟清理应成功');
+    assert.strictEqual(app.currentSuiteSession, null, '延迟清理后应释放套题会话');
+    assert.strictEqual(finalWindow.closed, true, '延迟清理兜底应关闭仍存活的子窗口');
 
     const completionMessage = windowStub._messages.find(msg => typeof msg.text === 'string' && msg.text.includes('套题练习已完成'));
     assert(completionMessage, '应提示套题练习完成');

--- a/developer/tests/js/suiteModeRegression.test.js
+++ b/developer/tests/js/suiteModeRegression.test.js
@@ -75,6 +75,27 @@ function createSandbox() {
                 async listActiveSessions() {
                     return cloneValue(activeSessions);
                 },
+                async saveActiveSession(value, options = {}) {
+                    if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) {
+                        return { committed: false };
+                    }
+                    const entity = cloneValue(value);
+                    const entityId = String(entity && (entity.id || entity.sessionId) || '');
+                    if (!entityId) return { committed: false };
+                    const index = activeSessions.findIndex(item => String(item && (item.id || item.sessionId) || '') === entityId);
+                    if (index >= 0) activeSessions[index] = entity;
+                    else activeSessions.push(entity);
+                    return { committed: true, value: cloneValue(entity) };
+                },
+                async discardActiveSession(entityId, options = {}) {
+                    if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) {
+                        return { committed: false };
+                    }
+                    const normalized = String(entityId || '');
+                    const before = activeSessions.length;
+                    activeSessions = activeSessions.filter(item => String(item && (item.id || item.sessionId) || '') !== normalized);
+                    return { committed: true, removed: before !== activeSessions.length };
+                },
                 windowSession: {
                     save(kind, value) {
                         windowSessionStore.set(String(kind), cloneValue(value));
@@ -175,6 +196,9 @@ function createApp(windowStub) {
         saveRealPracticeData: async () => {}
     };
     Object.assign(app, windowStub.ExamSystemAppMixins.examSession, windowStub.ExamSystemAppMixins.suitePractice);
+    app._suiteModeReady = true;
+    app.suiteExamMap = new Map();
+    app.multiSuiteSessionsMap = new Map();
     return app;
 }
 
@@ -407,14 +431,25 @@ async function run() {
         session.autoAdvanceAfterSubmit = false;
         session.results = [
             {
+                examId: 'reading-p1', title: 'Passage 1', duration: 10,
+                answers: { q1: 'A' }, answerComparison: {},
+                scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {}
+            },
+            {
                 examId: 'reading-p2',
                 title: 'Passage 2',
+                duration: 10,
                 answers: { q1: 'B' },
                 answerComparison: { q1: { userAnswer: 'B', correctAnswer: 'B', isCorrect: true } },
                 scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
                 highlights: [],
                 scrollY: 0,
                 rawData: {}
+            },
+            {
+                examId: 'reading-p3', title: 'Passage 3', duration: 10,
+                answers: { q1: 'C' }, answerComparison: {},
+                scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {}
             }
         ];
         session.draftsByExam['reading-p2'] = {
@@ -436,6 +471,7 @@ async function run() {
         };
         app._updatePracticeRecordsState = async () => {};
         app._teardownSuiteSession = async () => {};
+        app.currentSuiteSession = session;
         await app.finalizeSuiteRecord(session);
         const p2Entry = savedRecord.suiteEntries.find(entry => entry.examId === 'reading-p2');
         assert.deepStrictEqual(p2Entry.highlights, p2Highlights, '最终记录也必须保留 draft 中的 P2 高亮');
@@ -452,9 +488,9 @@ async function run() {
         const session = makeSession('suite_final_highlight');
         const p2Highlights = [{ scope: 'groups', text: 'P2 answer evidence', color: 'green' }];
         session.results = [
-            { examId: 'reading-p1', title: 'Passage 1', answers: { q1: 'A' }, answerComparison: { q1: { userAnswer: 'A', correctAnswer: 'A', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {} },
-            { examId: 'reading-p2', title: 'Passage 2', answers: { q1: 'B' }, answerComparison: { q1: { userAnswer: 'B', correctAnswer: 'B', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, highlights: p2Highlights, scrollY: 240, rawData: { highlights: p2Highlights, scrollY: 240 } },
-            { examId: 'reading-p3', title: 'Passage 3', answers: { q1: 'C' }, answerComparison: { q1: { userAnswer: 'C', correctAnswer: 'C', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {} }
+            { examId: 'reading-p1', title: 'Passage 1', duration: 10, answers: { q1: 'A' }, answerComparison: { q1: { userAnswer: 'A', correctAnswer: 'A', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {} },
+            { examId: 'reading-p2', title: 'Passage 2', duration: 10, answers: { q1: 'B' }, answerComparison: { q1: { userAnswer: 'B', correctAnswer: 'B', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, highlights: p2Highlights, scrollY: 240, rawData: { highlights: p2Highlights, scrollY: 240 } },
+            { examId: 'reading-p3', title: 'Passage 3', duration: 10, answers: { q1: 'C' }, answerComparison: { q1: { userAnswer: 'C', correctAnswer: 'C', isCorrect: true } }, scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }, rawData: {} }
         ];
         app.currentSuiteSession = session;
         app.suiteExamMap = new Map(session.sequence.map(item => [item.examId, session.id]));
@@ -466,6 +502,7 @@ async function run() {
         app._updatePracticeRecordsState = async () => {};
         app._teardownSuiteSession = async () => {};
 
+        app.currentSuiteSession = session;
         await app.finalizeSuiteRecord(session);
         const p2Entry = savedRecord.suiteEntries.find(entry => entry.examId === 'reading-p2');
         assert(p2Entry, '最终套题记录必须包含 P2 entry');
@@ -609,6 +646,7 @@ async function run() {
             }
         }, session.windowRef);
         const secondNavigate = app._handleSimulationNavigate('reading-p1', { direction: 'next' }, session.windowRef);
+        await new Promise(resolve => setTimeout(resolve, 0));
         assert.strictEqual(openCallCount, 1, '并发切题期间只允许一次窗口切换');
 
         if (typeof resolveOpen === 'function') {
@@ -646,7 +684,7 @@ async function run() {
             { direction: 'next' },
             session.windowRef
         );
-        await Promise.resolve();
+        await new Promise(resolve => setTimeout(resolve, 0));
         const queuedNavigate = app._handleSimulationNavigate(
             'reading-p2',
             { direction: 'next' },
@@ -795,6 +833,50 @@ async function run() {
         assert.strictEqual(session.draftsByExam['reading-p1'], undefined, 'P2 草稿不能误写到 P1');
         assert.deepStrictEqual(session.draftsByExam['reading-p2'].answers, { q1: 'P2 answer' }, 'P2 草稿应按 payload.examId 保存');
         assert.strictEqual(session.draftsByExam['reading-p2'].noteText, 'P2 note', 'P2 noteText 应保存');
+    }
+
+    // Case 2.4.1a: a queued classic draft cannot write through a replaced registration.
+    {
+        const app = createApp(windowStub);
+        const oldWindow = createStubWindow('old-reading-window');
+        const newWindow = createStubWindow('new-reading-window');
+        const oldInfo = {
+            window: oldWindow,
+            expectedSessionId: 'reading-session',
+            sessionGeneration: 1,
+            practiceMode: 'classic',
+            suiteSessionId: null,
+            reviewMode: false
+        };
+        const newInfo = { ...oldInfo, window: newWindow, sessionGeneration: 2 };
+        app.examWindows = new Map([['reading-p1', oldInfo]]);
+        let releaseQueue;
+        app._readingDraftStoreQueue = new Promise((resolve) => { releaseQueue = resolve; });
+        const pending = app._queueReadingDraftSync('reading-p1', {
+            sessionId: 'reading-session',
+            draft: { answers: { q1: 'stale' }, updatedAt: 100 },
+            draftUpdatedAt: 100
+        }, oldInfo);
+        app.examWindows.set('reading-p1', newInfo);
+        releaseQueue();
+        assert.strictEqual(await pending, false, '窗口重注册后排队中的旧草稿必须被拒绝');
+    }
+
+    // Case 2.4.1b: suite handler failure must not fall back to a standalone v2 attempt.
+    {
+        const app = createApp(windowStub);
+        const session = makeSession('suite_no_standalone_fallback');
+        app.currentSuiteSession = session;
+        app.suiteExamMap = new Map(session.sequence.map((item) => [item.examId, session.id]));
+        app.handleSuitePracticeComplete = async () => { throw new Error('suite handler failure'); };
+        let standaloneWrites = 0;
+        app.saveRealPracticeData = async () => { standaloneWrites += 1; return { id: 'unexpected' }; };
+        assert.strictEqual(await app.handlePracticeComplete('reading-p1', {
+            suiteSessionId: session.id,
+            answers: { q1: 'A' },
+            scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 }
+        }, session.windowRef), false);
+        assert.strictEqual(standaloneWrites, 0, '套题处理失败不得写入单篇 fallback');
     }
 
     // Case 2.4.2: inline simulation 草稿同步必须按篇拆分 elapsed，并镜像回窗口会话域
@@ -1321,7 +1403,7 @@ async function run() {
         assert.deepStrictEqual(p3.answers, { q1: 'C' }, '最终提交应覆盖旧快照答案');
     }
 
-    // Case 4: 套题意外关闭后，已作答篇应按单篇普通流程保存
+    // Case 4: 显式中断只清理 v2 套题会话，不拆分写入 v1 单篇记录
     {
         const app = createApp(windowStub);
         const session = makeSession('suite_abort');
@@ -1353,7 +1435,7 @@ async function run() {
         };
 
         await app._abortSuiteSession(session, {});
-        assert.deepStrictEqual(savedExamIds.sort(), ['reading-p1', 'reading-p2'], '中断后应保存所有已作答篇章');
+        assert.deepStrictEqual(savedExamIds, [], '中断后不得通过 v1 单篇路径写入记录');
     }
 
     // Case 5: AppData window-session mirror must be cleared after teardown
@@ -2007,6 +2089,67 @@ async function run() {
         assert.deepStrictEqual(status, { examId, status: 'completed' }, '完成后应更新题源状态');
     }
 
+    // Case 12.1: delayed injector callbacks cannot mutate a replaced registration.
+    {
+        const app = createApp(windowStub);
+        const examId = 'stale-injection-registration';
+        const appendedScripts = [];
+        let initialized = 0;
+        const injectionDocument = {
+            readyState: 'complete',
+            documentElement: { dataset: {} },
+            head: {
+                appendChild(script) {
+                    appendedScripts.push(script);
+                }
+            },
+            body: null,
+            getElementById() { return null; },
+            querySelector() { return null; },
+            createElement() {
+                return {
+                    dataset: {},
+                    remove() {}
+                };
+            }
+        };
+        const examWindow = {
+            ...createStubWindow('stale-injection-window'),
+            document: injectionDocument
+        };
+        const info = app.ensureExamWindowSession(examId, examWindow);
+        const firstRegistration = app._captureExamSessionRegistration(examId, info);
+        const scheduled = [];
+        const originalSetTimeout = sandbox.setTimeout;
+        sandbox.setTimeout = (callback) => {
+            scheduled.push(callback);
+            return scheduled.length;
+        };
+        app.initializePracticeSession = () => { initialized += 1; };
+        try {
+            app.injectDataCollectionScript(examWindow, examId, null, {
+                expectedRegistration: firstRegistration
+            });
+            assert.strictEqual(scheduled.length, 1, 'injector must queue its document-ready check');
+            info.sessionGeneration += 1;
+            scheduled.shift()();
+            assert.strictEqual(appendedScripts.length, 0, 'a stale document-ready callback must not append a script');
+
+            const secondRegistration = app._captureExamSessionRegistration(examId, info);
+            app.injectDataCollectionScript(examWindow, examId, null, {
+                expectedRegistration: secondRegistration
+            });
+            scheduled.shift()();
+            assert.strictEqual(appendedScripts.length, 1, 'the current registration may append its enhancer script');
+            info.sessionGeneration += 1;
+            appendedScripts[0].onload();
+            assert.strictEqual(scheduled.length, 0, 'a stale script onload must not queue session initialization');
+            assert.strictEqual(initialized, 0, 'a stale injector callback must not initialize the replacement session');
+        } finally {
+            sandbox.setTimeout = originalSetTimeout;
+        }
+    }
+
     // Case 13: 统一阅读提交后 reset 必须复用父页通信链路并重建 recorder session
     {
         const app = createApp(windowStub);
@@ -2020,6 +2163,7 @@ async function run() {
         const statuses = [];
         let cleanupCount = 0;
         let restartCount = 0;
+        let restartRegistration = null;
 
         app.generateSessionId = () => resetSessionId;
         app.components.practiceRecorder = {
@@ -2048,7 +2192,7 @@ async function run() {
                 this.activeSessions.set(payload.examId, session);
             }
         };
-        app.startPracticeSession = async (handledExamId) => {
+        app.startPracticeSession = async (handledExamId, options = {}) => {
             resetStarts.push(handledExamId);
             app.components.practiceRecorder.activeSessions.set(handledExamId, {
                 examId: handledExamId,
@@ -2057,12 +2201,18 @@ async function run() {
                 progress: {},
                 answers: {}
             });
+            return {
+                owned: true,
+                sessionId: resetSessionId,
+                registration: options.expectedRegistration
+            };
         };
         app.cleanupExamSession = async () => {
             cleanupCount += 1;
         };
-        app.restartExamHandshake = (targetWindow, handledExamId) => {
+        app.restartExamHandshake = (targetWindow, handledExamId, registration) => {
             restartCount += 1;
+            restartRegistration = registration;
             assert.strictEqual(targetWindow, examWindow, 'reset 应复用当前统一阅读窗口');
             assert.strictEqual(handledExamId, examId, 'reset 握手应使用当前题源');
         };
@@ -2082,6 +2232,8 @@ async function run() {
         info.expectedSessionId = firstSessionId;
         app._refreshExamWindowToken(examId, info);
         app.examWindows.set(examId, info);
+        const firstGeneration = info.sessionGeneration;
+        const firstWindowSessionToken = info.windowSessionToken;
 
         const handler = app.messageHandlers.get(examId);
         assert.strictEqual(typeof handler, 'function', '统一阅读题源应注册 message handler');
@@ -2139,6 +2291,8 @@ async function run() {
 
         const resetInfo = app.examWindows.get(examId);
         assert.strictEqual(resetInfo.expectedSessionId, resetSessionId, 'reset 必须生成新的 expectedSessionId');
+        assert.strictEqual(resetInfo.sessionGeneration, firstGeneration + 1, 'reset must advance the window session generation exactly once');
+        assert.notStrictEqual(resetInfo.windowSessionToken, firstWindowSessionToken, 'reset must rotate the window session token');
         assert.strictEqual(resetInfo.status, 'active', 'reset 后窗口应回到 active');
         assert.deepStrictEqual(resetStarts, [examId], 'reset 后必须补建练习会话');
         assert.strictEqual(recorderStarts.length, 1, 'reset 后必须同步 recorder sessionId');
@@ -2148,12 +2302,38 @@ async function run() {
             resetSessionId,
             'reset 后 active recorder session 必须可被下一次提交使用'
         );
-        assert(
-            examWindow._messages.some(message => message && message.type === 'INIT_SESSION' && message.data && message.data.sessionId === resetSessionId),
-            'reset 后必须向子页发送新的 INIT_SESSION'
-        );
+        const resetInit = examWindow._messages.find(message => message && message.type === 'INIT_SESSION'
+            && message.data && message.data.sessionId === resetSessionId);
+        assert(resetInit, 'reset 后必须向子页发送新的 INIT_SESSION');
+        assert.strictEqual(resetInit.data.windowSessionGeneration, firstGeneration + 1, 'reset INIT must carry the advanced generation');
+        assert.strictEqual(resetInit.data.windowSessionToken, resetInfo.windowSessionToken, 'reset INIT must carry the rotated token');
         assert.strictEqual(restartCount, 1, 'reset 后必须重启握手');
+        assert.strictEqual(app._isExamSessionRegistrationCurrent(examId, restartRegistration), true, 'reset handshake must use the new exact registration');
         assert(statuses.some(item => item.examId === examId && item.status === 'in-progress'), 'reset 后题源状态应回到 in-progress');
+
+        const resetHandler = app.messageHandlers.get(examId);
+        assert.notStrictEqual(resetHandler, handler, 'reset must bind a new exact-registration message handler');
+        let acceptedReady = 0;
+        app.handleSessionReady = () => { acceptedReady += 1; };
+        const readyEvent = {
+            source: examWindow,
+            origin: 'http://localhost',
+            data: {
+                type: 'SESSION_READY',
+                source: 'practice_page',
+                data: {
+                    examId,
+                    sessionId: resetSessionId,
+                    windowSessionToken: resetInfo.windowSessionToken,
+                    pageType: 'reading',
+                    source: 'practice_page'
+                }
+            }
+        };
+        await handler(readyEvent);
+        assert.strictEqual(acceptedReady, 0, 'the stale registration handler must ignore reset-era messages');
+        await resetHandler(readyEvent);
+        assert.strictEqual(acceptedReady, 1, 'the new exact registration handler must accept reset READY');
     }
 
     process.stdout.write(JSON.stringify({ status: 'pass', detail: 'simulation mode regression cases passed' }));

--- a/developer/tests/js/suiteSessionRecoveryV2.test.js
+++ b/developer/tests/js/suiteSessionRecoveryV2.test.js
@@ -1,0 +1,670 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const source = fs.readFileSync(path.join(repoRoot, 'js/app/suitePracticeMixin.js'), 'utf8');
+
+function createSessionStore() {
+    const values = new Map();
+    return {
+        save(name, value) { values.set(String(name), structuredClone(value)); return true; },
+        get(name) { return values.has(String(name)) ? structuredClone(values.get(String(name))) : null; },
+        discard(name) { values.delete(String(name)); return true; },
+        peek(name) { return values.get(String(name)) || null; }
+    };
+}
+
+function createHarness() {
+    const sessionStore = createSessionStore();
+    const durableSessions = new Map();
+    const durableWrites = [];
+    const durableDiscards = [];
+    const controls = { saveActiveSession: null, discardActiveSession: null };
+    const messages = [];
+    const windowStub = {
+        location: { protocol: 'http:', href: 'http://localhost/' },
+        showMessage(text, type) { messages.push({ text, type }); },
+        addEventListener() {},
+        removeEventListener() {}
+    };
+    const sandbox = {
+        window: windowStub,
+        console,
+        Date,
+        Math,
+        JSON,
+        Array,
+        Object,
+        Map,
+        Set,
+        URL,
+        structuredClone,
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        AppData: {
+            ready: Promise.resolve(),
+            recovery: {
+                windowSession: sessionStore,
+                async listActiveSessions() {
+                    return Array.from(durableSessions.values(), (value) => structuredClone(value));
+                },
+                async saveActiveSession(value, options = {}) {
+                    assert.deepEqual(Object.keys(options).sort(), ['operationId']);
+                    durableWrites.push({
+                        value: structuredClone(value),
+                        options: { operationId: options.operationId }
+                    });
+                    if (typeof controls.saveActiveSession === 'function') {
+                        return controls.saveActiveSession(value, options, durableSessions);
+                    }
+                    durableSessions.set(String(value.id), structuredClone(value));
+                    return { committed: true, value: structuredClone(value) };
+                },
+                async discardActiveSession(id, options = {}) {
+                    assert.deepEqual(Object.keys(options).sort(), ['operationId']);
+                    durableDiscards.push({
+                        id: String(id),
+                        options: { operationId: options.operationId }
+                    });
+                    if (typeof controls.discardActiveSession === 'function') {
+                        return controls.discardActiveSession(id, options, durableSessions);
+                    }
+                    durableSessions.delete(String(id));
+                    return { committed: true };
+                }
+            }
+        }
+    };
+    windowStub.AppData = sandbox.AppData;
+    windowStub.ExamSystemAppMixins = {};
+    sandbox.globalThis = windowStub;
+    vm.runInContext(source, vm.createContext(sandbox), { filename: 'js/app/suitePracticeMixin.js' });
+    const mixin = windowStub.ExamSystemAppMixins.suitePractice;
+    const sequence = ['p1', 'p2', 'p3'].map((examId, index) => ({
+        examId,
+        exam: { id: examId, title: `Passage ${index + 1}`, category: `P${index + 1}` },
+        category: `P${index + 1}`
+    }));
+    const makeApp = () => {
+        const app = { components: {}, currentSuiteSession: null, suiteExamMap: new Map(), messages };
+        Object.assign(app, mixin);
+        app._clearSuiteHandshakes = () => {};
+        app._ensureSuiteWindowGuard = () => {};
+        app._releaseSuiteWindowGuard = () => {};
+        app._focusSuiteWindow = () => {};
+        app._sendSimulationContext = () => true;
+        app.updateExamStatus = () => {};
+        app.cleanupExamSession = async () => {};
+        return app;
+    };
+    return { sessionStore, durableSessions, durableWrites, durableDiscards, controls, messages, makeApp, sequence };
+}
+
+async function main() {
+    const { sessionStore, durableSessions, durableWrites, messages, makeApp, sequence } = createHarness();
+    const firstApp = makeApp();
+    let firstWindow;
+    firstApp.openExam = async () => {
+        const snapshot = sessionStore.peek('simulation');
+        const durable = Array.from(durableSessions.values())[0];
+        assert.equal(snapshot.status, 'active');
+        assert.equal(durable.status, 'active', 'first passage must not open before durable recovery is committed');
+        assert.equal(snapshot.currentIndex, 0);
+        assert.equal(snapshot.sequence.length, 3);
+        firstWindow = { closed: false, name: 'suite-window' };
+        return firstWindow;
+    };
+    assert.equal(await firstApp._launchSuiteSessionFromSequence(sequence, { flowMode: 'simulation' }), true);
+    assert.equal(sessionStore.peek('simulation').status, 'active');
+    assert.equal(durableWrites.length, 1);
+
+    // Durable AppData is authoritative whenever it is available. A fast mirror
+    // without a matching durable entity is cleared instead of being promoted.
+    {
+        const zeroHarness = createHarness();
+        const writer = zeroHarness.makeApp();
+        writer.openExam = async () => ({ closed: false, name: 'zero-durable-writer' });
+        assert.equal(await writer._launchSuiteSessionFromSequence(zeroHarness.sequence, { flowMode: 'simulation' }), true);
+        assert.ok(zeroHarness.sessionStore.peek('simulation'));
+        zeroHarness.durableSessions.clear();
+
+        const zeroApp = zeroHarness.makeApp();
+        zeroApp.initializeSuiteMode();
+        await zeroApp._suiteRecoveryReady;
+        assert.equal(zeroApp.currentSuiteSession, null);
+        assert.equal(zeroHarness.sessionStore.peek('simulation'), null);
+        assert.equal(zeroHarness.durableWrites.length, 1, 'fast WAL must never be promoted into AppData');
+    }
+
+    // Exactly one valid durable entity wins and overwrites any newer-looking fast WAL.
+    {
+        const oneHarness = createHarness();
+        const writer = oneHarness.makeApp();
+        writer.openExam = async () => ({ closed: false, name: 'one-durable-writer' });
+        assert.equal(await writer._launchSuiteSessionFromSequence(oneHarness.sequence, { flowMode: 'simulation' }), true);
+        const durable = structuredClone(Array.from(oneHarness.durableSessions.values())[0]);
+        const uncommittedFast = oneHarness.sessionStore.peek('simulation');
+        uncommittedFast.revision = durable.revision + 100;
+        uncommittedFast.lastUpdate = durable.lastUpdate + 100;
+        uncommittedFast.draftsByExam = { p1: { answers: { ghost: 'not-durable' }, updatedAt: 9999 } };
+        oneHarness.sessionStore.save('simulation', uncommittedFast);
+
+        const oneApp = oneHarness.makeApp();
+        oneApp.initializeSuiteMode();
+        await oneApp._suiteRecoveryReady;
+        assert.equal(oneApp.currentSuiteSession.id, durable.id);
+        assert.equal(oneApp.currentSuiteSession.revision, durable.revision);
+        assert.deepEqual(oneApp.currentSuiteSession.draftsByExam, durable.draftsByExam);
+        const reconciledMirror = oneHarness.sessionStore.peek('simulation');
+        assert.equal(reconciledMirror.revision, durable.revision);
+        assert.deepEqual(reconciledMirror.draftsByExam, durable.draftsByExam);
+        assert.equal(oneHarness.durableWrites.length, 1, 'durable restore must not write back a fast snapshot');
+    }
+
+    // Multiple valid durable entities are ambiguous in the single-window build.
+    // Keep both durable records, clear the fast mirror, and refuse to choose/start.
+    {
+        const manyHarness = createHarness();
+        const writer = manyHarness.makeApp();
+        writer.openExam = async () => ({ closed: false, name: 'many-durable-writer' });
+        assert.equal(await writer._launchSuiteSessionFromSequence(manyHarness.sequence, { flowMode: 'simulation' }), true);
+        const firstDurable = structuredClone(Array.from(manyHarness.durableSessions.values())[0]);
+        const secondDurable = {
+            ...structuredClone(firstDurable),
+            id: 'suite_second_durable',
+            revision: firstDurable.revision + 100,
+            lastUpdate: firstDurable.lastUpdate + 100
+        };
+        manyHarness.durableSessions.set(secondDurable.id, secondDurable);
+
+        const manyApp = manyHarness.makeApp();
+        manyApp.initializeSuiteMode();
+        await manyApp._suiteRecoveryReady;
+        assert.equal(manyApp.currentSuiteSession, null);
+        assert.equal(manyApp._suiteRecoveryAmbiguous, true);
+        assert.equal(manyApp._suiteRecoveryAmbiguousCount, 2);
+        assert.equal(manyHarness.sessionStore.peek('simulation'), null);
+        assert.equal(manyHarness.durableSessions.size, 2);
+        assert.equal(manyHarness.messages.some((entry) => String(entry.text).includes('Multiple unfinished suites')), true);
+        assert.equal(await manyApp.startSuitePractice(), false);
+        assert.equal(manyHarness.durableSessions.size, 2);
+    }
+
+    // The passage result must be durable before the child receives a positive ACK
+    // or the next passage is opened.
+    {
+        const passageHarness = createHarness();
+        const passageApp = passageHarness.makeApp();
+        const firstPassageWindow = { closed: false, name: 'passage-one' };
+        let openCount = 0;
+        passageApp.openExam = async () => {
+            openCount += 1;
+            if (openCount === 1) return firstPassageWindow;
+            const durable = Array.from(passageHarness.durableSessions.values())[0];
+            assert.equal(durable.currentIndex, 1);
+            assert.equal(durable.results[0].examId, 'p1');
+            return { closed: false, name: 'passage-two' };
+        };
+        assert.equal(await passageApp._launchSuiteSessionFromSequence(passageHarness.sequence, { flowMode: 'simulation' }), true);
+        const passageOutcome = await passageApp.handleSuitePracticeComplete('p1', {
+            suiteSessionId: passageApp.currentSuiteSession.id,
+            submissionId: 'passage-one-submit',
+            duration: 10,
+            scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
+            answers: { q1: 'A' },
+            answerComparison: {}
+        }, firstPassageWindow);
+        assert.equal(passageOutcome.committed, true);
+        assert.equal(openCount, 2);
+    }
+
+    // A rejected durable write is a NACK and must not advance the child window.
+    {
+        const failedHarness = createHarness();
+        const failedApp = failedHarness.makeApp();
+        let openCount = 0;
+        const failedWindow = { closed: false, name: 'failed-save' };
+        failedApp.openExam = async () => {
+            openCount += 1;
+            return openCount === 1
+                ? failedWindow
+                : { closed: false, name: 'retry-success' };
+        };
+        assert.equal(await failedApp._launchSuiteSessionFromSequence(failedHarness.sequence, { flowMode: 'simulation' }), true);
+        const failedSession = failedApp.currentSuiteSession;
+        const beforeFailure = {
+            lastUpdate: failedSession.lastUpdate,
+            revision: failedSession.revision,
+            draftRevisionPresent: Object.prototype.hasOwnProperty.call(failedSession, 'draftRevision'),
+            draftRevision: failedSession.draftRevision,
+            currentIndex: failedSession.currentIndex,
+            activeExamId: failedSession.activeExamId,
+            pendingAdvancePresent: Object.prototype.hasOwnProperty.call(failedSession, 'pendingAdvance'),
+            pendingAdvance: failedSession.pendingAdvance,
+            globalTimerAnchorMs: failedSession.globalTimerAnchorMs,
+            suiteTimerPausedOffsetMs: failedSession.suiteTimerPausedOffsetMs,
+            suiteTimerPausedAtMs: failedSession.suiteTimerPausedAtMs,
+            suiteTimerRunning: failedSession.suiteTimerRunning
+        };
+        const failedPayload = {
+            suiteSessionId: failedSession.id,
+            submissionId: 'passage-save-failed',
+            duration: 10,
+            draft: { answers: { q1: 'A' }, updatedAt: 9000 },
+            draftUpdatedAt: 9000,
+            suiteTimerPausedOffsetMs: 1234,
+            suiteTimerPausedAtMs: 8000,
+            suiteTimerRunning: false,
+            scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
+            answers: { q1: 'A' },
+            answerComparison: {}
+        };
+        failedHarness.controls.saveActiveSession = async () => ({ committed: false });
+        const failedOutcome = await failedApp.handleSuitePracticeComplete('p1', failedPayload, failedWindow);
+        assert.equal(failedOutcome.committed, false);
+        assert.equal(failedOutcome.errorCode, 'suite_recovery_save_failed');
+        assert.equal(openCount, 1);
+        assert.deepEqual(failedSession.results, []);
+        assert.deepEqual(failedSession.draftsByExam, {});
+        assert.deepEqual(failedSession.elapsedByExam, {});
+        assert.equal(failedSession.lastUpdate, beforeFailure.lastUpdate);
+        assert.equal(failedSession.revision, beforeFailure.revision);
+        assert.equal(Object.prototype.hasOwnProperty.call(failedSession, 'draftRevision'), beforeFailure.draftRevisionPresent);
+        assert.equal(failedSession.draftRevision, beforeFailure.draftRevision);
+        assert.equal(failedSession.currentIndex, beforeFailure.currentIndex);
+        assert.equal(failedSession.activeExamId, beforeFailure.activeExamId);
+        assert.equal(Object.prototype.hasOwnProperty.call(failedSession, 'pendingAdvance'), beforeFailure.pendingAdvancePresent);
+        assert.equal(failedSession.pendingAdvance, beforeFailure.pendingAdvance);
+        assert.equal(failedSession.globalTimerAnchorMs, beforeFailure.globalTimerAnchorMs);
+        assert.equal(failedSession.suiteTimerPausedOffsetMs, beforeFailure.suiteTimerPausedOffsetMs);
+        assert.equal(failedSession.suiteTimerPausedAtMs, beforeFailure.suiteTimerPausedAtMs);
+        assert.equal(failedSession.suiteTimerRunning, beforeFailure.suiteTimerRunning);
+        const failedWal = failedHarness.sessionStore.peek('simulation');
+        const failedDurable = failedHarness.durableSessions.get(failedSession.id);
+        assert.deepEqual(failedWal.results, []);
+        assert.deepEqual(failedWal.draftsByExam, {});
+        assert.deepEqual(failedWal.elapsedByExam, {});
+        assert.equal(failedWal.revision, beforeFailure.revision);
+        assert.deepEqual(failedDurable.results, []);
+        assert.deepEqual(failedDurable.draftsByExam, {});
+        assert.deepEqual(failedDurable.elapsedByExam, {});
+        assert.equal(failedDurable.revision, beforeFailure.revision);
+
+        failedHarness.controls.saveActiveSession = null;
+        const retryOutcome = await failedApp.handleSuitePracticeComplete('p1', failedPayload, failedWindow);
+        assert.equal(retryOutcome.committed, true);
+        assert.equal(openCount, 2);
+        assert.equal(failedSession.results[0].examId, 'p1');
+        assert.equal(failedSession.draftsByExam.p1.answers.q1, 'A');
+        assert.equal(failedHarness.sessionStore.peek('simulation').results[0].examId, 'p1');
+        assert.equal(failedHarness.durableSessions.get(failedSession.id).results[0].examId, 'p1');
+    }
+
+    // Drafts may arrive after the child Window exists but before openExam() resolves.
+    // The initializing snapshot must bind that exact source and persist the draft.
+    const earlyHarness = createHarness();
+    const initializingApp = earlyHarness.makeApp();
+    let initializingWindow;
+    initializingApp.openExam = async () => {
+        initializingWindow = { closed: false, name: 'initializing-window' };
+        const initializingSession = initializingApp.currentSuiteSession;
+        assert.equal(initializingSession.status, 'active');
+        const accepted = initializingApp._handleSuiteDraftSync('p1', {
+            suiteSessionId: initializingSession.id,
+            draft: { answers: { q1: 'early' }, updatedAt: 120 },
+            draftUpdatedAt: 120,
+            elapsed: 4
+        }, { window: initializingWindow, suiteSessionId: initializingSession.id }, initializingWindow);
+        assert.equal(accepted, true);
+        assert.equal(initializingSession.windowRef, initializingWindow);
+        return initializingWindow;
+    };
+    assert.equal(await initializingApp._launchSuiteSessionFromSequence(sequence, { flowMode: 'simulation' }), true);
+
+    const resumedApp = makeApp();
+    resumedApp.initializeSuiteMode();
+    await resumedApp._suiteRecoveryReady;
+    assert.equal(resumedApp.currentSuiteSession.id, firstApp.currentSuiteSession.id);
+    assert.equal(resumedApp.currentSuiteSession.activeExamId, 'p1');
+    assert.equal(resumedApp.currentSuiteSession.globalTimerAnchorMs, firstApp.currentSuiteSession.globalTimerAnchorMs);
+
+    const suiteWindow = { closed: false, name: 'suite-window' };
+    const session = resumedApp.currentSuiteSession;
+    session.status = 'active';
+    session.windowRef = suiteWindow;
+    session.activeExamId = 'p2';
+    session.currentIndex = 1;
+    const windowInfo = { window: suiteWindow, suiteSessionId: session.id };
+    assert.equal(resumedApp._handleSuiteDraftSync('p2', {
+        suiteSessionId: session.id,
+        draft: { answers: { q2: 'new' }, updatedAt: 100 },
+        draftUpdatedAt: 100,
+        elapsed: 12
+    }, windowInfo, suiteWindow), true);
+    assert.deepEqual(session.draftsByExam.p2.answers, { q2: 'new' });
+    assert.equal(resumedApp._handleSuiteDraftSync('p2', {
+        suiteSessionId: session.id,
+        draft: { answers: { q2: 'equal-must-reject' }, updatedAt: 100 },
+        draftUpdatedAt: 100
+    }, windowInfo, suiteWindow), false);
+    assert.deepEqual(session.draftsByExam.p2.answers, { q2: 'new' });
+    assert.equal(resumedApp._handleSuiteDraftSync('p2', {
+        suiteSessionId: session.id,
+        draft: { answers: { q2: 'missing-time-must-reject' } }
+    }, windowInfo, suiteWindow), false);
+    assert.equal(resumedApp._handleSuiteDraftSync('p1', {
+        suiteSessionId: session.id,
+        draft: { answers: { q1: 'late-p1' }, updatedAt: 200 },
+        draftUpdatedAt: 200
+    }, windowInfo, suiteWindow), true);
+    assert.equal(session.activeExamId, 'p2', '迟到的旧篇草稿不得回滚活动篇章');
+    assert.equal(session.currentIndex, 1);
+
+    // A paused suite must retain its pause state when a draft omits timer fields.
+    const pausedSession = {
+        ...session,
+        suiteTimerRunning: false,
+        suiteTimerPausedAtMs: 5000,
+        suiteTimerPausedOffsetMs: 3000
+    };
+    resumedApp._syncSuiteTimerFromPayload(pausedSession, {
+        draft: { answers: { q1: 'paused' }, updatedAt: 300 }
+    });
+    assert.equal(pausedSession.suiteTimerRunning, false, '普通草稿同步不得恢复暂停套题计时');
+    assert.equal(pausedSession.suiteTimerPausedAtMs, 5000, '普通草稿同步不得清除暂停时间');
+
+    let openedOnResume = false;
+    resumedApp.openExam = async () => {
+        openedOnResume = true;
+        return { closed: false, name: 'replacement' };
+    };
+    session.windowRef = null;
+    session._restoredFromStorage = true;
+    resumedApp._fetchSuiteExamIndex = async () => sequence.map((entry) => entry.exam);
+    assert.equal(await resumedApp.resumeSuitePractice(session.id), true);
+    assert.equal(openedOnResume, true);
+    assert.equal(sessionStore.peek('simulation').draftsByExam.p2.answers.q2, 'new');
+
+    const missingApp = makeApp();
+    missingApp.initializeSuiteMode();
+    missingApp._fetchSuiteExamIndex = async () => [sequence[0].exam];
+    missingApp.openExam = async () => { throw new Error('must not open missing exam'); };
+    const missingSessionId = missingApp.currentSuiteSession.id;
+    assert.equal(await missingApp.resumeSuitePractice(missingSessionId), false);
+    assert.equal(sessionStore.peek('simulation'), null);
+
+    // Recovery choices are explicitly bound to the candidate id.
+    {
+        const choiceHarness = createHarness();
+        const choiceApp = choiceHarness.makeApp();
+        choiceApp.openExam = async () => ({ closed: false, name: 'choice-window' });
+        assert.equal(await choiceApp._launchSuiteSessionFromSequence(choiceHarness.sequence, { flowMode: 'simulation' }), true);
+        const candidate = await choiceApp.getSuiteRecoveryCandidate();
+        assert.equal(candidate.id, choiceApp.currentSuiteSession.id);
+        assert.equal(await choiceApp.resumeSuitePractice(), false);
+        assert.equal(await choiceApp.abandonSuiteRecovery('wrong-session'), false);
+        assert.equal(choiceHarness.durableSessions.has(candidate.id), true);
+        assert.equal(await choiceApp.abandonSuiteRecovery(candidate.id), true);
+        assert.equal(choiceHarness.durableSessions.has(candidate.id), false);
+    }
+
+    // Abandon waits for an in-flight save to finish, then discards it. The ordered
+    // save-then-discard sequence leaves no durable entity behind.
+    {
+        const pendingHarness = createHarness();
+        const pendingApp = pendingHarness.makeApp();
+        pendingApp.openExam = async () => ({ closed: false, name: 'pending-window' });
+        assert.equal(await pendingApp._launchSuiteSessionFromSequence(pendingHarness.sequence, { flowMode: 'simulation' }), true);
+        const pendingSession = pendingApp.currentSuiteSession;
+        let releaseSave;
+        let saveEntered;
+        const mutationOrder = [];
+        const saveEnteredPromise = new Promise((resolve) => { saveEntered = resolve; });
+        const saveReleasePromise = new Promise((resolve) => { releaseSave = resolve; });
+        pendingHarness.controls.saveActiveSession = async (value, options, store) => {
+            mutationOrder.push('save-start');
+            saveEntered();
+            await saveReleasePromise;
+            store.set(String(value.id), structuredClone(value));
+            mutationOrder.push('save-commit');
+            return { committed: true };
+        };
+        pendingHarness.controls.discardActiveSession = async (id, options, store) => {
+            mutationOrder.push('discard');
+            store.delete(String(id));
+            return { committed: true };
+        };
+        pendingSession.lastUpdate = Date.now();
+        const pendingCommit = pendingApp._commitSuiteRecovery(pendingSession, { notify: false });
+        await saveEnteredPromise;
+        const pendingAbandon = pendingApp.abandonSuiteRecovery(pendingSession.id);
+        await Promise.resolve();
+        releaseSave();
+        assert.equal(await pendingCommit, true);
+        assert.equal(await pendingAbandon, true);
+        assert.deepEqual(mutationOrder, ['save-start', 'save-commit', 'discard']);
+        assert.equal(pendingHarness.durableSessions.has(pendingSession.id), false);
+        await Promise.resolve();
+        assert.equal(pendingHarness.durableSessions.has(pendingSession.id), false);
+    }
+
+    const invalidTerminalSnapshot = {
+        schema: 'suite-session-v2',
+        version: 2,
+        id: 'suite_invalid_terminal',
+        status: 'finalizing',
+        sequence,
+        suiteSequence: sequence,
+        currentIndex: sequence.length,
+        activeExamId: null,
+        results: [{
+            examId: 'p1',
+            title: 'Passage 1',
+            category: 'P1',
+            scoreInfo: { correct: 1, total: 1 }
+        }],
+        draftsByExam: {},
+        elapsedByExam: {},
+        suiteTimerMode: 'elapsed',
+        suiteTimerLimitSeconds: 3600,
+        startTime: 1000,
+        globalTimerAnchorMs: 1000,
+        suiteTimerAnchorMs: 1000,
+        lastUpdate: 1000
+    };
+    sessionStore.save('simulation', invalidTerminalSnapshot);
+    const corruptApp = makeApp();
+    corruptApp.initializeSuiteMode();
+    assert.equal(corruptApp.currentSuiteSession, null, '不完整终态快照必须被丢弃');
+    assert.equal(sessionStore.peek('simulation'), null, '不完整终态快照不得永久卡在 finalizing');
+
+    const validTerminalResults = sequence.map((entry) => ({
+        examId: entry.examId,
+        title: entry.exam.title,
+        category: entry.category,
+        duration: 10,
+        scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
+        answers: { [`q-${entry.examId}`]: 'A' },
+        answerComparison: {}
+    }));
+    const terminalActiveId = 'suite_terminal_active_id';
+    sessionStore.save('simulation', {
+        ...invalidTerminalSnapshot,
+        id: terminalActiveId,
+        status: 'active',
+        activeExamId: 'p3',
+        results: validTerminalResults,
+        finalizeOperationId: null,
+        finalizeRecord: null
+    });
+    const terminalActiveApp = makeApp();
+    terminalActiveApp.initializeSuiteMode();
+    assert.equal(terminalActiveApp.currentSuiteSession.status, 'finalizing', '已完成索引的活动篇章快照必须转入终态恢复');
+    assert.equal(terminalActiveApp.currentSuiteSession.activeExamId, null, '终态恢复不得重新打开最后一篇');
+
+    const malformedRecordId = 'suite_malformed_record';
+    sessionStore.save('simulation', {
+        ...invalidTerminalSnapshot,
+        id: malformedRecordId,
+        results: validTerminalResults,
+        finalizeOperationId: `practice-suite:${malformedRecordId}:finalize`,
+        finalizeRecord: {
+            id: malformedRecordId,
+            sessionId: malformedRecordId,
+            operationId: `practice-suite:${malformedRecordId}:finalize`,
+            suiteEntries: sequence.map((entry) => ({ examId: entry.examId }))
+        }
+    });
+    const malformedRecordApp = makeApp();
+    malformedRecordApp.initializeSuiteMode();
+    assert.equal(malformedRecordApp.currentSuiteSession, null, '缺少聚合字段的终态记录不得重放');
+    assert.equal(sessionStore.peek('simulation'), null);
+
+    const incompleteFinalizeApp = makeApp();
+    const incompleteFinalizeSession = {
+        id: 'suite_incomplete_finalize',
+        status: 'active',
+        startTime: 1000,
+        sequence,
+        currentIndex: 2,
+        activeExamId: 'p3',
+        results: validTerminalResults.filter((entry) => entry.examId !== 'p2'),
+        draftsByExam: {},
+        elapsedByExam: {},
+        flowMode: 'stationary',
+        windowRef: null
+    };
+    incompleteFinalizeApp.currentSuiteSession = incompleteFinalizeSession;
+    incompleteFinalizeApp._saveSuitePracticeRecord = async () => {
+        throw new Error('incomplete suite must not be persisted');
+    };
+    assert.equal(await incompleteFinalizeApp._finalizeSuiteRecordWithGate(incompleteFinalizeSession), false);
+    assert.equal(incompleteFinalizeSession.status, 'active');
+    assert.equal(incompleteFinalizeSession.currentIndex, 1);
+    assert.equal(incompleteFinalizeSession.activeExamId, 'p2');
+
+    const finalApp = makeApp();
+    let committedRecord = null;
+    const finalSession = {
+        id: 'suite_terminal',
+        status: 'active',
+        startTime: 1000,
+        globalTimerAnchorMs: 1000,
+        suiteTimerAnchorMs: 1000,
+        sequence,
+        currentIndex: sequence.length,
+        activeExamId: null,
+        results: sequence.map((entry) => ({
+            examId: entry.examId,
+            title: entry.exam.title,
+            category: entry.category,
+            duration: 10,
+            scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
+            answers: { [`q-${entry.examId}`]: 'A' },
+            answerComparison: {}
+        })),
+        draftsByExam: {},
+        elapsedByExam: {},
+        windowRef: null
+    };
+    finalApp.currentSuiteSession = finalSession;
+    finalApp._suiteModeReady = true;
+    finalApp._resolveSuiteSequenceNumber = async () => 1;
+    finalApp._formatSuiteDateLabel = () => '2026-08-07';
+    finalApp._updatePracticeRecordsState = async () => {};
+    finalApp.refreshOverviewData = () => {};
+    finalApp._saveSuitePracticeRecord = async (record) => {
+        committedRecord = structuredClone(record);
+        const snapshot = sessionStore.peek('simulation');
+        assert.equal(snapshot.status, 'finalizing');
+        assert.equal(snapshot.currentIndex, sequence.length);
+        assert.equal(snapshot.finalizeOperationId, 'practice-suite:suite_terminal:finalize');
+        assert.equal(snapshot.finalizeRecord.operationId, snapshot.finalizeOperationId);
+        return record;
+    };
+    assert.equal(await finalApp.resumeSuitePractice(finalSession.id), true);
+    assert.equal(sessionStore.peek('simulation'), null);
+    assert.equal(finalSession.status, 'completed');
+    assert.equal(messages.some((entry) => entry.type === 'error'), false);
+
+    const divergentId = 'suite_divergent_record';
+    sessionStore.save('simulation', {
+        ...invalidTerminalSnapshot,
+        id: divergentId,
+        results: validTerminalResults,
+        finalizeOperationId: `practice-suite:${divergentId}:finalize`,
+        finalizeRecord: {
+            ...committedRecord,
+            id: divergentId,
+            sessionId: divergentId,
+            operationId: `practice-suite:${divergentId}:finalize`,
+            correctAnswers: 999,
+            scoreInfo: { ...committedRecord.scoreInfo, correct: 999 }
+        }
+    });
+    const divergentApp = makeApp();
+    divergentApp.initializeSuiteMode();
+    assert.equal(divergentApp.currentSuiteSession, null, '分数与结果不一致的终态聚合记录必须被丢弃');
+    assert.equal(sessionStore.peek('simulation'), null);
+
+    const concurrentApp = makeApp();
+    const concurrentWindow = { closed: false, name: 'concurrent-window' };
+    const concurrentSession = {
+        ...finalSession,
+        id: 'suite_concurrent_finalize',
+        status: 'active',
+        currentIndex: 0,
+        activeExamId: 'p1',
+        results: [],
+        draftsByExam: {},
+        elapsedByExam: {},
+        flowMode: 'simulation',
+        windowRef: concurrentWindow,
+        finalizeRecord: null,
+        finalizeOperationId: null,
+        _suiteRecoveryClosed: false
+    };
+    concurrentApp.currentSuiteSession = concurrentSession;
+    concurrentApp._resolveSuiteSequenceNumber = async () => 1;
+    concurrentApp._formatSuiteDateLabel = () => '2026-08-07';
+    concurrentApp._updatePracticeRecordsState = async () => {};
+    concurrentApp.refreshOverviewData = () => {};
+    let finalizeCalls = 0;
+    concurrentApp._saveSuitePracticeRecord = async (record) => {
+        finalizeCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return record;
+    };
+    const concurrentPayload = {
+        suiteSessionId: concurrentSession.id,
+        suiteSubmission: true,
+        submissionId: 'submission-concurrent',
+        suiteEntries: sequence.map((entry) => ({
+            examId: entry.examId,
+            duration: 10,
+            scoreInfo: { correct: 1, total: 1, accuracy: 1, percentage: 100 },
+            answers: { [`q-${entry.examId}`]: 'A' },
+            answerComparison: {}
+        }))
+    };
+    const concurrentOutcomes = await Promise.all([
+        concurrentApp._handleInlineSimulationSuiteSubmit('p1', concurrentPayload, concurrentWindow),
+        concurrentApp._handleInlineSimulationSuiteSubmit('p1', concurrentPayload, concurrentWindow)
+    ]);
+    assert.equal(finalizeCalls, 1, '并发 inline submit 必须复用同一个 finalize promise');
+    assert.equal(concurrentOutcomes.every((outcome) => outcome && outcome.committed === true), true);
+
+    process.stdout.write(JSON.stringify({ status: 'pass', detail: 'v2 suite recovery state machine passed' }));
+}
+
+main().catch((error) => {
+    process.stdout.write(JSON.stringify({ status: 'fail', detail: error.stack || String(error) }));
+    process.exit(1);
+});

--- a/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
+++ b/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
@@ -36,7 +36,23 @@ function createWindowSessionStub() {
 function createDocumentStub() {
     const radio = { checked: true, value: 'A' };
     const notes = { value: 'fresh note' };
+    const timerClasses = new Set();
+    const timer = {
+        textContent: '',
+        dataset: {},
+        style: {},
+        classList: {
+            add(...names) { names.forEach((name) => timerClasses.add(name)); },
+            remove(...names) { names.forEach((name) => timerClasses.delete(name)); },
+            toggle(name, enabled) {
+                if (enabled) timerClasses.add(name);
+                else timerClasses.delete(name);
+            },
+            contains(name) { return timerClasses.has(name); }
+        }
+    };
     return {
+        __timer: timer,
         body: {
             dataset: {},
             classList: {
@@ -58,8 +74,8 @@ function createDocumentStub() {
             }
             return [];
         },
-        getElementById() {
-            return null;
+        getElementById(id) {
+            return id === 'timer' ? timer : null;
         },
         addEventListener() {},
         removeEventListener() {}
@@ -77,6 +93,7 @@ function hostEvent(sourceWindow, type, data, overrides = {}) {
 function createContext() {
     const windowSession = createWindowSessionStub();
     const document = createDocumentStub();
+    let closeCount = 0;
     const window = {
         location: {
             href: 'http://localhost/assets/generated/reading-exams/reading-practice-unified.html?examId=reading-p1',
@@ -95,7 +112,7 @@ function createContext() {
         removeEventListener() {},
         scrollTo() {},
         scrollY: 0,
-        close() {},
+        close() { closeCount += 1; },
         console,
         setTimeout,
         clearTimeout,
@@ -149,18 +166,24 @@ function createContext() {
         location: window.location
     };
     sandbox.globalThis = window;
-    return { context: vm.createContext(sandbox), window, document, windowSession };
+    return {
+        context: vm.createContext(sandbox),
+        window,
+        document,
+        windowSession,
+        getCloseCount: () => closeCount
+    };
 }
 
 function loadHooks() {
-    const { context, window, windowSession } = createContext();
+    const { context, window, document, windowSession, getCloseCount } = createContext();
     window.__IELTS_READING_PAGE_TEST_HOOKS__ = true;
     window.__READING_EXAM_MANIFEST__ = {};
     window.__READING_EXAM_DATA__ = new Map();
     loadScript('js/runtime/unifiedReadingPage.js', context);
     const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
     assert(hooks, 'should expose unified reading page test hooks');
-    return { hooks, window, windowSession };
+    return { hooks, window, document, windowSession, getCloseCount };
 }
 
 function plain(value) {
@@ -189,6 +212,31 @@ async function testDraftArbitration() {
     assert.deepStrictEqual(plain(fresh.highlights), [{ id: 'new' }], 'newer draft must win highlights');
     assert.strictEqual(fresh.scrollY, 9, 'newer draft must win scrollY');
     assert.strictEqual(fresh.updatedAt, 3000, 'newer draft must win updatedAt');
+}
+
+async function testSuiteTimerModePrecedence() {
+    const { hooks, document } = loadHooks();
+    const pausedAtMs = Date.now();
+    hooks.setTestState({
+        suiteSessionId: 'suite-timer',
+        suiteTimerMode: 'elapsed',
+        suiteTimerLimitSeconds: 60,
+        suiteTimerAnchorMs: pausedAtMs - 120000,
+        pagePausedAtMs: pausedAtMs,
+        pagePausedOffsetMs: 0
+    });
+    hooks.renderTimer();
+    assert.strictEqual(document.__timer.textContent, '02:00', 'elapsed 套题必须显示正计时');
+    assert.strictEqual(document.__timer.dataset.timerMode, 'elapsed');
+    assert.strictEqual(document.__timer.classList.contains('timer-expired'), false, 'elapsed 套题不得按 limit 触发倒计时过期');
+
+    hooks.setTestState({
+        suiteTimerMode: 'countdown',
+        suiteTimerLimitSeconds: 3600
+    });
+    hooks.renderTimer();
+    assert.strictEqual(document.__timer.textContent, '58 minutes remaining');
+    assert.strictEqual(document.__timer.dataset.timerMode, 'countdown');
 }
 
 async function testInlineEnvelopeGuard() {
@@ -316,6 +364,7 @@ async function testWindowSessionMessageGuard() {
         parentOriginIsOpaque: false,
         windowSessionToken: 'token-new',
         windowSessionIssuedAtMs: 5000,
+        windowSessionGeneration: 2,
         lastInitSignature: '',
         simulationCtx: { examId: 'reading-p2', flowMode: 'simulation', currentIndex: 1 },
         suite: {
@@ -336,6 +385,7 @@ async function testWindowSessionMessageGuard() {
                 sessionId: 'session-new',
                 suiteSessionId: 'suite-new',
                 windowSessionToken: 'token-old',
+                windowSessionGeneration: 1,
                 messageIssuedAtMs: 4000,
                 parentOrigin: 'http://localhost'
     }));
@@ -352,6 +402,7 @@ async function testWindowSessionMessageGuard() {
                 currentIndex: 0,
                 total: 3,
                 windowSessionToken: 'token-old',
+                windowSessionGeneration: 1,
                 messageIssuedAtMs: 4000,
                 suiteSequence: [
                     { examId: 'reading-p1' },
@@ -368,6 +419,7 @@ async function testWindowSessionMessageGuard() {
                 sessionId: 'session-newer',
                 suiteSessionId: 'suite-new',
                 windowSessionToken: 'token-newer',
+                windowSessionGeneration: 3,
                 messageIssuedAtMs: 6000,
                 parentOrigin: 'http://localhost'
     }));
@@ -375,6 +427,38 @@ async function testWindowSessionMessageGuard() {
     state = hooks.getTestState();
     assert.strictEqual(state.sessionId, 'session-newer', 'newer INIT_SESSION must still be accepted');
     assert.strictEqual(state.windowSessionToken, 'token-newer', 'newer INIT_SESSION must adopt the latest window token');
+
+    assert.strictEqual(
+        hooks.shouldAcceptWindowSessionMessage({
+            windowSessionToken: 'token-same-ms-old',
+            windowSessionGeneration: 3,
+            messageIssuedAtMs: 6000
+        }, sourceWindow),
+        false,
+        '同一注册代际的旧 token 即使时间戳相同也必须拒绝'
+    );
+    assert.strictEqual(
+        hooks.shouldAcceptWindowSessionMessage({
+            windowSessionToken: 'token-next-generation',
+            windowSessionGeneration: 4,
+            messageIssuedAtMs: 6000
+        }, sourceWindow),
+        true,
+        '更高注册代际必须覆盖旧 token'
+    );
+    hooks.setTestState({
+        windowSessionToken: 'token-current-no-generation',
+        windowSessionIssuedAtMs: 6000,
+        windowSessionGeneration: 0
+    });
+    assert.strictEqual(
+        hooks.shouldAcceptWindowSessionMessage({
+            windowSessionToken: 'token-equal-ms-no-generation',
+            messageIssuedAtMs: 6000
+        }, sourceWindow),
+        false,
+        '缺少注册代际且时间戳相等的不同 token 必须拒绝'
+    );
     hooks.stopReadingDraftSync();
     hooks.stopSimulationDraftSync();
 }
@@ -579,7 +663,7 @@ async function testSubmitAcknowledgementStateMachine() {
             delivered.push(message);
         }
     };
-    const { hooks } = loadHooks();
+    const { hooks, getCloseCount } = loadHooks();
     hooks.setTestState({
         examId: 'reading-p1',
         sessionId: 'session-submit-current',
@@ -647,6 +731,115 @@ async function testSubmitAcknowledgementStateMachine() {
     assert.strictEqual(state.submissionStatus, 'submitted');
     assert.strictEqual(state.submitted, true);
     assert.strictEqual(state.readOnly, true, 'only a valid ACK may lock the page');
+    assert.strictEqual(getCloseCount(), 0, 'a single-passage ACK must keep its result page open');
+
+    const suiteHarness = loadHooks();
+    const suiteParent = { postMessage() {} };
+    const finalPresentation = {
+        results: {
+            answerComparison: {},
+            scoreInfo: { correct: 0, totalQuestions: 0, percentage: 0 }
+        },
+        highlights: []
+    };
+    suiteHarness.hooks.setTestOverride('renderExplanations', () => Promise.resolve());
+    suiteHarness.hooks.setTestState({
+        examId: 'reading-p3',
+        sessionId: 'session-suite-final',
+        suiteSessionId: 'suite-final',
+        parentWindow: suiteParent,
+        expectedParentOrigin: 'http://localhost',
+        parentOrigin: 'http://localhost',
+        parentOriginIsOpaque: false,
+        windowSessionToken: 'token-suite-final',
+        windowSessionGeneration: 1,
+        simulationMode: true,
+        simulationCtx: { isLast: true },
+        submissionStatus: 'draft',
+        submissionId: ''
+    });
+    assert.strictEqual(suiteHarness.hooks.beginSubmission('SIMULATION_SUBMIT', {
+        suiteSessionId: 'suite-final'
+    }, finalPresentation), true);
+    const suiteSubmissionId = suiteHarness.hooks.getTestState().submissionId;
+    assert.strictEqual(suiteHarness.getCloseCount(), 0, 'sending the final result must not close before an ACK');
+    await suiteHarness.hooks.handleIncoming(hostEvent(suiteParent, 'PRACTICE_SUBMIT_FAILED', {
+        examId: 'reading-p3',
+        sessionId: 'session-suite-final',
+        suiteSessionId: 'suite-final',
+        submissionId: suiteSubmissionId,
+        windowSessionToken: 'token-suite-final'
+    }));
+    assert.strictEqual(suiteHarness.getCloseCount(), 0, 'a persistence NACK must keep the final child open for retry');
+    assert.strictEqual(suiteHarness.hooks.getTestState().submissionStatus, 'draft');
+    assert.strictEqual(suiteHarness.hooks.beginSubmission('SIMULATION_SUBMIT', {
+        suiteSessionId: 'suite-final'
+    }, finalPresentation), true);
+    assert.strictEqual(
+        suiteHarness.hooks.getTestState().submissionId,
+        suiteSubmissionId,
+        'the persistence retry must retain its idempotency key'
+    );
+    await suiteHarness.hooks.handleIncoming(hostEvent(suiteParent, 'PRACTICE_SUBMIT_ACK', {
+        examId: 'reading-p3',
+        sessionId: 'session-suite-final',
+        suiteSessionId: 'suite-final',
+        submissionId: suiteSubmissionId,
+        windowSessionToken: 'token-suite-final'
+    }));
+    assert.strictEqual(suiteHarness.getCloseCount(), 1, 'the final suite child must close after its valid ACK');
+
+    const lateHarness = loadHooks();
+    const lateParent = { postMessage() {} };
+    const nextDraftName = 'simulation-draft:suite-next:reading-p3';
+    lateHarness.hooks.setTestState({
+        examId: 'reading-p3',
+        sessionId: 'session-suite-old',
+        suiteSessionId: 'suite-old',
+        parentWindow: lateParent,
+        expectedParentOrigin: 'http://localhost',
+        parentOrigin: 'http://localhost',
+        parentOriginIsOpaque: false,
+        windowSessionToken: 'token-suite-old',
+        windowSessionGeneration: 1,
+        windowSessionIssuedAtMs: 1000,
+        simulationMode: true,
+        simulationCtx: { isLast: true },
+        submissionStatus: 'draft',
+        submissionId: ''
+    });
+    lateHarness.hooks.setTestOverride('renderExplanations', () => Promise.resolve().then(async () => {
+        await lateHarness.hooks.handleIncoming(hostEvent(lateParent, 'INIT_SESSION', {
+            examId: 'reading-p3',
+            sessionId: 'session-suite-next',
+            suiteSessionId: 'suite-next',
+            parentOrigin: 'http://localhost',
+            windowSessionToken: 'token-suite-next',
+            windowSessionGeneration: 2,
+            messageIssuedAtMs: 2000
+        }));
+        lateHarness.windowSession.save(nextDraftName, {
+            draft: { answers: { q1: 'new-session-answer' } },
+            updatedAt: 2000
+        });
+    }));
+    assert.strictEqual(lateHarness.hooks.beginSubmission('SIMULATION_SUBMIT', {
+        suiteSessionId: 'suite-old'
+    }, finalPresentation), true);
+    const lateSubmissionId = lateHarness.hooks.getTestState().submissionId;
+    await lateHarness.hooks.handleIncoming(hostEvent(lateParent, 'PRACTICE_SUBMIT_ACK', {
+        examId: 'reading-p3',
+        sessionId: 'session-suite-old',
+        suiteSessionId: 'suite-old',
+        submissionId: lateSubmissionId,
+        windowSessionToken: 'token-suite-old'
+    }));
+    const lateState = lateHarness.hooks.getTestState();
+    assert.strictEqual(lateState.sessionId, 'session-suite-next', 'the queued INIT must install the new session');
+    assert.strictEqual(lateState.suiteSessionId, 'suite-next', 'the queued INIT must install the new suite binding');
+    assert.strictEqual(lateState.windowSessionToken, 'token-suite-next', 'the queued INIT must install the new registration');
+    assert(lateHarness.windowSession.get(nextDraftName), 'the stale ACK continuation must not clear the new session draft');
+    assert.strictEqual(lateHarness.getCloseCount(), 0, 'the stale ACK continuation must not close the new registration');
 
     const timeoutHarness = loadHooks();
     const timeoutParent = { postMessage() {} };
@@ -678,6 +871,7 @@ async function testSubmitAcknowledgementStateMachine() {
 
 async function main() {
     await testDraftArbitration();
+    await testSuiteTimerModePrecedence();
     await testInlineEnvelopeGuard();
     await testInlineReinitSnapshot();
     await testWindowSessionMessageGuard();

--- a/js/app/examSessionMixin.js
+++ b/js/app/examSessionMixin.js
@@ -319,11 +319,166 @@
             };
         },
 
+        _beginExamOpenGeneration(examId, options = {}) {
+            if (!this._examOpenGenerations) this._examOpenGenerations = new Map();
+            if (!this._examOpenWindowGenerations) this._examOpenWindowGenerations = new WeakMap();
+            this._examOpenGenerationSequence = Math.max(0, Number(this._examOpenGenerationSequence) || 0) + 1;
+
+            const normalizedExamId = String(examId || '').trim();
+            const targetNames = [`exam_${normalizedExamId}`, `pdf_${normalizedExamId}`];
+            if (typeof options.windowName === 'string') {
+                targetNames.push(options.windowName.trim());
+            }
+            const names = Object.freeze(Array.from(new Set(targetNames.filter(name => name && !name.startsWith('_')))));
+            const generation = Object.freeze({
+                examId: normalizedExamId,
+                sequence: this._examOpenGenerationSequence,
+                targetNames: names,
+                hasReuseWindow: Boolean(options.reuseWindow)
+            });
+            this._examOpenGenerations.set(`exam:${normalizedExamId}`, generation);
+            names.forEach(name => this._examOpenGenerations.set(`target:${name}`, generation));
+            if (options.reuseWindow) {
+                this._examOpenWindowGenerations.set(options.reuseWindow, generation);
+            }
+            return generation;
+        },
+
+        _isExamOpenGenerationCurrent(generation, targetWindow = null) {
+            if (!generation || !this._examOpenGenerations
+                || this._examOpenGenerations.get(`exam:${generation.examId}`) !== generation) {
+                return false;
+            }
+            if (generation.targetNames.some(name => this._examOpenGenerations.get(`target:${name}`) !== generation)) {
+                return false;
+            }
+            if (generation.hasReuseWindow) {
+                if (!targetWindow || !this._examOpenWindowGenerations
+                    || this._examOpenWindowGenerations.get(targetWindow) !== generation) {
+                    return false;
+                }
+            }
+            return true;
+        },
+
+        _recordExamWindowNavigation(targetWindow) {
+            if (!targetWindow || (typeof targetWindow !== 'object' && typeof targetWindow !== 'function')) {
+                return 0;
+            }
+            if (!this._examWindowNavigationEpochs) this._examWindowNavigationEpochs = new WeakMap();
+            const epoch = Math.max(0, Number(this._examWindowNavigationEpochs.get(targetWindow)) || 0) + 1;
+            this._examWindowNavigationEpochs.set(targetWindow, epoch);
+            return epoch;
+        },
+
+        _isExamWindowNavigationCurrent(targetWindow, epoch) {
+            return Boolean(targetWindow && epoch && this._examWindowNavigationEpochs
+                && this._examWindowNavigationEpochs.get(targetWindow) === epoch);
+        },
+
+        _captureExamSessionRegistration(examId, windowInfo = null) {
+            const info = windowInfo || (this.examWindows && this.examWindows.get(examId)) || null;
+            if (!info || !info.window || !Number.isInteger(info.registrationId)) return null;
+            return Object.freeze({
+                examId: String(examId || ''),
+                window: info.window,
+                windowInfo: info,
+                registrationId: info.registrationId,
+                sessionGeneration: Number(info.sessionGeneration) || 0,
+                navigationEpoch: Number(info.navigationEpoch) || 0,
+                suiteSessionId: Object.prototype.hasOwnProperty.call(info, 'suiteSessionId')
+                    ? (info.suiteSessionId || null)
+                    : undefined
+            });
+        },
+
+        _isExamSessionRegistrationCurrent(examId, registration) {
+            const current = this.examWindows && this.examWindows.get(examId);
+            return Boolean(
+                registration
+                && current
+                && current === registration.windowInfo
+                && current.window === registration.window
+                && current.registrationId === registration.registrationId
+                && Number(current.sessionGeneration || 0) === Number(registration.sessionGeneration || 0)
+            );
+        },
+
+        _installExamNavigationRegistration(examId, examWindow, exam, options, generation) {
+            if (!examWindow || !this._isExamOpenGenerationCurrent(generation, options.reuseWindow || null)) {
+                return null;
+            }
+            if (!this.examWindows) this.examWindows = new Map();
+            const previous = this.examWindows.get(examId) || null;
+            if (previous && previous.closeMonitor) {
+                try { clearInterval(previous.closeMonitor); } catch (_) {}
+            }
+            if (this.messageHandlers && this.messageHandlers.has(examId)) {
+                try { window.removeEventListener('message', this.messageHandlers.get(examId)); } catch (_) {}
+                this.messageHandlers.delete(examId);
+            }
+            if (this._handshakeTimers && this._handshakeTimers.has(examId)) {
+                try { clearInterval(this._handshakeTimers.get(examId)); } catch (_) {}
+                this._handshakeTimers.delete(examId);
+            }
+
+            const endpoint = this._resolveExamMessageEndpoint(options.expectedUrl || (exam ? this.buildExamUrl(exam) : ''));
+            this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+            const windowInfo = {
+                window: examWindow,
+                startTime: Date.now(),
+                status: 'opening',
+                expectedSessionId: this.generateSessionId(examId),
+                windowSessionToken: null,
+                windowSessionTokenSessionId: null,
+                expectedUrl: endpoint.expectedUrl,
+                expectedOrigin: endpoint.expectedOrigin,
+                allowOpaqueOrigin: endpoint.allowOpaqueOrigin,
+                observedOrigin: '',
+                suiteSessionId: options.suiteSessionId || null,
+                suiteFlowMode: options.suiteFlowMode ? String(options.suiteFlowMode) : null,
+                reviewMode: Boolean(options.reviewMode),
+                reviewSessionId: options.reviewSessionId ? String(options.reviewSessionId) : null,
+                reviewEntryIndex: Number.isInteger(options.reviewEntryIndex) ? options.reviewEntryIndex : 0,
+                practiceMode: typeof options.practiceMode === 'string' ? options.practiceMode.trim().toLowerCase() : null,
+                readOnly: Object.prototype.hasOwnProperty.call(options, 'readOnly')
+                    ? Boolean(options.readOnly)
+                    : Boolean(options.reviewMode),
+                sessionGeneration: Math.max(0, Number(previous && previous.sessionGeneration) || 0) + 1,
+                registrationId: this._examRegistrationSequence,
+                navigationEpoch: Number(options.navigationEpoch) || 0,
+                launchProvisional: true,
+                closeMonitor: null
+            };
+            this._refreshExamWindowToken(examId, windowInfo);
+            this.examWindows.set(examId, windowInfo);
+            return this._captureExamSessionRegistration(examId, windowInfo);
+        },
+
+        async _abortExamOpen(examId, registration) {
+            if (!this._isExamSessionRegistrationCurrent(examId, registration)) return false;
+            const targetWindow = registration.window;
+            const navigationEpoch = registration.navigationEpoch;
+            await this.cleanupExamSession(examId, { expectedRegistration: registration });
+            const reassigned = Boolean(this.examWindows && Array.from(this.examWindows.values())
+                .some(info => info && info.window === targetWindow));
+            if (!reassigned && targetWindow !== window
+                && this._isExamWindowNavigationCurrent(targetWindow, navigationEpoch)) {
+                try {
+                    if (!targetWindow.closed && typeof targetWindow.close === 'function') targetWindow.close();
+                } catch (_) {}
+            }
+            return true;
+        },
+
         /**
           * 打开指定题目进行练习
           */
         async openExam(examId, options = {}) {
+            const openGeneration = this._beginExamOpenGeneration(examId, options);
             const reviewMode = Boolean(options && options.reviewMode);
+            let examWindow = null;
+            let launchRegistration = null;
             let exam = options && options.examDefinition && typeof options.examDefinition === 'object'
                 ? options.examDefinition
                 : null;
@@ -332,6 +487,7 @@
                     throw new Error('历史记录的题库来源不可用');
                 }
                 const examIndex = await getActiveExamIndexSnapshot();
+                if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
                 const list = Array.isArray(examIndex) ? examIndex : [];
                 exam = list.find(e => e.id === examId);
             }
@@ -345,13 +501,15 @@
                 return;
             }
 
+            if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+
             try {
                 const readingLaunch = typeof this.resolveReadingLaunchDescriptor === 'function'
                     ? this.resolveReadingLaunchDescriptor(exam, options)
                     : null;
 
                 if (readingLaunch && readingLaunch.mode === 'pdf_manual' && readingLaunch.pdfUrl) {
-                    return this._openPdfWindow(exam, readingLaunch.pdfUrl, options);
+                    return this._openPdfWindow(exam, readingLaunch.pdfUrl, { ...options, openGeneration });
                 }
 
                 // 若无HTML，直接打开PDF
@@ -360,10 +518,10 @@
                         ? window.buildResourcePath(exam, 'pdf')
                         : ((exam.path || '').replace(/\\/g, '/').replace(/\/+\//g, '/') + (exam.pdfFilename || ''));
                     const resolvedPdfUrl = this._ensureAbsoluteUrl(pdfUrl);
-                    return this._openPdfWindow(exam, resolvedPdfUrl, options);
+                    return this._openPdfWindow(exam, resolvedPdfUrl, { ...options, openGeneration });
                 }
 
-                const guardOptions = { ...options, examId };
+                const guardOptions = { ...options, examId, openGeneration };
                 // 测试环境的套题练习统一使用占位页，避免因题目资源差异导致 E2E 不稳定
                 let examUrl = (readingLaunch && readingLaunch.mode === 'unified_html' && readingLaunch.url)
                     ? readingLaunch.url
@@ -380,44 +538,78 @@
                 if (guardOptions.endlessMode) {
                     examUrl = this._appendEndlessContextToExamUrl(examUrl);
                 }
-                let examWindow = this.openExamWindow(examUrl, exam, guardOptions);
+                if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+                examWindow = this.openExamWindow(examUrl, exam, guardOptions);
+                if (!examWindow || !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+                launchRegistration = this._installExamNavigationRegistration(examId, examWindow, exam, {
+                    ...guardOptions,
+                    expectedUrl: this._ensureAbsoluteUrl(examUrl)
+                }, openGeneration);
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
 
                 try {
                     const guardedWindow = this._guardExamWindowContent(examWindow, exam, guardOptions);
                     if (guardedWindow) {
                         examWindow = guardedWindow;
+                        if (!guardOptions.navigationEpoch) {
+                            guardOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
+                        }
+                        launchRegistration = this._installExamNavigationRegistration(examId, examWindow, exam, {
+                            ...guardOptions,
+                            expectedUrl: this._ensureAbsoluteUrl(examUrl)
+                        }, openGeneration);
                     }
                 } catch (guardError) {
                     console.warn('[App] 题目窗口占位页守护失败:', guardError);
                 }
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 if (guardOptions.reuseWindow && examWindow && !examWindow.closed && typeof this._cleanupReusedWindowSessions === 'function') {
-                    await this._cleanupReusedWindowSessions(examWindow, examId);
+                    await this._cleanupReusedWindowSessions(examWindow, examId, launchRegistration);
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 }
 
                 // 在启动窗口前捕获激活的题库配置 ID，确保后续练习记录 metadata 来源
                 // 一律按"启动时"的题库写入，避免用户在考试过程中切换题库导致提交时来源不一致。
                 if (!reviewMode) {
                     try {
-                        await this._captureLaunchLibraryConfigurationId(examId);
+                        await this._captureLaunchLibraryConfigurationId(examId, {
+                            commitGuard: () => this._isExamSessionRegistrationCurrent(examId, launchRegistration)
+                        });
                     } catch (captureError) {
                         console.warn('[App] 捕获启动题库配置 ID 失败:', captureError);
                     }
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 }
 
                 // Register the window first so the host expectedSessionId exists, then start the
                 // recorder with that same id.  Starting the recorder before window setup used
                 // to mint a second session id that never matched INIT/COMPLETE.
-                this.setupExamWindowManagement(examWindow, examId, exam, {
+                launchRegistration = this.setupExamWindowManagement(examWindow, examId, exam, {
                     ...options,
+                    expectedRegistration: launchRegistration,
+                    navigationEpoch: guardOptions.navigationEpoch,
+                    skipContentGuard: true,
+                    deferInitialHandshake: !reviewMode && !memorizeMode,
                     expectedUrl: this._ensureAbsoluteUrl(examUrl)
                 });
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 if (!reviewMode && !memorizeMode) {
-                    await this.startPracticeSession(examId);
+                    const startResult = await this.startPracticeSession(examId, {
+                        examDefinition: exam,
+                        expectedRegistration: launchRegistration
+                    });
+                    if (!startResult || startResult.owned !== true
+                        || !this._isExamSessionRegistrationCurrent(examId, startResult.registration)) {
+                        await this._abortExamOpen(examId, launchRegistration);
+                        return null;
+                    }
+                    launchRegistration = startResult.registration;
+                    this.restartExamHandshake(examWindow, examId, launchRegistration);
                 }
-                this.injectDataCollectionScript(examWindow, examId, exam);
 
                 if (options && options.suiteSessionId) {
-                    const sessionInfo = this.ensureExamWindowSession(examId, examWindow);
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
+                    const sessionInfo = launchRegistration.windowInfo;
                     sessionInfo.suiteSessionId = options.suiteSessionId;
                     if (options.suiteFlowMode) {
                         sessionInfo.suiteFlowMode = options.suiteFlowMode;
@@ -446,7 +638,11 @@
                         sessionInfo.suiteSequenceTotal = options.sequenceTotal;
                     }
                     this.examWindows && this.examWindows.set(examId, sessionInfo);
+                    launchRegistration = this._captureExamSessionRegistration(examId, sessionInfo);
                 }
+
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
+                this.injectDataCollectionScript(examWindow, examId, exam, { expectedRegistration: launchRegistration });
 
                 if (reviewMode && typeof this._bindReviewWindowRef === 'function') {
                     this._bindReviewWindowRef(options.reviewSessionId, examWindow);
@@ -457,20 +653,29 @@
                     'info'
                 );
 
-                return examWindow;
+                return options.returnLaunchContext === true
+                    ? Object.freeze({ window: examWindow, registration: launchRegistration })
+                    : examWindow;
 
             } catch (error) {
                 console.error('Failed to open exam:', error);
                 window.showMessage('打开题目失败，请重试', 'error');
+                if (launchRegistration) await this._abortExamOpen(examId, launchRegistration);
+                return null;
             }
         },
 
         _openPdfWindow(exam, resolvedPdfUrl, options = {}) {
             let pdfWin = null;
+            const openGeneration = options.openGeneration || null;
 
             if (options.reuseWindow && !options.reuseWindow.closed) {
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow)) {
+                        return null;
+                    }
                     options.reuseWindow.location.href = resolvedPdfUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(options.reuseWindow);
                     options.reuseWindow.focus();
                     pdfWin = options.reuseWindow;
                 } catch (reuseError) {
@@ -479,6 +684,7 @@
             }
 
             if (!pdfWin) {
+                if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
                 if (options.target === 'tab') {
                     try {
                         pdfWin = window.open(resolvedPdfUrl, '_blank');
@@ -488,11 +694,13 @@
                         pdfWin = window.open(resolvedPdfUrl, `pdf_${exam.id}`, 'width=1000,height=800,scrollbars=yes,resizable=yes,status=yes,toolbar=yes');
                     } catch (_) { }
                 }
+                if (pdfWin) options.navigationEpoch = this._recordExamWindowNavigation(pdfWin);
             }
 
             if (!pdfWin) {
                 try {
                     window.location.href = resolvedPdfUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(window);
                     return window;
                 } catch (error) {
                     throw new Error('无法打开PDF窗口，请检查弹窗设置');
@@ -540,10 +748,15 @@
          */
         openExamWindow(examUrl, exam, options = {}) {
             const reuseWindow = options.reuseWindow;
+            const openGeneration = options.openGeneration || null;
             const finalUrl = this._ensureAbsoluteUrl(examUrl);
             if (reuseWindow && !reuseWindow.closed) {
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow)) {
+                        return null;
+                    }
                     reuseWindow.location.href = finalUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(reuseWindow);
                     reuseWindow.focus();
                     return reuseWindow;
                 } catch (error) {
@@ -557,7 +770,9 @@
                     ? options.windowName.trim()
                     : '_blank';
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow || null)) return null;
                     tabWindow = window.open(finalUrl, requestedName);
+                    if (tabWindow) options.navigationEpoch = this._recordExamWindowNavigation(tabWindow);
                     if (tabWindow && typeof tabWindow.focus === 'function') {
                         tabWindow.focus();
                     }
@@ -574,17 +789,20 @@
             // 打开新窗口
             let examWindow = null;
             try {
+                if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow || null)) return null;
                 examWindow = window.open(
                     finalUrl,
                     `exam_${exam.id}`,
                     windowFeatures
                 );
+                if (examWindow) options.navigationEpoch = this._recordExamWindowNavigation(examWindow);
             } catch (_) { }
 
             // 弹窗被拦截时，降级为当前窗口打开，确保用户可进入练习页
             if (!examWindow) {
                 try {
                     window.location.href = finalUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(window);
                     return window; // 以当前窗口作为返回引用
                 } catch (e) {
                     throw new Error('无法打开题目页面，请检查弹窗/文件路径设置');
@@ -965,6 +1183,7 @@
                         } else {
                             examWindow.location.href = placeholderUrl;
                         }
+                        retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                         return examWindow;
                     } catch (forceError) {
                         console.warn('[App] 套题模式强制跳转占位页失败，继续使用原窗口:', forceError);
@@ -1020,9 +1239,11 @@
             try {
                 if (examWindow.location && typeof examWindow.location.replace === 'function') {
                     examWindow.location.replace(placeholderUrl);
+                    retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                     return examWindow;
                 }
                 examWindow.location.href = placeholderUrl;
+                retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                 return examWindow;
             } catch (navigationError) {
                 console.warn('[App] 题目窗口导航占位页失败，尝试重新打开:', navigationError);
@@ -1032,6 +1253,7 @@
                         : (examWindow.name || '_blank');
                     const reopened = window.open(placeholderUrl, windowName);
                     if (reopened) {
+                        retryOptions.navigationEpoch = this._recordExamWindowNavigation(reopened);
                         return reopened;
                     }
                 } catch (openError) {
@@ -1122,7 +1344,13 @@
         /**
          * 注入数据采集脚本到练习页面
          */
-        injectDataCollectionScript(examWindow, examId, exam = null) {
+        injectDataCollectionScript(examWindow, examId, exam = null, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            if (!ownsRegistration()) {
+                return false;
+            }
             if (this._isUnifiedReadingExam(exam)) {
                 return;
             }
@@ -1151,6 +1379,9 @@
             };
             const injectScript = () => {
                 try {
+                    if (!ownsRegistration()) {
+                        return false;
+                    }
                     if (!examWindow || examWindow.closed) {
                         console.warn('[DataInjection] 目标窗口已关闭');
                         return;
@@ -1160,7 +1391,7 @@
                         ? (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)
                         : (examWindow.practicePageEnhancer && typeof examWindow.practicePageEnhancer.initialize === 'function');
                     if (bridgeReady) {
-                        this.initializePracticeSession(examWindow, examId);
+                        this.initializePracticeSession(examWindow, examId, expectedRegistration);
                         return;
                     }
 
@@ -1197,12 +1428,15 @@
                         : (host && typeof host.querySelector === 'function' ? host.querySelector(existingSelector) : null);
                     if (existingEnhancerScript) {
                         if (isListeningExam && (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)) {
-                            this.initializePracticeSession(examWindow, examId);
+                            this.initializePracticeSession(examWindow, examId, expectedRegistration);
                         }
                         return;
                     }
                     let enhancerInjected = false;
                     const appendEnhancer = () => {
+                        if (!ownsRegistration()) {
+                            return false;
+                        }
                         const alreadyReady = isListeningExam
                             ? (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)
                             : (examWindow.practicePageEnhancer && typeof examWindow.practicePageEnhancer.initialize === 'function');
@@ -1217,9 +1451,15 @@
                         scriptEl.src = ensureScriptUrl();
 
                         scriptEl.onload = () => {
+                            if (!ownsRegistration()) {
+                                return;
+                            }
                             setTimeout(() => {
+                                if (!ownsRegistration()) {
+                                    return;
+                                }
                                 try {
-                                    this.initializePracticeSession(examWindow, examId);
+                                    this.initializePracticeSession(examWindow, examId, expectedRegistration);
                                 } catch (sessionError) {
                                     console.warn('[DataInjection] 初始化练习会话失败:', sessionError);
                                 }
@@ -1227,27 +1467,40 @@
                         };
 
                         scriptEl.onerror = (loadError) => {
+                            if (!ownsRegistration()) {
+                                return;
+                            }
                             console.warn('[DataInjection] 加载增强器失败:', loadError);
                             scriptEl.remove();
                             if (!isListeningExam) {
-                                this.injectInlineScript(examWindow, examId);
+                                this.injectInlineScript(examWindow, examId, expectedRegistration);
                             }
                         };
 
+                        if (!ownsRegistration()) {
+                            return false;
+                        }
                         host.appendChild(scriptEl);
+                        return true;
                     };
 
-                    appendEnhancer();
+                    return appendEnhancer();
                 } catch (error) {
+                    if (!ownsRegistration()) {
+                        return false;
+                    }
                     console.error('[DataInjection] 注入增强器脚本时出错:', error);
                     if (!isListeningExam) {
-                        this.injectInlineScript(examWindow, examId);
+                        this.injectInlineScript(examWindow, examId, expectedRegistration);
                     }
                 }
             };
 
             const checkAndInject = () => {
                 try {
+                    if (!ownsRegistration()) {
+                        return;
+                    }
                     if (!examWindow || examWindow.closed) {
                         return;
                     }
@@ -1255,7 +1508,7 @@
                     const doc = examWindow.document;
                     if (doc && (doc.readyState === 'interactive' || doc.readyState === 'complete')) {
                         injectScript();
-                    } else {
+                    } else if (ownsRegistration()) {
                         setTimeout(checkAndInject, 200);
                     }
                 } catch (error) {
@@ -1263,14 +1516,21 @@
                 }
             };
 
-            setTimeout(checkAndInject, 300);
+            if (ownsRegistration()) {
+                setTimeout(checkAndInject, 300);
+            }
         },
 
         /**
          * 内联脚本注入（备用方案）
          */
-        injectInlineScript(examWindow, examId) {
+        injectInlineScript(examWindow, examId, expectedRegistration = null) {
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
             try {
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 if (!examWindow || !examWindow.document || !examWindow.document.head) {
                     throw new Error('inline_target_unavailable');
                 }
@@ -1636,35 +1896,49 @@
                     })();
                 `;
 
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 examWindow.document.head.appendChild(inlineScript);
 
                 setTimeout(() => {
-                    this.initializePracticeSession(examWindow, examId);
+                    if (!ownsRegistration()) {
+                        return;
+                    }
+                    this.initializePracticeSession(examWindow, examId, expectedRegistration);
                 }, 300);
 
             } catch (error) {
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 console.error('[DataInjection] 内联脚本注入失败:', error);
                 this.handleInjectionError(examId, error);
             }
+            return true;
         },
 
         /**
          * 初始化练习会话
          */
-        initializePracticeSession(examWindow, examId) {
+        initializePracticeSession(examWindow, examId, expectedRegistration = null) {
             try {
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return false;
+                }
                 const now = Date.now();
 
-                let existingInfo = null;
-                if (this.examWindows && this.examWindows.has(examId)) {
+                let existingInfo = expectedRegistration ? expectedRegistration.windowInfo : null;
+                if (!existingInfo && this.examWindows && this.examWindows.has(examId)) {
                     existingInfo = this.examWindows.get(examId) || null;
                 }
 
-                let suiteSessionId = existingInfo && existingInfo.suiteSessionId
-                    ? existingInfo.suiteSessionId
-                    : null;
+                const hasExplicitSuiteBinding = Boolean(
+                    existingInfo && Object.prototype.hasOwnProperty.call(existingInfo, 'suiteSessionId')
+                );
+                let suiteSessionId = hasExplicitSuiteBinding ? (existingInfo.suiteSessionId || null) : null;
 
-                if (!suiteSessionId && this.currentSuiteSession) {
+                if (!hasExplicitSuiteBinding && !suiteSessionId && this.currentSuiteSession) {
                     const activeMatch = this.currentSuiteSession.activeExamId === examId;
                     const sequenceIndex = Number.isInteger(this.currentSuiteSession.currentIndex)
                         ? this.currentSuiteSession.currentIndex
@@ -1679,8 +1953,10 @@
                     }
                 }
 
-                const windowInfo = this.ensureExamWindowSession(examId, examWindow);
-                if (suiteSessionId && !windowInfo.suiteSessionId) {
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : this.ensureExamWindowSession(examId, examWindow);
+                if (suiteSessionId && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                     windowInfo.suiteSessionId = suiteSessionId;
                 }
                 const timerContext = this._resolveSuiteTimerContext({}, windowInfo);
@@ -1708,7 +1984,7 @@
                     existingInfo.sessionId = initPayload.sessionId;
                     existingInfo.initTime = now;
                     existingInfo.status = 'initialized';
-                    if (suiteSessionId && !existingInfo.suiteSessionId) {
+                    if (suiteSessionId && !Object.prototype.hasOwnProperty.call(existingInfo, 'suiteSessionId')) {
                         existingInfo.suiteSessionId = suiteSessionId;
                     }
                     if (!existingInfo.window || existingInfo.window.closed) {
@@ -1726,8 +2002,11 @@
                     }));
                 }
 
+                return true;
+
             } catch (error) {
                 console.error('[DataInjection] 会话初始化失败:', error);
+                return false;
             }
         },
 
@@ -1757,16 +2036,23 @@
         setupExamWindowManagement(examWindow, examId, exam = null, options = {}) {
             if (!examWindow) {
                 console.warn('[App] 缺少题目窗口引用，无法完成窗口管理');
-                return;
+                return null;
             }
 
-            try {
-                const guardedWindow = this._guardExamWindowContent(examWindow, exam, { ...options, examId });
-                if (guardedWindow) {
-                    examWindow = guardedWindow;
+            const expectedRegistration = options && options.expectedRegistration || null;
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return null;
+            }
+
+            if (!(options && options.skipContentGuard)) {
+                try {
+                    const guardedWindow = this._guardExamWindowContent(examWindow, exam, { ...options, examId });
+                    if (guardedWindow) {
+                        examWindow = guardedWindow;
+                    }
+                } catch (guardError) {
+                    console.warn('[App] 守护题目窗口内容失败:', guardError);
                 }
-            } catch (guardError) {
-                console.warn('[App] 守护题目窗口内容失败:', guardError);
             }
 
             // 存储窗口引用
@@ -1774,16 +2060,28 @@
                 this.examWindows = new Map();
             }
 
+            const previousWindowInfo = this.examWindows.get(examId);
+            if (previousWindowInfo && previousWindowInfo.closeMonitor) {
+                try {
+                    clearInterval(previousWindowInfo.closeMonitor);
+                } catch (_) {}
+            }
+
             const endpoint = this._resolveExamMessageEndpoint(
                 options && options.expectedUrl
                     ? options.expectedUrl
                     : (exam ? this.buildExamUrl(exam) : '')
             );
-            this.examWindows.set(examId, {
+            this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+            const windowInfo = {
                 window: examWindow,
                 startTime: Date.now(),
                 status: 'active',
-                expectedSessionId: null,
+                expectedSessionId: expectedRegistration && expectedRegistration.windowInfo.expectedSessionId
+                    ? String(expectedRegistration.windowInfo.expectedSessionId)
+                    : null,
+                windowSessionToken: expectedRegistration && expectedRegistration.windowInfo.windowSessionToken || null,
+                windowSessionTokenSessionId: expectedRegistration && expectedRegistration.windowInfo.windowSessionTokenSessionId || null,
                 expectedUrl: endpoint.expectedUrl,
                 expectedOrigin: endpoint.expectedOrigin,
                 allowOpaqueOrigin: endpoint.allowOpaqueOrigin,
@@ -1800,8 +2098,24 @@
                     : null,
                 readOnly: options && Object.prototype.hasOwnProperty.call(options, 'readOnly')
                     ? Boolean(options.readOnly)
-                    : Boolean(options && options.reviewMode)
-            });
+                    : Boolean(options && options.reviewMode),
+                // Async INIT/draft work must be tied to this exact registration.
+                // Reusing an exam ID replaces the map entry even when the browser
+                // keeps the same WindowProxy alive.
+                sessionGeneration: expectedRegistration
+                    ? expectedRegistration.sessionGeneration
+                    : (previousWindowInfo && Number.isFinite(previousWindowInfo.sessionGeneration)
+                        ? previousWindowInfo.sessionGeneration + 1
+                        : 1),
+                registrationId: this._examRegistrationSequence,
+                navigationEpoch: Number(options && options.navigationEpoch)
+                    || Number(expectedRegistration && expectedRegistration.navigationEpoch)
+                    || 0,
+                closeMonitor: null
+            };
+            this.examWindows.set(examId, windowInfo);
+            this._refreshExamWindowToken(examId, windowInfo);
+            const registration = this._captureExamSessionRegistration(examId, windowInfo);
 
             // 监听窗口关闭事件
             let checkClosed = null;
@@ -1810,33 +2124,45 @@
                     try {
                         if (examWindow.closed) {
                             clearInterval(checkClosed);
-                            this.handleExamWindowClosed(examId);
+                            if (windowInfo.closeMonitor === checkClosed) {
+                                windowInfo.closeMonitor = null;
+                            }
+                            this.handleExamWindowClosed(examId, examWindow, registration);
                         }
                     } catch (monitorError) {
                         clearInterval(checkClosed);
                         console.warn('[App] 无法检测题目窗口状态:', monitorError);
                     }
                 }, 1000);
+                windowInfo.closeMonitor = checkClosed;
             } catch (error) {
                 console.warn('[App] 启动窗口关闭监控失败:', error);
             }
 
             // 设置窗口通信
             try {
-                this.setupExamWindowCommunication(examWindow, examId, exam, options);
+                this.setupExamWindowCommunication(examWindow, examId, exam, {
+                    ...options,
+                    expectedRegistration: registration
+                });
             } catch (error) {
                 console.warn('[App] 初始化题目窗口通信失败:', error);
             }
 
             // 启动与练习页的会话握手（file:// 下更可靠）
-            try {
-                this.startExamHandshake(examWindow, examId);
-            } catch (e) {
-                console.warn('[App] 启动握手失败:', e);
+            if (!(options && options.deferInitialHandshake)) {
+                try {
+                    this.startExamHandshake(examWindow, examId, registration);
+                } catch (e) {
+                    console.warn('[App] 启动握手失败:', e);
+                }
             }
 
             const emitInitEnvelope = async () => {
-                const windowInfo = this.ensureExamWindowSession(examId, examWindow);
+                if (!this._isExamSessionRegistrationCurrent(examId, registration)) return;
+                const windowInfo = registration.windowInfo;
+                const generation = windowInfo && windowInfo.sessionGeneration;
+                const expectedSessionId = windowInfo && windowInfo.expectedSessionId;
                 // 让最早到达的 INIT 即携带 draft，避免无 draft 的 envelope 先被去重守卫登记，
                 // 从而使后续携带 draft 的 INIT 被当作重复而丢弃、草稿无法恢复。
                 if (
@@ -1858,6 +2184,20 @@
                         // draft restore is best-effort
                     }
                 }
+                // The exam may have been reopened while draft restoration was
+                // pending. Never let the old continuation post its session into
+                // the replacement registration.
+                const currentWindowInfo = this.examWindows && this.examWindows.get(examId);
+                if (
+                    !windowInfo
+                    || !this._isExamSessionRegistrationCurrent(examId, registration)
+                    || currentWindowInfo !== windowInfo
+                    || windowInfo.window !== examWindow
+                    || windowInfo.sessionGeneration !== generation
+                    || windowInfo.expectedSessionId !== expectedSessionId
+                ) {
+                    return;
+                }
                 const initPayload = this._buildExamInitPayload(examId, windowInfo);
                 try {
                     this._postExamMessage(examId, examWindow, 'INIT_SESSION', initPayload);
@@ -1867,7 +2207,9 @@
                 }
             };
 
-            if (!isFileProtocol) {
+            if (options && options.deferInitialHandshake) {
+                // startPracticeSession owns the first INIT for managed practice launches.
+            } else if (!isFileProtocol) {
                 try {
                     examWindow.addEventListener('load', emitInitEnvelope);
                 } catch (error) {
@@ -1882,12 +2224,25 @@
             if (!(options && options.reviewMode)) {
                 this.updateExamStatus(examId, 'in-progress');
             }
+            return registration;
         },
 
         /**
          * 设置题目窗口通信
          */
         setupExamWindowCommunication(examWindow, examId, exam = null, options = {}) {
+            let expectedRegistration = options && options.expectedRegistration || null;
+            if (!expectedRegistration) {
+                const fallbackWindowInfo = this.ensureExamWindowSession(examId, examWindow);
+                if (!Object.prototype.hasOwnProperty.call(fallbackWindowInfo, 'suiteSessionId')) {
+                    fallbackWindowInfo.suiteSessionId = options && options.suiteSessionId || null;
+                }
+                expectedRegistration = this._captureExamSessionRegistration(
+                    examId,
+                    fallbackWindowInfo
+                );
+            }
+            const ownsRegistration = () => this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
             const parseJsonSafely = (value) => {
                 if (typeof value !== 'string' || !value.trim()) return null;
                 try {
@@ -2053,9 +2408,11 @@
             };
 
             const messageHandler = async (event) => {
-                // 取得当前题目窗口引用（可能在 handshake 期间被更新）
-                const storedInfo = (this.examWindows && this.examWindows.get(examId)) || {};
-                const expectedWindow = storedInfo.window || examWindow;
+                if (!ownsRegistration()) {
+                    this._reportExamMessageRejected(examId, '', 'stale-registration', event);
+                    return;
+                }
+                const expectedWindow = expectedRegistration.window;
                 const sourceWindow = event ? (event.source || null) : null;
 
                 // 缺少来源窗口直接拒绝
@@ -2070,7 +2427,7 @@
                     return;
                 }
 
-                const windowInfo = this.ensureExamWindowSession(examId, expectedWindow);
+                const windowInfo = expectedRegistration.windowInfo;
                 const expectedSessionId = windowInfo.expectedSessionId || '';
                 // Most messages must still come from the exact exam window.  A small
                 // suite/listening compatibility path below can prove an equivalent
@@ -2235,6 +2592,32 @@
                         || !payloadExamId
                         || payloadExamId !== expectedExamId
                     ) {
+                        return;
+                    }
+                }
+                if (type === 'SIMULATION_DRAFT_SYNC' && isExamInActiveSuite) {
+                    const incomingUpdatedAt = Number(data && (data.draftUpdatedAt
+                        ?? (data.draft && data.draft.updatedAt)
+                        ?? data.updatedAt));
+                    const suiteWindowBound = Boolean(
+                        windowInfo
+                        && windowInfo.suiteSessionId
+                        && String(windowInfo.suiteSessionId) === activeSuiteSessionId
+                    );
+                    const exactSuiteDraftBinding = Boolean(
+                        sourceMatched
+                        && suiteWindowBound
+                        && payloadSuiteSessionId === activeSuiteSessionId
+                        && isPayloadExamInActiveSuite
+                        && expectedWindowSessionToken
+                        && payloadWindowSessionToken === expectedWindowSessionToken
+                        && Number.isFinite(incomingUpdatedAt)
+                        && incomingUpdatedAt > 0
+                        && this.currentSuiteSession
+                        && ['active', 'initializing'].includes(this.currentSuiteSession.status)
+                    );
+                    if (!exactSuiteDraftBinding) {
+                        this._reportExamMessageRejected(examId, type, 'suite-draft-binding-mismatch', event);
                         return;
                     }
                 }
@@ -2422,7 +2805,7 @@
                         break;
                     // 新增：处理数据采集器的消息
                     case 'SESSION_READY':
-                        this.handleSessionReady(examId, data);
+                        this.handleSessionReady(examId, data, expectedRegistration);
                         if (typeof this._maybeRestoreSuiteReviewState === 'function') {
                             this._maybeRestoreSuiteReviewState(examId, sourceWindow || expectedWindow, windowInfo).catch((restoreError) => {
                                 console.warn('[SuitePractice] 恢复回看态失败:', restoreError);
@@ -2445,11 +2828,14 @@
                             console.info('[ReadingMemorize] 背题模式结果仅在统一阅读页内展示，跳过练习记录:', examId);
                             break;
                         }
-                        if (data && data.suiteSessionId && windowInfo) {
+                        if (data && data.suiteSessionId && windowInfo
+                            && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                             windowInfo.suiteSessionId = data.suiteSessionId;
                             this.examWindows && this.examWindows.set(examId, windowInfo);
                         }
-                        await this.handlePracticeComplete(examId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeComplete(examId, data, sourceWindow || expectedWindow, {
+                            expectedRegistration
+                        });
                         break;
                     case 'ERROR_OCCURRED':
                         this.handleDataCollectionError(examId, data);
@@ -2458,7 +2844,7 @@
                         sendInitEnvelope(sourceWindow || examWindow);
                         break;
                     case 'PRACTICE_RESET_REQUEST':
-                        await this.handlePracticeResetRequest(examId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeResetRequest(examId, data, sourceWindow || expectedWindow, expectedRegistration);
                         break;
                     case 'SUITE_CLOSE_ATTEMPT':
                         console.warn('[SuitePractice] 练习页尝试关闭套题窗口:', data);
@@ -2532,36 +2918,8 @@
                         await this.handleReviewReplayNavigate(examId, data, sourceWindow || expectedWindow);
                         break;
                     case 'SIMULATION_DRAFT_SYNC':
-                        if (this.currentSuiteSession && data && data.draft) {
-                            const incomingUpdatedAt = Number(data.draftUpdatedAt ?? data.draft.updatedAt);
-                            const previousDraft = this.currentSuiteSession.draftsByExam[routedExamId] || null;
-                            const previousUpdatedAt = Number(previousDraft && previousDraft.updatedAt);
-                            const shouldAcceptDraft = !(
-                                previousDraft
-                                && Number.isFinite(previousUpdatedAt)
-                                && Number.isFinite(incomingUpdatedAt)
-                                && incomingUpdatedAt < previousUpdatedAt
-                            );
-                            if (shouldAcceptDraft) {
-                                this.currentSuiteSession.draftsByExam[routedExamId] = {
-                                    ...data.draft,
-                                    updatedAt: Number.isFinite(incomingUpdatedAt) ? incomingUpdatedAt : Date.now()
-                                };
-                            }
-                            if (Number.isFinite(Number(data.elapsed))) {
-                                if (typeof this._deriveSuiteExamElapsedSeconds === 'function') {
-                                    this.currentSuiteSession.elapsedByExam[routedExamId] = this._deriveSuiteExamElapsedSeconds(
-                                        this.currentSuiteSession,
-                                        routedExamId,
-                                        Number(data.elapsed)
-                                    );
-                                } else {
-                                    this.currentSuiteSession.elapsedByExam[routedExamId] = Math.max(0, Number(data.elapsed));
-                                }
-                            }
-                            if (typeof this._mirrorSessionToStorage === 'function') {
-                                this._mirrorSessionToStorage(this.currentSuiteSession);
-                            }
+                        if (typeof this._handleSuiteDraftSync === 'function') {
+                            await this._handleSuiteDraftSync(routedExamId, data, windowInfo, sourceWindow || expectedWindow);
                         }
                         break;
                     case 'READING_DRAFT_SYNC':
@@ -2614,7 +2972,9 @@
                         if (windowInfo && windowInfo.reviewMode) {
                             break;
                         }
-                        await this.handlePracticeComplete(routedExamId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeComplete(routedExamId, data, sourceWindow || expectedWindow, {
+                            expectedRegistration: routedExamId === examId ? expectedRegistration : null
+                        });
                         break;
                     default:
                 }
@@ -2639,7 +2999,12 @@
             }
             this.messageHandlers.set(examId, messageHandler);
 
-            const sendInitEnvelope = (targetWindow) => this._sendExamInitEnvelope(examId, targetWindow);
+            const sendInitEnvelope = (targetWindow) => this._sendExamInitEnvelope(
+                examId,
+                targetWindow,
+                {},
+                expectedRegistration
+            );
 
             const tryAttachInitHandler = (targetWindow) => {
                 if (!targetWindow || isFileProtocol) {
@@ -2656,7 +3021,7 @@
                 return false;
             };
 
-            let initAttached = tryAttachInitHandler(examWindow);
+            let initAttached = Boolean(options && options.deferInitialHandshake);
 
             if (!initAttached) {
                 try {
@@ -2673,12 +3038,13 @@
             if (!initAttached) {
                 sendInitEnvelope(examWindow);
             }
+            return expectedRegistration;
         },
 
         /**
          * 与练习页建立握手（重复发送 INIT_SESSION，直到收到 SESSION_READY）
          */
-        startExamHandshake(examWindow, examId) {
+        startExamHandshake(examWindow, examId, expectedRegistration = null) {
             if (!this._handshakeTimers) this._handshakeTimers = new Map();
 
             // 避免重复握手
@@ -2687,13 +3053,20 @@
             let attempts = 0;
             const maxAttempts = 30; // ~9s
             const tick = async () => {
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    clearInterval(timer);
+                    if (this._handshakeTimers.get(examId) === timer) this._handshakeTimers.delete(examId);
+                    return;
+                }
                 if (examWindow && !examWindow.closed) {
                     try {
-                        const windowInfo = this.ensureExamWindowSession(examId, examWindow);
+                        const windowInfo = expectedRegistration
+                            ? expectedRegistration.windowInfo
+                            : this.ensureExamWindowSession(examId, examWindow);
                         windowInfo.handshakeAttempts = attempts + 1;
                         windowInfo.lastHandshakeAt = Date.now();
                         this.examWindows && this.examWindows.set(examId, windowInfo);
-                        await this._sendExamInitEnvelope(examId, examWindow);
+                        await this._sendExamInitEnvelope(examId, examWindow, {}, expectedRegistration);
                     } catch (_) { /* 忽略 */ }
                 }
                 attempts++;
@@ -3454,6 +3827,9 @@
             if (!info || info.reviewMode) {
                 return false;
             }
+            if (windowInfo && this.examWindows && this.examWindows.get(examId) !== info) {
+                return false;
+            }
             if (String(info.practiceMode || '').toLowerCase() === 'memorize') {
                 return false;
             }
@@ -3461,8 +3837,9 @@
             // 否则当任意套题会话仍活跃时，普通独立阅读窗口（windowInfo.suiteSessionId 为空）
             // 的草稿也会被拒绝，关闭该窗口会丢失该题的在做答案/笔记。
             if (info.suiteSessionId) {
-                // Suite drafts stay on the suite session path.
-                return false;
+                return typeof this._handleSuiteDraftSync === 'function'
+                    ? this._handleSuiteDraftSync(examId, data, info, info.window)
+                    : false;
             }
             const expectedSessionId = info.expectedSessionId ? String(info.expectedSessionId) : '';
             const payloadSessionId = data && data.sessionId != null ? String(data.sessionId) : '';
@@ -3473,9 +3850,23 @@
             if (!draft.sessionId) {
                 return false;
             }
+            const isCurrentRegistration = () => {
+                const current = this.examWindows && this.examWindows.get(examId);
+                return current === info
+                    && (!current.window || !current.window.closed)
+                    && (!Number.isInteger(data.windowSessionGeneration)
+                        || !Number.isInteger(info.sessionGeneration)
+                        || Number(data.windowSessionGeneration) === Number(info.sessionGeneration));
+            };
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             // 必须在写队列里重新读取最新 store 再合并，否则并发不同 exam 的 write 会互相覆盖、
             // 后写者会丢掉前者的草稿（整个 map 是同一个存储 key，read-modify-write 非原子）。
             const store = await this._readReadingDraftStore();
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             const previous = store[String(draft.id)] || null;
             const previousNumericUpdatedAt = Number(previous && previous.updatedAt);
             const previousUpdatedAt = Number.isFinite(previousNumericUpdatedAt)
@@ -3495,7 +3886,13 @@
                 return false;
             }
             store[String(draft.id)] = draft;
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             if (!await this._writeReadingDraftStore(store, draft)) {
+                return false;
+            }
+            if (!isCurrentRegistration()) {
                 return false;
             }
             info.lastReadingDraft = draft;
@@ -3513,7 +3910,20 @@
             }
             const queued = this._readingDraftStoreQueue
                 .catch(() => undefined)
-                .then(() => this.handleReadingDraftSync(examId, data, windowInfo));
+                .then(() => {
+                    const currentWindowInfo = this.examWindows && this.examWindows.get(examId);
+                    if (
+                        windowInfo
+                        && (
+                            currentWindowInfo !== windowInfo
+                            || currentWindowInfo.window !== windowInfo.window
+                            || currentWindowInfo.sessionGeneration !== windowInfo.sessionGeneration
+                        )
+                    ) {
+                        return false;
+                    }
+                    return this.handleReadingDraftSync(examId, data, windowInfo);
+                });
             this._readingDraftStoreQueue = queued.catch(() => undefined).then(() => {
                 if (this._readingDraftStoreQueue === queued) {
                     this._readingDraftStoreQueue = Promise.resolve();
@@ -4023,9 +4433,11 @@
                 info.expectedSessionId = this.generateSessionId(examId);
             }
             this._refreshExamWindowToken(examId, info);
-            const suiteSessionId = typeof this._resolveSuiteSessionId === 'function'
-                ? this._resolveSuiteSessionId(examId, info)
-                : (info.suiteSessionId || null);
+            const suiteSessionId = Object.prototype.hasOwnProperty.call(info, 'suiteSessionId')
+                ? (info.suiteSessionId || null)
+                : (typeof this._resolveSuiteSessionId === 'function'
+                    ? this._resolveSuiteSessionId(examId, info)
+                    : null);
             const activeSuite = suiteSessionId
                 && this.currentSuiteSession
                 && String(this.currentSuiteSession.id || '') === String(suiteSessionId)
@@ -4055,6 +4467,7 @@
                 parentOrigin: info.allowOpaqueOrigin ? 'null' : window.location.origin,
                 sessionId: info.expectedSessionId,
                 windowSessionToken: info.windowSessionToken || null,
+                windowSessionGeneration: Number.isInteger(info.sessionGeneration) ? info.sessionGeneration : 0,
                 messageIssuedAtMs,
                 suiteSessionId: suiteSessionId || null,
                 suiteFlowMode: info.suiteFlowMode || null,
@@ -4105,12 +4518,17 @@
             return payload;
         },
 
-        async _sendExamInitEnvelope(examId, targetWindow, extras = {}) {
+        async _sendExamInitEnvelope(examId, targetWindow, extras = {}, expectedRegistration = null) {
             if (!targetWindow || targetWindow.closed) {
                 return null;
             }
             try {
-                const windowInfo = this.ensureExamWindowSession(examId, targetWindow);
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return null;
+                }
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : this.ensureExamWindowSession(examId, targetWindow);
                 if (
                     windowInfo
                     && !windowInfo.reviewMode
@@ -4131,6 +4549,9 @@
                         // draft restore is best-effort
                     }
                 }
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return null;
+                }
                 const initPayload = this._buildExamInitPayload(examId, windowInfo, extras);
                 this._postExamMessage(examId, targetWindow, 'INIT_SESSION', initPayload);
                 this._postExamMessage(examId, targetWindow, 'init_exam_session', initPayload);
@@ -4141,7 +4562,7 @@
             }
         },
 
-        restartExamHandshake(examWindow, examId) {
+        restartExamHandshake(examWindow, examId, expectedRegistration = null) {
             if (this._handshakeTimers && this._handshakeTimers.has(examId)) {
                 try {
                     clearInterval(this._handshakeTimers.get(examId));
@@ -4150,7 +4571,7 @@
                 }
                 this._handshakeTimers.delete(examId);
             }
-            this.startExamHandshake(examWindow, examId);
+            this.startExamHandshake(examWindow, examId, expectedRegistration);
         },
 
         ensureExamWindowSession(examId, examWindow = null) {
@@ -4182,11 +4603,19 @@
                     reviewSessionId: null,
                     reviewEntryIndex: 0,
                     readOnly: false,
+                    sessionGeneration: 1,
                     submittedRecordId: ''
                 });
             }
 
             const windowInfo = this.examWindows.get(examId);
+
+            if (!Number.isInteger(windowInfo.registrationId)) {
+                this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+                windowInfo.registrationId = this._examRegistrationSequence;
+            }
+            if (!Number.isInteger(windowInfo.sessionGeneration)) windowInfo.sessionGeneration = 1;
+            if (!Number.isInteger(windowInfo.navigationEpoch)) windowInfo.navigationEpoch = 0;
 
             if (examWindow && (!windowInfo.window || windowInfo.window.closed || windowInfo.window !== examWindow)) {
                 windowInfo.window = examWindow;
@@ -4243,7 +4672,7 @@
          * 当前激活题库而拿到不一致的来源。
          * 该方法为 async：必要时调用方需 await。
          */
-        async _captureLaunchLibraryConfigurationId(examId) {
+        async _captureLaunchLibraryConfigurationId(examId, options = {}) {
             if (!examId) return null;
             if (!this._launchLibraryConfigurationIds) {
                 this._launchLibraryConfigurationIds = new Map();
@@ -4261,6 +4690,9 @@
             const normalized = (configurationId === undefined || configurationId === null)
                 ? null
                 : configurationId;
+            if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) {
+                return null;
+            }
             this._launchLibraryConfigurationIds.set(String(examId), normalized);
             // 同步作用中 windowInfo：避免后续 _buildExamInitPayload 等同步路径漏读
             try {
@@ -4339,11 +4771,17 @@
             }
         },
 
-        async _discardActiveSessionsForExam(examId) {
+        async _discardActiveSessionsForExam(examId, options = {}) {
             const activeSessions = await window.AppData.recovery.listActiveSessions();
+            if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) return 0;
+            const expectedSessionId = String(options.expectedSessionId || '').trim();
             const matches = (Array.isArray(activeSessions) ? activeSessions : [])
-                .filter((session) => session && session.examId === examId);
+                .filter((session) => session && session.examId === examId)
+                .filter((session) => !expectedSessionId
+                    || String(session.sessionId || '') === expectedSessionId
+                    || String(session.id || '').endsWith(`:${expectedSessionId}`));
             for (const session of matches) {
+                if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) break;
                 const entityId = session.id || session.sessionId || session.recordId;
                 if (entityId) {
                     await window.AppData.recovery.discardActiveSession(entityId);
@@ -4371,8 +4809,13 @@
             return renderMode === 'unified-reading' || pageType === 'unified-reading';
         },
 
-        async retainExamWindowAfterCompletion(examId, sourceWindow, data = {}) {
-            const windowInfo = this.ensureExamWindowSession(examId, sourceWindow);
+        async retainExamWindowAfterCompletion(examId, sourceWindow, data = {}, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const windowInfo = expectedRegistration
+                ? expectedRegistration.windowInfo
+                : this.ensureExamWindowSession(examId, sourceWindow);
             windowInfo.window = sourceWindow || windowInfo.window || null;
             windowInfo.status = 'completed';
             windowInfo.completedAt = Date.now();
@@ -4382,10 +4825,14 @@
             windowInfo.readOnly = false;
             this.examWindows && this.examWindows.set(examId, windowInfo);
             await this._removeActiveExamSessionMetadata(examId);
+            return !expectedRegistration || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
         },
 
-        async handlePracticeResetRequest(examId, data = {}, sourceWindow = null) {
-            const targetWindow = sourceWindow
+        async handlePracticeResetRequest(examId, data = {}, sourceWindow = null, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const targetWindow = (expectedRegistration && expectedRegistration.window) || sourceWindow
                 || (this.examWindows && this.examWindows.has(examId) ? this.examWindows.get(examId).window : null);
             if (!targetWindow || targetWindow.closed) {
                 window.showMessage && window.showMessage('题目窗口已关闭，无法重置测试', 'warning');
@@ -4395,7 +4842,9 @@
             const payload = data && typeof data === 'object' ? data : {};
             const reason = String(payload.reason || '').trim().toLowerCase();
             const fromPracticeMode = String(payload.fromPracticeMode || payload.practiceMode || '').trim().toLowerCase();
-            const windowInfo = this.ensureExamWindowSession(examId, targetWindow);
+            const windowInfo = expectedRegistration
+                ? expectedRegistration.windowInfo
+                : this.ensureExamWindowSession(examId, targetWindow);
             const shouldReopenAsNormal = reason === 'memorize-start-test'
                 || fromPracticeMode === 'memorize'
                 || windowInfo.practiceMode === 'memorize';
@@ -4419,7 +4868,9 @@
             windowInfo.status = 'active';
             windowInfo.startTime = Date.now();
             windowInfo.completedAt = null;
+            windowInfo.sessionGeneration = Math.max(0, Number(windowInfo.sessionGeneration) || 0) + 1;
             windowInfo.expectedSessionId = this.generateSessionId(examId);
+            this._refreshExamWindowToken(examId, windowInfo);
             windowInfo.sessionId = null;
             windowInfo.practiceMode = null;
             windowInfo.reviewMode = false;
@@ -4432,7 +4883,24 @@
             windowInfo.lastResetReason = reason || 'reset';
             this.examWindows && this.examWindows.set(examId, windowInfo);
 
-            await this.startPracticeSession(examId);
+            let resetRegistration = this._captureExamSessionRegistration(examId, windowInfo);
+            if (!this._isExamSessionRegistrationCurrent(examId, resetRegistration)) {
+                return false;
+            }
+            resetRegistration = this.setupExamWindowCommunication(targetWindow, examId, null, {
+                expectedRegistration: resetRegistration,
+                deferInitialHandshake: true,
+                skipContentGuard: true
+            }) || resetRegistration;
+
+            const startResult = await this.startPracticeSession(examId, {
+                expectedRegistration: resetRegistration
+            });
+            if (!startResult || startResult.owned !== true
+                || !this._isExamSessionRegistrationCurrent(examId, startResult.registration)) {
+                return false;
+            }
+            resetRegistration = startResult.registration;
             this._syncRecorderSessionStarted(examId, windowInfo, {
                 pageType: 'unified-reading',
                 url: payload.normalUrl || payload.url || null,
@@ -4444,24 +4912,38 @@
                 practiceMode: null,
                 reviewMode: false,
                 readOnly: false
-            });
-            this.restartExamHandshake(targetWindow, examId);
+            }, resetRegistration);
+            if (!this._isExamSessionRegistrationCurrent(examId, resetRegistration)) {
+                return false;
+            }
+            this.restartExamHandshake(targetWindow, examId, resetRegistration);
             this.updateExamStatus(examId, 'in-progress');
+            return true;
         },
 
         /**
          * 开始练习会话
          */
-        async startPracticeSession(examId) {
-            const exam = await findExamDefinition(examId);
+        async startPracticeSession(examId, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            const exam = options && options.examDefinition
+                ? options.examDefinition
+                : await findExamDefinition(examId);
+            if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
             if (!exam) {
                 console.error('Exam not found:', examId);
                 window.showMessage && window.showMessage('题目索引未加载，请重试或重新导入题库。', 'error');
-                return;
+                return expectedRegistration
+                    ? { owned: false, sessionId: null, registration: expectedRegistration }
+                    : undefined;
             }
 
             try {
-                const windowInfo = this.examWindows && this.examWindows.get(examId);
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : (this.examWindows && this.examWindows.get(examId));
                 const hostSessionId = windowInfo && windowInfo.expectedSessionId
                     ? String(windowInfo.expectedSessionId)
                     : this.generateSessionId(examId);
@@ -4473,10 +4955,13 @@
                 // 优先使用新的练习页面管理器
                 if (window.practicePageManager) {
                     const sessionId = await window.practicePageManager.startPracticeSession(examId, exam);
+                    if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
 
                     // 更新题目状态
                     this.updateExamStatus(examId, 'in-progress');
-                    return sessionId;
+                    return expectedRegistration
+                        ? { owned: true, sessionId, registration: this._captureExamSessionRegistration(examId, windowInfo) }
+                        : sessionId;
                 }
 
                 // 使用练习记录器开始会话
@@ -4521,15 +5006,26 @@
                     };
 
                     await window.AppData.recovery.saveActiveSession(sessionData);
+                    if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
                 }
 
                 // 更新题目状态
                 this.updateExamStatus(examId, 'in-progress');
+                if (expectedRegistration) {
+                    return {
+                        owned: ownsRegistration(),
+                        sessionId: windowInfo && windowInfo.expectedSessionId || hostSessionId,
+                        registration: this._captureExamSessionRegistration(examId, windowInfo)
+                    };
+                }
 
             } catch (error) {
                 console.error('[App] 启动练习会话失败:', error);
 
                 // 最终降级方案
+                if (expectedRegistration) {
+                    return { owned: false, sessionId: null, registration: expectedRegistration };
+                }
                 await this.startPracticeSessionFallback(examId, exam);
             }
         },
@@ -4597,7 +5093,10 @@
         /**
          * 处理数据采集器会话就绪
          */
-        handleSessionReady(examId, data) {
+        handleSessionReady(examId, data, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
             const payload = data && typeof data === 'object' ? data : {};
             const isListeningBridgeReady = payload.source === 'listening_record_bridge'
                 || payload.metadata?.source === 'listening_record_bridge'
@@ -4610,7 +5109,9 @@
 
             // 更新会话状态
             let windowInfo = null;
-            if (this.examWindows && this.examWindows.has(examId)) {
+            if (expectedRegistration) {
+                windowInfo = expectedRegistration.windowInfo;
+            } else if (this.examWindows && this.examWindows.has(examId)) {
                 windowInfo = this.examWindows.get(examId);
             } else {
                 windowInfo = this.ensureExamWindowSession(examId);
@@ -4630,7 +5131,8 @@
                 if (!isPreInitReady && payload.sessionId && windowInfo.expectedSessionId !== payload.sessionId) {
                     windowInfo.expectedSessionId = payload.sessionId;
                 }
-                if (payload.suiteSessionId && !windowInfo.suiteSessionId) {
+                if (payload.suiteSessionId
+                    && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                     windowInfo.suiteSessionId = payload.suiteSessionId;
                 }
                 if (payload.suiteFlowMode && !windowInfo.suiteFlowMode) {
@@ -4705,7 +5207,9 @@
                             pageType: payload.pageType || null,
                             url: payload.url || null,
                             title: payload.title || null,
-                            suiteSessionId: payload.suiteSessionId || null,
+                            suiteSessionId: Object.prototype.hasOwnProperty.call(windowInfo || {}, 'suiteSessionId')
+                                ? (windowInfo.suiteSessionId || null)
+                                : (payload.suiteSessionId || null),
                             // 此处是练习页 SESSION_READY 后同步会话状态的时刻，注入启动时捕获的题库配置 ID。
                             libraryConfigurationId: this._readLaunchLibraryConfigurationId(examId, payload, windowInfo)
                         }
@@ -4848,6 +5352,7 @@
                     console.warn('[PracticeRecorder] 完成前同步会话状态失败:', startedError);
                 }
             }
+            return true;
         },
 
         _normalizeListeningSpellingErrors(examId, data) {
@@ -4879,7 +5384,11 @@
         /**
          * 处理练习完成（真实数据）
          */
-        async handlePracticeComplete(examId, data, sourceWindow = null) {
+        async handlePracticeComplete(examId, data, sourceWindow = null, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            if (!ownsRegistration()) return false;
             if (data && !data.sessionId) {
                 data.sessionId = `${examId}_${Date.now()}`;
             }
@@ -4958,6 +5467,7 @@
             if (shouldDelegateToSuiteHandler && typeof this.handleSuitePracticeComplete === 'function') {
                 try {
                     const suiteOutcome = await this.handleSuitePracticeComplete(examId, data, sourceWindow);
+                    if (!ownsRegistration()) return false;
                     const handled = suiteOutcome === true || Boolean(suiteOutcome && suiteOutcome.handled);
                     if (handled) {
                         const committed = !suiteOutcome || typeof suiteOutcome !== 'object' || suiteOutcome.committed !== false;
@@ -4975,19 +5485,21 @@
                     }
                     suiteHandlerDeclined = true;
                 } catch (suiteError) {
-                    console.error('[SuitePractice] 处理套题结果失败，回退至普通流程:', suiteError);
-                    window.showMessage && window.showMessage('套题模式出现异常，记录将以单篇形式保存。', 'warning');
+                    console.error('[SuitePractice] 处理套题结果失败，保留 v2 恢复快照:', suiteError);
+                    window.showMessage && window.showMessage('套题模式出现异常，恢复快照已保留，请稍后重试。', 'error');
                     suiteHandlerDeclined = true;
                 }
             }
 
+            if (suiteHandlerDeclined && shouldDelegateToSuiteHandler) {
+                return false;
+            }
+            if (shouldDelegateToSuiteHandler && typeof this.handleSuitePracticeComplete !== 'function') {
+                return false;
+            }
+
             const recorder = this.components && this.components.practiceRecorder;
-            const completionData = suiteHandlerDeclined
-                ? Object.assign({}, data, {
-                    allowStandaloneSave: true,
-                    metadata: Object.assign({}, data?.metadata || {}, { allowStandaloneSave: true, suiteRecovery: true })
-                })
-                : data;
+            const completionData = data;
             // The generic completion rebind above already covers listening payloads.
 
             let completionCommitted = false;
@@ -5010,6 +5522,7 @@
                 if (!persistedRecord || typeof persistedRecord !== 'object' || !String(persistedRecord.id || '').trim()) {
                     throw new Error('Practice completion returned without a committed record');
                 }
+                if (!ownsRegistration()) return false;
 
                 let completionReadable = false;
                 if (typeof this._isPracticeCompletionPersisted === 'function') {
@@ -5022,6 +5535,7 @@
                 if (!completionReadable) {
                     throw new Error('Practice completion could not be verified in canonical storage');
                 }
+                if (!ownsRegistration()) return false;
                 completionCommitted = true;
 
                 if (completedViaFallback && recorder && typeof recorder.endPracticeSession === 'function') {
@@ -5102,9 +5616,14 @@
                 if (completionCommitted) {
                     try {
                         if (this._isResetCapableUnifiedReadingCompletion(completionData, sourceWindow)) {
-                            await this.retainExamWindowAfterCompletion(examId, sourceWindow, completionData);
+                            await this.retainExamWindowAfterCompletion(
+                                examId,
+                                sourceWindow,
+                                completionData,
+                                expectedRegistration
+                            );
                         } else {
-                            await this.cleanupExamSession(examId);
+                            await this.cleanupExamSession(examId, { expectedRegistration });
                         }
                     } catch (cleanupError) {
                         console.warn('[DataCollection] 练习已提交，但会话清理失败:', cleanupError);
@@ -5291,22 +5810,52 @@
         /**
          * 处理题目窗口关闭
          */
-        handleExamWindowClosed(examId) {
+        handleExamWindowClosed(examId, closedWindow = null, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const info = this.examWindows && this.examWindows.get(examId);
+            const expectedWindow = info && info.window ? info.window : null;
+            if (closedWindow && expectedWindow && closedWindow !== expectedWindow) {
+                return false;
+            }
+            if (info && info.closeMonitor) {
+                try { clearInterval(info.closeMonitor); } catch (_) {}
+                info.closeMonitor = null;
+            }
 
-            if (this.suiteExamMap && this.suiteExamMap.has(examId) && this.currentSuiteSession && this.currentSuiteSession.status === 'active' && this.suiteExamMap.get(examId) === this.currentSuiteSession.id) {
-                window.showMessage && window.showMessage('套题练习窗口已关闭，套题模式将被中断并回退到普通模式。', 'warning');
-                if (typeof this._abortSuiteSession === 'function') {
-                    this._abortSuiteSession(this.currentSuiteSession, {}).catch(error => {
-                        console.error('[SuitePractice] 中断套题失败:', error);
-                    });
+            const suite = this.currentSuiteSession;
+            const isSuiteExam = Boolean(
+                suite
+                && this.suiteExamMap
+                && this.suiteExamMap.get(examId) === suite.id
+                && suite.status === 'active'
+            );
+            if (isSuiteExam) {
+                if (String(suite.activeExamId || '') !== String(examId)) {
+                    return false;
+                }
+                if (closedWindow && suite.windowRef && closedWindow !== suite.windowRef) {
+                    return false;
+                }
+                suite.windowRef = null;
+                suite.status = 'active';
+                suite.lastUpdate = Date.now();
+                const persisted = typeof this._mirrorSessionToStorage === 'function'
+                    ? this._mirrorSessionToStorage(suite)
+                    : false;
+                if (persisted) {
+                    window.showMessage && window.showMessage('套题练习窗口已关闭，当前进度已暂停并保留，可从套题模式继续。', 'warning');
+                } else {
+                    window.showMessage && window.showMessage('套题窗口已关闭，但恢复快照保存失败，请勿关闭主页面。', 'error');
                 }
             }
 
-            // 更新题目状态
             this.updateExamStatus(examId, 'interrupted');
-
-            // 清理会话
-            this.cleanupExamSession(examId);
+            if (typeof this.cleanupExamSession === 'function') {
+                this.cleanupExamSession(examId, { expectedRegistration });
+            }
+            return true;
         },
 
         /**
@@ -5452,32 +6001,43 @@
         /**
          * 清理题目会话
          */
-        async _cleanupReusedWindowSessions(targetWindow, keepExamId = null) {
+        async _cleanupReusedWindowSessions(targetWindow, keepExamId = null, keepRegistration = null) {
             if (!targetWindow || !this.examWindows || typeof this.cleanupExamSession !== 'function') {
                 return [];
             }
             const normalizedKeepExamId = keepExamId != null ? String(keepExamId).trim() : '';
-            const staleExamIds = [];
+            const staleRegistrations = [];
             this.examWindows.forEach((windowInfo, candidateExamId) => {
                 const normalizedCandidateExamId = candidateExamId != null ? String(candidateExamId).trim() : '';
                 if (!normalizedCandidateExamId || (normalizedKeepExamId && normalizedCandidateExamId === normalizedKeepExamId)) {
                     return;
                 }
                 if (windowInfo && windowInfo.window === targetWindow) {
-                    staleExamIds.push(normalizedCandidateExamId);
+                    staleRegistrations.push({
+                        examId: normalizedCandidateExamId,
+                        registration: this._captureExamSessionRegistration(normalizedCandidateExamId, windowInfo)
+                    });
                 }
             });
-            for (const staleExamId of staleExamIds) {
+            for (const stale of staleRegistrations) {
                 try {
-                    await this.cleanupExamSession(staleExamId);
+                    if (keepRegistration && !this._isExamSessionRegistrationCurrent(keepExamId, keepRegistration)) break;
+                    await this.cleanupExamSession(stale.examId, { expectedRegistration: stale.registration });
                 } catch (error) {
-                    console.warn('[App] 清理复用窗口旧题目会话失败:', staleExamId, error);
+                    console.warn('[App] 清理复用窗口旧题目会话失败:', stale.examId, error);
                 }
             }
-            return staleExamIds;
+            return staleRegistrations.map(item => item.examId);
         },
 
-        async cleanupExamSession(examId) {
+        async cleanupExamSession(examId, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const expectedSessionId = expectedRegistration && expectedRegistration.windowInfo.expectedSessionId
+                ? String(expectedRegistration.windowInfo.expectedSessionId)
+                : '';
             // 清理窗口引用
             if (this.examWindows && this.examWindows.has(examId)) {
                 this.examWindows.delete(examId);
@@ -5491,7 +6051,11 @@
             }
 
             // 清理活动会话
-            await this._discardActiveSessionsForExam(examId);
+            await this._discardActiveSessionsForExam(examId, {
+                expectedSessionId,
+                commitGuard: () => !(this.examWindows && this.examWindows.has(examId))
+            });
+            return true;
         },
 
         /**

--- a/js/app/suitePracticeMixin.js
+++ b/js/app/suitePracticeMixin.js
@@ -57,6 +57,141 @@
             if (typeof this._clearSuiteHandshakes === 'function') {
                 this._clearSuiteHandshakes();
             }
+
+            const restored = this._restoreSessionFromStorage();
+            if (restored) {
+                this._installRestoredSuiteSession(restored);
+            }
+            this._suiteRecoveryReady = this._restorePersistentSuiteSession(restored);
+        },
+
+        _installRestoredSuiteSession(restored) {
+            if (!restored) return null;
+            this.currentSuiteSession = restored;
+            this._registerSuiteSequence(restored);
+            this._suiteResumeNoticeShown = false;
+            return restored;
+        },
+
+        _clearInstalledSuiteRecoverySession(session = this.currentSuiteSession) {
+            if (session && this.suiteExamMap && Array.isArray(session.sequence)) {
+                session.sequence.forEach((entry) => {
+                    const examId = entry && entry.examId != null ? String(entry.examId) : '';
+                    if (examId && this.suiteExamMap.get(examId) === session.id) {
+                        this.suiteExamMap.delete(examId);
+                    }
+                });
+            }
+            if (!session || this.currentSuiteSession === session) this.currentSuiteSession = null;
+        },
+
+        async _restorePersistentSuiteSession(fastSnapshotSession = null) {
+            const recovery = global.AppData && global.AppData.recovery;
+            if (!recovery || typeof recovery.listActiveSessions !== 'function') {
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                if (fastSnapshotSession) this._notifySuiteResumeAvailable(fastSnapshotSession);
+                return fastSnapshotSession;
+            }
+
+            try {
+                if (global.AppData.ready && typeof global.AppData.ready.then === 'function') {
+                    await global.AppData.ready;
+                }
+                const items = await recovery.listActiveSessions();
+                const durableCandidates = [];
+                for (const item of Array.isArray(items) ? items : []) {
+                    if (!item || item.schema !== 'suite-session-v2' || Number(item.version) !== 2 || !item.id) {
+                        continue;
+                    }
+                    const restored = this._restoreSessionFromStorage(item);
+                    if (restored) {
+                        durableCandidates.push(restored);
+                    }
+                }
+
+                if (durableCandidates.length === 0) {
+                    this._suiteRecoveryAmbiguous = false;
+                    this._suiteRecoveryAmbiguousCount = 0;
+                    this._clearInstalledSuiteRecoverySession(this.currentSuiteSession || fastSnapshotSession);
+                    this._clearSessionStorage();
+                    return null;
+                }
+
+                if (durableCandidates.length > 1) {
+                    this._suiteRecoveryAmbiguous = true;
+                    this._suiteRecoveryAmbiguousCount = durableCandidates.length;
+                    this._clearInstalledSuiteRecoverySession(this.currentSuiteSession || fastSnapshotSession);
+                    this._clearSessionStorage();
+                    window.showMessage && window.showMessage(
+                        'Multiple unfinished suites were found. Recovery is paused because this single-window build cannot choose one safely.',
+                        'warning'
+                    );
+                    return null;
+                }
+
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                const selected = durableCandidates[0];
+                this._clearInstalledSuiteRecoverySession(this.currentSuiteSession);
+                this._installRestoredSuiteSession(selected);
+                this._mirrorSuiteRecoverySnapshot(this._buildSuiteRecoverySnapshot(selected, {
+                    bumpRevision: false,
+                    bumpLastUpdate: false
+                }));
+                this._notifySuiteResumeAvailable(selected);
+                return selected;
+            } catch (error) {
+                console.warn('[SuitePractice] Unable to restore durable suite recovery:', error);
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                if (fastSnapshotSession) this._notifySuiteResumeAvailable(fastSnapshotSession);
+                return fastSnapshotSession;
+            }
+        },
+
+        async _ensureSuiteRecoveryReady() {
+            if (!this._suiteModeReady) {
+                if (this.currentSuiteSession) {
+                    this._suiteModeReady = true;
+                } else {
+                    this.initializeSuiteMode();
+                }
+            }
+            if (this._suiteRecoveryReady && typeof this._suiteRecoveryReady.then === 'function') {
+                await this._suiteRecoveryReady;
+            }
+            return this.currentSuiteSession;
+        },
+
+        async getSuiteRecoveryCandidate() {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            if (!session || !['active', 'initializing', 'finalizing'].includes(session.status)) return null;
+            const sequence = Array.isArray(session.sequence) ? session.sequence : [];
+            const index = Math.min(Math.max(0, Number(session.currentIndex) || 0), Math.max(0, sequence.length - 1));
+            const entry = sequence[index] || null;
+            return {
+                id: String(session.id),
+                status: session.status,
+                currentIndex: index,
+                total: sequence.length,
+                title: entry && entry.exam && entry.exam.title
+                    ? entry.exam.title
+                    : (entry && entry.examId) || 'Unfinished suite',
+                completedCount: Array.isArray(session.results) ? session.results.length : 0
+            };
+        },
+
+        async abandonSuiteRecovery(expectedSessionId = '') {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            const expectedId = String(expectedSessionId || '').trim();
+            if (!expectedId || !session || String(session.id) !== expectedId) {
+                window.showMessage && window.showMessage('The unfinished suite changed. Please review it again before abandoning it.', 'warning');
+                return false;
+            }
+            return this._abortSuiteSession(session, { reason: 'user_discard' });
         },
 
         async startSuitePractice(options = {}) {
@@ -66,13 +201,34 @@
                 if (!this._suiteModeReady) {
                     this.initializeSuiteMode();
                 }
+                await this._ensureSuiteRecoveryReady();
+                if (this._suiteRecoveryAmbiguous === true) {
+                    window.showMessage && window.showMessage(
+                        'Multiple unfinished suites require manual cleanup before starting another suite.',
+                        'warning'
+                    );
+                    return false;
+                }
+                const recoveryAction = String(options.recoveryAction || '').trim().toLowerCase();
+                const recoverySessionId = String(options.recoverySessionId || '').trim();
                 const suitePreference = this._resolveSuitePreference(options);
                 const flowMode = suitePreference.flowMode;
                 const frequencyScope = suitePreference.frequencyScope;
 
-                if (this.currentSuiteSession && this.currentSuiteSession.status === 'active') {
-                    window.showMessage && window.showMessage('套题练习正在进行中，请先完成当前套题。', 'warning');
-                    return;
+                if (this.currentSuiteSession && ['active', 'initializing', 'finalizing'].includes(this.currentSuiteSession.status)) {
+                    if (!recoverySessionId || String(this.currentSuiteSession.id) !== recoverySessionId) {
+                        window.showMessage && window.showMessage('The unfinished suite changed. Please choose Continue or Abandon again.', 'warning');
+                        return false;
+                    }
+                    if (recoveryAction === 'continue' || recoveryAction === 'resume') {
+                        return this.resumeSuitePractice(recoverySessionId);
+                    }
+                    if (recoveryAction === 'restart' || recoveryAction === 'discard' || recoveryAction === 'abandon') {
+                        if (!await this.abandonSuiteRecovery(recoverySessionId)) return false;
+                    } else {
+                        window.showMessage && window.showMessage('Choose Continue or Abandon for the unfinished suite before starting another one.', 'warning');
+                        return false;
+                    }
                 }
 
                 if (frequencyScope === 'custom') {
@@ -159,15 +315,18 @@
                         ? '驻足模式'
                         : (flowMode === 'simulation' ? '模拟模式' : '经典模式')
                 });
-                if (!started && this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
-                }
+                return started;
             } catch (error) {
                 console.error('[SuitePractice] 启动失败:', error);
                 window.showMessage && window.showMessage('套题练习启动失败，请稍后重试。', 'error');
-                if (this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
+                if (this.currentSuiteSession && ['initializing', 'active'].includes(this.currentSuiteSession.status)) {
+                    this.currentSuiteSession.windowRef = null;
+                    this.currentSuiteSession._restoredFromStorage = true;
+                    this.currentSuiteSession.lastUpdate = Date.now();
+                    await this._commitSuiteRecovery(this.currentSuiteSession, { notify: false, reason: 'startup-error' });
+                    window.showMessage && window.showMessage('首篇窗口未能打开，套题恢复快照已保留，可稍后重试。', 'warning');
                 }
+                return false;
             }
         },
         async handleSuitePracticeComplete(examId, data, sourceWindow = null) {
@@ -189,6 +348,7 @@
                 return await this._handleInlineSimulationSuiteSubmit(examId, data, sourceWindow);
             }
 
+            await this._ensureSuiteRecoveryReady();
             const session = this.currentSuiteSession;
             if (!session) {
                 return false;
@@ -200,13 +360,28 @@
             if (payloadSuiteSessionId && payloadSuiteSessionId !== session.id) {
                 return false;
             }
+            if (session.status === 'finalizing') {
+                session._finalizeSubmissionId = data && data.submissionId
+                    ? String(data.submissionId)
+                    : (session._finalizeSubmissionId || null);
+                const committed = await this._finalizeSuiteRecordWithGate(session, {
+                    deferTeardown: Boolean(
+                        session._finalizeSubmissionId
+                        && sourceWindow
+                        && !sourceWindow.closed
+                    )
+                });
+                return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', data && data.submissionId ? {
+                    teardownSession: committed ? session : null
+                } : null);
+            }
             if (session.status === 'completed') {
                 return withSubmitOutcome(true, true, '', data && data.submissionId ? {
                     teardownSession: session
                 } : null);
             }
             if (session.status !== 'active') {
-                return false;
+                return withSubmitOutcome(true, false, 'suite_finalizing');
             }
 
             const mappingMissing = !this.suiteExamMap || !this.suiteExamMap.has(examId);
@@ -240,6 +415,74 @@
                 return withSubmitOutcome(true, false, 'inactive_suite_exam');
             }
 
+            const timerFields = [
+                'globalTimerAnchorMs',
+                'suiteTimerAnchorMs',
+                'suiteTimerMode',
+                'suiteTimerLimitSeconds',
+                'suiteTimerPausedOffsetMs',
+                'suiteTimerPausedAtMs',
+                'suiteTimerRunning'
+            ];
+            const passageRollbackState = {
+                results: this._cloneSuitePlainObject(session.results || []),
+                draftsByExam: this._cloneSuitePlainObject(session.draftsByExam || {}),
+                elapsedByExam: this._cloneSuitePlainObject(session.elapsedByExam || {}),
+                scalar: Object.fromEntries([
+                    'lastUpdate',
+                    'revision',
+                    'draftRevision',
+                    'currentIndex',
+                    'activeExamId',
+                    'pendingAdvance'
+                ].map((field) => [field, {
+                    present: Object.prototype.hasOwnProperty.call(session, field),
+                    value: field === 'pendingAdvance'
+                        ? this._cloneSuitePlainObject(session[field])
+                        : session[field]
+                }])),
+                timer: Object.fromEntries(timerFields.map((field) => [field, {
+                    present: Object.prototype.hasOwnProperty.call(session, field),
+                    value: session[field]
+                }]))
+            };
+            let previousWindowSnapshot = null;
+            try {
+                previousWindowSnapshot = global.AppData?.recovery?.windowSession?.get('simulation') || null;
+            } catch (_) {}
+            const rollbackPassageSubmission = () => {
+                session.results = this._cloneSuitePlainObject(passageRollbackState.results);
+                session.draftsByExam = this._cloneSuitePlainObject(passageRollbackState.draftsByExam);
+                session.elapsedByExam = this._cloneSuitePlainObject(passageRollbackState.elapsedByExam);
+                Object.keys(passageRollbackState.scalar).forEach((field) => {
+                    const captured = passageRollbackState.scalar[field];
+                    if (captured.present) {
+                        session[field] = field === 'pendingAdvance'
+                            ? this._cloneSuitePlainObject(captured.value)
+                            : captured.value;
+                    } else {
+                        delete session[field];
+                    }
+                });
+                timerFields.forEach((field) => {
+                    const captured = passageRollbackState.timer[field];
+                    if (captured.present) session[field] = captured.value;
+                    else delete session[field];
+                });
+                try {
+                    if (previousWindowSnapshot) {
+                        global.AppData.recovery.windowSession.save('simulation', previousWindowSnapshot);
+                    } else {
+                        const currentSnapshot = global.AppData?.recovery?.windowSession?.get('simulation');
+                        if (currentSnapshot && String(currentSnapshot.id || '') === String(session.id)) {
+                            global.AppData.recovery.windowSession.discard('simulation');
+                        }
+                    }
+                } catch (rollbackError) {
+                    console.warn('[SuitePractice] Unable to restore the pre-submit recovery mirror:', rollbackError);
+                }
+            };
+
             const derivedDuration = this._deriveSuiteExamElapsedSeconds(session, examId, data && data.duration);
             const normalized = this._normalizeSuiteResult(sequenceEntry.exam, Object.assign({}, data, {
                 duration: derivedDuration
@@ -247,7 +490,6 @@
             this._upsertSuiteResult(session, examId, normalized);
             this._syncSuiteTimerFromPayload(session, data);
             session.lastUpdate = Date.now();
-            this.updateExamStatus && this.updateExamStatus(examId, 'completed');
 
             this._persistSuiteDraftSnapshot(session, examId, data);
             if (Number.isFinite(Number(data && data.duration))) {
@@ -268,7 +510,12 @@
                     finalReview: currentIndex >= session.sequence.length - 1,
                     updatedAt: Date.now()
                 };
-                this._mirrorSessionToStorage(session);
+                const committed = await this._commitSuiteRecovery(session, { reason: 'passage-submit' });
+                if (!committed) {
+                    rollbackPassageSubmission();
+                    return withSubmitOutcome(true, false, 'suite_recovery_save_failed');
+                }
+                this.updateExamStatus && this.updateExamStatus(examId, 'completed');
                 const replayWindow = sourceWindow && !sourceWindow.closed
                     ? sourceWindow
                     : (session.windowRef && !session.windowRef.closed ? session.windowRef : null);
@@ -279,13 +526,22 @@
             }
 
             session.currentIndex = currentIndex + 1;
+            session.activeExamId = session.currentIndex < session.sequence.length
+                ? session.sequence[session.currentIndex].examId
+                : null;
             session.pendingAdvance = null;
-            this._mirrorSessionToStorage(session);
+            const passageCommitted = await this._commitSuiteRecovery(session, { reason: 'passage-submit' });
+            if (!passageCommitted) {
+                rollbackPassageSubmission();
+                return withSubmitOutcome(true, false, 'suite_recovery_save_failed');
+            }
+            this.updateExamStatus && this.updateExamStatus(examId, 'completed');
 
             // Last passage -> finalize the entire simulation
             if (session.currentIndex >= session.sequence.length) {
                 const deferTeardown = Boolean(data && data.submissionId && sourceWindow && !sourceWindow.closed);
-                const committed = await this.finalizeSuiteRecord(session, { deferTeardown });
+                session._finalizeSubmissionId = data && data.submissionId ? String(data.submissionId) : null;
+                const committed = await this._finalizeSuiteRecordWithGate(session, { deferTeardown });
                 return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', deferTeardown ? {
                     teardownSession: session
                 } : null);
@@ -301,7 +557,7 @@
             }
 
             const advanced = await this._advanceSuiteToNext(session, sequenceEntry.exam.title, examId);
-            return withSubmitOutcome(advanced, advanced, advanced ? '' : 'suite_advance_failed');
+            return withSubmitOutcome(true, true, advanced ? '' : 'suite_advance_failed');
         },
 
         async continueSuitePractice() {
@@ -314,6 +570,138 @@
                 return false;
             }
             return this._advanceSuiteToNext(session, 'previous section', null);
+        },
+
+        async resumeSuitePractice(expectedSessionId = '') {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            const expectedId = String(expectedSessionId || '').trim();
+            if (!expectedId || !session || String(session.id) !== expectedId) {
+                window.showMessage && window.showMessage('The unfinished suite changed. Please choose Continue again.', 'warning');
+                return false;
+            }
+            if (!session || !['active', 'initializing', 'finalizing'].includes(session.status)) {
+                return false;
+            }
+            if (session._resumePromise && typeof session._resumePromise.then === 'function') {
+                return session._resumePromise;
+            }
+
+            const resumePromise = (async () => {
+                const sequence = Array.isArray(session.sequence) ? session.sequence : [];
+                if (!sequence.length) {
+                    await this._discardStoredSuiteSession(session);
+                    return false;
+                }
+
+                // A terminal snapshot is deliberately never clamped back to P3. The
+                // aggregate record and operation id are replayed until v2 confirms it.
+                if (session.status === 'finalizing' || session.currentIndex >= sequence.length) {
+                    session.status = 'finalizing';
+                    session.currentIndex = sequence.length;
+                    session.activeExamId = null;
+                    if (!await this._commitSuiteRecovery(session, { reason: 'finalize-resume' })) return false;
+                    return this._finalizeSuiteRecordWithGate(session, { fromRecovery: true });
+                }
+                if (typeof this.openExam !== 'function') return false;
+
+                let currentExamIndex = null;
+                if (session._restoredFromStorage === true && typeof this._fetchSuiteExamIndex === 'function') {
+                    try {
+                        currentExamIndex = await this._fetchSuiteExamIndex();
+                    } catch (validationError) {
+                        console.warn('[SuitePractice] 无法验证恢复目标，保留快照供稍后重试:', validationError);
+                        window.showMessage && window.showMessage('暂时无法读取当前题库，未完成套题仍会保留。', 'warning');
+                        return false;
+                    }
+                    if (Array.isArray(currentExamIndex)) {
+                        const byId = new Map(currentExamIndex.map((entry) => {
+                            const id = entry && (entry.id ?? entry.examId);
+                            return id == null ? null : [String(id), entry];
+                        }).filter(Boolean));
+                        const targetId = String(sequence[session.currentIndex].examId);
+                        const missingSequenceEntry = sequence.some((entry) => !byId.has(String(entry.examId)));
+                        if (missingSequenceEntry || !byId.has(targetId)) {
+                            await this._discardStoredSuiteSession(session);
+                            window.showMessage && window.showMessage('未完成套题与当前题库不一致，恢复数据已清除。', 'warning');
+                            return false;
+                        }
+                        session.sequence = sequence.map((entry) => {
+                            const indexed = byId.get(String(entry.examId));
+                            return indexed
+                                ? { ...entry, exam: indexed, title: entry.title || indexed.title, category: entry.category || indexed.category }
+                                : entry;
+                        });
+                    }
+                }
+
+                const targetEntry = session.sequence[session.currentIndex];
+                if (!targetEntry || !targetEntry.examId) return false;
+                session.status = 'active';
+                session.activeExamId = targetEntry.examId;
+                session.windowRef = null;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'suite-resume' })) return false;
+
+                let launchContext = null;
+                try {
+                    launchContext = await this.openExam(targetEntry.examId, {
+                        target: 'tab',
+                        examDefinition: targetEntry.exam,
+                        windowName: session.windowName || 'ielts-suite-mode-tab',
+                        suiteSessionId: session.id,
+                        suiteFlowMode: session.flowMode || 'simulation',
+                        suiteTimerMode: session.suiteTimerMode || 'countdown',
+                        suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds))
+                            ? Number(session.suiteTimerLimitSeconds)
+                            : 3600,
+                        sequenceIndex: session.currentIndex,
+                        sequenceTotal: session.sequence.length,
+                        returnLaunchContext: true
+                    });
+                } catch (error) {
+                    console.warn('[SuitePractice] 恢复套题窗口失败:', error);
+                }
+                const examWindow = launchContext && launchContext.window
+                    ? launchContext.window
+                    : launchContext;
+                const registration = launchContext && launchContext.registration
+                    ? launchContext.registration
+                    : null;
+                if (!examWindow || examWindow.closed) {
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    this._mirrorSessionToStorage(session);
+                    window.showMessage && window.showMessage('未能打开未完成套题，请检查弹窗权限后再次点击套题模式。', 'warning');
+                    return false;
+                }
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                    return false;
+                }
+
+                session.windowRef = examWindow;
+                session._activeLaunchRegistration = registration;
+                session._restoredFromStorage = false;
+                this._ensureSuiteWindowGuard(session, examWindow);
+                this._focusSuiteWindow(examWindow);
+                if (session.flowMode === 'simulation') {
+                    this._sendSimulationContext(session, targetEntry.examId, examWindow);
+                } else if (session.pendingAdvance || (session.results || []).some((entry) => entry && entry.examId === targetEntry.examId)) {
+                    await this._sendSuiteReviewState(session, targetEntry.examId, examWindow).catch((error) => {
+                        console.warn('[SuitePractice] 恢复套题回看状态失败:', error);
+                    });
+                }
+                window.showMessage && window.showMessage(`已恢复未完成套题：${targetEntry.exam?.title || targetEntry.examId}`, 'success');
+                return true;
+            })();
+            session._resumePromise = resumePromise;
+            try {
+                return await resumePromise;
+            } finally {
+                if (session._resumePromise === resumePromise) delete session._resumePromise;
+            }
         },
 
         async _handleInlineSimulationSuiteSubmit(examId, data, sourceWindow = null) {
@@ -335,6 +723,21 @@
                 : '';
             if (payloadSuiteSessionId && payloadSuiteSessionId !== session.id) {
                 return false;
+            }
+            if (session.status === 'finalizing') {
+                session._finalizeSubmissionId = data && data.submissionId
+                    ? String(data.submissionId)
+                    : (session._finalizeSubmissionId || null);
+                const committed = await this._finalizeSuiteRecordWithGate(session, {
+                    deferTeardown: Boolean(
+                        session._finalizeSubmissionId
+                        && sourceWindow
+                        && !sourceWindow.closed
+                    )
+                });
+                return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', session._finalizeSubmissionId ? {
+                    teardownSession: committed ? session : null
+                } : null);
             }
             if (session.status === 'completed') {
                 return withSubmitOutcome(true, true, '', data && data.submissionId ? {
@@ -420,7 +823,8 @@
             }
             this._mirrorSessionToStorage(session);
             const deferTeardown = Boolean(data && data.submissionId && sourceWindow && !sourceWindow.closed);
-            const committed = await this.finalizeSuiteRecord(session, { deferTeardown });
+            session._finalizeSubmissionId = data && data.submissionId ? String(data.submissionId) : null;
+            const committed = await this._finalizeSuiteRecordWithGate(session, { deferTeardown });
             return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', deferTeardown ? {
                 teardownSession: session
             } : null);
@@ -553,16 +957,87 @@
             const previousDraft = session.draftsByExam[normalizedExamId] || null;
             const previousUpdatedAt = Number(previousDraft && previousDraft.updatedAt);
             const nextUpdatedAt = Number(nextDraft.updatedAt);
+            const suppliedUpdatedAt = Number(data && (data.draftUpdatedAt
+                ?? (data.draft && data.draft.updatedAt)
+                ?? data.updatedAt));
+            if (previousDraft && !Number.isFinite(suppliedUpdatedAt)) {
+                return false;
+            }
             if (
                 previousDraft
                 && Number.isFinite(previousUpdatedAt)
                 && Number.isFinite(nextUpdatedAt)
-                && nextUpdatedAt < previousUpdatedAt
+                && nextUpdatedAt <= previousUpdatedAt
             ) {
                 return false;
             }
+            nextDraft.updatedAt = Number.isFinite(suppliedUpdatedAt) ? suppliedUpdatedAt : nextDraft.updatedAt;
             session.draftsByExam[normalizedExamId] = nextDraft;
+            session.draftRevision = Math.max(0, Number(session.draftRevision) || 0) + 1;
+            const previousUpdate = Number(session.lastUpdate);
+            session.lastUpdate = Math.max(
+                Number.isFinite(previousUpdate) ? previousUpdate : 0,
+                Number.isFinite(suppliedUpdatedAt) ? suppliedUpdatedAt : Date.now(),
+                Date.now()
+            );
             return true;
+        },
+
+        _handleSuiteDraftSync(examId, data = {}, windowInfo = null, sourceWindow = null) {
+            const session = this.currentSuiteSession;
+            const normalizedExamId = examId != null ? String(examId).trim() : '';
+            const registeredWindowInfo = !this.examWindows
+                || (typeof this.examWindows.values === 'function'
+                    ? Array.from(this.examWindows.values()).includes(windowInfo)
+                    : Object.values(this.examWindows).includes(windowInfo));
+            const payloadSuiteId = data && data.suiteSessionId != null ? String(data.suiteSessionId).trim() : '';
+            const expectedSuiteId = windowInfo && windowInfo.suiteSessionId != null
+                ? String(windowInfo.suiteSessionId).trim()
+                : '';
+            const incomingUpdatedAt = Number(data && (data.draftUpdatedAt
+                ?? (data.draft && data.draft.updatedAt)
+                ?? data.updatedAt));
+            if (
+                !session
+                || !['active', 'initializing'].includes(session.status)
+                || !normalizedExamId
+                || !payloadSuiteId
+                || payloadSuiteId !== String(session.id)
+                || (expectedSuiteId && expectedSuiteId !== String(session.id))
+                || !windowInfo
+                || (this.examWindows && !registeredWindowInfo)
+                || !windowInfo.window
+                || windowInfo.window.closed
+                || (sourceWindow && sourceWindow !== windowInfo.window)
+                || (session.windowRef && session.windowRef.closed)
+                || (session.flowMode !== 'simulation' && session.windowRef && session.windowRef !== windowInfo.window)
+                || (session.flowMode !== 'simulation' && !session.windowRef && session.status !== 'initializing')
+                || !Number.isFinite(incomingUpdatedAt)
+                || incomingUpdatedAt <= 0
+                || !Array.isArray(session.sequence)
+                || !session.sequence.some((entry) => entry && String(entry.examId) === normalizedExamId)
+                || !data.draft
+                || typeof data.draft !== 'object'
+            ) {
+                return false;
+            }
+            if (!this._persistSuiteDraftSnapshot(session, normalizedExamId, data)) {
+                return false;
+            }
+            if (Number.isFinite(Number(data.elapsed))) {
+                session.elapsedByExam[normalizedExamId] = typeof this._deriveSuiteExamElapsedSeconds === 'function'
+                    ? this._deriveSuiteExamElapsedSeconds(session, normalizedExamId, Number(data.elapsed))
+                    : Math.max(0, Number(data.elapsed));
+            }
+            this._syncSuiteTimerFromPayload(session, data);
+            session.windowRef = windowInfo.window;
+            const indexedEntry = Number.isInteger(session.currentIndex)
+                ? session.sequence[session.currentIndex]
+                : null;
+            if (indexedEntry && String(indexedEntry.examId) === normalizedExamId) {
+                session.activeExamId = normalizedExamId;
+            }
+            return this._mirrorSessionToStorage(session);
         },
 
         _buildSuiteSequencePayload(session) {
@@ -596,6 +1071,28 @@
                 return JSON.parse(JSON.stringify(value));
             } catch (_) {
                 return Array.isArray(value) ? value.slice() : { ...value };
+            }
+        },
+
+        _suiteComparableValue(value) {
+            if (Array.isArray(value)) {
+                return value.map((item) => this._suiteComparableValue(item));
+            }
+            if (value && typeof value === 'object') {
+                return Object.keys(value).sort().reduce((result, key) => {
+                    result[key] = this._suiteComparableValue(value[key]);
+                    return result;
+                }, {});
+            }
+            return value;
+        },
+
+        _suiteValuesEqual(left, right) {
+            try {
+                return JSON.stringify(this._suiteComparableValue(left))
+                    === JSON.stringify(this._suiteComparableValue(right));
+            } catch (_) {
+                return false;
             }
         },
 
@@ -860,7 +1357,7 @@
                 currentIndex: sequenceIndex,
                 total: session.sequence.length,
                 canPrev: sequenceIndex > 0,
-                canNext: sequenceIndex < session.sequence.length - 1 || allowFinalizeFromNav,
+                canNext: viewMode === 'review' && (sequenceIndex < session.sequence.length - 1 || allowFinalizeFromNav),
                 finalizeOnNext: allowFinalizeFromNav,
                 title: (sequenceEntry.exam && sequenceEntry.exam.title) || sequenceEntry.examId || '',
                 examId: examId,
@@ -1062,6 +1559,9 @@
             const hasCurrentResult = Array.isArray(session.results)
                 ? session.results.some(item => item && item.examId === examId)
                 : false;
+            if (direction === 'next' && !hasCurrentResult) {
+                return false;
+            }
             const requestedFinalizeOnNext = Boolean(
                 direction === 'next'
                 && currentIndex === session.sequence.length - 1
@@ -1071,7 +1571,7 @@
             );
             if (requestedFinalizeOnNext) {
                 session.pendingAdvance = null;
-                await this.finalizeSuiteRecord(session);
+                await this._finalizeSuiteRecordWithGate(session);
                 return true;
             }
 
@@ -1085,7 +1585,7 @@
                 );
                 if (canFinalize) {
                     session.pendingAdvance = null;
-                    await this.finalizeSuiteRecord(session);
+                    await this._finalizeSuiteRecordWithGate(session);
                     return true;
                 }
                 return true;
@@ -1096,7 +1596,19 @@
                 return false;
             }
 
+            const previousIndex = session.currentIndex;
+            const previousActiveExamId = session.activeExamId;
+            session.currentIndex = targetIndex;
+            session.activeExamId = targetEntry.examId;
+            session.lastUpdate = Date.now();
+            if (!await this._commitSuiteRecovery(session, { reason: 'review-navigate' })) {
+                session.currentIndex = previousIndex;
+                session.activeExamId = previousActiveExamId;
+                return false;
+            }
+
             let targetWindow = sourceWindow && !sourceWindow.closed ? sourceWindow : (session.windowRef && !session.windowRef.closed ? session.windowRef : null);
+            let registration = null;
 
             const isCrossExamNavigation = targetEntry.examId !== examId;
             if (isCrossExamNavigation && typeof this.cleanupExamSession === 'function') {
@@ -1107,7 +1619,7 @@
                 }
             }
             if (isCrossExamNavigation || !targetWindow) {
-                targetWindow = await this.openExam(targetEntry.examId, {
+                const launchContext = await this.openExam(targetEntry.examId, {
                     examDefinition: targetEntry.exam,
                     target: 'tab',
                     windowName: session.windowName || 'ielts-suite-mode-tab',
@@ -1117,19 +1629,24 @@
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: targetIndex,
                     sequenceTotal: session.sequence.length,
-                    reuseWindow: targetWindow || undefined
+                    reuseWindow: targetWindow || undefined,
+                    returnLaunchContext: true
                 });
+                targetWindow = launchContext && launchContext.window ? launchContext.window : launchContext;
+                registration = launchContext && launchContext.registration ? launchContext.registration : null;
             }
 
             if (!targetWindow || targetWindow.closed) {
                 return false;
             }
+            if (registration
+                && typeof this._isExamSessionRegistrationCurrent === 'function'
+                && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                return false;
+            }
 
             session.windowRef = targetWindow;
-            session.currentIndex = targetIndex;
-            session.activeExamId = targetEntry.examId;
-            session.lastUpdate = Date.now();
-            this._mirrorSessionToStorage(session);
+            session._activeLaunchRegistration = registration;
             this._focusSuiteWindow(targetWindow);
             if (isCrossExamNavigation) {
                 const ready = await this._waitForSuiteWindowExamReady(session, targetEntry.examId, targetWindow);
@@ -1154,13 +1671,11 @@
         async _advanceSuiteToNext(session, completedTitle, skipExamIdForAbort) {
             if (typeof this.openExam !== 'function') {
                 window.showMessage && window.showMessage('无法继续套题练习，已回退到普通模式。', 'warning');
-                await this._abortSuiteSession(session, { reason: 'missing_open_exam', skipExamId: skipExamIdForAbort || null });
                 return false;
             }
 
             const nextEntry = session.sequence[session.currentIndex];
             if (!nextEntry || !nextEntry.examId) {
-                await this._abortSuiteSession(session, { reason: 'missing_next_entry', skipExamId: skipExamIdForAbort || null });
                 return false;
             }
 
@@ -1178,7 +1693,8 @@
                     suiteTimerMode: session.suiteTimerMode || 'countdown',
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: session.currentIndex,
-                    sequenceTotal: session.sequence.length
+                    sequenceTotal: session.sequence.length,
+                    returnLaunchContext: true
                 };
 
                 if (candidateWindow && !candidateWindow.closed) {
@@ -1190,8 +1706,12 @@
                         ...options,
                         examDefinition: nextEntry.exam
                     });
-                    if (opened && !opened.closed) {
-                        return opened;
+                    const openedWindow = opened && opened.window ? opened.window : opened;
+                    if (openedWindow && !openedWindow.closed) {
+                        return {
+                            window: openedWindow,
+                            registration: opened && opened.registration ? opened.registration : null
+                        };
                     }
                 } catch (error) {
                     openError = error;
@@ -1201,33 +1721,41 @@
                 return null;
             };
 
-            let nextWindow = null;
+            let nextLaunch = null;
             if (reuseWindow) {
-                nextWindow = await attemptOpen(reuseWindow);
+                nextLaunch = await attemptOpen(reuseWindow);
             }
 
-            if ((!nextWindow || nextWindow.closed) && windowName) {
+            if ((!nextLaunch || !nextLaunch.window || nextLaunch.window.closed) && windowName) {
                 const fallbackWindow = typeof this._reacquireSuiteWindow === 'function'
                     ? this._reacquireSuiteWindow(windowName, session)
                     : this._openNamedSuiteWindow(windowName, session);
                 if (fallbackWindow && !fallbackWindow.closed) {
-                    nextWindow = await attemptOpen(fallbackWindow);
+                    nextLaunch = await attemptOpen(fallbackWindow);
                 }
             }
 
+            const nextWindow = nextLaunch && nextLaunch.window;
             if (!nextWindow || nextWindow.closed) {
                 if (openError) {
                     console.warn('[SuitePractice] 套题无法打开下一篇:', openError);
                 }
                 window.showMessage && window.showMessage('无法继续套题练习，已回退到普通模式。', 'warning');
-                await this._abortSuiteSession(session, { reason: 'open_next_failed', skipExamId: skipExamIdForAbort || null });
+                session.windowRef = null;
+                session._restoredFromStorage = true;
+                return false;
+            }
+            if (nextLaunch.registration
+                && typeof this._isExamSessionRegistrationCurrent === 'function'
+                && !this._isExamSessionRegistrationCurrent(nextEntry.examId, nextLaunch.registration)) {
                 return false;
             }
 
             session.windowRef = nextWindow;
+            session._activeLaunchRegistration = nextLaunch.registration || null;
+            session._restoredFromStorage = false;
             this._ensureSuiteWindowGuard(session, session.windowRef);
             this._focusSuiteWindow(session.windowRef);
-            this._mirrorSessionToStorage(session);
             const reusedNextWindow = Boolean(reuseWindow && nextWindow === reuseWindow);
             if (reusedNextWindow) {
                 const ready = await this._waitForSuiteWindowExamReady(session, nextEntry.examId, session.windowRef);
@@ -1247,21 +1775,40 @@
             return true;
         },
 
-        _mirrorSessionToStorage(session) {
-            if (!session) return;
+        _buildSuiteRecoverySnapshot(session, options = {}) {
+            if (!session) return null;
             try {
+                const now = Date.now();
+                const previousUpdate = Number(session.lastUpdate);
+                if (options.bumpLastUpdate !== false) {
+                    session.lastUpdate = Number.isFinite(previousUpdate)
+                        ? Math.max(now, previousUpdate + 1)
+                        : now;
+                }
+                if (options.bumpRevision !== false) {
+                    session.revision = Math.max(0, Number(session.revision) || 0) + 1;
+                }
                 const snapshot = {
+                    schema: 'suite-session-v2',
+                    version: 2,
                     id: session.id,
-                    sequence: session.sequence,
+                    status: session.status || 'active',
+                    sequence: this._cloneSuitePlainObject(session.sequence || []),
                     suiteSequence: this._buildSuiteSequencePayload(session),
-                    currentIndex: session.currentIndex,
-                    draftsByExam: session.draftsByExam || {},
-                    elapsedByExam: session.elapsedByExam || {},
-                    globalTimerAnchorMs: session.globalTimerAnchorMs,
+                    currentIndex: Number.isInteger(session.currentIndex) ? session.currentIndex : 0,
+                    draftsByExam: this._cloneSuitePlainObject(session.draftsByExam || {}),
+                    elapsedByExam: this._cloneSuitePlainObject(session.elapsedByExam || {}),
+                    globalTimerAnchorMs: Number(session.globalTimerAnchorMs) || Number(session.startTime) || now,
+                    suiteTimerAnchorMs: Number(session.suiteTimerAnchorMs) || Number(session.globalTimerAnchorMs) || Number(session.startTime) || now,
+                    suiteTimerMode: session.suiteTimerMode || 'countdown',
+                    suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds))
+                        ? Number(session.suiteTimerLimitSeconds)
+                        : 3600,
                     suiteTimerPausedOffsetMs: Math.max(0, Number(session.suiteTimerPausedOffsetMs) || 0),
                     suiteTimerPausedAtMs: Number.isFinite(Number(session.suiteTimerPausedAtMs)) ? Number(session.suiteTimerPausedAtMs) : null,
                     suiteTimerRunning: session.suiteTimerRunning !== false,
                     flowMode: session.flowMode || 'simulation',
+                    frequencyScope: session.frequencyScope || 'all',
                     autoAdvanceAfterSubmit: typeof session.autoAdvanceAfterSubmit === 'boolean'
                         ? session.autoAdvanceAfterSubmit
                         : true,
@@ -1272,25 +1819,320 @@
                         markedQuestions: Array.isArray(r.markedQuestions) ? r.markedQuestions.slice() : [],
                         rawData: this._sanitizeSuiteRawData(r.rawData)
                     })),
-                    startTime: session.startTime,
-                    activeExamId: session.activeExamId
+                    startTime: Number(session.startTime) || now,
+                    activeExamId: session.activeExamId || null,
+                    pendingAdvance: session.pendingAdvance && typeof session.pendingAdvance === 'object'
+                        ? this._cloneSuitePlainObject(session.pendingAdvance)
+                        : null,
+                    windowName: session.windowName || 'ielts-suite-mode-tab',
+                    lastUpdate: session.lastUpdate,
+                    revision: session.revision,
+                    draftRevision: Math.max(0, Number(session.draftRevision) || 0),
+                    finalizeOperationId: session.finalizeOperationId || null,
+                    finalizeRecord: session.finalizeRecord
+                        ? this._cloneSuitePlainObject(session.finalizeRecord)
+                        : null
                 };
-                global.AppData.recovery.windowSession.save('simulation', snapshot);
-            } catch (_) { /* file:// may not support */ }
-        },
-
-        _restoreSessionFromStorage() {
-            try {
-                const snapshot = global.AppData.recovery.windowSession.get('simulation');
-                if (!snapshot || !snapshot.id || !Array.isArray(snapshot.sequence)) return null;
                 return snapshot;
-            } catch (_) { return null; }
+            } catch (error) {
+                console.warn('[SuitePractice] Unable to build suite recovery snapshot:', error);
+                return null;
+            }
         },
 
-        _clearSessionStorage() {
+        _mirrorSuiteRecoverySnapshot(snapshot) {
+            if (!snapshot || !global.AppData?.recovery?.windowSession) return false;
             try {
+                return global.AppData.recovery.windowSession.save('simulation', snapshot) !== false;
+            } catch (error) {
+                console.warn('[SuitePractice] Suite recovery window mirror failed:', error);
+                return false;
+            }
+        },
+
+        _mirrorSessionToStorage(session) {
+            return this._mirrorSuiteRecoverySnapshot(this._buildSuiteRecoverySnapshot(session));
+        },
+
+        async _commitSuiteRecovery(session, options = {}) {
+            if (!session || !session.id || session._suiteRecoveryClosed === true) return false;
+            const previous = session._suiteRecoveryCommitTail && typeof session._suiteRecoveryCommitTail.then === 'function'
+                ? session._suiteRecoveryCommitTail
+                : Promise.resolve();
+            const commit = previous.catch(() => undefined).then(async () => {
+                if (session._suiteRecoveryClosed === true) return false;
+                const recovery = global.AppData && global.AppData.recovery;
+                if (!recovery || typeof recovery.saveActiveSession !== 'function') {
+                    throw new Error('AppData recovery.saveActiveSession is unavailable');
+                }
+                const snapshot = this._buildSuiteRecoverySnapshot(session);
+                if (!snapshot) throw new Error('Suite recovery snapshot could not be built');
+                const snapshotRevision = Number(snapshot.revision) || 0;
+                const receipt = await recovery.saveActiveSession(snapshot, {
+                    operationId: `suite-recovery:${String(session.id)}:${snapshotRevision}`
+                });
+                if (!receipt || receipt.committed !== true) {
+                    throw new Error('Suite recovery commit was not confirmed');
+                }
+                this._mirrorSuiteRecoverySnapshot(snapshot);
+                return true;
+            });
+            session._suiteRecoveryCommitTail = commit;
+            try {
+                return await commit;
+            } catch (error) {
+                console.warn('[SuitePractice] Durable suite recovery write failed:', error);
+                if (options.notify !== false) {
+                    window.showMessage && window.showMessage('Suite progress could not be saved. This action was paused; allow site storage and try again.', 'error');
+                }
+                return false;
+            } finally {
+                if (session._suiteRecoveryCommitTail === commit) {
+                    delete session._suiteRecoveryCommitTail;
+                }
+            }
+        },
+
+        async _discardPersistentSuiteRecovery(session) {
+            if (!session || !session.id) return false;
+            session._suiteRecoveryClosed = true;
+            const pending = session._suiteRecoveryCommitTail;
+            if (pending && typeof pending.then === 'function') {
+                try {
+                    await pending;
+                } catch (_) {}
+            }
+            const recovery = global.AppData && global.AppData.recovery;
+            if (!recovery || typeof recovery.discardActiveSession !== 'function') {
+                session._suiteRecoveryClosed = false;
+                return false;
+            }
+            try {
+                const receipt = await recovery.discardActiveSession(String(session.id), {
+                    operationId: `suite-recovery:${String(session.id)}:discard`
+                });
+                if (!receipt || receipt.committed !== true) {
+                    throw new Error('Suite recovery discard was not confirmed');
+                }
+                return true;
+            } catch (error) {
+                session._suiteRecoveryClosed = false;
+                console.warn('[SuitePractice] Durable suite recovery discard failed:', error);
+                window.showMessage && window.showMessage('The unfinished suite could not be removed from storage. Please try again.', 'error');
+                return false;
+            }
+        },
+
+        _restoreSessionFromStorage(providedSnapshot = null) {
+            const clearInvalidWindowSnapshot = () => {
+                if (providedSnapshot == null) this._clearSessionStorage();
+            };
+            try {
+                const snapshot = providedSnapshot
+                    || global.AppData?.recovery?.windowSession?.get?.('simulation')
+                    || null;
+                if (!snapshot || typeof snapshot !== 'object' || !snapshot.id) return null;
+                if (snapshot.schema !== 'suite-session-v2' || Number(snapshot.version) !== 2) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const statusValue = String(snapshot.status || 'active').trim().toLowerCase();
+                if (!['initializing', 'active', 'finalizing'].includes(statusValue)) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const rawSequence = Array.isArray(snapshot.sequence)
+                    ? snapshot.sequence
+                    : (Array.isArray(snapshot.suiteSequence) ? snapshot.suiteSequence : []);
+                const sequence = rawSequence.map((entry) => {
+                    if (!entry || typeof entry !== 'object') return null;
+                    const exam = entry.exam && typeof entry.exam === 'object' ? entry.exam : entry;
+                    const examId = String(entry.examId ?? exam.id ?? '').trim();
+                    if (!examId) return null;
+                    return {
+                        ...this._cloneSuitePlainObject(entry),
+                        examId,
+                        exam: { ...this._cloneSuitePlainObject(exam), id: exam.id || examId }
+                    };
+                }).filter(Boolean);
+                const sequenceIds = sequence.map((entry) => String(entry.examId));
+                const flowMode = String(snapshot.flowMode || 'simulation').trim().toLowerCase();
+                const timerMode = String(snapshot.suiteTimerMode || 'countdown').trim().toLowerCase();
+                const timerLimit = Number(snapshot.suiteTimerLimitSeconds);
+                if (
+                    !sequence.length
+                    || new Set(sequenceIds).size !== sequenceIds.length
+                    || !['classic', 'simulation', 'stationary'].includes(flowMode)
+                    || !['countdown', 'elapsed'].includes(timerMode)
+                    || !Number.isFinite(timerLimit)
+                    || timerLimit <= 0
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const rawIndex = Number(snapshot.currentIndex);
+                if (!Number.isInteger(rawIndex) || rawIndex < 0 || rawIndex > sequence.length) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const results = Array.isArray(snapshot.results)
+                    ? this._cloneSuitePlainObject(snapshot.results)
+                    : [];
+                if (results.some((entry) => !this._isValidSuiteRecoveryResult(entry, sequenceIds))) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const expectedOperationId = `practice-suite:${String(snapshot.id)}:finalize`;
+                if (snapshot.finalizeOperationId && snapshot.finalizeOperationId !== expectedOperationId) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                if (snapshot.finalizeRecord) {
+                    const finalizeRecord = snapshot.finalizeRecord;
+                    if (!this._isValidSuiteFinalizeRecord({
+                        id: snapshot.id,
+                        sequence,
+                        results
+                    }, finalizeRecord)) {
+                        clearInvalidWindowSnapshot();
+                        return null;
+                    }
+                }
+                const autoAdvance = snapshot.autoAdvanceAfterSubmit !== false;
+                const activeId = snapshot.activeExamId != null ? String(snapshot.activeExamId).trim() : '';
+                const activeIndex = activeId
+                    ? sequence.findIndex((entry) => String(entry.examId) === activeId)
+                    : -1;
+                const resultIds = results
+                    .map((entry) => entry && String(entry.examId || '').trim())
+                    .filter(Boolean);
+                const terminalSnapshot = statusValue === 'finalizing' || rawIndex === sequence.length;
+                if (
+                    new Set(resultIds).size !== resultIds.length
+                    || resultIds.some((examId) => !sequenceIds.includes(examId))
+                    || (terminalSnapshot && (
+                        resultIds.length !== sequenceIds.length
+                        || sequenceIds.some((examId) => !resultIds.includes(examId))
+                    ))
+                    || (statusValue !== 'finalizing' && activeId && activeIndex < 0)
+                    || (terminalSnapshot && rawIndex !== sequence.length)
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                if (
+                    statusValue !== 'finalizing'
+                    && activeIndex >= 0
+                    && activeIndex !== rawIndex
+                    && !(autoAdvance && rawIndex === activeIndex + 1 && results.some((entry) => entry && String(entry.examId) === activeId))
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                let currentIndex = rawIndex;
+                let status = statusValue;
+                if (status === 'finalizing' || currentIndex === sequence.length) {
+                    status = 'finalizing';
+                    currentIndex = sequence.length;
+                } else if (
+                    autoAdvance
+                    && activeIndex >= 0
+                    && currentIndex === activeIndex
+                    && results.some((entry) => entry && String(entry.examId) === activeId)
+                    && currentIndex + 1 < sequence.length
+                ) {
+                    currentIndex += 1;
+                }
+                const activeExamId = status === 'finalizing'
+                    ? null
+                    : (sequence[currentIndex] && sequence[currentIndex].examId) || activeId || sequence[0].examId;
+                const now = Date.now();
+                return {
+                    id: String(snapshot.id),
+                    status,
+                    startTime: Number(snapshot.startTime) || now,
+                    sequence,
+                    currentIndex,
+                    results,
+                    draftsByExam: snapshot.draftsByExam && typeof snapshot.draftsByExam === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.draftsByExam)
+                        : {},
+                    elapsedByExam: snapshot.elapsedByExam && typeof snapshot.elapsedByExam === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.elapsedByExam)
+                        : {},
+                    globalTimerAnchorMs: Number(snapshot.globalTimerAnchorMs) || Number(snapshot.startTime) || now,
+                    suiteTimerAnchorMs: Number(snapshot.suiteTimerAnchorMs) || Number(snapshot.globalTimerAnchorMs) || Number(snapshot.startTime) || now,
+                    suiteTimerMode: timerMode,
+                    suiteTimerLimitSeconds: timerLimit,
+                    suiteTimerPausedOffsetMs: Math.max(0, Number(snapshot.suiteTimerPausedOffsetMs) || 0),
+                    suiteTimerPausedAtMs: Number.isFinite(Number(snapshot.suiteTimerPausedAtMs)) ? Number(snapshot.suiteTimerPausedAtMs) : null,
+                    suiteTimerRunning: snapshot.suiteTimerRunning !== false,
+                    flowMode,
+                    frequencyScope: snapshot.frequencyScope || 'all',
+                    autoAdvanceAfterSubmit: autoAdvance,
+                    pendingAdvance: snapshot.pendingAdvance && typeof snapshot.pendingAdvance === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.pendingAdvance)
+                        : null,
+                    activeExamId,
+                    windowRef: null,
+                    windowName: snapshot.windowName || 'ielts-suite-mode-tab',
+                    lastUpdate: Number.isFinite(Number(snapshot.lastUpdate)) ? Number(snapshot.lastUpdate) : now,
+                    revision: Math.max(0, Number(snapshot.revision) || 0),
+                    draftRevision: Math.max(0, Number(snapshot.draftRevision) || 0),
+                    finalizeOperationId: snapshot.finalizeOperationId || (snapshot.finalizeRecord ? expectedOperationId : null),
+                    finalizeRecord: snapshot.finalizeRecord && typeof snapshot.finalizeRecord === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.finalizeRecord)
+                        : null,
+                    _restoredFromStorage: true
+                };
+            } catch (error) {
+                console.warn('[SuitePractice] 套题恢复快照读取失败:', error);
+                clearInvalidWindowSnapshot();
+                return null;
+            }
+        },
+
+        _clearSessionStorage(session = null) {
+            try {
+                if (session && global.AppData?.recovery?.windowSession
+                    && typeof global.AppData.recovery.windowSession.get === 'function') {
+                    const snapshot = global.AppData.recovery.windowSession.get('simulation');
+                    if (snapshot && snapshot.id && String(snapshot.id) !== String(session.id)) {
+                        return false;
+                    }
+                }
                 global.AppData.recovery.windowSession.discard('simulation');
+                return true;
             } catch (_) { /* ignore */ }
+            return false;
+        },
+
+        async _discardStoredSuiteSession(session) {
+            if (!session) return false;
+            if (!await this._discardPersistentSuiteRecovery(session)) return false;
+            if (this.suiteExamMap && Array.isArray(session.sequence)) {
+                session.sequence.forEach((entry) => {
+                    if (entry && entry.examId != null
+                        && this.suiteExamMap.get(String(entry.examId)) === session.id) {
+                        this.suiteExamMap.delete(String(entry.examId));
+                    }
+                });
+            }
+            if (this.currentSuiteSession === session) this.currentSuiteSession = null;
+            this._clearSessionStorage(session);
+            return true;
+        },
+
+        _notifySuiteResumeAvailable(session) {
+            if (!session || this._suiteResumeNoticeShown) return;
+            this._suiteResumeNoticeShown = true;
+            const activeEntry = Array.isArray(session.sequence)
+                ? session.sequence.find((entry) => entry && String(entry.examId) === String(session.activeExamId))
+                : null;
+            const title = activeEntry && activeEntry.exam && activeEntry.exam.title
+                ? activeEntry.exam.title
+                : (session.activeExamId || '当前篇章');
+            window.showMessage && window.showMessage(`检测到未完成套题：${title}。请选择继续或放弃。`, 'info');
         },
 
         _syncSuiteTimerFromPayload(session, data = {}) {
@@ -1316,18 +2158,31 @@
                 const existingOffsetMs = Math.max(0, Number(session.suiteTimerPausedOffsetMs) || 0);
                 session.suiteTimerPausedOffsetMs = Math.max(existingOffsetMs, Math.max(0, pausedOffsetMs));
             }
-            const running = timerSnapshot ? timerSnapshot.running : data.suiteTimerRunning;
-            session.suiteTimerRunning = running !== false;
-            const pausedAtMs = Number(
-                (timerSnapshot && timerSnapshot.pausedAtMs)
-                ?? data.suiteTimerPausedAtMs
-                ?? data.pausedAtMs
+            const hasExplicitRunning = Boolean(
+                (timerSnapshot && Object.prototype.hasOwnProperty.call(timerSnapshot, 'running'))
+                || Object.prototype.hasOwnProperty.call(data, 'suiteTimerRunning')
             );
-            session.suiteTimerPausedAtMs = (
-                session.suiteTimerRunning === false
-                && Number.isFinite(pausedAtMs)
-                && pausedAtMs > 0
-            ) ? Math.floor(pausedAtMs) : null;
+            const hasExplicitPausedAt = Boolean(
+                (timerSnapshot && Object.prototype.hasOwnProperty.call(timerSnapshot, 'pausedAtMs'))
+                || Object.prototype.hasOwnProperty.call(data, 'suiteTimerPausedAtMs')
+                || Object.prototype.hasOwnProperty.call(data, 'pausedAtMs')
+            );
+            if (hasExplicitRunning || hasExplicitPausedAt) {
+                const pausedAtMs = Number(
+                    (timerSnapshot && timerSnapshot.pausedAtMs)
+                    ?? data.suiteTimerPausedAtMs
+                    ?? data.pausedAtMs
+                );
+                const running = hasExplicitRunning
+                    ? (timerSnapshot ? timerSnapshot.running : data.suiteTimerRunning)
+                    : !(Number.isFinite(pausedAtMs) && pausedAtMs > 0);
+                session.suiteTimerRunning = running !== false;
+                session.suiteTimerPausedAtMs = (
+                    session.suiteTimerRunning === false
+                    && Number.isFinite(pausedAtMs)
+                    && pausedAtMs > 0
+                ) ? Math.floor(pausedAtMs) : null;
+            }
         },
 
         _computeSuiteElapsedSeconds(session, referenceNow = Date.now()) {
@@ -1404,6 +2259,9 @@
                     examId,
                     sessionId: windowInfo && windowInfo.expectedSessionId ? windowInfo.expectedSessionId : null,
                     windowSessionToken: windowInfo && windowInfo.windowSessionToken ? windowInfo.windowSessionToken : null,
+                    windowSessionGeneration: windowInfo && Number.isInteger(windowInfo.sessionGeneration)
+                        ? windowInfo.sessionGeneration
+                        : 0,
                     messageIssuedAtMs,
                     suiteSequence: this._buildSuiteSequencePayload(session),
                     currentIndex: idx,
@@ -1508,10 +2366,18 @@
                 const targetEntry = session.sequence[targetIdx];
                 if (!targetEntry || !targetEntry.examId) return false;
 
+                const previousIndex = session.currentIndex;
+                const previousActiveExamId = session.activeExamId;
                 session.currentIndex = targetIdx;
                 session.activeExamId = targetEntry.examId;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'simulation-navigate' })) {
+                    session.currentIndex = previousIndex;
+                    session.activeExamId = previousActiveExamId;
+                    return false;
+                }
 
-                const targetWindow = await this.openExam(targetEntry.examId, {
+                const launchContext = await this.openExam(targetEntry.examId, {
                     examDefinition: targetEntry.exam,
                     target: 'tab',
                     windowName: session.windowName || 'ielts-suite-mode-tab',
@@ -1521,13 +2387,21 @@
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: targetIdx,
                     sequenceTotal: session.sequence.length,
-                    reuseWindow: sourceWindow && !sourceWindow.closed ? sourceWindow : undefined
+                    reuseWindow: sourceWindow && !sourceWindow.closed ? sourceWindow : undefined,
+                    returnLaunchContext: true
                 });
+                const targetWindow = launchContext && launchContext.window ? launchContext.window : launchContext;
+                const registration = launchContext && launchContext.registration ? launchContext.registration : null;
 
                 if (!targetWindow || targetWindow.closed) return false;
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                    return false;
+                }
 
                 session.windowRef = targetWindow;
-                this._mirrorSessionToStorage(session);
+                session._activeLaunchRegistration = registration;
                 const reusedSourceWindow = Boolean(
                     sourceWindow
                     && !sourceWindow.closed
@@ -2087,13 +2961,70 @@
             return aggregated;
         },
 
+        async _finalizeSuiteRecordWithGate(session, options = {}) {
+            if (!session) return false;
+            if (session._finalizePromise && typeof session._finalizePromise.then === 'function') {
+                return session._finalizePromise;
+            }
+            const finalizePromise = this.finalizeSuiteRecord(session, options);
+            session._finalizePromise = finalizePromise;
+            try {
+                return await finalizePromise;
+            } finally {
+                if (session._finalizePromise === finalizePromise) {
+                    session._finalizePromise = null;
+                }
+            }
+        },
+
         async finalizeSuiteRecord(session, options = {}) {
-            if (!session || !session.results || !session.results.length) {
-                await this._teardownSuiteSession(session);
+            if (!session || !Array.isArray(session.sequence) || !session.sequence.length) {
+                return false;
+            }
+
+            const sequenceIds = session.sequence
+                .map((entry) => entry && String(entry.examId || '').trim())
+                .filter(Boolean);
+            const results = Array.isArray(session.results) ? session.results : [];
+            const resultIds = results
+                .map((entry) => entry && String(entry.examId || '').trim())
+                .filter(Boolean);
+            const invalidResultIndex = results.findIndex((entry) => !this._isValidSuiteRecoveryResult(entry, sequenceIds));
+            const invalidResultExamId = invalidResultIndex >= 0 && results[invalidResultIndex]
+                ? String(results[invalidResultIndex].examId || '').trim()
+                : '';
+            const invalidSequenceIndex = invalidResultExamId ? sequenceIds.indexOf(invalidResultExamId) : -1;
+            const missingResultIndex = session.sequence.findIndex((entry) => (
+                entry && !resultIds.includes(String(entry.examId))
+            ));
+            const completeResults = Boolean(
+                sequenceIds.length === session.sequence.length
+                && resultIds.length === sequenceIds.length
+                && new Set(resultIds).size === resultIds.length
+                && invalidResultIndex < 0
+                && sequenceIds.every((examId) => resultIds.includes(examId))
+            );
+            if (!completeResults) {
+                const recoveryIndex = invalidSequenceIndex >= 0 ? invalidSequenceIndex : missingResultIndex;
+                const safeIndex = recoveryIndex >= 0
+                    ? recoveryIndex
+                    : Math.min(Math.max(0, Number(session.currentIndex) || 0), session.sequence.length - 1);
+                session.status = 'active';
+                session.currentIndex = safeIndex;
+                session.activeExamId = session.sequence[safeIndex] && session.sequence[safeIndex].examId || null;
+                session.finalizeOperationId = null;
+                session.finalizeRecord = null;
+                session.lastUpdate = Date.now();
+                await this._commitSuiteRecovery(session, { notify: false, reason: 'incomplete-finalize' });
+                window.showMessage && window.showMessage('套题结果不完整，请完成缺失篇章后再提交。', 'warning');
                 return false;
             }
 
             session.status = 'finalizing';
+            session.currentIndex = session.sequence.length;
+            session.activeExamId = null;
+            session.lastUpdate = Date.now();
+            if (!await this._commitSuiteRecovery(session, { reason: 'finalize-start' })) return false;
 
             let committed = false;
             try {
@@ -2167,7 +3098,7 @@
                 const dateLabel = this._formatSuiteDateLabel(startTime);
                 const displayTitle = dateLabel + '套题练习' + suiteSequence;
 
-                const record = {
+                const builtRecord = {
                     id: session.id,
                     examId: 'suite-' + session.id,
                     title: displayTitle,
@@ -2210,22 +3141,29 @@
                     sessionId: session.id
                 };
 
+                const expectedOperationId = `practice-suite:${String(session.id)}:finalize`;
+                session.finalizeOperationId = expectedOperationId;
+                const persistedRecord = session.finalizeRecord && this._isValidSuiteFinalizeRecord(session, session.finalizeRecord)
+                    ? this._cloneSuitePlainObject(session.finalizeRecord)
+                    : builtRecord;
+                const record = persistedRecord;
+                record.operationId = expectedOperationId;
+                session.finalizeRecord = this._cloneSuitePlainObject(record);
+                if (!await this._commitSuiteRecovery(session, { reason: 'finalize-record' })) return false;
+
                 await this._saveSuitePracticeRecord(record);
                 committed = true;
                 session.status = 'completed';
             } catch (error) {
                 console.error('[SuitePractice] 保存套题记录失败:', error);
                 try {
-                    window.showMessage && window.showMessage('套题记录保存失败，系统将尝试恢复到普通模式。', 'error');
+                    window.showMessage && window.showMessage('套题记录保存失败，恢复快照已保留，请稍后重试。', 'error');
                 } catch (notificationError) {
                     console.warn('[SuitePractice] 显示套题保存失败通知时出错:', notificationError);
                 }
-                try {
-                    await this._savePartialSuiteAsIndividual(session);
-                } catch (fallbackError) {
-                    console.warn('[SuitePractice] 聚合记录未保存，单篇恢复也失败:', fallbackError);
-                }
-                session.status = options.deferTeardown ? 'active' : 'error';
+                session.status = 'finalizing';
+                session.lastUpdate = Date.now();
+                await this._commitSuiteRecovery(session, { notify: false, reason: 'finalize-error' });
             }
 
             if (committed) {
@@ -2238,7 +3176,7 @@
                 });
             }
 
-            if (!options.deferTeardown) {
+            if (committed && !options.deferTeardown) {
                 await this._runSuitePostCommitStep('清理套题会话窗口', () => this._teardownSuiteSession(session));
             }
             return committed;
@@ -2533,7 +3471,10 @@
             );
 
             try {
-                if (this.currentSuiteSession && this.currentSuiteSession.status === 'active') {
+                if (this.currentSuiteSession && this.currentSuiteSession.status === 'completed') {
+                    if (!await this._teardownSuiteSession(this.currentSuiteSession)) return false;
+                }
+                if (this.currentSuiteSession && ['active', 'initializing', 'finalizing'].includes(this.currentSuiteSession.status)) {
                     window.showMessage && window.showMessage('套题练习正在进行中，请先完成当前套题。', 'warning');
                     return false;
                 }
@@ -2560,9 +3501,10 @@
                 const timerAnchorMs = Date.now();
                 const suiteTimerMode = 'countdown';
                 const suiteTimerLimitSeconds = 3600;
+                const firstEntry = normalizedSequence[0];
                 const session = {
                     id: suiteSessionId,
-                    status: 'initializing',
+                    status: 'active',
                     startTime: timerAnchorMs,
                     sequence: normalizedSequence,
                     currentIndex: 0,
@@ -2579,19 +3521,25 @@
                     flowMode,
                     frequencyScope,
                     autoAdvanceAfterSubmit: lockedAutoAdvance,
+                    activeExamId: firstEntry.examId,
                     windowRef: null,
                     windowName: suiteWindowName
                 };
 
                 this.currentSuiteSession = session;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'suite-start' })) {
+                    if (this.currentSuiteSession === session) this.currentSuiteSession = null;
+                    this._clearSessionStorage(session);
+                    return false;
+                }
                 this._registerSuiteSequence(session);
 
-                const firstEntry = normalizedSequence[0];
                 window.showMessage && window.showMessage(launchLabel + ' 已启动，正在打开第一篇。', 'info');
 
-                let examWindow = null;
+                let launchContext = null;
                 try {
-                    examWindow = await this.openExam(firstEntry.examId, {
+                    launchContext = await this.openExam(firstEntry.examId, {
                         examDefinition: firstEntry.exam,
                         target: 'tab',
                         windowName: suiteWindowName,
@@ -2600,21 +3548,39 @@
                         suiteTimerMode,
                         suiteTimerLimitSeconds,
                         sequenceIndex: 0,
-                        sequenceTotal: normalizedSequence.length
+                        sequenceTotal: normalizedSequence.length,
+                        returnLaunchContext: true
                     });
                 } catch (openError) {
                     console.error('[SuitePractice] 打开首篇失败:', openError);
-                    examWindow = null;
+                    launchContext = null;
                 }
 
+                const examWindow = launchContext && launchContext.window
+                    ? launchContext.window
+                    : launchContext;
+                const registration = launchContext && launchContext.registration
+                    ? launchContext.registration
+                    : null;
                 if (!examWindow || examWindow.closed) {
-                    throw new Error('first_exam_window_unavailable');
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    window.showMessage && window.showMessage('首篇窗口未能打开，套题已安全保存；允许弹窗后可继续。', 'warning');
+                    return false;
+                }
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(firstEntry.examId, registration)) {
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    return false;
                 }
 
                 session.windowRef = examWindow;
+                session._activeLaunchRegistration = registration;
                 this._ensureSuiteWindowGuard(session, session.windowRef);
-                session.status = 'active';
-                session.activeExamId = firstEntry.examId;
+                session._restoredFromStorage = false;
+                session.lastUpdate = Date.now();
                 this._focusSuiteWindow(session.windowRef);
                 if (flowMode === 'simulation') {
                     this._sendSimulationContext(session, firstEntry.examId, session.windowRef);
@@ -2623,9 +3589,6 @@
             } catch (error) {
                 console.error('[SuitePractice] 启动失败:', error);
                 window.showMessage && window.showMessage('套题练习启动失败，请稍后重试。', 'error');
-                if (this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
-                }
                 return false;
             }
         },
@@ -2720,6 +3683,143 @@
             };
         },
 
+        _isValidSuiteScoreInfo(scoreInfo) {
+            if (!scoreInfo || typeof scoreInfo !== 'object' || Array.isArray(scoreInfo)) return false;
+            const correct = Number(scoreInfo.correct);
+            const total = Number(scoreInfo.total);
+            const accuracy = Number(scoreInfo.accuracy);
+            const percentage = Number(scoreInfo.percentage);
+            return Boolean(
+                Number.isFinite(correct)
+                && Number.isFinite(total)
+                && Number.isFinite(accuracy)
+                && Number.isFinite(percentage)
+                && correct >= 0
+                && total >= 0
+                && correct <= total
+                && accuracy >= 0
+                && accuracy <= 1
+                && percentage >= 0
+                && percentage <= 100
+            );
+        },
+
+        _isValidSuiteRecoveryResult(entry, sequenceIds = []) {
+            if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+            const examId = String(entry.examId || '').trim();
+            const duration = Number(entry.duration);
+            return Boolean(
+                examId
+                && (!sequenceIds.length || sequenceIds.includes(examId))
+                && Number.isFinite(duration)
+                && duration >= 0
+                && this._isValidSuiteScoreInfo(entry.scoreInfo)
+                && entry.answers
+                && typeof entry.answers === 'object'
+                && entry.answerComparison
+                && typeof entry.answerComparison === 'object'
+            );
+        },
+
+        _isValidSuiteFinalizeEntry(entry, sequenceIds = []) {
+            return Boolean(
+                this._isValidSuiteRecoveryResult(entry, sequenceIds)
+                && Array.isArray(entry.markedQuestions)
+                && Array.isArray(entry.highlights)
+                && typeof entry.noteText === 'string'
+                && Array.isArray(entry.notes)
+                && Array.isArray(entry.noteOutlines)
+                && Number.isFinite(Number(entry.scrollY))
+            );
+        },
+
+        _isValidSuiteFinalizeRecord(session, record) {
+            if (!session || !record || typeof record !== 'object') return false;
+            const sequenceIds = Array.isArray(session.sequence)
+                ? session.sequence.map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean)
+                : [];
+            const recordEntries = Array.isArray(record.suiteEntries) ? record.suiteEntries : [];
+            const recordIds = recordEntries
+                .map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean);
+            const results = Array.isArray(session.results) ? session.results : [];
+            const resultIds = results.map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean);
+            const expectedAnswers = {};
+            const expectedComparison = {};
+            let expectedCorrect = 0;
+            let expectedTotal = 0;
+            results.forEach((entry) => {
+                const examId = String(entry && entry.examId || '').trim();
+                const prefix = examId ? `${examId}::` : '';
+                expectedCorrect += Number(entry && entry.scoreInfo && entry.scoreInfo.correct) || 0;
+                expectedTotal += Number(entry && entry.scoreInfo && entry.scoreInfo.total) || 0;
+                Object.entries(entry && entry.answers && typeof entry.answers === 'object' ? entry.answers : {})
+                    .forEach(([questionId, answer]) => {
+                        expectedAnswers[prefix + questionId] = answer;
+                    });
+                Object.entries(entry && entry.answerComparison && typeof entry.answerComparison === 'object' ? entry.answerComparison : {})
+                    .forEach(([questionId, comparison]) => {
+                        expectedComparison[prefix + questionId] = comparison;
+                    });
+            });
+            const expectedAccuracy = expectedTotal > 0 ? expectedCorrect / expectedTotal : 0;
+            const expectedPercentage = Math.round(expectedAccuracy * 100);
+            const scoreInfo = record.scoreInfo;
+            const numericMatches = (left, right) => Number.isFinite(Number(left)) && Number(left) === Number(right);
+            return Boolean(
+                session.id
+                && String(record.id || '') === String(session.id)
+                && String(record.sessionId || '') === String(session.id)
+                && sequenceIds.length > 0
+                && record.examId === `suite-${String(session.id)}`
+                && record.type === 'reading'
+                && record.suiteMode === true
+                && record.frequency === 'suite'
+                && typeof record.title === 'string'
+                && typeof record.date === 'string'
+                && typeof record.startTime === 'string'
+                && typeof record.endTime === 'string'
+                && Number.isFinite(Number(record.duration))
+                && Number(record.duration) >= 0
+                && this._isValidSuiteScoreInfo(scoreInfo)
+                && numericMatches(record.totalQuestions, expectedTotal)
+                && numericMatches(record.correctAnswers, expectedCorrect)
+                && numericMatches(scoreInfo.correct, expectedCorrect)
+                && numericMatches(scoreInfo.total, expectedTotal)
+                && Math.abs(Number(scoreInfo.accuracy) - expectedAccuracy) < 1e-9
+                && Number(scoreInfo.percentage) === expectedPercentage
+                && this._suiteValuesEqual(record.answers, expectedAnswers)
+                && this._suiteValuesEqual(record.answerComparison, expectedComparison)
+                && recordEntries.length === sequenceIds.length
+                && recordIds.length === sequenceIds.length
+                && new Set(recordIds).size === recordIds.length
+                && recordIds.every((examId, index) => examId === sequenceIds[index])
+                && resultIds.length === sequenceIds.length
+                && new Set(resultIds).size === resultIds.length
+                && resultIds.every((examId) => sequenceIds.includes(examId))
+                && recordEntries.every((entry, index) => {
+                    const result = results.find((candidate) => String(candidate && candidate.examId || '').trim() === sequenceIds[index]);
+                    return this._isValidSuiteFinalizeEntry(entry, sequenceIds)
+                        && result
+                        && numericMatches(entry.duration, result.duration)
+                        && this._suiteValuesEqual(entry.scoreInfo, result.scoreInfo)
+                        && this._suiteValuesEqual(entry.answers, result.answers)
+                        && this._suiteValuesEqual(entry.answerComparison, result.answerComparison);
+                })
+                && record.metadata
+                && typeof record.metadata === 'object'
+                && String(record.metadata.suiteSessionId || '') === String(session.id)
+                && Number(record.metadata.suiteEntryCount) === sequenceIds.length
+                && record.realData
+                && typeof record.realData === 'object'
+                && record.realData.source === 'suite_mode'
+                && numericMatches(record.realData.correct, expectedCorrect)
+                && numericMatches(record.realData.total, expectedTotal)
+                && numericMatches(record.realData.duration, record.duration)
+                && typeof record.operationId === 'string'
+                && record.operationId === `practice-suite:${String(session.id)}:finalize`
+            );
+        },
+
         async _saveSuitePracticeRecord(record) {
             const childSessionIds = [];
             (Array.isArray(record && record.suiteEntries) ? record.suiteEntries : []).forEach((entry) => {
@@ -2731,9 +3831,6 @@
                 record,
                 childSessionIds,
                 operationId: record.operationId
-                    || (record.submissionId
-                        ? `practice-suite:${String(record.sessionId || 'session')}:${String(record.submissionId)}`
-                        : undefined)
             });
             if (!receipt || receipt.committed !== true) {
                 const error = new Error('Suite aggregate commit was not confirmed');
@@ -2862,24 +3959,6 @@
             return count + 1;
         },
 
-        async _savePartialSuiteAsIndividual(session) {
-            if (!session || !session.results || !session.results.length) {
-                return;
-            }
-
-            for (const entry of session.results) {
-                try {
-                    await this.saveRealPracticeData(entry.examId, this._buildSuiteEntryIndividualPayload(session, entry), { forceIndividualSave: true });
-                    this.updateExamStatus && this.updateExamStatus(entry.examId, 'completed');
-                } catch (error) {
-                    console.error('[SuitePractice] 保存单篇记录失败:', error);
-                }
-            }
-
-            await this._updatePracticeRecordsState();
-            this.refreshOverviewData && this.refreshOverviewData();
-        },
-
         _focusSuiteWindow(targetWindow) {
             if (!targetWindow || targetWindow.closed) {
                 return;
@@ -2914,13 +3993,30 @@
 
         async _teardownSuiteSession(session) {
             if (!session) {
-                return;
+                return false;
             }
+            if (session._teardownPromise && typeof session._teardownPromise.then === 'function') {
+                return session._teardownPromise;
+            }
+            const teardownPromise = this._teardownSuiteSessionInternal(session);
+            session._teardownPromise = teardownPromise;
+            try {
+                return await teardownPromise;
+            } finally {
+                if (session._teardownPromise === teardownPromise) delete session._teardownPromise;
+            }
+        },
+
+        async _teardownSuiteSessionInternal(session) {
+            if (this.currentSuiteSession !== session) return false;
 
             if (session.submitReceiptTeardownTimer) {
                 clearTimeout(session.submitReceiptTeardownTimer);
                 session.submitReceiptTeardownTimer = null;
             }
+
+            if (!await this._discardPersistentSuiteRecovery(session)) return false;
+            if (this.currentSuiteSession !== session) return false;
 
             this._clearSuiteHandshakes();
 
@@ -2946,7 +4042,11 @@
             }
 
             if (this.suiteExamMap) {
-                session.sequence && session.sequence.forEach(item => this.suiteExamMap.delete(item.examId));
+                session.sequence && session.sequence.forEach(item => {
+                    if (item && this.suiteExamMap.get(item.examId) === session.id) {
+                        this.suiteExamMap.delete(item.examId);
+                    }
+                });
             }
 
             if (this.currentSuiteSession && this.currentSuiteSession.id === session.id) {
@@ -2957,36 +4057,23 @@
             if (typeof this._clearSuiteHandshakes === 'function') {
                 this._clearSuiteHandshakes();
             }
-            this._clearSessionStorage();
+            this._clearSessionStorage(session);
+            return true;
         },
 
         async _abortSuiteSession(session, options = {}) {
             if (!session) {
-                return;
+                return false;
             }
 
+            const previousStatus = session.status;
             session.status = 'aborted';
 
             this._clearSuiteHandshakes();
 
-            const skipExamId = options.skipExamId;
-            if (session.results && session.results.length) {
-                for (const entry of session.results) {
-                    if (skipExamId && entry.examId === skipExamId) {
-                        continue;
-                    }
-                    try {
-                        await this.saveRealPracticeData(entry.examId, this._buildSuiteEntryIndividualPayload(session, entry), { forceIndividualSave: true });
-                        this.updateExamStatus && this.updateExamStatus(entry.examId, 'completed');
-                    } catch (error) {
-                        console.error('[SuitePractice] 套题中断时保存记录失败:', error);
-                    }
-                }
-                await this._updatePracticeRecordsState();
-                this.refreshOverviewData && this.refreshOverviewData();
-            }
-
-            await this._teardownSuiteSession(session);
+            const tornDown = await this._teardownSuiteSession(session);
+            if (!tornDown) session.status = previousStatus;
+            return tornDown;
         },
 
         _openNamedSuiteWindow(windowName, session = null) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -7207,11 +7207,166 @@
             };
         },
 
+        _beginExamOpenGeneration(examId, options = {}) {
+            if (!this._examOpenGenerations) this._examOpenGenerations = new Map();
+            if (!this._examOpenWindowGenerations) this._examOpenWindowGenerations = new WeakMap();
+            this._examOpenGenerationSequence = Math.max(0, Number(this._examOpenGenerationSequence) || 0) + 1;
+
+            const normalizedExamId = String(examId || '').trim();
+            const targetNames = [`exam_${normalizedExamId}`, `pdf_${normalizedExamId}`];
+            if (typeof options.windowName === 'string') {
+                targetNames.push(options.windowName.trim());
+            }
+            const names = Object.freeze(Array.from(new Set(targetNames.filter(name => name && !name.startsWith('_')))));
+            const generation = Object.freeze({
+                examId: normalizedExamId,
+                sequence: this._examOpenGenerationSequence,
+                targetNames: names,
+                hasReuseWindow: Boolean(options.reuseWindow)
+            });
+            this._examOpenGenerations.set(`exam:${normalizedExamId}`, generation);
+            names.forEach(name => this._examOpenGenerations.set(`target:${name}`, generation));
+            if (options.reuseWindow) {
+                this._examOpenWindowGenerations.set(options.reuseWindow, generation);
+            }
+            return generation;
+        },
+
+        _isExamOpenGenerationCurrent(generation, targetWindow = null) {
+            if (!generation || !this._examOpenGenerations
+                || this._examOpenGenerations.get(`exam:${generation.examId}`) !== generation) {
+                return false;
+            }
+            if (generation.targetNames.some(name => this._examOpenGenerations.get(`target:${name}`) !== generation)) {
+                return false;
+            }
+            if (generation.hasReuseWindow) {
+                if (!targetWindow || !this._examOpenWindowGenerations
+                    || this._examOpenWindowGenerations.get(targetWindow) !== generation) {
+                    return false;
+                }
+            }
+            return true;
+        },
+
+        _recordExamWindowNavigation(targetWindow) {
+            if (!targetWindow || (typeof targetWindow !== 'object' && typeof targetWindow !== 'function')) {
+                return 0;
+            }
+            if (!this._examWindowNavigationEpochs) this._examWindowNavigationEpochs = new WeakMap();
+            const epoch = Math.max(0, Number(this._examWindowNavigationEpochs.get(targetWindow)) || 0) + 1;
+            this._examWindowNavigationEpochs.set(targetWindow, epoch);
+            return epoch;
+        },
+
+        _isExamWindowNavigationCurrent(targetWindow, epoch) {
+            return Boolean(targetWindow && epoch && this._examWindowNavigationEpochs
+                && this._examWindowNavigationEpochs.get(targetWindow) === epoch);
+        },
+
+        _captureExamSessionRegistration(examId, windowInfo = null) {
+            const info = windowInfo || (this.examWindows && this.examWindows.get(examId)) || null;
+            if (!info || !info.window || !Number.isInteger(info.registrationId)) return null;
+            return Object.freeze({
+                examId: String(examId || ''),
+                window: info.window,
+                windowInfo: info,
+                registrationId: info.registrationId,
+                sessionGeneration: Number(info.sessionGeneration) || 0,
+                navigationEpoch: Number(info.navigationEpoch) || 0,
+                suiteSessionId: Object.prototype.hasOwnProperty.call(info, 'suiteSessionId')
+                    ? (info.suiteSessionId || null)
+                    : undefined
+            });
+        },
+
+        _isExamSessionRegistrationCurrent(examId, registration) {
+            const current = this.examWindows && this.examWindows.get(examId);
+            return Boolean(
+                registration
+                && current
+                && current === registration.windowInfo
+                && current.window === registration.window
+                && current.registrationId === registration.registrationId
+                && Number(current.sessionGeneration || 0) === Number(registration.sessionGeneration || 0)
+            );
+        },
+
+        _installExamNavigationRegistration(examId, examWindow, exam, options, generation) {
+            if (!examWindow || !this._isExamOpenGenerationCurrent(generation, options.reuseWindow || null)) {
+                return null;
+            }
+            if (!this.examWindows) this.examWindows = new Map();
+            const previous = this.examWindows.get(examId) || null;
+            if (previous && previous.closeMonitor) {
+                try { clearInterval(previous.closeMonitor); } catch (_) {}
+            }
+            if (this.messageHandlers && this.messageHandlers.has(examId)) {
+                try { window.removeEventListener('message', this.messageHandlers.get(examId)); } catch (_) {}
+                this.messageHandlers.delete(examId);
+            }
+            if (this._handshakeTimers && this._handshakeTimers.has(examId)) {
+                try { clearInterval(this._handshakeTimers.get(examId)); } catch (_) {}
+                this._handshakeTimers.delete(examId);
+            }
+
+            const endpoint = this._resolveExamMessageEndpoint(options.expectedUrl || (exam ? this.buildExamUrl(exam) : ''));
+            this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+            const windowInfo = {
+                window: examWindow,
+                startTime: Date.now(),
+                status: 'opening',
+                expectedSessionId: this.generateSessionId(examId),
+                windowSessionToken: null,
+                windowSessionTokenSessionId: null,
+                expectedUrl: endpoint.expectedUrl,
+                expectedOrigin: endpoint.expectedOrigin,
+                allowOpaqueOrigin: endpoint.allowOpaqueOrigin,
+                observedOrigin: '',
+                suiteSessionId: options.suiteSessionId || null,
+                suiteFlowMode: options.suiteFlowMode ? String(options.suiteFlowMode) : null,
+                reviewMode: Boolean(options.reviewMode),
+                reviewSessionId: options.reviewSessionId ? String(options.reviewSessionId) : null,
+                reviewEntryIndex: Number.isInteger(options.reviewEntryIndex) ? options.reviewEntryIndex : 0,
+                practiceMode: typeof options.practiceMode === 'string' ? options.practiceMode.trim().toLowerCase() : null,
+                readOnly: Object.prototype.hasOwnProperty.call(options, 'readOnly')
+                    ? Boolean(options.readOnly)
+                    : Boolean(options.reviewMode),
+                sessionGeneration: Math.max(0, Number(previous && previous.sessionGeneration) || 0) + 1,
+                registrationId: this._examRegistrationSequence,
+                navigationEpoch: Number(options.navigationEpoch) || 0,
+                launchProvisional: true,
+                closeMonitor: null
+            };
+            this._refreshExamWindowToken(examId, windowInfo);
+            this.examWindows.set(examId, windowInfo);
+            return this._captureExamSessionRegistration(examId, windowInfo);
+        },
+
+        async _abortExamOpen(examId, registration) {
+            if (!this._isExamSessionRegistrationCurrent(examId, registration)) return false;
+            const targetWindow = registration.window;
+            const navigationEpoch = registration.navigationEpoch;
+            await this.cleanupExamSession(examId, { expectedRegistration: registration });
+            const reassigned = Boolean(this.examWindows && Array.from(this.examWindows.values())
+                .some(info => info && info.window === targetWindow));
+            if (!reassigned && targetWindow !== window
+                && this._isExamWindowNavigationCurrent(targetWindow, navigationEpoch)) {
+                try {
+                    if (!targetWindow.closed && typeof targetWindow.close === 'function') targetWindow.close();
+                } catch (_) {}
+            }
+            return true;
+        },
+
         /**
           * 打开指定题目进行练习
           */
         async openExam(examId, options = {}) {
+            const openGeneration = this._beginExamOpenGeneration(examId, options);
             const reviewMode = Boolean(options && options.reviewMode);
+            let examWindow = null;
+            let launchRegistration = null;
             let exam = options && options.examDefinition && typeof options.examDefinition === 'object'
                 ? options.examDefinition
                 : null;
@@ -7220,6 +7375,7 @@
                     throw new Error('历史记录的题库来源不可用');
                 }
                 const examIndex = await getActiveExamIndexSnapshot();
+                if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
                 const list = Array.isArray(examIndex) ? examIndex : [];
                 exam = list.find(e => e.id === examId);
             }
@@ -7233,13 +7389,15 @@
                 return;
             }
 
+            if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+
             try {
                 const readingLaunch = typeof this.resolveReadingLaunchDescriptor === 'function'
                     ? this.resolveReadingLaunchDescriptor(exam, options)
                     : null;
 
                 if (readingLaunch && readingLaunch.mode === 'pdf_manual' && readingLaunch.pdfUrl) {
-                    return this._openPdfWindow(exam, readingLaunch.pdfUrl, options);
+                    return this._openPdfWindow(exam, readingLaunch.pdfUrl, { ...options, openGeneration });
                 }
 
                 // 若无HTML，直接打开PDF
@@ -7248,10 +7406,10 @@
                         ? window.buildResourcePath(exam, 'pdf')
                         : ((exam.path || '').replace(/\\/g, '/').replace(/\/+\//g, '/') + (exam.pdfFilename || ''));
                     const resolvedPdfUrl = this._ensureAbsoluteUrl(pdfUrl);
-                    return this._openPdfWindow(exam, resolvedPdfUrl, options);
+                    return this._openPdfWindow(exam, resolvedPdfUrl, { ...options, openGeneration });
                 }
 
-                const guardOptions = { ...options, examId };
+                const guardOptions = { ...options, examId, openGeneration };
                 // 测试环境的套题练习统一使用占位页，避免因题目资源差异导致 E2E 不稳定
                 let examUrl = (readingLaunch && readingLaunch.mode === 'unified_html' && readingLaunch.url)
                     ? readingLaunch.url
@@ -7268,44 +7426,78 @@
                 if (guardOptions.endlessMode) {
                     examUrl = this._appendEndlessContextToExamUrl(examUrl);
                 }
-                let examWindow = this.openExamWindow(examUrl, exam, guardOptions);
+                if (!this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+                examWindow = this.openExamWindow(examUrl, exam, guardOptions);
+                if (!examWindow || !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
+                launchRegistration = this._installExamNavigationRegistration(examId, examWindow, exam, {
+                    ...guardOptions,
+                    expectedUrl: this._ensureAbsoluteUrl(examUrl)
+                }, openGeneration);
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
 
                 try {
                     const guardedWindow = this._guardExamWindowContent(examWindow, exam, guardOptions);
                     if (guardedWindow) {
                         examWindow = guardedWindow;
+                        if (!guardOptions.navigationEpoch) {
+                            guardOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
+                        }
+                        launchRegistration = this._installExamNavigationRegistration(examId, examWindow, exam, {
+                            ...guardOptions,
+                            expectedUrl: this._ensureAbsoluteUrl(examUrl)
+                        }, openGeneration);
                     }
                 } catch (guardError) {
                     console.warn('[App] 题目窗口占位页守护失败:', guardError);
                 }
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 if (guardOptions.reuseWindow && examWindow && !examWindow.closed && typeof this._cleanupReusedWindowSessions === 'function') {
-                    await this._cleanupReusedWindowSessions(examWindow, examId);
+                    await this._cleanupReusedWindowSessions(examWindow, examId, launchRegistration);
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 }
 
                 // 在启动窗口前捕获激活的题库配置 ID，确保后续练习记录 metadata 来源
                 // 一律按"启动时"的题库写入，避免用户在考试过程中切换题库导致提交时来源不一致。
                 if (!reviewMode) {
                     try {
-                        await this._captureLaunchLibraryConfigurationId(examId);
+                        await this._captureLaunchLibraryConfigurationId(examId, {
+                            commitGuard: () => this._isExamSessionRegistrationCurrent(examId, launchRegistration)
+                        });
                     } catch (captureError) {
                         console.warn('[App] 捕获启动题库配置 ID 失败:', captureError);
                     }
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 }
 
                 // Register the window first so the host expectedSessionId exists, then start the
                 // recorder with that same id.  Starting the recorder before window setup used
                 // to mint a second session id that never matched INIT/COMPLETE.
-                this.setupExamWindowManagement(examWindow, examId, exam, {
+                launchRegistration = this.setupExamWindowManagement(examWindow, examId, exam, {
                     ...options,
+                    expectedRegistration: launchRegistration,
+                    navigationEpoch: guardOptions.navigationEpoch,
+                    skipContentGuard: true,
+                    deferInitialHandshake: !reviewMode && !memorizeMode,
                     expectedUrl: this._ensureAbsoluteUrl(examUrl)
                 });
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
                 if (!reviewMode && !memorizeMode) {
-                    await this.startPracticeSession(examId);
+                    const startResult = await this.startPracticeSession(examId, {
+                        examDefinition: exam,
+                        expectedRegistration: launchRegistration
+                    });
+                    if (!startResult || startResult.owned !== true
+                        || !this._isExamSessionRegistrationCurrent(examId, startResult.registration)) {
+                        await this._abortExamOpen(examId, launchRegistration);
+                        return null;
+                    }
+                    launchRegistration = startResult.registration;
+                    this.restartExamHandshake(examWindow, examId, launchRegistration);
                 }
-                this.injectDataCollectionScript(examWindow, examId, exam);
 
                 if (options && options.suiteSessionId) {
-                    const sessionInfo = this.ensureExamWindowSession(examId, examWindow);
+                    if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
+                    const sessionInfo = launchRegistration.windowInfo;
                     sessionInfo.suiteSessionId = options.suiteSessionId;
                     if (options.suiteFlowMode) {
                         sessionInfo.suiteFlowMode = options.suiteFlowMode;
@@ -7334,7 +7526,11 @@
                         sessionInfo.suiteSequenceTotal = options.sequenceTotal;
                     }
                     this.examWindows && this.examWindows.set(examId, sessionInfo);
+                    launchRegistration = this._captureExamSessionRegistration(examId, sessionInfo);
                 }
+
+                if (!this._isExamSessionRegistrationCurrent(examId, launchRegistration)) return null;
+                this.injectDataCollectionScript(examWindow, examId, exam, { expectedRegistration: launchRegistration });
 
                 if (reviewMode && typeof this._bindReviewWindowRef === 'function') {
                     this._bindReviewWindowRef(options.reviewSessionId, examWindow);
@@ -7345,20 +7541,29 @@
                     'info'
                 );
 
-                return examWindow;
+                return options.returnLaunchContext === true
+                    ? Object.freeze({ window: examWindow, registration: launchRegistration })
+                    : examWindow;
 
             } catch (error) {
                 console.error('Failed to open exam:', error);
                 window.showMessage('打开题目失败，请重试', 'error');
+                if (launchRegistration) await this._abortExamOpen(examId, launchRegistration);
+                return null;
             }
         },
 
         _openPdfWindow(exam, resolvedPdfUrl, options = {}) {
             let pdfWin = null;
+            const openGeneration = options.openGeneration || null;
 
             if (options.reuseWindow && !options.reuseWindow.closed) {
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow)) {
+                        return null;
+                    }
                     options.reuseWindow.location.href = resolvedPdfUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(options.reuseWindow);
                     options.reuseWindow.focus();
                     pdfWin = options.reuseWindow;
                 } catch (reuseError) {
@@ -7367,6 +7572,7 @@
             }
 
             if (!pdfWin) {
+                if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, options.reuseWindow || null)) return null;
                 if (options.target === 'tab') {
                     try {
                         pdfWin = window.open(resolvedPdfUrl, '_blank');
@@ -7376,11 +7582,13 @@
                         pdfWin = window.open(resolvedPdfUrl, `pdf_${exam.id}`, 'width=1000,height=800,scrollbars=yes,resizable=yes,status=yes,toolbar=yes');
                     } catch (_) { }
                 }
+                if (pdfWin) options.navigationEpoch = this._recordExamWindowNavigation(pdfWin);
             }
 
             if (!pdfWin) {
                 try {
                     window.location.href = resolvedPdfUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(window);
                     return window;
                 } catch (error) {
                     throw new Error('无法打开PDF窗口，请检查弹窗设置');
@@ -7428,10 +7636,15 @@
          */
         openExamWindow(examUrl, exam, options = {}) {
             const reuseWindow = options.reuseWindow;
+            const openGeneration = options.openGeneration || null;
             const finalUrl = this._ensureAbsoluteUrl(examUrl);
             if (reuseWindow && !reuseWindow.closed) {
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow)) {
+                        return null;
+                    }
                     reuseWindow.location.href = finalUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(reuseWindow);
                     reuseWindow.focus();
                     return reuseWindow;
                 } catch (error) {
@@ -7445,7 +7658,9 @@
                     ? options.windowName.trim()
                     : '_blank';
                 try {
+                    if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow || null)) return null;
                     tabWindow = window.open(finalUrl, requestedName);
+                    if (tabWindow) options.navigationEpoch = this._recordExamWindowNavigation(tabWindow);
                     if (tabWindow && typeof tabWindow.focus === 'function') {
                         tabWindow.focus();
                     }
@@ -7462,17 +7677,20 @@
             // 打开新窗口
             let examWindow = null;
             try {
+                if (openGeneration && !this._isExamOpenGenerationCurrent(openGeneration, reuseWindow || null)) return null;
                 examWindow = window.open(
                     finalUrl,
                     `exam_${exam.id}`,
                     windowFeatures
                 );
+                if (examWindow) options.navigationEpoch = this._recordExamWindowNavigation(examWindow);
             } catch (_) { }
 
             // 弹窗被拦截时，降级为当前窗口打开，确保用户可进入练习页
             if (!examWindow) {
                 try {
                     window.location.href = finalUrl;
+                    options.navigationEpoch = this._recordExamWindowNavigation(window);
                     return window; // 以当前窗口作为返回引用
                 } catch (e) {
                     throw new Error('无法打开题目页面，请检查弹窗/文件路径设置');
@@ -7853,6 +8071,7 @@
                         } else {
                             examWindow.location.href = placeholderUrl;
                         }
+                        retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                         return examWindow;
                     } catch (forceError) {
                         console.warn('[App] 套题模式强制跳转占位页失败，继续使用原窗口:', forceError);
@@ -7908,9 +8127,11 @@
             try {
                 if (examWindow.location && typeof examWindow.location.replace === 'function') {
                     examWindow.location.replace(placeholderUrl);
+                    retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                     return examWindow;
                 }
                 examWindow.location.href = placeholderUrl;
+                retryOptions.navigationEpoch = this._recordExamWindowNavigation(examWindow);
                 return examWindow;
             } catch (navigationError) {
                 console.warn('[App] 题目窗口导航占位页失败，尝试重新打开:', navigationError);
@@ -7920,6 +8141,7 @@
                         : (examWindow.name || '_blank');
                     const reopened = window.open(placeholderUrl, windowName);
                     if (reopened) {
+                        retryOptions.navigationEpoch = this._recordExamWindowNavigation(reopened);
                         return reopened;
                     }
                 } catch (openError) {
@@ -8010,7 +8232,13 @@
         /**
          * 注入数据采集脚本到练习页面
          */
-        injectDataCollectionScript(examWindow, examId, exam = null) {
+        injectDataCollectionScript(examWindow, examId, exam = null, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            if (!ownsRegistration()) {
+                return false;
+            }
             if (this._isUnifiedReadingExam(exam)) {
                 return;
             }
@@ -8039,6 +8267,9 @@
             };
             const injectScript = () => {
                 try {
+                    if (!ownsRegistration()) {
+                        return false;
+                    }
                     if (!examWindow || examWindow.closed) {
                         console.warn('[DataInjection] 目标窗口已关闭');
                         return;
@@ -8048,7 +8279,7 @@
                         ? (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)
                         : (examWindow.practicePageEnhancer && typeof examWindow.practicePageEnhancer.initialize === 'function');
                     if (bridgeReady) {
-                        this.initializePracticeSession(examWindow, examId);
+                        this.initializePracticeSession(examWindow, examId, expectedRegistration);
                         return;
                     }
 
@@ -8085,12 +8316,15 @@
                         : (host && typeof host.querySelector === 'function' ? host.querySelector(existingSelector) : null);
                     if (existingEnhancerScript) {
                         if (isListeningExam && (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)) {
-                            this.initializePracticeSession(examWindow, examId);
+                            this.initializePracticeSession(examWindow, examId, expectedRegistration);
                         }
                         return;
                     }
                     let enhancerInjected = false;
                     const appendEnhancer = () => {
+                        if (!ownsRegistration()) {
+                            return false;
+                        }
                         const alreadyReady = isListeningExam
                             ? (examWindow.__listeningBridgeGetState || examWindow.__listeningBridgeComplete)
                             : (examWindow.practicePageEnhancer && typeof examWindow.practicePageEnhancer.initialize === 'function');
@@ -8105,9 +8339,15 @@
                         scriptEl.src = ensureScriptUrl();
 
                         scriptEl.onload = () => {
+                            if (!ownsRegistration()) {
+                                return;
+                            }
                             setTimeout(() => {
+                                if (!ownsRegistration()) {
+                                    return;
+                                }
                                 try {
-                                    this.initializePracticeSession(examWindow, examId);
+                                    this.initializePracticeSession(examWindow, examId, expectedRegistration);
                                 } catch (sessionError) {
                                     console.warn('[DataInjection] 初始化练习会话失败:', sessionError);
                                 }
@@ -8115,27 +8355,40 @@
                         };
 
                         scriptEl.onerror = (loadError) => {
+                            if (!ownsRegistration()) {
+                                return;
+                            }
                             console.warn('[DataInjection] 加载增强器失败:', loadError);
                             scriptEl.remove();
                             if (!isListeningExam) {
-                                this.injectInlineScript(examWindow, examId);
+                                this.injectInlineScript(examWindow, examId, expectedRegistration);
                             }
                         };
 
+                        if (!ownsRegistration()) {
+                            return false;
+                        }
                         host.appendChild(scriptEl);
+                        return true;
                     };
 
-                    appendEnhancer();
+                    return appendEnhancer();
                 } catch (error) {
+                    if (!ownsRegistration()) {
+                        return false;
+                    }
                     console.error('[DataInjection] 注入增强器脚本时出错:', error);
                     if (!isListeningExam) {
-                        this.injectInlineScript(examWindow, examId);
+                        this.injectInlineScript(examWindow, examId, expectedRegistration);
                     }
                 }
             };
 
             const checkAndInject = () => {
                 try {
+                    if (!ownsRegistration()) {
+                        return;
+                    }
                     if (!examWindow || examWindow.closed) {
                         return;
                     }
@@ -8143,7 +8396,7 @@
                     const doc = examWindow.document;
                     if (doc && (doc.readyState === 'interactive' || doc.readyState === 'complete')) {
                         injectScript();
-                    } else {
+                    } else if (ownsRegistration()) {
                         setTimeout(checkAndInject, 200);
                     }
                 } catch (error) {
@@ -8151,14 +8404,21 @@
                 }
             };
 
-            setTimeout(checkAndInject, 300);
+            if (ownsRegistration()) {
+                setTimeout(checkAndInject, 300);
+            }
         },
 
         /**
          * 内联脚本注入（备用方案）
          */
-        injectInlineScript(examWindow, examId) {
+        injectInlineScript(examWindow, examId, expectedRegistration = null) {
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
             try {
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 if (!examWindow || !examWindow.document || !examWindow.document.head) {
                     throw new Error('inline_target_unavailable');
                 }
@@ -8524,35 +8784,49 @@
                     })();
                 `;
 
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 examWindow.document.head.appendChild(inlineScript);
 
                 setTimeout(() => {
-                    this.initializePracticeSession(examWindow, examId);
+                    if (!ownsRegistration()) {
+                        return;
+                    }
+                    this.initializePracticeSession(examWindow, examId, expectedRegistration);
                 }, 300);
 
             } catch (error) {
+                if (!ownsRegistration()) {
+                    return false;
+                }
                 console.error('[DataInjection] 内联脚本注入失败:', error);
                 this.handleInjectionError(examId, error);
             }
+            return true;
         },
 
         /**
          * 初始化练习会话
          */
-        initializePracticeSession(examWindow, examId) {
+        initializePracticeSession(examWindow, examId, expectedRegistration = null) {
             try {
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return false;
+                }
                 const now = Date.now();
 
-                let existingInfo = null;
-                if (this.examWindows && this.examWindows.has(examId)) {
+                let existingInfo = expectedRegistration ? expectedRegistration.windowInfo : null;
+                if (!existingInfo && this.examWindows && this.examWindows.has(examId)) {
                     existingInfo = this.examWindows.get(examId) || null;
                 }
 
-                let suiteSessionId = existingInfo && existingInfo.suiteSessionId
-                    ? existingInfo.suiteSessionId
-                    : null;
+                const hasExplicitSuiteBinding = Boolean(
+                    existingInfo && Object.prototype.hasOwnProperty.call(existingInfo, 'suiteSessionId')
+                );
+                let suiteSessionId = hasExplicitSuiteBinding ? (existingInfo.suiteSessionId || null) : null;
 
-                if (!suiteSessionId && this.currentSuiteSession) {
+                if (!hasExplicitSuiteBinding && !suiteSessionId && this.currentSuiteSession) {
                     const activeMatch = this.currentSuiteSession.activeExamId === examId;
                     const sequenceIndex = Number.isInteger(this.currentSuiteSession.currentIndex)
                         ? this.currentSuiteSession.currentIndex
@@ -8567,8 +8841,10 @@
                     }
                 }
 
-                const windowInfo = this.ensureExamWindowSession(examId, examWindow);
-                if (suiteSessionId && !windowInfo.suiteSessionId) {
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : this.ensureExamWindowSession(examId, examWindow);
+                if (suiteSessionId && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                     windowInfo.suiteSessionId = suiteSessionId;
                 }
                 const timerContext = this._resolveSuiteTimerContext({}, windowInfo);
@@ -8596,7 +8872,7 @@
                     existingInfo.sessionId = initPayload.sessionId;
                     existingInfo.initTime = now;
                     existingInfo.status = 'initialized';
-                    if (suiteSessionId && !existingInfo.suiteSessionId) {
+                    if (suiteSessionId && !Object.prototype.hasOwnProperty.call(existingInfo, 'suiteSessionId')) {
                         existingInfo.suiteSessionId = suiteSessionId;
                     }
                     if (!existingInfo.window || existingInfo.window.closed) {
@@ -8614,8 +8890,11 @@
                     }));
                 }
 
+                return true;
+
             } catch (error) {
                 console.error('[DataInjection] 会话初始化失败:', error);
+                return false;
             }
         },
 
@@ -8645,16 +8924,23 @@
         setupExamWindowManagement(examWindow, examId, exam = null, options = {}) {
             if (!examWindow) {
                 console.warn('[App] 缺少题目窗口引用，无法完成窗口管理');
-                return;
+                return null;
             }
 
-            try {
-                const guardedWindow = this._guardExamWindowContent(examWindow, exam, { ...options, examId });
-                if (guardedWindow) {
-                    examWindow = guardedWindow;
+            const expectedRegistration = options && options.expectedRegistration || null;
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return null;
+            }
+
+            if (!(options && options.skipContentGuard)) {
+                try {
+                    const guardedWindow = this._guardExamWindowContent(examWindow, exam, { ...options, examId });
+                    if (guardedWindow) {
+                        examWindow = guardedWindow;
+                    }
+                } catch (guardError) {
+                    console.warn('[App] 守护题目窗口内容失败:', guardError);
                 }
-            } catch (guardError) {
-                console.warn('[App] 守护题目窗口内容失败:', guardError);
             }
 
             // 存储窗口引用
@@ -8662,16 +8948,28 @@
                 this.examWindows = new Map();
             }
 
+            const previousWindowInfo = this.examWindows.get(examId);
+            if (previousWindowInfo && previousWindowInfo.closeMonitor) {
+                try {
+                    clearInterval(previousWindowInfo.closeMonitor);
+                } catch (_) {}
+            }
+
             const endpoint = this._resolveExamMessageEndpoint(
                 options && options.expectedUrl
                     ? options.expectedUrl
                     : (exam ? this.buildExamUrl(exam) : '')
             );
-            this.examWindows.set(examId, {
+            this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+            const windowInfo = {
                 window: examWindow,
                 startTime: Date.now(),
                 status: 'active',
-                expectedSessionId: null,
+                expectedSessionId: expectedRegistration && expectedRegistration.windowInfo.expectedSessionId
+                    ? String(expectedRegistration.windowInfo.expectedSessionId)
+                    : null,
+                windowSessionToken: expectedRegistration && expectedRegistration.windowInfo.windowSessionToken || null,
+                windowSessionTokenSessionId: expectedRegistration && expectedRegistration.windowInfo.windowSessionTokenSessionId || null,
                 expectedUrl: endpoint.expectedUrl,
                 expectedOrigin: endpoint.expectedOrigin,
                 allowOpaqueOrigin: endpoint.allowOpaqueOrigin,
@@ -8688,8 +8986,24 @@
                     : null,
                 readOnly: options && Object.prototype.hasOwnProperty.call(options, 'readOnly')
                     ? Boolean(options.readOnly)
-                    : Boolean(options && options.reviewMode)
-            });
+                    : Boolean(options && options.reviewMode),
+                // Async INIT/draft work must be tied to this exact registration.
+                // Reusing an exam ID replaces the map entry even when the browser
+                // keeps the same WindowProxy alive.
+                sessionGeneration: expectedRegistration
+                    ? expectedRegistration.sessionGeneration
+                    : (previousWindowInfo && Number.isFinite(previousWindowInfo.sessionGeneration)
+                        ? previousWindowInfo.sessionGeneration + 1
+                        : 1),
+                registrationId: this._examRegistrationSequence,
+                navigationEpoch: Number(options && options.navigationEpoch)
+                    || Number(expectedRegistration && expectedRegistration.navigationEpoch)
+                    || 0,
+                closeMonitor: null
+            };
+            this.examWindows.set(examId, windowInfo);
+            this._refreshExamWindowToken(examId, windowInfo);
+            const registration = this._captureExamSessionRegistration(examId, windowInfo);
 
             // 监听窗口关闭事件
             let checkClosed = null;
@@ -8698,33 +9012,45 @@
                     try {
                         if (examWindow.closed) {
                             clearInterval(checkClosed);
-                            this.handleExamWindowClosed(examId);
+                            if (windowInfo.closeMonitor === checkClosed) {
+                                windowInfo.closeMonitor = null;
+                            }
+                            this.handleExamWindowClosed(examId, examWindow, registration);
                         }
                     } catch (monitorError) {
                         clearInterval(checkClosed);
                         console.warn('[App] 无法检测题目窗口状态:', monitorError);
                     }
                 }, 1000);
+                windowInfo.closeMonitor = checkClosed;
             } catch (error) {
                 console.warn('[App] 启动窗口关闭监控失败:', error);
             }
 
             // 设置窗口通信
             try {
-                this.setupExamWindowCommunication(examWindow, examId, exam, options);
+                this.setupExamWindowCommunication(examWindow, examId, exam, {
+                    ...options,
+                    expectedRegistration: registration
+                });
             } catch (error) {
                 console.warn('[App] 初始化题目窗口通信失败:', error);
             }
 
             // 启动与练习页的会话握手（file:// 下更可靠）
-            try {
-                this.startExamHandshake(examWindow, examId);
-            } catch (e) {
-                console.warn('[App] 启动握手失败:', e);
+            if (!(options && options.deferInitialHandshake)) {
+                try {
+                    this.startExamHandshake(examWindow, examId, registration);
+                } catch (e) {
+                    console.warn('[App] 启动握手失败:', e);
+                }
             }
 
             const emitInitEnvelope = async () => {
-                const windowInfo = this.ensureExamWindowSession(examId, examWindow);
+                if (!this._isExamSessionRegistrationCurrent(examId, registration)) return;
+                const windowInfo = registration.windowInfo;
+                const generation = windowInfo && windowInfo.sessionGeneration;
+                const expectedSessionId = windowInfo && windowInfo.expectedSessionId;
                 // 让最早到达的 INIT 即携带 draft，避免无 draft 的 envelope 先被去重守卫登记，
                 // 从而使后续携带 draft 的 INIT 被当作重复而丢弃、草稿无法恢复。
                 if (
@@ -8746,6 +9072,20 @@
                         // draft restore is best-effort
                     }
                 }
+                // The exam may have been reopened while draft restoration was
+                // pending. Never let the old continuation post its session into
+                // the replacement registration.
+                const currentWindowInfo = this.examWindows && this.examWindows.get(examId);
+                if (
+                    !windowInfo
+                    || !this._isExamSessionRegistrationCurrent(examId, registration)
+                    || currentWindowInfo !== windowInfo
+                    || windowInfo.window !== examWindow
+                    || windowInfo.sessionGeneration !== generation
+                    || windowInfo.expectedSessionId !== expectedSessionId
+                ) {
+                    return;
+                }
                 const initPayload = this._buildExamInitPayload(examId, windowInfo);
                 try {
                     this._postExamMessage(examId, examWindow, 'INIT_SESSION', initPayload);
@@ -8755,7 +9095,9 @@
                 }
             };
 
-            if (!isFileProtocol) {
+            if (options && options.deferInitialHandshake) {
+                // startPracticeSession owns the first INIT for managed practice launches.
+            } else if (!isFileProtocol) {
                 try {
                     examWindow.addEventListener('load', emitInitEnvelope);
                 } catch (error) {
@@ -8770,12 +9112,25 @@
             if (!(options && options.reviewMode)) {
                 this.updateExamStatus(examId, 'in-progress');
             }
+            return registration;
         },
 
         /**
          * 设置题目窗口通信
          */
         setupExamWindowCommunication(examWindow, examId, exam = null, options = {}) {
+            let expectedRegistration = options && options.expectedRegistration || null;
+            if (!expectedRegistration) {
+                const fallbackWindowInfo = this.ensureExamWindowSession(examId, examWindow);
+                if (!Object.prototype.hasOwnProperty.call(fallbackWindowInfo, 'suiteSessionId')) {
+                    fallbackWindowInfo.suiteSessionId = options && options.suiteSessionId || null;
+                }
+                expectedRegistration = this._captureExamSessionRegistration(
+                    examId,
+                    fallbackWindowInfo
+                );
+            }
+            const ownsRegistration = () => this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
             const parseJsonSafely = (value) => {
                 if (typeof value !== 'string' || !value.trim()) return null;
                 try {
@@ -8941,9 +9296,11 @@
             };
 
             const messageHandler = async (event) => {
-                // 取得当前题目窗口引用（可能在 handshake 期间被更新）
-                const storedInfo = (this.examWindows && this.examWindows.get(examId)) || {};
-                const expectedWindow = storedInfo.window || examWindow;
+                if (!ownsRegistration()) {
+                    this._reportExamMessageRejected(examId, '', 'stale-registration', event);
+                    return;
+                }
+                const expectedWindow = expectedRegistration.window;
                 const sourceWindow = event ? (event.source || null) : null;
 
                 // 缺少来源窗口直接拒绝
@@ -8958,7 +9315,7 @@
                     return;
                 }
 
-                const windowInfo = this.ensureExamWindowSession(examId, expectedWindow);
+                const windowInfo = expectedRegistration.windowInfo;
                 const expectedSessionId = windowInfo.expectedSessionId || '';
                 // Most messages must still come from the exact exam window.  A small
                 // suite/listening compatibility path below can prove an equivalent
@@ -9123,6 +9480,32 @@
                         || !payloadExamId
                         || payloadExamId !== expectedExamId
                     ) {
+                        return;
+                    }
+                }
+                if (type === 'SIMULATION_DRAFT_SYNC' && isExamInActiveSuite) {
+                    const incomingUpdatedAt = Number(data && (data.draftUpdatedAt
+                        ?? (data.draft && data.draft.updatedAt)
+                        ?? data.updatedAt));
+                    const suiteWindowBound = Boolean(
+                        windowInfo
+                        && windowInfo.suiteSessionId
+                        && String(windowInfo.suiteSessionId) === activeSuiteSessionId
+                    );
+                    const exactSuiteDraftBinding = Boolean(
+                        sourceMatched
+                        && suiteWindowBound
+                        && payloadSuiteSessionId === activeSuiteSessionId
+                        && isPayloadExamInActiveSuite
+                        && expectedWindowSessionToken
+                        && payloadWindowSessionToken === expectedWindowSessionToken
+                        && Number.isFinite(incomingUpdatedAt)
+                        && incomingUpdatedAt > 0
+                        && this.currentSuiteSession
+                        && ['active', 'initializing'].includes(this.currentSuiteSession.status)
+                    );
+                    if (!exactSuiteDraftBinding) {
+                        this._reportExamMessageRejected(examId, type, 'suite-draft-binding-mismatch', event);
                         return;
                     }
                 }
@@ -9310,7 +9693,7 @@
                         break;
                     // 新增：处理数据采集器的消息
                     case 'SESSION_READY':
-                        this.handleSessionReady(examId, data);
+                        this.handleSessionReady(examId, data, expectedRegistration);
                         if (typeof this._maybeRestoreSuiteReviewState === 'function') {
                             this._maybeRestoreSuiteReviewState(examId, sourceWindow || expectedWindow, windowInfo).catch((restoreError) => {
                                 console.warn('[SuitePractice] 恢复回看态失败:', restoreError);
@@ -9333,11 +9716,14 @@
                             console.info('[ReadingMemorize] 背题模式结果仅在统一阅读页内展示，跳过练习记录:', examId);
                             break;
                         }
-                        if (data && data.suiteSessionId && windowInfo) {
+                        if (data && data.suiteSessionId && windowInfo
+                            && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                             windowInfo.suiteSessionId = data.suiteSessionId;
                             this.examWindows && this.examWindows.set(examId, windowInfo);
                         }
-                        await this.handlePracticeComplete(examId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeComplete(examId, data, sourceWindow || expectedWindow, {
+                            expectedRegistration
+                        });
                         break;
                     case 'ERROR_OCCURRED':
                         this.handleDataCollectionError(examId, data);
@@ -9346,7 +9732,7 @@
                         sendInitEnvelope(sourceWindow || examWindow);
                         break;
                     case 'PRACTICE_RESET_REQUEST':
-                        await this.handlePracticeResetRequest(examId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeResetRequest(examId, data, sourceWindow || expectedWindow, expectedRegistration);
                         break;
                     case 'SUITE_CLOSE_ATTEMPT':
                         console.warn('[SuitePractice] 练习页尝试关闭套题窗口:', data);
@@ -9420,36 +9806,8 @@
                         await this.handleReviewReplayNavigate(examId, data, sourceWindow || expectedWindow);
                         break;
                     case 'SIMULATION_DRAFT_SYNC':
-                        if (this.currentSuiteSession && data && data.draft) {
-                            const incomingUpdatedAt = Number(data.draftUpdatedAt ?? data.draft.updatedAt);
-                            const previousDraft = this.currentSuiteSession.draftsByExam[routedExamId] || null;
-                            const previousUpdatedAt = Number(previousDraft && previousDraft.updatedAt);
-                            const shouldAcceptDraft = !(
-                                previousDraft
-                                && Number.isFinite(previousUpdatedAt)
-                                && Number.isFinite(incomingUpdatedAt)
-                                && incomingUpdatedAt < previousUpdatedAt
-                            );
-                            if (shouldAcceptDraft) {
-                                this.currentSuiteSession.draftsByExam[routedExamId] = {
-                                    ...data.draft,
-                                    updatedAt: Number.isFinite(incomingUpdatedAt) ? incomingUpdatedAt : Date.now()
-                                };
-                            }
-                            if (Number.isFinite(Number(data.elapsed))) {
-                                if (typeof this._deriveSuiteExamElapsedSeconds === 'function') {
-                                    this.currentSuiteSession.elapsedByExam[routedExamId] = this._deriveSuiteExamElapsedSeconds(
-                                        this.currentSuiteSession,
-                                        routedExamId,
-                                        Number(data.elapsed)
-                                    );
-                                } else {
-                                    this.currentSuiteSession.elapsedByExam[routedExamId] = Math.max(0, Number(data.elapsed));
-                                }
-                            }
-                            if (typeof this._mirrorSessionToStorage === 'function') {
-                                this._mirrorSessionToStorage(this.currentSuiteSession);
-                            }
+                        if (typeof this._handleSuiteDraftSync === 'function') {
+                            await this._handleSuiteDraftSync(routedExamId, data, windowInfo, sourceWindow || expectedWindow);
                         }
                         break;
                     case 'READING_DRAFT_SYNC':
@@ -9502,7 +9860,9 @@
                         if (windowInfo && windowInfo.reviewMode) {
                             break;
                         }
-                        await this.handlePracticeComplete(routedExamId, data, sourceWindow || expectedWindow);
+                        await this.handlePracticeComplete(routedExamId, data, sourceWindow || expectedWindow, {
+                            expectedRegistration: routedExamId === examId ? expectedRegistration : null
+                        });
                         break;
                     default:
                 }
@@ -9527,7 +9887,12 @@
             }
             this.messageHandlers.set(examId, messageHandler);
 
-            const sendInitEnvelope = (targetWindow) => this._sendExamInitEnvelope(examId, targetWindow);
+            const sendInitEnvelope = (targetWindow) => this._sendExamInitEnvelope(
+                examId,
+                targetWindow,
+                {},
+                expectedRegistration
+            );
 
             const tryAttachInitHandler = (targetWindow) => {
                 if (!targetWindow || isFileProtocol) {
@@ -9544,7 +9909,7 @@
                 return false;
             };
 
-            let initAttached = tryAttachInitHandler(examWindow);
+            let initAttached = Boolean(options && options.deferInitialHandshake);
 
             if (!initAttached) {
                 try {
@@ -9561,12 +9926,13 @@
             if (!initAttached) {
                 sendInitEnvelope(examWindow);
             }
+            return expectedRegistration;
         },
 
         /**
          * 与练习页建立握手（重复发送 INIT_SESSION，直到收到 SESSION_READY）
          */
-        startExamHandshake(examWindow, examId) {
+        startExamHandshake(examWindow, examId, expectedRegistration = null) {
             if (!this._handshakeTimers) this._handshakeTimers = new Map();
 
             // 避免重复握手
@@ -9575,13 +9941,20 @@
             let attempts = 0;
             const maxAttempts = 30; // ~9s
             const tick = async () => {
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    clearInterval(timer);
+                    if (this._handshakeTimers.get(examId) === timer) this._handshakeTimers.delete(examId);
+                    return;
+                }
                 if (examWindow && !examWindow.closed) {
                     try {
-                        const windowInfo = this.ensureExamWindowSession(examId, examWindow);
+                        const windowInfo = expectedRegistration
+                            ? expectedRegistration.windowInfo
+                            : this.ensureExamWindowSession(examId, examWindow);
                         windowInfo.handshakeAttempts = attempts + 1;
                         windowInfo.lastHandshakeAt = Date.now();
                         this.examWindows && this.examWindows.set(examId, windowInfo);
-                        await this._sendExamInitEnvelope(examId, examWindow);
+                        await this._sendExamInitEnvelope(examId, examWindow, {}, expectedRegistration);
                     } catch (_) { /* 忽略 */ }
                 }
                 attempts++;
@@ -10342,6 +10715,9 @@
             if (!info || info.reviewMode) {
                 return false;
             }
+            if (windowInfo && this.examWindows && this.examWindows.get(examId) !== info) {
+                return false;
+            }
             if (String(info.practiceMode || '').toLowerCase() === 'memorize') {
                 return false;
             }
@@ -10349,8 +10725,9 @@
             // 否则当任意套题会话仍活跃时，普通独立阅读窗口（windowInfo.suiteSessionId 为空）
             // 的草稿也会被拒绝，关闭该窗口会丢失该题的在做答案/笔记。
             if (info.suiteSessionId) {
-                // Suite drafts stay on the suite session path.
-                return false;
+                return typeof this._handleSuiteDraftSync === 'function'
+                    ? this._handleSuiteDraftSync(examId, data, info, info.window)
+                    : false;
             }
             const expectedSessionId = info.expectedSessionId ? String(info.expectedSessionId) : '';
             const payloadSessionId = data && data.sessionId != null ? String(data.sessionId) : '';
@@ -10361,9 +10738,23 @@
             if (!draft.sessionId) {
                 return false;
             }
+            const isCurrentRegistration = () => {
+                const current = this.examWindows && this.examWindows.get(examId);
+                return current === info
+                    && (!current.window || !current.window.closed)
+                    && (!Number.isInteger(data.windowSessionGeneration)
+                        || !Number.isInteger(info.sessionGeneration)
+                        || Number(data.windowSessionGeneration) === Number(info.sessionGeneration));
+            };
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             // 必须在写队列里重新读取最新 store 再合并，否则并发不同 exam 的 write 会互相覆盖、
             // 后写者会丢掉前者的草稿（整个 map 是同一个存储 key，read-modify-write 非原子）。
             const store = await this._readReadingDraftStore();
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             const previous = store[String(draft.id)] || null;
             const previousNumericUpdatedAt = Number(previous && previous.updatedAt);
             const previousUpdatedAt = Number.isFinite(previousNumericUpdatedAt)
@@ -10383,7 +10774,13 @@
                 return false;
             }
             store[String(draft.id)] = draft;
+            if (!isCurrentRegistration()) {
+                return false;
+            }
             if (!await this._writeReadingDraftStore(store, draft)) {
+                return false;
+            }
+            if (!isCurrentRegistration()) {
                 return false;
             }
             info.lastReadingDraft = draft;
@@ -10401,7 +10798,20 @@
             }
             const queued = this._readingDraftStoreQueue
                 .catch(() => undefined)
-                .then(() => this.handleReadingDraftSync(examId, data, windowInfo));
+                .then(() => {
+                    const currentWindowInfo = this.examWindows && this.examWindows.get(examId);
+                    if (
+                        windowInfo
+                        && (
+                            currentWindowInfo !== windowInfo
+                            || currentWindowInfo.window !== windowInfo.window
+                            || currentWindowInfo.sessionGeneration !== windowInfo.sessionGeneration
+                        )
+                    ) {
+                        return false;
+                    }
+                    return this.handleReadingDraftSync(examId, data, windowInfo);
+                });
             this._readingDraftStoreQueue = queued.catch(() => undefined).then(() => {
                 if (this._readingDraftStoreQueue === queued) {
                     this._readingDraftStoreQueue = Promise.resolve();
@@ -10911,9 +11321,11 @@
                 info.expectedSessionId = this.generateSessionId(examId);
             }
             this._refreshExamWindowToken(examId, info);
-            const suiteSessionId = typeof this._resolveSuiteSessionId === 'function'
-                ? this._resolveSuiteSessionId(examId, info)
-                : (info.suiteSessionId || null);
+            const suiteSessionId = Object.prototype.hasOwnProperty.call(info, 'suiteSessionId')
+                ? (info.suiteSessionId || null)
+                : (typeof this._resolveSuiteSessionId === 'function'
+                    ? this._resolveSuiteSessionId(examId, info)
+                    : null);
             const activeSuite = suiteSessionId
                 && this.currentSuiteSession
                 && String(this.currentSuiteSession.id || '') === String(suiteSessionId)
@@ -10943,6 +11355,7 @@
                 parentOrigin: info.allowOpaqueOrigin ? 'null' : window.location.origin,
                 sessionId: info.expectedSessionId,
                 windowSessionToken: info.windowSessionToken || null,
+                windowSessionGeneration: Number.isInteger(info.sessionGeneration) ? info.sessionGeneration : 0,
                 messageIssuedAtMs,
                 suiteSessionId: suiteSessionId || null,
                 suiteFlowMode: info.suiteFlowMode || null,
@@ -10993,12 +11406,17 @@
             return payload;
         },
 
-        async _sendExamInitEnvelope(examId, targetWindow, extras = {}) {
+        async _sendExamInitEnvelope(examId, targetWindow, extras = {}, expectedRegistration = null) {
             if (!targetWindow || targetWindow.closed) {
                 return null;
             }
             try {
-                const windowInfo = this.ensureExamWindowSession(examId, targetWindow);
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return null;
+                }
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : this.ensureExamWindowSession(examId, targetWindow);
                 if (
                     windowInfo
                     && !windowInfo.reviewMode
@@ -11019,6 +11437,9 @@
                         // draft restore is best-effort
                     }
                 }
+                if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                    return null;
+                }
                 const initPayload = this._buildExamInitPayload(examId, windowInfo, extras);
                 this._postExamMessage(examId, targetWindow, 'INIT_SESSION', initPayload);
                 this._postExamMessage(examId, targetWindow, 'init_exam_session', initPayload);
@@ -11029,7 +11450,7 @@
             }
         },
 
-        restartExamHandshake(examWindow, examId) {
+        restartExamHandshake(examWindow, examId, expectedRegistration = null) {
             if (this._handshakeTimers && this._handshakeTimers.has(examId)) {
                 try {
                     clearInterval(this._handshakeTimers.get(examId));
@@ -11038,7 +11459,7 @@
                 }
                 this._handshakeTimers.delete(examId);
             }
-            this.startExamHandshake(examWindow, examId);
+            this.startExamHandshake(examWindow, examId, expectedRegistration);
         },
 
         ensureExamWindowSession(examId, examWindow = null) {
@@ -11070,11 +11491,19 @@
                     reviewSessionId: null,
                     reviewEntryIndex: 0,
                     readOnly: false,
+                    sessionGeneration: 1,
                     submittedRecordId: ''
                 });
             }
 
             const windowInfo = this.examWindows.get(examId);
+
+            if (!Number.isInteger(windowInfo.registrationId)) {
+                this._examRegistrationSequence = Math.max(0, Number(this._examRegistrationSequence) || 0) + 1;
+                windowInfo.registrationId = this._examRegistrationSequence;
+            }
+            if (!Number.isInteger(windowInfo.sessionGeneration)) windowInfo.sessionGeneration = 1;
+            if (!Number.isInteger(windowInfo.navigationEpoch)) windowInfo.navigationEpoch = 0;
 
             if (examWindow && (!windowInfo.window || windowInfo.window.closed || windowInfo.window !== examWindow)) {
                 windowInfo.window = examWindow;
@@ -11131,7 +11560,7 @@
          * 当前激活题库而拿到不一致的来源。
          * 该方法为 async：必要时调用方需 await。
          */
-        async _captureLaunchLibraryConfigurationId(examId) {
+        async _captureLaunchLibraryConfigurationId(examId, options = {}) {
             if (!examId) return null;
             if (!this._launchLibraryConfigurationIds) {
                 this._launchLibraryConfigurationIds = new Map();
@@ -11149,6 +11578,9 @@
             const normalized = (configurationId === undefined || configurationId === null)
                 ? null
                 : configurationId;
+            if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) {
+                return null;
+            }
             this._launchLibraryConfigurationIds.set(String(examId), normalized);
             // 同步作用中 windowInfo：避免后续 _buildExamInitPayload 等同步路径漏读
             try {
@@ -11227,11 +11659,17 @@
             }
         },
 
-        async _discardActiveSessionsForExam(examId) {
+        async _discardActiveSessionsForExam(examId, options = {}) {
             const activeSessions = await window.AppData.recovery.listActiveSessions();
+            if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) return 0;
+            const expectedSessionId = String(options.expectedSessionId || '').trim();
             const matches = (Array.isArray(activeSessions) ? activeSessions : [])
-                .filter((session) => session && session.examId === examId);
+                .filter((session) => session && session.examId === examId)
+                .filter((session) => !expectedSessionId
+                    || String(session.sessionId || '') === expectedSessionId
+                    || String(session.id || '').endsWith(`:${expectedSessionId}`));
             for (const session of matches) {
+                if (typeof options.commitGuard === 'function' && options.commitGuard() !== true) break;
                 const entityId = session.id || session.sessionId || session.recordId;
                 if (entityId) {
                     await window.AppData.recovery.discardActiveSession(entityId);
@@ -11259,8 +11697,13 @@
             return renderMode === 'unified-reading' || pageType === 'unified-reading';
         },
 
-        async retainExamWindowAfterCompletion(examId, sourceWindow, data = {}) {
-            const windowInfo = this.ensureExamWindowSession(examId, sourceWindow);
+        async retainExamWindowAfterCompletion(examId, sourceWindow, data = {}, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const windowInfo = expectedRegistration
+                ? expectedRegistration.windowInfo
+                : this.ensureExamWindowSession(examId, sourceWindow);
             windowInfo.window = sourceWindow || windowInfo.window || null;
             windowInfo.status = 'completed';
             windowInfo.completedAt = Date.now();
@@ -11270,10 +11713,14 @@
             windowInfo.readOnly = false;
             this.examWindows && this.examWindows.set(examId, windowInfo);
             await this._removeActiveExamSessionMetadata(examId);
+            return !expectedRegistration || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
         },
 
-        async handlePracticeResetRequest(examId, data = {}, sourceWindow = null) {
-            const targetWindow = sourceWindow
+        async handlePracticeResetRequest(examId, data = {}, sourceWindow = null, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const targetWindow = (expectedRegistration && expectedRegistration.window) || sourceWindow
                 || (this.examWindows && this.examWindows.has(examId) ? this.examWindows.get(examId).window : null);
             if (!targetWindow || targetWindow.closed) {
                 window.showMessage && window.showMessage('题目窗口已关闭，无法重置测试', 'warning');
@@ -11283,7 +11730,9 @@
             const payload = data && typeof data === 'object' ? data : {};
             const reason = String(payload.reason || '').trim().toLowerCase();
             const fromPracticeMode = String(payload.fromPracticeMode || payload.practiceMode || '').trim().toLowerCase();
-            const windowInfo = this.ensureExamWindowSession(examId, targetWindow);
+            const windowInfo = expectedRegistration
+                ? expectedRegistration.windowInfo
+                : this.ensureExamWindowSession(examId, targetWindow);
             const shouldReopenAsNormal = reason === 'memorize-start-test'
                 || fromPracticeMode === 'memorize'
                 || windowInfo.practiceMode === 'memorize';
@@ -11307,7 +11756,9 @@
             windowInfo.status = 'active';
             windowInfo.startTime = Date.now();
             windowInfo.completedAt = null;
+            windowInfo.sessionGeneration = Math.max(0, Number(windowInfo.sessionGeneration) || 0) + 1;
             windowInfo.expectedSessionId = this.generateSessionId(examId);
+            this._refreshExamWindowToken(examId, windowInfo);
             windowInfo.sessionId = null;
             windowInfo.practiceMode = null;
             windowInfo.reviewMode = false;
@@ -11320,7 +11771,24 @@
             windowInfo.lastResetReason = reason || 'reset';
             this.examWindows && this.examWindows.set(examId, windowInfo);
 
-            await this.startPracticeSession(examId);
+            let resetRegistration = this._captureExamSessionRegistration(examId, windowInfo);
+            if (!this._isExamSessionRegistrationCurrent(examId, resetRegistration)) {
+                return false;
+            }
+            resetRegistration = this.setupExamWindowCommunication(targetWindow, examId, null, {
+                expectedRegistration: resetRegistration,
+                deferInitialHandshake: true,
+                skipContentGuard: true
+            }) || resetRegistration;
+
+            const startResult = await this.startPracticeSession(examId, {
+                expectedRegistration: resetRegistration
+            });
+            if (!startResult || startResult.owned !== true
+                || !this._isExamSessionRegistrationCurrent(examId, startResult.registration)) {
+                return false;
+            }
+            resetRegistration = startResult.registration;
             this._syncRecorderSessionStarted(examId, windowInfo, {
                 pageType: 'unified-reading',
                 url: payload.normalUrl || payload.url || null,
@@ -11332,24 +11800,38 @@
                 practiceMode: null,
                 reviewMode: false,
                 readOnly: false
-            });
-            this.restartExamHandshake(targetWindow, examId);
+            }, resetRegistration);
+            if (!this._isExamSessionRegistrationCurrent(examId, resetRegistration)) {
+                return false;
+            }
+            this.restartExamHandshake(targetWindow, examId, resetRegistration);
             this.updateExamStatus(examId, 'in-progress');
+            return true;
         },
 
         /**
          * 开始练习会话
          */
-        async startPracticeSession(examId) {
-            const exam = await findExamDefinition(examId);
+        async startPracticeSession(examId, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            const exam = options && options.examDefinition
+                ? options.examDefinition
+                : await findExamDefinition(examId);
+            if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
             if (!exam) {
                 console.error('Exam not found:', examId);
                 window.showMessage && window.showMessage('题目索引未加载，请重试或重新导入题库。', 'error');
-                return;
+                return expectedRegistration
+                    ? { owned: false, sessionId: null, registration: expectedRegistration }
+                    : undefined;
             }
 
             try {
-                const windowInfo = this.examWindows && this.examWindows.get(examId);
+                const windowInfo = expectedRegistration
+                    ? expectedRegistration.windowInfo
+                    : (this.examWindows && this.examWindows.get(examId));
                 const hostSessionId = windowInfo && windowInfo.expectedSessionId
                     ? String(windowInfo.expectedSessionId)
                     : this.generateSessionId(examId);
@@ -11361,10 +11843,13 @@
                 // 优先使用新的练习页面管理器
                 if (window.practicePageManager) {
                     const sessionId = await window.practicePageManager.startPracticeSession(examId, exam);
+                    if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
 
                     // 更新题目状态
                     this.updateExamStatus(examId, 'in-progress');
-                    return sessionId;
+                    return expectedRegistration
+                        ? { owned: true, sessionId, registration: this._captureExamSessionRegistration(examId, windowInfo) }
+                        : sessionId;
                 }
 
                 // 使用练习记录器开始会话
@@ -11409,15 +11894,26 @@
                     };
 
                     await window.AppData.recovery.saveActiveSession(sessionData);
+                    if (!ownsRegistration()) return { owned: false, sessionId: null, registration: expectedRegistration };
                 }
 
                 // 更新题目状态
                 this.updateExamStatus(examId, 'in-progress');
+                if (expectedRegistration) {
+                    return {
+                        owned: ownsRegistration(),
+                        sessionId: windowInfo && windowInfo.expectedSessionId || hostSessionId,
+                        registration: this._captureExamSessionRegistration(examId, windowInfo)
+                    };
+                }
 
             } catch (error) {
                 console.error('[App] 启动练习会话失败:', error);
 
                 // 最终降级方案
+                if (expectedRegistration) {
+                    return { owned: false, sessionId: null, registration: expectedRegistration };
+                }
                 await this.startPracticeSessionFallback(examId, exam);
             }
         },
@@ -11485,7 +11981,10 @@
         /**
          * 处理数据采集器会话就绪
          */
-        handleSessionReady(examId, data) {
+        handleSessionReady(examId, data, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
             const payload = data && typeof data === 'object' ? data : {};
             const isListeningBridgeReady = payload.source === 'listening_record_bridge'
                 || payload.metadata?.source === 'listening_record_bridge'
@@ -11498,7 +11997,9 @@
 
             // 更新会话状态
             let windowInfo = null;
-            if (this.examWindows && this.examWindows.has(examId)) {
+            if (expectedRegistration) {
+                windowInfo = expectedRegistration.windowInfo;
+            } else if (this.examWindows && this.examWindows.has(examId)) {
                 windowInfo = this.examWindows.get(examId);
             } else {
                 windowInfo = this.ensureExamWindowSession(examId);
@@ -11518,7 +12019,8 @@
                 if (!isPreInitReady && payload.sessionId && windowInfo.expectedSessionId !== payload.sessionId) {
                     windowInfo.expectedSessionId = payload.sessionId;
                 }
-                if (payload.suiteSessionId && !windowInfo.suiteSessionId) {
+                if (payload.suiteSessionId
+                    && !Object.prototype.hasOwnProperty.call(windowInfo, 'suiteSessionId')) {
                     windowInfo.suiteSessionId = payload.suiteSessionId;
                 }
                 if (payload.suiteFlowMode && !windowInfo.suiteFlowMode) {
@@ -11593,7 +12095,9 @@
                             pageType: payload.pageType || null,
                             url: payload.url || null,
                             title: payload.title || null,
-                            suiteSessionId: payload.suiteSessionId || null,
+                            suiteSessionId: Object.prototype.hasOwnProperty.call(windowInfo || {}, 'suiteSessionId')
+                                ? (windowInfo.suiteSessionId || null)
+                                : (payload.suiteSessionId || null),
                             // 此处是练习页 SESSION_READY 后同步会话状态的时刻，注入启动时捕获的题库配置 ID。
                             libraryConfigurationId: this._readLaunchLibraryConfigurationId(examId, payload, windowInfo)
                         }
@@ -11736,6 +12240,7 @@
                     console.warn('[PracticeRecorder] 完成前同步会话状态失败:', startedError);
                 }
             }
+            return true;
         },
 
         _normalizeListeningSpellingErrors(examId, data) {
@@ -11767,7 +12272,11 @@
         /**
          * 处理练习完成（真实数据）
          */
-        async handlePracticeComplete(examId, data, sourceWindow = null) {
+        async handlePracticeComplete(examId, data, sourceWindow = null, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            const ownsRegistration = () => !expectedRegistration
+                || this._isExamSessionRegistrationCurrent(examId, expectedRegistration);
+            if (!ownsRegistration()) return false;
             if (data && !data.sessionId) {
                 data.sessionId = `${examId}_${Date.now()}`;
             }
@@ -11846,6 +12355,7 @@
             if (shouldDelegateToSuiteHandler && typeof this.handleSuitePracticeComplete === 'function') {
                 try {
                     const suiteOutcome = await this.handleSuitePracticeComplete(examId, data, sourceWindow);
+                    if (!ownsRegistration()) return false;
                     const handled = suiteOutcome === true || Boolean(suiteOutcome && suiteOutcome.handled);
                     if (handled) {
                         const committed = !suiteOutcome || typeof suiteOutcome !== 'object' || suiteOutcome.committed !== false;
@@ -11863,19 +12373,21 @@
                     }
                     suiteHandlerDeclined = true;
                 } catch (suiteError) {
-                    console.error('[SuitePractice] 处理套题结果失败，回退至普通流程:', suiteError);
-                    window.showMessage && window.showMessage('套题模式出现异常，记录将以单篇形式保存。', 'warning');
+                    console.error('[SuitePractice] 处理套题结果失败，保留 v2 恢复快照:', suiteError);
+                    window.showMessage && window.showMessage('套题模式出现异常，恢复快照已保留，请稍后重试。', 'error');
                     suiteHandlerDeclined = true;
                 }
             }
 
+            if (suiteHandlerDeclined && shouldDelegateToSuiteHandler) {
+                return false;
+            }
+            if (shouldDelegateToSuiteHandler && typeof this.handleSuitePracticeComplete !== 'function') {
+                return false;
+            }
+
             const recorder = this.components && this.components.practiceRecorder;
-            const completionData = suiteHandlerDeclined
-                ? Object.assign({}, data, {
-                    allowStandaloneSave: true,
-                    metadata: Object.assign({}, data?.metadata || {}, { allowStandaloneSave: true, suiteRecovery: true })
-                })
-                : data;
+            const completionData = data;
             // The generic completion rebind above already covers listening payloads.
 
             let completionCommitted = false;
@@ -11898,6 +12410,7 @@
                 if (!persistedRecord || typeof persistedRecord !== 'object' || !String(persistedRecord.id || '').trim()) {
                     throw new Error('Practice completion returned without a committed record');
                 }
+                if (!ownsRegistration()) return false;
 
                 let completionReadable = false;
                 if (typeof this._isPracticeCompletionPersisted === 'function') {
@@ -11910,6 +12423,7 @@
                 if (!completionReadable) {
                     throw new Error('Practice completion could not be verified in canonical storage');
                 }
+                if (!ownsRegistration()) return false;
                 completionCommitted = true;
 
                 if (completedViaFallback && recorder && typeof recorder.endPracticeSession === 'function') {
@@ -11990,9 +12504,14 @@
                 if (completionCommitted) {
                     try {
                         if (this._isResetCapableUnifiedReadingCompletion(completionData, sourceWindow)) {
-                            await this.retainExamWindowAfterCompletion(examId, sourceWindow, completionData);
+                            await this.retainExamWindowAfterCompletion(
+                                examId,
+                                sourceWindow,
+                                completionData,
+                                expectedRegistration
+                            );
                         } else {
-                            await this.cleanupExamSession(examId);
+                            await this.cleanupExamSession(examId, { expectedRegistration });
                         }
                     } catch (cleanupError) {
                         console.warn('[DataCollection] 练习已提交，但会话清理失败:', cleanupError);
@@ -12179,22 +12698,52 @@
         /**
          * 处理题目窗口关闭
          */
-        handleExamWindowClosed(examId) {
+        handleExamWindowClosed(examId, closedWindow = null, expectedRegistration = null) {
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const info = this.examWindows && this.examWindows.get(examId);
+            const expectedWindow = info && info.window ? info.window : null;
+            if (closedWindow && expectedWindow && closedWindow !== expectedWindow) {
+                return false;
+            }
+            if (info && info.closeMonitor) {
+                try { clearInterval(info.closeMonitor); } catch (_) {}
+                info.closeMonitor = null;
+            }
 
-            if (this.suiteExamMap && this.suiteExamMap.has(examId) && this.currentSuiteSession && this.currentSuiteSession.status === 'active' && this.suiteExamMap.get(examId) === this.currentSuiteSession.id) {
-                window.showMessage && window.showMessage('套题练习窗口已关闭，套题模式将被中断并回退到普通模式。', 'warning');
-                if (typeof this._abortSuiteSession === 'function') {
-                    this._abortSuiteSession(this.currentSuiteSession, {}).catch(error => {
-                        console.error('[SuitePractice] 中断套题失败:', error);
-                    });
+            const suite = this.currentSuiteSession;
+            const isSuiteExam = Boolean(
+                suite
+                && this.suiteExamMap
+                && this.suiteExamMap.get(examId) === suite.id
+                && suite.status === 'active'
+            );
+            if (isSuiteExam) {
+                if (String(suite.activeExamId || '') !== String(examId)) {
+                    return false;
+                }
+                if (closedWindow && suite.windowRef && closedWindow !== suite.windowRef) {
+                    return false;
+                }
+                suite.windowRef = null;
+                suite.status = 'active';
+                suite.lastUpdate = Date.now();
+                const persisted = typeof this._mirrorSessionToStorage === 'function'
+                    ? this._mirrorSessionToStorage(suite)
+                    : false;
+                if (persisted) {
+                    window.showMessage && window.showMessage('套题练习窗口已关闭，当前进度已暂停并保留，可从套题模式继续。', 'warning');
+                } else {
+                    window.showMessage && window.showMessage('套题窗口已关闭，但恢复快照保存失败，请勿关闭主页面。', 'error');
                 }
             }
 
-            // 更新题目状态
             this.updateExamStatus(examId, 'interrupted');
-
-            // 清理会话
-            this.cleanupExamSession(examId);
+            if (typeof this.cleanupExamSession === 'function') {
+                this.cleanupExamSession(examId, { expectedRegistration });
+            }
+            return true;
         },
 
         /**
@@ -12340,32 +12889,43 @@
         /**
          * 清理题目会话
          */
-        async _cleanupReusedWindowSessions(targetWindow, keepExamId = null) {
+        async _cleanupReusedWindowSessions(targetWindow, keepExamId = null, keepRegistration = null) {
             if (!targetWindow || !this.examWindows || typeof this.cleanupExamSession !== 'function') {
                 return [];
             }
             const normalizedKeepExamId = keepExamId != null ? String(keepExamId).trim() : '';
-            const staleExamIds = [];
+            const staleRegistrations = [];
             this.examWindows.forEach((windowInfo, candidateExamId) => {
                 const normalizedCandidateExamId = candidateExamId != null ? String(candidateExamId).trim() : '';
                 if (!normalizedCandidateExamId || (normalizedKeepExamId && normalizedCandidateExamId === normalizedKeepExamId)) {
                     return;
                 }
                 if (windowInfo && windowInfo.window === targetWindow) {
-                    staleExamIds.push(normalizedCandidateExamId);
+                    staleRegistrations.push({
+                        examId: normalizedCandidateExamId,
+                        registration: this._captureExamSessionRegistration(normalizedCandidateExamId, windowInfo)
+                    });
                 }
             });
-            for (const staleExamId of staleExamIds) {
+            for (const stale of staleRegistrations) {
                 try {
-                    await this.cleanupExamSession(staleExamId);
+                    if (keepRegistration && !this._isExamSessionRegistrationCurrent(keepExamId, keepRegistration)) break;
+                    await this.cleanupExamSession(stale.examId, { expectedRegistration: stale.registration });
                 } catch (error) {
-                    console.warn('[App] 清理复用窗口旧题目会话失败:', staleExamId, error);
+                    console.warn('[App] 清理复用窗口旧题目会话失败:', stale.examId, error);
                 }
             }
-            return staleExamIds;
+            return staleRegistrations.map(item => item.examId);
         },
 
-        async cleanupExamSession(examId) {
+        async cleanupExamSession(examId, options = {}) {
+            const expectedRegistration = options && options.expectedRegistration || null;
+            if (expectedRegistration && !this._isExamSessionRegistrationCurrent(examId, expectedRegistration)) {
+                return false;
+            }
+            const expectedSessionId = expectedRegistration && expectedRegistration.windowInfo.expectedSessionId
+                ? String(expectedRegistration.windowInfo.expectedSessionId)
+                : '';
             // 清理窗口引用
             if (this.examWindows && this.examWindows.has(examId)) {
                 this.examWindows.delete(examId);
@@ -12379,7 +12939,11 @@
             }
 
             // 清理活动会话
-            await this._discardActiveSessionsForExam(examId);
+            await this._discardActiveSessionsForExam(examId, {
+                expectedSessionId,
+                commitGuard: () => !(this.examWindows && this.examWindows.has(examId))
+            });
+            return true;
         },
 
         /**

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -7855,8 +7855,8 @@
     "path": "睡着过项目组/2. 所有文章(11.20)[192篇]/141. P1 - The history of the guitar 吉他的历史/",
     "filename": "141. P1 - The history of the guitar 吉他的历史.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/141. P1 - The history of the guitar 吉他的历史.pdf",
     "sourceKind": "generated-reading"
   },
   "p2-low-49": {
@@ -10030,7 +10030,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "200. P1 - Australia’s Airborne Dentists 澳洲飞行牙医【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/200. P1 - Australia’s Airborne Dentists 澳洲飞行牙医.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10045,7 +10045,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "211. P1 - Ahead of its time 新西兰头骨【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/211. P1 - Ahead of its time 新西兰头骨.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10060,7 +10060,7 @@
     "path": "三月/1.P1 高频/",
     "filename": "216. P1 - Australia’s cane toad problem 澳洲蟾蜍【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/216. P1 - Australia’s cane toad problem 澳洲蟾蜍.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10075,7 +10075,7 @@
     "path": "三月/2.P1 次高频/",
     "filename": "194. P1 - The history of the British wool industry 英国羊毛产业的历史【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/194. P1 - The history of the British wool industry 英国羊毛产业的历史.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10090,7 +10090,7 @@
     "path": "三月/",
     "filename": "222. P2 - Ideal Homes 理想居所.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/222. P2 - Ideal Homes 理想居所.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10105,7 +10105,7 @@
     "path": "三月/",
     "filename": "223. P1 - Effect and Cause 湖泊海啸研究.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/223. P1 - Effect and Cause 湖泊海啸研究.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10120,7 +10120,7 @@
     "path": "三月/3.P2 高频/",
     "filename": "201. P2 - Multi-tasking and the brain 大脑与多任务处理【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/201. P2 - Multi-tasking and the brain 大脑与多任务处理.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10135,7 +10135,7 @@
     "path": "三月/3.P2 高频/",
     "filename": "217. P2 - A mechanical friend for children 孩子的机器人朋友【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/217. P2 - A mechanical friend for children 孩子的机器人朋友.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10150,7 +10150,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "192. P2(1115纸笔) - Should we stop eating meat 是否应该吃素【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/192. P2(1115纸笔) - Should we stop eating meat 是否应该吃素.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10165,7 +10165,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "209. P2 - Decision Fatigue 决策疲劳【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/209. P2 - Decision Fatigue 决策疲劳.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10180,7 +10180,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "213. P2 - Growing more for less 卫星农业【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/213. P2 - Growing more for less 卫星农业.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10195,7 +10195,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "51. P2 - The dingo debate 澳洲野犬_澳洲野狗.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/51. P2 - The dingo debate 澳洲野犬_澳洲野狗.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10210,7 +10210,7 @@
     "path": "三月/4.P2 次高频/",
     "filename": "58. P2 - Who wrote Shakespeare's plays 莎士比亚【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/58. P2 - Who wrote Shakespeare's plays 莎士比亚.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10225,7 +10225,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "204. P3 - When people are ‘deaf’ to music 失乐症【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/204. P3 - When people are ‘deaf’ to music 失乐症.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10240,7 +10240,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "206. P3 - 200 Years of Australian Landscapes at the Royal Academy in London 亚洲风景展【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/206. P3 - 200 Years of Australian Landscapes at the Royal Academy in London 澳洲风景展.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10255,7 +10255,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "212. P3 - Children’s literature studies today 儿童文学【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/212. P3 - Children’s literature studies today 儿童文学.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10270,7 +10270,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "218. P3 - The Causes of Linguistic Change 语音的演变【高】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/218. P3 - The Causes of Linguistic Change 语音的演变.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10285,7 +10285,7 @@
     "path": "三月/5.P3 高频/",
     "filename": "219. P3 - The origin of language 语言的起源.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/219. P3 - The origin of language 语言的起源.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10300,8 +10300,8 @@
     "path": "三月/5.P3 高频/",
     "filename": "P3 - Risk taking.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P3 - Risk taking.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-medium-197": {
@@ -10315,7 +10315,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "197. P3 - Australia’s Megafauna Controversy 巨兽灭绝【次】.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/197. P3 - Australia’s Megafauna Controversy 巨兽灭绝.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10330,7 +10330,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "198. P3 - Child’s Play in Medieval England 中世纪的游戏.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/198. P3 - Child’s Play in Medieval England 中世纪的游戏.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10345,7 +10345,7 @@
     "path": "三月/6.P3 次高频/",
     "filename": "78. P3 (ds做出来的) - Music Language We All Speak 音乐语言.html",
     "hasHtml": true,
-    "hasPdf": false,
+    "hasPdf": true,
     "pdfFilename": "ReadingPractice/PDF/78. P3 (仅原文无题) - Music Language We All Speak 音乐语言.pdf",
     "sourceKind": "generated-reading"
   },
@@ -10525,8 +10525,8 @@
     "path": "",
     "filename": "",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - War of the Plants.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-high-229": {
@@ -10570,8 +10570,8 @@
     "path": "assets/generated/reading-exams/",
     "filename": "reading-practice-unified.html",
     "hasHtml": true,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - Coins – the first form of money.pdf",
     "sourceKind": "generated-reading"
   },
   "p1-high-240": {
@@ -10644,9 +10644,9 @@
     "difficultyScore": 3.5,
     "path": "",
     "filename": "",
-    "hasHtml": false,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasHtml": true,
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P2 - The internal body clock 生物钟.pdf",
     "sourceKind": "generated-reading"
   },
   "p3-medium-244": {
@@ -10659,9 +10659,9 @@
     "difficultyScore": 4,
     "path": "",
     "filename": "",
-    "hasHtml": false,
-    "hasPdf": false,
-    "pdfFilename": "",
+    "hasHtml": true,
+    "hasPdf": true,
+    "pdfFilename": "ReadingPractice/PDF/P3 - Look who was talking.pdf",
     "sourceKind": "generated-reading"
   }
 

--- a/js/bundles/practice.bundle.js
+++ b/js/bundles/practice.bundle.js
@@ -4277,7 +4277,8 @@ class PracticeRecorder {
      */
     async restoreActiveSessions() {
         const raw = await window.AppData.recovery.listActiveSessions();
-        const storedSessions = Array.isArray(raw) ? raw : [];
+        const storedSessions = (Array.isArray(raw) ? raw : [])
+            .filter((sessionData) => sessionData.schema !== 'suite-session-v2');
 
         storedSessions
             .slice()

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -5620,7 +5620,8 @@
         parentOrigin: '',
         parentOriginIsOpaque: false,
         windowSessionToken: '',
-        windowSessionIssuedAtMs: 0
+        windowSessionIssuedAtMs: 0,
+        windowSessionGeneration: 0
     };
 
     const dom = {
@@ -5881,6 +5882,10 @@
         var displaySeconds;
         var elapsed = getPageElapsedSeconds();
         var limitSeconds;
+        const isSuiteTimer = Boolean(state.suiteSessionId);
+        const suiteTimerMode = isSuiteTimer && state.suiteTimerMode === 'elapsed'
+            ? 'elapsed'
+            : (isSuiteTimer ? 'countdown' : '');
         const rawLimitSeconds = Number(state.suiteTimerLimitSeconds);
         if (Number.isFinite(rawLimitSeconds) && rawLimitSeconds > 0) {
             limitSeconds = Math.floor(rawLimitSeconds);
@@ -5901,21 +5906,26 @@
             }
             var remainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
             timer.textContent = remainingMinutes + ' minutes remaining';
+        } else if (suiteTimerMode === 'countdown') {
+            displaySeconds = Math.max(0, Number(limitSeconds || 0) - elapsed);
+            var suiteRemainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
+            timer.textContent = suiteRemainingMinutes + ' minutes remaining';
+        } else if (suiteTimerMode === 'elapsed') {
+            displaySeconds = elapsed;
+            timer.textContent = formatTimerSeconds(displaySeconds);
         } else if (preferences.mode === 'countdown') {
             const countdownSeconds = minutesToSeconds(preferences.countdownMinutes, 60);
             displaySeconds = Math.max(0, countdownSeconds - elapsed);
             timer.textContent = formatTimerSeconds(displaySeconds);
-        } else if (state.suiteSessionId && Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0) {
-            displaySeconds = Math.max(0, limitSeconds - elapsed);
-            var remainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
-            timer.textContent = remainingMinutes + ' minutes remaining';
         } else {
             displaySeconds = elapsed;
             timer.textContent = formatTimerSeconds(displaySeconds);
         }
         var hasEndlessCountdown = state.endlessCountdownEndTime && Number.isFinite(state.endlessCountdownEndTime);
-        var countdownExpired = preferences.mode === 'countdown' && !hasEndlessCountdown && displaySeconds <= 0;
-        var limitExpired = Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds);
+        var countdownExpired = !isSuiteTimer && preferences.mode === 'countdown' && !hasEndlessCountdown && displaySeconds <= 0;
+        var limitExpired = suiteTimerMode === 'countdown'
+            ? Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds)
+            : (!isSuiteTimer && Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds));
         var expired = Boolean(countdownExpired || limitExpired);
         state.timerExpired = expired;
         if (expired) {
@@ -5924,12 +5934,18 @@
         timer.classList.toggle('paused', !interaction.timerRunning && !hasEndlessCountdown);
         timer.classList.toggle('timer-expired', expired);
         if (timer.dataset) {
-            timer.dataset.timerMode = preferences.mode;
+            timer.dataset.timerMode = suiteTimerMode || preferences.mode;
             timer.dataset.expiryAction = preferences.expiryAction;
         }
         timer.style.opacity = (interaction.timerRunning || hasEndlessCountdown) ? '1' : '0.5';
         var _warnRemaining = !hasEndlessCountdown
-            && (preferences.mode === 'countdown' || (Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0))
+            && (
+                suiteTimerMode === 'countdown'
+                || (!isSuiteTimer && (
+                    preferences.mode === 'countdown'
+                    || (Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0)
+                ))
+            )
             && Number.isFinite(Number(displaySeconds))
             ? Math.max(0, Number(displaySeconds))
             : null;
@@ -6731,8 +6747,8 @@
         const baseUpdatedAt = Number(baseDraft && baseDraft.updatedAt);
         const nextUpdatedAt = Number(nextDraft && nextDraft.updatedAt);
         return Number.isFinite(baseUpdatedAt)
-            && Number.isFinite(nextUpdatedAt)
-            && nextUpdatedAt < baseUpdatedAt;
+            && baseUpdatedAt > 0
+            && (!Number.isFinite(nextUpdatedAt) || nextUpdatedAt <= baseUpdatedAt);
     }
 
     function mergeDraft(baseDraft, nextDraft) {
@@ -11021,8 +11037,44 @@
         return true;
     }
 
+    function capturePendingSubmissionOwnership(data = {}) {
+        if (!matchesPendingSubmission(data)) return null;
+        const generation = Number(state.windowSessionGeneration);
+        return {
+            parentWindow: state.parentWindow || null,
+            examId: String(state.examId || ''),
+            sessionId: String(state.sessionId || ''),
+            suiteSessionId: String(state.suiteSessionId || ''),
+            windowSessionToken: normalizeWindowSessionToken(state.windowSessionToken),
+            windowSessionGeneration: Number.isInteger(generation) && generation > 0 ? generation : 0,
+            submissionId: String(state.submissionId || ''),
+            finalSuiteSubmission: Boolean(
+                state.simulationMode
+                && state.simulationCtx
+                && state.simulationCtx.isLast
+                && state.suiteSessionId
+            )
+        };
+    }
+
+    function retainsSubmissionOwnership(ownership) {
+        if (!ownership || state.submissionStatus !== 'submitted') return false;
+        const generation = Number(state.windowSessionGeneration);
+        const currentGeneration = Number.isInteger(generation) && generation > 0 ? generation : 0;
+        return Boolean(
+            state.parentWindow === ownership.parentWindow
+            && String(state.examId || '') === ownership.examId
+            && String(state.sessionId || '') === ownership.sessionId
+            && String(state.suiteSessionId || '') === ownership.suiteSessionId
+            && normalizeWindowSessionToken(state.windowSessionToken) === ownership.windowSessionToken
+            && currentGeneration === ownership.windowSessionGeneration
+            && String(state.submissionId || '') === ownership.submissionId
+        );
+    }
+
     async function acceptSubmissionAcknowledgement(data = {}) {
-        if (!matchesPendingSubmission(data)) {
+        const ownership = capturePendingSubmissionOwnership(data);
+        if (!ownership) {
             return false;
         }
         const presentation = state.pendingSubmissionPresentation;
@@ -11032,6 +11084,9 @@
             state.lastResults = presentation.results;
             renderResults(presentation.results);
             await renderExplanations();
+            if (!retainsSubmissionOwnership(ownership)) {
+                return false;
+            }
             applyHighlights(Array.isArray(presentation.highlights) ? presentation.highlights : []);
             refreshNoteHighlightAttributes();
             restoreMissingNoteAnchors();
@@ -11039,11 +11094,21 @@
             enhanceReviewHighlights();
             updateNavStatuses(presentation.results);
         }
+        if (!retainsSubmissionOwnership(ownership)) {
+            return false;
+        }
         state.pendingSubmissionPresentation = null;
-        if (state.simulationMode && state.simulationCtx && state.simulationCtx.isLast) {
+        if (ownership.finalSuiteSubmission) {
             stopSimulationDraftSync();
             clearSimulationDraftMirror();
             state.simulationDraftFingerprint = '';
+            if (state.suiteSessionId && typeof global.close === 'function') {
+                try {
+                    global.close();
+                } catch (_) {
+                    // The host teardown remains the fallback when the browser refuses self-close.
+                }
+            }
         }
         return true;
     }
@@ -11493,6 +11558,7 @@
                 suiteTimerMode: state.suiteTimerMode,
                 suiteTimerLimitSeconds: state.suiteTimerLimitSeconds,
                 windowSessionToken: state.windowSessionToken || null,
+                windowSessionGeneration: Number.isInteger(state.windowSessionGeneration) ? state.windowSessionGeneration : 0,
                 messageIssuedAtMs,
                 source: MESSAGE_SOURCE
             }, payload || {}),
@@ -11539,6 +11605,8 @@
         const currentIssuedAtMs = Number.isFinite(Number(state.windowSessionIssuedAtMs))
             ? Number(state.windowSessionIssuedAtMs)
             : 0;
+        const incomingGeneration = Number(data && data.windowSessionGeneration);
+        const currentGeneration = Number(state.windowSessionGeneration);
 
         if (sourceWindow && state.parentWindow && sourceWindow !== state.parentWindow && currentToken) {
             return false;
@@ -11552,7 +11620,19 @@
         if (incomingToken === currentToken) {
             return true;
         }
-        if (incomingIssuedAtMs && currentIssuedAtMs && incomingIssuedAtMs >= currentIssuedAtMs) {
+        if (Number.isInteger(incomingGeneration) && incomingGeneration > 0) {
+            if (Number.isInteger(currentGeneration) && currentGeneration > 0) {
+                return incomingGeneration > currentGeneration;
+            }
+            return true;
+        }
+        if (Number.isInteger(currentGeneration) && currentGeneration > 0) {
+            return false;
+        }
+        // A timestamp alone cannot establish ordering when two registrations
+        // occur in the same millisecond.  Without a generation, keep the
+        // current token rather than allowing an ambiguous message to replace it.
+        if (incomingIssuedAtMs && currentIssuedAtMs && incomingIssuedAtMs > currentIssuedAtMs) {
             return true;
         }
         return false;
@@ -11561,6 +11641,7 @@
     function adoptWindowSessionMessage(data = {}, sourceWindow = null) {
         const incomingToken = normalizeWindowSessionToken(data && data.windowSessionToken);
         const incomingIssuedAtMs = readMessageIssuedAtMs(data);
+        const incomingGeneration = Number(data && data.windowSessionGeneration);
         if (incomingToken) {
             state.windowSessionToken = incomingToken;
         }
@@ -11568,6 +11649,9 @@
             state.windowSessionIssuedAtMs = incomingIssuedAtMs;
         } else if (incomingToken && !state.windowSessionIssuedAtMs) {
             state.windowSessionIssuedAtMs = Date.now();
+        }
+        if (Number.isInteger(incomingGeneration) && incomingGeneration > 0) {
+            state.windowSessionGeneration = incomingGeneration;
         }
     }
 
@@ -11820,7 +11904,7 @@
                 updatedAt: Date.now()
             });
         } catch (_) {
-            // ignore sessionStorage failures in restricted environments
+            // AppData v2 recovery is best-effort during page teardown.
         }
     }
 
@@ -11850,7 +11934,7 @@
         try {
             global.AppData.recovery.windowSession.discard(name);
         } catch (_) {
-            // ignore sessionStorage failures in restricted environments
+            // AppData v2 recovery is best-effort during page teardown.
         }
     }
 
@@ -11911,6 +11995,7 @@
             draft: mirroredDraft,
             draftUpdatedAt: Number.isFinite(Number(mirroredDraft.updatedAt)) ? Number(mirroredDraft.updatedAt) : Date.now(),
             elapsed: getPageElapsedSeconds(),
+            timerSnapshot: getPracticeTimerSnapshot(),
             reason
         });
     }
@@ -11936,6 +12021,10 @@
     }
 
     function flushReadingDraftOnLifecycle(reason = 'pagehide') {
+        if (state.simulationMode && state.suiteSessionId) {
+            syncSimulationDraftSnapshot(reason);
+            return;
+        }
         if (canSyncReadingDraft()) {
             syncReadingDraftSnapshot(reason);
             return;
@@ -11977,7 +12066,9 @@
             examId: state.examId,
             draft: mirroredDraft,
             draftUpdatedAt: Number.isFinite(Number(mirroredDraft.updatedAt)) ? Number(mirroredDraft.updatedAt) : Date.now(),
-            elapsed: getPageElapsedSeconds()
+            elapsed: getPageElapsedSeconds(),
+            timerSnapshot: getPracticeTimerSnapshot(),
+            reason
         });
     }
 

--- a/js/bundles/runtime-entry.bundle.js
+++ b/js/bundles/runtime-entry.bundle.js
@@ -1459,7 +1459,10 @@
     // Phase 3: 套题/随机练习/导出功能
     // ============================================================================
 
+    var suitePracticeLaunchPromise = null;
+
     function startSuitePractice() {
+        if (suitePracticeLaunchPromise) return suitePracticeLaunchPromise;
         function getSuitePreferenceUtils() {
             return global.SuitePreferenceUtils || null;
         }
@@ -1636,38 +1639,109 @@
             });
         }
 
+        function promptSuiteRecoveryChoice(candidate) {
+            return new Promise(function resolveRecoveryChoice(resolve) {
+                if (!global.document || !global.document.body) {
+                    resolve(null);
+                    return;
+                }
+                var existing = global.document.getElementById('suite-recovery-choice-modal');
+                if (existing && existing.parentNode) {
+                    existing.parentNode.removeChild(existing);
+                }
+                var completedCount = Math.max(0, Number(candidate && candidate.completedCount) || 0);
+                var total = Math.max(0, Number(candidate && candidate.total) || 0);
+                var escapedTitle = String(candidate && candidate.title || '当前篇章')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+                var host = global.document.createElement('div');
+                host.id = 'suite-recovery-choice-modal';
+                host.style.cssText = 'position:fixed;inset:0;background:rgba(15,23,42,0.55);display:flex;align-items:center;justify-content:center;z-index:10000;padding:16px;';
+                host.innerHTML = [
+                    '<div role="dialog" aria-modal="true" aria-labelledby="suite-recovery-title" style="width:min(440px,100%);background:var(--color-white, #fff);border:1px solid var(--color-gray-200, #e2e8f0);border-radius:8px;padding:24px;box-shadow:var(--shadow-xl, 0 20px 25px -5px rgba(0,0,0,0.1));font-family:var(--font-family-primary, sans-serif);">',
+                    '<h3 id="suite-recovery-title" style="margin:0 0 8px;font-size:20px;font-weight:700;color:var(--color-gray-900, #0f172a);letter-spacing:0;">发现未完成套题</h3>',
+                    '<p style="margin:0 0 6px;font-size:14px;line-height:1.6;color:var(--color-gray-700, #334155);">' + escapedTitle + '</p>',
+                    '<p style="margin:0 0 20px;font-size:13px;line-height:1.6;color:var(--color-gray-500, #64748b);">已完成 ' + completedCount + ' / ' + total + ' 篇。放弃后将删除这套未完成进度，但不会生成单篇记录。</p>',
+                    '<div style="display:flex;flex-wrap:wrap;justify-content:flex-end;gap:10px;">',
+                    '<button type="button" data-suite-recovery-choice="cancel" style="padding:10px 14px;border:1px solid var(--color-gray-300, #cbd5e1);border-radius:8px;background:var(--color-white, #fff);color:var(--color-gray-700, #334155);font-weight:600;cursor:pointer;">取消</button>',
+                    '<button type="button" data-suite-recovery-choice="discard" style="padding:10px 14px;border:1px solid #dc2626;border-radius:8px;background:var(--color-white, #fff);color:#b91c1c;font-weight:600;cursor:pointer;">放弃并新建</button>',
+                    '<button type="button" data-suite-recovery-choice="continue" style="padding:10px 14px;border:1px solid var(--color-brand-primary, #4f46e5);border-radius:8px;background:var(--color-brand-primary, #4f46e5);color:#fff;font-weight:600;cursor:pointer;">继续上次套题</button>',
+                    '</div>',
+                    '</div>'
+                ].join('');
+                host.addEventListener('click', function onRecoveryChoice(event) {
+                    var target = event.target && event.target.closest
+                        ? event.target.closest('button[data-suite-recovery-choice]')
+                        : null;
+                    if (!target) return;
+                    var choice = target.getAttribute('data-suite-recovery-choice');
+                    if (host.parentNode) host.parentNode.removeChild(host);
+                    resolve(choice === 'continue' || choice === 'discard' ? choice : null);
+                });
+                global.document.body.appendChild(host);
+            });
+        }
+
         var ensureSuiteReady = (global.AppEntry && typeof global.AppEntry.ensureSessionSuiteReady === 'function')
             ? global.AppEntry.ensureSessionSuiteReady()
             : ensurePracticeSuite();
 
-        return Promise.resolve(ensureSuiteReady).then(function afterReady() {
-            return promptSuiteModeSelection().then(function handleMode(selection) {
-                if (!selection || !selection.flowMode) {
-                    return undefined;
-                }
-                var appInstance = global.app;
-                if (appInstance && typeof appInstance.startSuitePractice === 'function') {
-                    try {
-                        return appInstance.startSuitePractice({
-                            flowMode: selection.flowMode,
-                            frequencyScope: selection.frequencyScope
-                        });
-                    } catch (error) {
-                        console.error('[AppActions] 套题模式启动失败', error);
-                        if (typeof global.showMessage === 'function') {
-                            global.showMessage('套题模式启动失败，请稍后重试', 'error');
-                        }
+        var launchPromise = Promise.resolve(ensureSuiteReady).then(function afterReady() {
+            var appInstance = global.app;
+            var launchNewSuite = function launchNewSuite() {
+                return promptSuiteModeSelection().then(function handleMode(selection) {
+                    if (!selection || !selection.flowMode) {
                         return undefined;
                     }
-                }
+                    if (appInstance && typeof appInstance.startSuitePractice === 'function') {
+                        try {
+                            return appInstance.startSuitePractice({
+                                flowMode: selection.flowMode,
+                                frequencyScope: selection.frequencyScope
+                            });
+                        } catch (error) {
+                            console.error('[AppActions] 套题模式启动失败', error);
+                            if (typeof global.showMessage === 'function') {
+                                global.showMessage('套题模式启动失败，请稍后重试', 'error');
+                            }
+                            return undefined;
+                        }
+                    }
 
-                var fallbackNotice = '套题模式尚未初始化，请完成加载后再试。';
-                if (typeof global.showMessage === 'function') {
-                    global.showMessage(fallbackNotice, 'warning');
-                } else if (typeof alert === 'function') {
-                    alert(fallbackNotice);
-                }
-                return undefined;
+                    var fallbackNotice = '套题模式尚未初始化，请完成加载后再试。';
+                    if (typeof global.showMessage === 'function') {
+                        global.showMessage(fallbackNotice, 'warning');
+                    } else if (typeof alert === 'function') {
+                        alert(fallbackNotice);
+                    }
+                    return undefined;
+                });
+            };
+
+            if (!appInstance || typeof appInstance.getSuiteRecoveryCandidate !== 'function') {
+                return launchNewSuite();
+            }
+            return Promise.resolve(appInstance.getSuiteRecoveryCandidate()).then(function handleRecoveryCandidate(candidate) {
+                if (!candidate) return launchNewSuite();
+                return promptSuiteRecoveryChoice(candidate).then(function handleRecoveryChoice(choice) {
+                    if (choice === 'continue') {
+                        return appInstance.startSuitePractice({
+                            recoveryAction: 'continue',
+                            recoverySessionId: candidate.id
+                        });
+                    }
+                    if (choice === 'discard') {
+                        if (typeof appInstance.abandonSuiteRecovery !== 'function') return undefined;
+                        return Promise.resolve(appInstance.abandonSuiteRecovery(candidate.id)).then(function afterAbandon(abandoned) {
+                            if (!abandoned) return undefined;
+                            return launchNewSuite();
+                        });
+                    }
+                    return undefined;
+                });
             });
         }).catch(function handleSuiteError(error) {
             console.error('[AppActions] 套题模块加载失败:', error);
@@ -1675,6 +1749,12 @@
                 global.showMessage('套题模块加载失败，请稍后重试', 'error');
             }
             return undefined;
+        });
+        suitePracticeLaunchPromise = launchPromise;
+        return launchPromise.finally(function clearSuitePracticeLaunchPromise() {
+            if (suitePracticeLaunchPromise === launchPromise) {
+                suitePracticeLaunchPromise = null;
+            }
         });
     }
 

--- a/js/bundles/session.bundle.js
+++ b/js/bundles/session.bundle.js
@@ -60,6 +60,141 @@
             if (typeof this._clearSuiteHandshakes === 'function') {
                 this._clearSuiteHandshakes();
             }
+
+            const restored = this._restoreSessionFromStorage();
+            if (restored) {
+                this._installRestoredSuiteSession(restored);
+            }
+            this._suiteRecoveryReady = this._restorePersistentSuiteSession(restored);
+        },
+
+        _installRestoredSuiteSession(restored) {
+            if (!restored) return null;
+            this.currentSuiteSession = restored;
+            this._registerSuiteSequence(restored);
+            this._suiteResumeNoticeShown = false;
+            return restored;
+        },
+
+        _clearInstalledSuiteRecoverySession(session = this.currentSuiteSession) {
+            if (session && this.suiteExamMap && Array.isArray(session.sequence)) {
+                session.sequence.forEach((entry) => {
+                    const examId = entry && entry.examId != null ? String(entry.examId) : '';
+                    if (examId && this.suiteExamMap.get(examId) === session.id) {
+                        this.suiteExamMap.delete(examId);
+                    }
+                });
+            }
+            if (!session || this.currentSuiteSession === session) this.currentSuiteSession = null;
+        },
+
+        async _restorePersistentSuiteSession(fastSnapshotSession = null) {
+            const recovery = global.AppData && global.AppData.recovery;
+            if (!recovery || typeof recovery.listActiveSessions !== 'function') {
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                if (fastSnapshotSession) this._notifySuiteResumeAvailable(fastSnapshotSession);
+                return fastSnapshotSession;
+            }
+
+            try {
+                if (global.AppData.ready && typeof global.AppData.ready.then === 'function') {
+                    await global.AppData.ready;
+                }
+                const items = await recovery.listActiveSessions();
+                const durableCandidates = [];
+                for (const item of Array.isArray(items) ? items : []) {
+                    if (!item || item.schema !== 'suite-session-v2' || Number(item.version) !== 2 || !item.id) {
+                        continue;
+                    }
+                    const restored = this._restoreSessionFromStorage(item);
+                    if (restored) {
+                        durableCandidates.push(restored);
+                    }
+                }
+
+                if (durableCandidates.length === 0) {
+                    this._suiteRecoveryAmbiguous = false;
+                    this._suiteRecoveryAmbiguousCount = 0;
+                    this._clearInstalledSuiteRecoverySession(this.currentSuiteSession || fastSnapshotSession);
+                    this._clearSessionStorage();
+                    return null;
+                }
+
+                if (durableCandidates.length > 1) {
+                    this._suiteRecoveryAmbiguous = true;
+                    this._suiteRecoveryAmbiguousCount = durableCandidates.length;
+                    this._clearInstalledSuiteRecoverySession(this.currentSuiteSession || fastSnapshotSession);
+                    this._clearSessionStorage();
+                    window.showMessage && window.showMessage(
+                        'Multiple unfinished suites were found. Recovery is paused because this single-window build cannot choose one safely.',
+                        'warning'
+                    );
+                    return null;
+                }
+
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                const selected = durableCandidates[0];
+                this._clearInstalledSuiteRecoverySession(this.currentSuiteSession);
+                this._installRestoredSuiteSession(selected);
+                this._mirrorSuiteRecoverySnapshot(this._buildSuiteRecoverySnapshot(selected, {
+                    bumpRevision: false,
+                    bumpLastUpdate: false
+                }));
+                this._notifySuiteResumeAvailable(selected);
+                return selected;
+            } catch (error) {
+                console.warn('[SuitePractice] Unable to restore durable suite recovery:', error);
+                this._suiteRecoveryAmbiguous = false;
+                this._suiteRecoveryAmbiguousCount = 0;
+                if (fastSnapshotSession) this._notifySuiteResumeAvailable(fastSnapshotSession);
+                return fastSnapshotSession;
+            }
+        },
+
+        async _ensureSuiteRecoveryReady() {
+            if (!this._suiteModeReady) {
+                if (this.currentSuiteSession) {
+                    this._suiteModeReady = true;
+                } else {
+                    this.initializeSuiteMode();
+                }
+            }
+            if (this._suiteRecoveryReady && typeof this._suiteRecoveryReady.then === 'function') {
+                await this._suiteRecoveryReady;
+            }
+            return this.currentSuiteSession;
+        },
+
+        async getSuiteRecoveryCandidate() {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            if (!session || !['active', 'initializing', 'finalizing'].includes(session.status)) return null;
+            const sequence = Array.isArray(session.sequence) ? session.sequence : [];
+            const index = Math.min(Math.max(0, Number(session.currentIndex) || 0), Math.max(0, sequence.length - 1));
+            const entry = sequence[index] || null;
+            return {
+                id: String(session.id),
+                status: session.status,
+                currentIndex: index,
+                total: sequence.length,
+                title: entry && entry.exam && entry.exam.title
+                    ? entry.exam.title
+                    : (entry && entry.examId) || 'Unfinished suite',
+                completedCount: Array.isArray(session.results) ? session.results.length : 0
+            };
+        },
+
+        async abandonSuiteRecovery(expectedSessionId = '') {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            const expectedId = String(expectedSessionId || '').trim();
+            if (!expectedId || !session || String(session.id) !== expectedId) {
+                window.showMessage && window.showMessage('The unfinished suite changed. Please review it again before abandoning it.', 'warning');
+                return false;
+            }
+            return this._abortSuiteSession(session, { reason: 'user_discard' });
         },
 
         async startSuitePractice(options = {}) {
@@ -69,13 +204,34 @@
                 if (!this._suiteModeReady) {
                     this.initializeSuiteMode();
                 }
+                await this._ensureSuiteRecoveryReady();
+                if (this._suiteRecoveryAmbiguous === true) {
+                    window.showMessage && window.showMessage(
+                        'Multiple unfinished suites require manual cleanup before starting another suite.',
+                        'warning'
+                    );
+                    return false;
+                }
+                const recoveryAction = String(options.recoveryAction || '').trim().toLowerCase();
+                const recoverySessionId = String(options.recoverySessionId || '').trim();
                 const suitePreference = this._resolveSuitePreference(options);
                 const flowMode = suitePreference.flowMode;
                 const frequencyScope = suitePreference.frequencyScope;
 
-                if (this.currentSuiteSession && this.currentSuiteSession.status === 'active') {
-                    window.showMessage && window.showMessage('套题练习正在进行中，请先完成当前套题。', 'warning');
-                    return;
+                if (this.currentSuiteSession && ['active', 'initializing', 'finalizing'].includes(this.currentSuiteSession.status)) {
+                    if (!recoverySessionId || String(this.currentSuiteSession.id) !== recoverySessionId) {
+                        window.showMessage && window.showMessage('The unfinished suite changed. Please choose Continue or Abandon again.', 'warning');
+                        return false;
+                    }
+                    if (recoveryAction === 'continue' || recoveryAction === 'resume') {
+                        return this.resumeSuitePractice(recoverySessionId);
+                    }
+                    if (recoveryAction === 'restart' || recoveryAction === 'discard' || recoveryAction === 'abandon') {
+                        if (!await this.abandonSuiteRecovery(recoverySessionId)) return false;
+                    } else {
+                        window.showMessage && window.showMessage('Choose Continue or Abandon for the unfinished suite before starting another one.', 'warning');
+                        return false;
+                    }
                 }
 
                 if (frequencyScope === 'custom') {
@@ -162,15 +318,18 @@
                         ? '驻足模式'
                         : (flowMode === 'simulation' ? '模拟模式' : '经典模式')
                 });
-                if (!started && this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
-                }
+                return started;
             } catch (error) {
                 console.error('[SuitePractice] 启动失败:', error);
                 window.showMessage && window.showMessage('套题练习启动失败，请稍后重试。', 'error');
-                if (this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
+                if (this.currentSuiteSession && ['initializing', 'active'].includes(this.currentSuiteSession.status)) {
+                    this.currentSuiteSession.windowRef = null;
+                    this.currentSuiteSession._restoredFromStorage = true;
+                    this.currentSuiteSession.lastUpdate = Date.now();
+                    await this._commitSuiteRecovery(this.currentSuiteSession, { notify: false, reason: 'startup-error' });
+                    window.showMessage && window.showMessage('首篇窗口未能打开，套题恢复快照已保留，可稍后重试。', 'warning');
                 }
+                return false;
             }
         },
         async handleSuitePracticeComplete(examId, data, sourceWindow = null) {
@@ -192,6 +351,7 @@
                 return await this._handleInlineSimulationSuiteSubmit(examId, data, sourceWindow);
             }
 
+            await this._ensureSuiteRecoveryReady();
             const session = this.currentSuiteSession;
             if (!session) {
                 return false;
@@ -203,13 +363,28 @@
             if (payloadSuiteSessionId && payloadSuiteSessionId !== session.id) {
                 return false;
             }
+            if (session.status === 'finalizing') {
+                session._finalizeSubmissionId = data && data.submissionId
+                    ? String(data.submissionId)
+                    : (session._finalizeSubmissionId || null);
+                const committed = await this._finalizeSuiteRecordWithGate(session, {
+                    deferTeardown: Boolean(
+                        session._finalizeSubmissionId
+                        && sourceWindow
+                        && !sourceWindow.closed
+                    )
+                });
+                return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', data && data.submissionId ? {
+                    teardownSession: committed ? session : null
+                } : null);
+            }
             if (session.status === 'completed') {
                 return withSubmitOutcome(true, true, '', data && data.submissionId ? {
                     teardownSession: session
                 } : null);
             }
             if (session.status !== 'active') {
-                return false;
+                return withSubmitOutcome(true, false, 'suite_finalizing');
             }
 
             const mappingMissing = !this.suiteExamMap || !this.suiteExamMap.has(examId);
@@ -243,6 +418,74 @@
                 return withSubmitOutcome(true, false, 'inactive_suite_exam');
             }
 
+            const timerFields = [
+                'globalTimerAnchorMs',
+                'suiteTimerAnchorMs',
+                'suiteTimerMode',
+                'suiteTimerLimitSeconds',
+                'suiteTimerPausedOffsetMs',
+                'suiteTimerPausedAtMs',
+                'suiteTimerRunning'
+            ];
+            const passageRollbackState = {
+                results: this._cloneSuitePlainObject(session.results || []),
+                draftsByExam: this._cloneSuitePlainObject(session.draftsByExam || {}),
+                elapsedByExam: this._cloneSuitePlainObject(session.elapsedByExam || {}),
+                scalar: Object.fromEntries([
+                    'lastUpdate',
+                    'revision',
+                    'draftRevision',
+                    'currentIndex',
+                    'activeExamId',
+                    'pendingAdvance'
+                ].map((field) => [field, {
+                    present: Object.prototype.hasOwnProperty.call(session, field),
+                    value: field === 'pendingAdvance'
+                        ? this._cloneSuitePlainObject(session[field])
+                        : session[field]
+                }])),
+                timer: Object.fromEntries(timerFields.map((field) => [field, {
+                    present: Object.prototype.hasOwnProperty.call(session, field),
+                    value: session[field]
+                }]))
+            };
+            let previousWindowSnapshot = null;
+            try {
+                previousWindowSnapshot = global.AppData?.recovery?.windowSession?.get('simulation') || null;
+            } catch (_) {}
+            const rollbackPassageSubmission = () => {
+                session.results = this._cloneSuitePlainObject(passageRollbackState.results);
+                session.draftsByExam = this._cloneSuitePlainObject(passageRollbackState.draftsByExam);
+                session.elapsedByExam = this._cloneSuitePlainObject(passageRollbackState.elapsedByExam);
+                Object.keys(passageRollbackState.scalar).forEach((field) => {
+                    const captured = passageRollbackState.scalar[field];
+                    if (captured.present) {
+                        session[field] = field === 'pendingAdvance'
+                            ? this._cloneSuitePlainObject(captured.value)
+                            : captured.value;
+                    } else {
+                        delete session[field];
+                    }
+                });
+                timerFields.forEach((field) => {
+                    const captured = passageRollbackState.timer[field];
+                    if (captured.present) session[field] = captured.value;
+                    else delete session[field];
+                });
+                try {
+                    if (previousWindowSnapshot) {
+                        global.AppData.recovery.windowSession.save('simulation', previousWindowSnapshot);
+                    } else {
+                        const currentSnapshot = global.AppData?.recovery?.windowSession?.get('simulation');
+                        if (currentSnapshot && String(currentSnapshot.id || '') === String(session.id)) {
+                            global.AppData.recovery.windowSession.discard('simulation');
+                        }
+                    }
+                } catch (rollbackError) {
+                    console.warn('[SuitePractice] Unable to restore the pre-submit recovery mirror:', rollbackError);
+                }
+            };
+
             const derivedDuration = this._deriveSuiteExamElapsedSeconds(session, examId, data && data.duration);
             const normalized = this._normalizeSuiteResult(sequenceEntry.exam, Object.assign({}, data, {
                 duration: derivedDuration
@@ -250,7 +493,6 @@
             this._upsertSuiteResult(session, examId, normalized);
             this._syncSuiteTimerFromPayload(session, data);
             session.lastUpdate = Date.now();
-            this.updateExamStatus && this.updateExamStatus(examId, 'completed');
 
             this._persistSuiteDraftSnapshot(session, examId, data);
             if (Number.isFinite(Number(data && data.duration))) {
@@ -271,7 +513,12 @@
                     finalReview: currentIndex >= session.sequence.length - 1,
                     updatedAt: Date.now()
                 };
-                this._mirrorSessionToStorage(session);
+                const committed = await this._commitSuiteRecovery(session, { reason: 'passage-submit' });
+                if (!committed) {
+                    rollbackPassageSubmission();
+                    return withSubmitOutcome(true, false, 'suite_recovery_save_failed');
+                }
+                this.updateExamStatus && this.updateExamStatus(examId, 'completed');
                 const replayWindow = sourceWindow && !sourceWindow.closed
                     ? sourceWindow
                     : (session.windowRef && !session.windowRef.closed ? session.windowRef : null);
@@ -282,13 +529,22 @@
             }
 
             session.currentIndex = currentIndex + 1;
+            session.activeExamId = session.currentIndex < session.sequence.length
+                ? session.sequence[session.currentIndex].examId
+                : null;
             session.pendingAdvance = null;
-            this._mirrorSessionToStorage(session);
+            const passageCommitted = await this._commitSuiteRecovery(session, { reason: 'passage-submit' });
+            if (!passageCommitted) {
+                rollbackPassageSubmission();
+                return withSubmitOutcome(true, false, 'suite_recovery_save_failed');
+            }
+            this.updateExamStatus && this.updateExamStatus(examId, 'completed');
 
             // Last passage -> finalize the entire simulation
             if (session.currentIndex >= session.sequence.length) {
                 const deferTeardown = Boolean(data && data.submissionId && sourceWindow && !sourceWindow.closed);
-                const committed = await this.finalizeSuiteRecord(session, { deferTeardown });
+                session._finalizeSubmissionId = data && data.submissionId ? String(data.submissionId) : null;
+                const committed = await this._finalizeSuiteRecordWithGate(session, { deferTeardown });
                 return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', deferTeardown ? {
                     teardownSession: session
                 } : null);
@@ -304,7 +560,7 @@
             }
 
             const advanced = await this._advanceSuiteToNext(session, sequenceEntry.exam.title, examId);
-            return withSubmitOutcome(advanced, advanced, advanced ? '' : 'suite_advance_failed');
+            return withSubmitOutcome(true, true, advanced ? '' : 'suite_advance_failed');
         },
 
         async continueSuitePractice() {
@@ -317,6 +573,138 @@
                 return false;
             }
             return this._advanceSuiteToNext(session, 'previous section', null);
+        },
+
+        async resumeSuitePractice(expectedSessionId = '') {
+            await this._ensureSuiteRecoveryReady();
+            const session = this.currentSuiteSession;
+            const expectedId = String(expectedSessionId || '').trim();
+            if (!expectedId || !session || String(session.id) !== expectedId) {
+                window.showMessage && window.showMessage('The unfinished suite changed. Please choose Continue again.', 'warning');
+                return false;
+            }
+            if (!session || !['active', 'initializing', 'finalizing'].includes(session.status)) {
+                return false;
+            }
+            if (session._resumePromise && typeof session._resumePromise.then === 'function') {
+                return session._resumePromise;
+            }
+
+            const resumePromise = (async () => {
+                const sequence = Array.isArray(session.sequence) ? session.sequence : [];
+                if (!sequence.length) {
+                    await this._discardStoredSuiteSession(session);
+                    return false;
+                }
+
+                // A terminal snapshot is deliberately never clamped back to P3. The
+                // aggregate record and operation id are replayed until v2 confirms it.
+                if (session.status === 'finalizing' || session.currentIndex >= sequence.length) {
+                    session.status = 'finalizing';
+                    session.currentIndex = sequence.length;
+                    session.activeExamId = null;
+                    if (!await this._commitSuiteRecovery(session, { reason: 'finalize-resume' })) return false;
+                    return this._finalizeSuiteRecordWithGate(session, { fromRecovery: true });
+                }
+                if (typeof this.openExam !== 'function') return false;
+
+                let currentExamIndex = null;
+                if (session._restoredFromStorage === true && typeof this._fetchSuiteExamIndex === 'function') {
+                    try {
+                        currentExamIndex = await this._fetchSuiteExamIndex();
+                    } catch (validationError) {
+                        console.warn('[SuitePractice] 无法验证恢复目标，保留快照供稍后重试:', validationError);
+                        window.showMessage && window.showMessage('暂时无法读取当前题库，未完成套题仍会保留。', 'warning');
+                        return false;
+                    }
+                    if (Array.isArray(currentExamIndex)) {
+                        const byId = new Map(currentExamIndex.map((entry) => {
+                            const id = entry && (entry.id ?? entry.examId);
+                            return id == null ? null : [String(id), entry];
+                        }).filter(Boolean));
+                        const targetId = String(sequence[session.currentIndex].examId);
+                        const missingSequenceEntry = sequence.some((entry) => !byId.has(String(entry.examId)));
+                        if (missingSequenceEntry || !byId.has(targetId)) {
+                            await this._discardStoredSuiteSession(session);
+                            window.showMessage && window.showMessage('未完成套题与当前题库不一致，恢复数据已清除。', 'warning');
+                            return false;
+                        }
+                        session.sequence = sequence.map((entry) => {
+                            const indexed = byId.get(String(entry.examId));
+                            return indexed
+                                ? { ...entry, exam: indexed, title: entry.title || indexed.title, category: entry.category || indexed.category }
+                                : entry;
+                        });
+                    }
+                }
+
+                const targetEntry = session.sequence[session.currentIndex];
+                if (!targetEntry || !targetEntry.examId) return false;
+                session.status = 'active';
+                session.activeExamId = targetEntry.examId;
+                session.windowRef = null;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'suite-resume' })) return false;
+
+                let launchContext = null;
+                try {
+                    launchContext = await this.openExam(targetEntry.examId, {
+                        target: 'tab',
+                        examDefinition: targetEntry.exam,
+                        windowName: session.windowName || 'ielts-suite-mode-tab',
+                        suiteSessionId: session.id,
+                        suiteFlowMode: session.flowMode || 'simulation',
+                        suiteTimerMode: session.suiteTimerMode || 'countdown',
+                        suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds))
+                            ? Number(session.suiteTimerLimitSeconds)
+                            : 3600,
+                        sequenceIndex: session.currentIndex,
+                        sequenceTotal: session.sequence.length,
+                        returnLaunchContext: true
+                    });
+                } catch (error) {
+                    console.warn('[SuitePractice] 恢复套题窗口失败:', error);
+                }
+                const examWindow = launchContext && launchContext.window
+                    ? launchContext.window
+                    : launchContext;
+                const registration = launchContext && launchContext.registration
+                    ? launchContext.registration
+                    : null;
+                if (!examWindow || examWindow.closed) {
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    this._mirrorSessionToStorage(session);
+                    window.showMessage && window.showMessage('未能打开未完成套题，请检查弹窗权限后再次点击套题模式。', 'warning');
+                    return false;
+                }
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                    return false;
+                }
+
+                session.windowRef = examWindow;
+                session._activeLaunchRegistration = registration;
+                session._restoredFromStorage = false;
+                this._ensureSuiteWindowGuard(session, examWindow);
+                this._focusSuiteWindow(examWindow);
+                if (session.flowMode === 'simulation') {
+                    this._sendSimulationContext(session, targetEntry.examId, examWindow);
+                } else if (session.pendingAdvance || (session.results || []).some((entry) => entry && entry.examId === targetEntry.examId)) {
+                    await this._sendSuiteReviewState(session, targetEntry.examId, examWindow).catch((error) => {
+                        console.warn('[SuitePractice] 恢复套题回看状态失败:', error);
+                    });
+                }
+                window.showMessage && window.showMessage(`已恢复未完成套题：${targetEntry.exam?.title || targetEntry.examId}`, 'success');
+                return true;
+            })();
+            session._resumePromise = resumePromise;
+            try {
+                return await resumePromise;
+            } finally {
+                if (session._resumePromise === resumePromise) delete session._resumePromise;
+            }
         },
 
         async _handleInlineSimulationSuiteSubmit(examId, data, sourceWindow = null) {
@@ -338,6 +726,21 @@
                 : '';
             if (payloadSuiteSessionId && payloadSuiteSessionId !== session.id) {
                 return false;
+            }
+            if (session.status === 'finalizing') {
+                session._finalizeSubmissionId = data && data.submissionId
+                    ? String(data.submissionId)
+                    : (session._finalizeSubmissionId || null);
+                const committed = await this._finalizeSuiteRecordWithGate(session, {
+                    deferTeardown: Boolean(
+                        session._finalizeSubmissionId
+                        && sourceWindow
+                        && !sourceWindow.closed
+                    )
+                });
+                return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', session._finalizeSubmissionId ? {
+                    teardownSession: committed ? session : null
+                } : null);
             }
             if (session.status === 'completed') {
                 return withSubmitOutcome(true, true, '', data && data.submissionId ? {
@@ -423,7 +826,8 @@
             }
             this._mirrorSessionToStorage(session);
             const deferTeardown = Boolean(data && data.submissionId && sourceWindow && !sourceWindow.closed);
-            const committed = await this.finalizeSuiteRecord(session, { deferTeardown });
+            session._finalizeSubmissionId = data && data.submissionId ? String(data.submissionId) : null;
+            const committed = await this._finalizeSuiteRecordWithGate(session, { deferTeardown });
             return withSubmitOutcome(true, committed, committed ? '' : 'suite_save_failed', deferTeardown ? {
                 teardownSession: session
             } : null);
@@ -556,16 +960,87 @@
             const previousDraft = session.draftsByExam[normalizedExamId] || null;
             const previousUpdatedAt = Number(previousDraft && previousDraft.updatedAt);
             const nextUpdatedAt = Number(nextDraft.updatedAt);
+            const suppliedUpdatedAt = Number(data && (data.draftUpdatedAt
+                ?? (data.draft && data.draft.updatedAt)
+                ?? data.updatedAt));
+            if (previousDraft && !Number.isFinite(suppliedUpdatedAt)) {
+                return false;
+            }
             if (
                 previousDraft
                 && Number.isFinite(previousUpdatedAt)
                 && Number.isFinite(nextUpdatedAt)
-                && nextUpdatedAt < previousUpdatedAt
+                && nextUpdatedAt <= previousUpdatedAt
             ) {
                 return false;
             }
+            nextDraft.updatedAt = Number.isFinite(suppliedUpdatedAt) ? suppliedUpdatedAt : nextDraft.updatedAt;
             session.draftsByExam[normalizedExamId] = nextDraft;
+            session.draftRevision = Math.max(0, Number(session.draftRevision) || 0) + 1;
+            const previousUpdate = Number(session.lastUpdate);
+            session.lastUpdate = Math.max(
+                Number.isFinite(previousUpdate) ? previousUpdate : 0,
+                Number.isFinite(suppliedUpdatedAt) ? suppliedUpdatedAt : Date.now(),
+                Date.now()
+            );
             return true;
+        },
+
+        _handleSuiteDraftSync(examId, data = {}, windowInfo = null, sourceWindow = null) {
+            const session = this.currentSuiteSession;
+            const normalizedExamId = examId != null ? String(examId).trim() : '';
+            const registeredWindowInfo = !this.examWindows
+                || (typeof this.examWindows.values === 'function'
+                    ? Array.from(this.examWindows.values()).includes(windowInfo)
+                    : Object.values(this.examWindows).includes(windowInfo));
+            const payloadSuiteId = data && data.suiteSessionId != null ? String(data.suiteSessionId).trim() : '';
+            const expectedSuiteId = windowInfo && windowInfo.suiteSessionId != null
+                ? String(windowInfo.suiteSessionId).trim()
+                : '';
+            const incomingUpdatedAt = Number(data && (data.draftUpdatedAt
+                ?? (data.draft && data.draft.updatedAt)
+                ?? data.updatedAt));
+            if (
+                !session
+                || !['active', 'initializing'].includes(session.status)
+                || !normalizedExamId
+                || !payloadSuiteId
+                || payloadSuiteId !== String(session.id)
+                || (expectedSuiteId && expectedSuiteId !== String(session.id))
+                || !windowInfo
+                || (this.examWindows && !registeredWindowInfo)
+                || !windowInfo.window
+                || windowInfo.window.closed
+                || (sourceWindow && sourceWindow !== windowInfo.window)
+                || (session.windowRef && session.windowRef.closed)
+                || (session.flowMode !== 'simulation' && session.windowRef && session.windowRef !== windowInfo.window)
+                || (session.flowMode !== 'simulation' && !session.windowRef && session.status !== 'initializing')
+                || !Number.isFinite(incomingUpdatedAt)
+                || incomingUpdatedAt <= 0
+                || !Array.isArray(session.sequence)
+                || !session.sequence.some((entry) => entry && String(entry.examId) === normalizedExamId)
+                || !data.draft
+                || typeof data.draft !== 'object'
+            ) {
+                return false;
+            }
+            if (!this._persistSuiteDraftSnapshot(session, normalizedExamId, data)) {
+                return false;
+            }
+            if (Number.isFinite(Number(data.elapsed))) {
+                session.elapsedByExam[normalizedExamId] = typeof this._deriveSuiteExamElapsedSeconds === 'function'
+                    ? this._deriveSuiteExamElapsedSeconds(session, normalizedExamId, Number(data.elapsed))
+                    : Math.max(0, Number(data.elapsed));
+            }
+            this._syncSuiteTimerFromPayload(session, data);
+            session.windowRef = windowInfo.window;
+            const indexedEntry = Number.isInteger(session.currentIndex)
+                ? session.sequence[session.currentIndex]
+                : null;
+            if (indexedEntry && String(indexedEntry.examId) === normalizedExamId) {
+                session.activeExamId = normalizedExamId;
+            }
+            return this._mirrorSessionToStorage(session);
         },
 
         _buildSuiteSequencePayload(session) {
@@ -599,6 +1074,28 @@
                 return JSON.parse(JSON.stringify(value));
             } catch (_) {
                 return Array.isArray(value) ? value.slice() : { ...value };
+            }
+        },
+
+        _suiteComparableValue(value) {
+            if (Array.isArray(value)) {
+                return value.map((item) => this._suiteComparableValue(item));
+            }
+            if (value && typeof value === 'object') {
+                return Object.keys(value).sort().reduce((result, key) => {
+                    result[key] = this._suiteComparableValue(value[key]);
+                    return result;
+                }, {});
+            }
+            return value;
+        },
+
+        _suiteValuesEqual(left, right) {
+            try {
+                return JSON.stringify(this._suiteComparableValue(left))
+                    === JSON.stringify(this._suiteComparableValue(right));
+            } catch (_) {
+                return false;
             }
         },
 
@@ -863,7 +1360,7 @@
                 currentIndex: sequenceIndex,
                 total: session.sequence.length,
                 canPrev: sequenceIndex > 0,
-                canNext: sequenceIndex < session.sequence.length - 1 || allowFinalizeFromNav,
+                canNext: viewMode === 'review' && (sequenceIndex < session.sequence.length - 1 || allowFinalizeFromNav),
                 finalizeOnNext: allowFinalizeFromNav,
                 title: (sequenceEntry.exam && sequenceEntry.exam.title) || sequenceEntry.examId || '',
                 examId: examId,
@@ -1065,6 +1562,9 @@
             const hasCurrentResult = Array.isArray(session.results)
                 ? session.results.some(item => item && item.examId === examId)
                 : false;
+            if (direction === 'next' && !hasCurrentResult) {
+                return false;
+            }
             const requestedFinalizeOnNext = Boolean(
                 direction === 'next'
                 && currentIndex === session.sequence.length - 1
@@ -1074,7 +1574,7 @@
             );
             if (requestedFinalizeOnNext) {
                 session.pendingAdvance = null;
-                await this.finalizeSuiteRecord(session);
+                await this._finalizeSuiteRecordWithGate(session);
                 return true;
             }
 
@@ -1088,7 +1588,7 @@
                 );
                 if (canFinalize) {
                     session.pendingAdvance = null;
-                    await this.finalizeSuiteRecord(session);
+                    await this._finalizeSuiteRecordWithGate(session);
                     return true;
                 }
                 return true;
@@ -1099,7 +1599,19 @@
                 return false;
             }
 
+            const previousIndex = session.currentIndex;
+            const previousActiveExamId = session.activeExamId;
+            session.currentIndex = targetIndex;
+            session.activeExamId = targetEntry.examId;
+            session.lastUpdate = Date.now();
+            if (!await this._commitSuiteRecovery(session, { reason: 'review-navigate' })) {
+                session.currentIndex = previousIndex;
+                session.activeExamId = previousActiveExamId;
+                return false;
+            }
+
             let targetWindow = sourceWindow && !sourceWindow.closed ? sourceWindow : (session.windowRef && !session.windowRef.closed ? session.windowRef : null);
+            let registration = null;
 
             const isCrossExamNavigation = targetEntry.examId !== examId;
             if (isCrossExamNavigation && typeof this.cleanupExamSession === 'function') {
@@ -1110,7 +1622,7 @@
                 }
             }
             if (isCrossExamNavigation || !targetWindow) {
-                targetWindow = await this.openExam(targetEntry.examId, {
+                const launchContext = await this.openExam(targetEntry.examId, {
                     examDefinition: targetEntry.exam,
                     target: 'tab',
                     windowName: session.windowName || 'ielts-suite-mode-tab',
@@ -1120,19 +1632,24 @@
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: targetIndex,
                     sequenceTotal: session.sequence.length,
-                    reuseWindow: targetWindow || undefined
+                    reuseWindow: targetWindow || undefined,
+                    returnLaunchContext: true
                 });
+                targetWindow = launchContext && launchContext.window ? launchContext.window : launchContext;
+                registration = launchContext && launchContext.registration ? launchContext.registration : null;
             }
 
             if (!targetWindow || targetWindow.closed) {
                 return false;
             }
+            if (registration
+                && typeof this._isExamSessionRegistrationCurrent === 'function'
+                && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                return false;
+            }
 
             session.windowRef = targetWindow;
-            session.currentIndex = targetIndex;
-            session.activeExamId = targetEntry.examId;
-            session.lastUpdate = Date.now();
-            this._mirrorSessionToStorage(session);
+            session._activeLaunchRegistration = registration;
             this._focusSuiteWindow(targetWindow);
             if (isCrossExamNavigation) {
                 const ready = await this._waitForSuiteWindowExamReady(session, targetEntry.examId, targetWindow);
@@ -1157,13 +1674,11 @@
         async _advanceSuiteToNext(session, completedTitle, skipExamIdForAbort) {
             if (typeof this.openExam !== 'function') {
                 window.showMessage && window.showMessage('无法继续套题练习，已回退到普通模式。', 'warning');
-                await this._abortSuiteSession(session, { reason: 'missing_open_exam', skipExamId: skipExamIdForAbort || null });
                 return false;
             }
 
             const nextEntry = session.sequence[session.currentIndex];
             if (!nextEntry || !nextEntry.examId) {
-                await this._abortSuiteSession(session, { reason: 'missing_next_entry', skipExamId: skipExamIdForAbort || null });
                 return false;
             }
 
@@ -1181,7 +1696,8 @@
                     suiteTimerMode: session.suiteTimerMode || 'countdown',
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: session.currentIndex,
-                    sequenceTotal: session.sequence.length
+                    sequenceTotal: session.sequence.length,
+                    returnLaunchContext: true
                 };
 
                 if (candidateWindow && !candidateWindow.closed) {
@@ -1193,8 +1709,12 @@
                         ...options,
                         examDefinition: nextEntry.exam
                     });
-                    if (opened && !opened.closed) {
-                        return opened;
+                    const openedWindow = opened && opened.window ? opened.window : opened;
+                    if (openedWindow && !openedWindow.closed) {
+                        return {
+                            window: openedWindow,
+                            registration: opened && opened.registration ? opened.registration : null
+                        };
                     }
                 } catch (error) {
                     openError = error;
@@ -1204,33 +1724,41 @@
                 return null;
             };
 
-            let nextWindow = null;
+            let nextLaunch = null;
             if (reuseWindow) {
-                nextWindow = await attemptOpen(reuseWindow);
+                nextLaunch = await attemptOpen(reuseWindow);
             }
 
-            if ((!nextWindow || nextWindow.closed) && windowName) {
+            if ((!nextLaunch || !nextLaunch.window || nextLaunch.window.closed) && windowName) {
                 const fallbackWindow = typeof this._reacquireSuiteWindow === 'function'
                     ? this._reacquireSuiteWindow(windowName, session)
                     : this._openNamedSuiteWindow(windowName, session);
                 if (fallbackWindow && !fallbackWindow.closed) {
-                    nextWindow = await attemptOpen(fallbackWindow);
+                    nextLaunch = await attemptOpen(fallbackWindow);
                 }
             }
 
+            const nextWindow = nextLaunch && nextLaunch.window;
             if (!nextWindow || nextWindow.closed) {
                 if (openError) {
                     console.warn('[SuitePractice] 套题无法打开下一篇:', openError);
                 }
                 window.showMessage && window.showMessage('无法继续套题练习，已回退到普通模式。', 'warning');
-                await this._abortSuiteSession(session, { reason: 'open_next_failed', skipExamId: skipExamIdForAbort || null });
+                session.windowRef = null;
+                session._restoredFromStorage = true;
+                return false;
+            }
+            if (nextLaunch.registration
+                && typeof this._isExamSessionRegistrationCurrent === 'function'
+                && !this._isExamSessionRegistrationCurrent(nextEntry.examId, nextLaunch.registration)) {
                 return false;
             }
 
             session.windowRef = nextWindow;
+            session._activeLaunchRegistration = nextLaunch.registration || null;
+            session._restoredFromStorage = false;
             this._ensureSuiteWindowGuard(session, session.windowRef);
             this._focusSuiteWindow(session.windowRef);
-            this._mirrorSessionToStorage(session);
             const reusedNextWindow = Boolean(reuseWindow && nextWindow === reuseWindow);
             if (reusedNextWindow) {
                 const ready = await this._waitForSuiteWindowExamReady(session, nextEntry.examId, session.windowRef);
@@ -1250,21 +1778,40 @@
             return true;
         },
 
-        _mirrorSessionToStorage(session) {
-            if (!session) return;
+        _buildSuiteRecoverySnapshot(session, options = {}) {
+            if (!session) return null;
             try {
+                const now = Date.now();
+                const previousUpdate = Number(session.lastUpdate);
+                if (options.bumpLastUpdate !== false) {
+                    session.lastUpdate = Number.isFinite(previousUpdate)
+                        ? Math.max(now, previousUpdate + 1)
+                        : now;
+                }
+                if (options.bumpRevision !== false) {
+                    session.revision = Math.max(0, Number(session.revision) || 0) + 1;
+                }
                 const snapshot = {
+                    schema: 'suite-session-v2',
+                    version: 2,
                     id: session.id,
-                    sequence: session.sequence,
+                    status: session.status || 'active',
+                    sequence: this._cloneSuitePlainObject(session.sequence || []),
                     suiteSequence: this._buildSuiteSequencePayload(session),
-                    currentIndex: session.currentIndex,
-                    draftsByExam: session.draftsByExam || {},
-                    elapsedByExam: session.elapsedByExam || {},
-                    globalTimerAnchorMs: session.globalTimerAnchorMs,
+                    currentIndex: Number.isInteger(session.currentIndex) ? session.currentIndex : 0,
+                    draftsByExam: this._cloneSuitePlainObject(session.draftsByExam || {}),
+                    elapsedByExam: this._cloneSuitePlainObject(session.elapsedByExam || {}),
+                    globalTimerAnchorMs: Number(session.globalTimerAnchorMs) || Number(session.startTime) || now,
+                    suiteTimerAnchorMs: Number(session.suiteTimerAnchorMs) || Number(session.globalTimerAnchorMs) || Number(session.startTime) || now,
+                    suiteTimerMode: session.suiteTimerMode || 'countdown',
+                    suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds))
+                        ? Number(session.suiteTimerLimitSeconds)
+                        : 3600,
                     suiteTimerPausedOffsetMs: Math.max(0, Number(session.suiteTimerPausedOffsetMs) || 0),
                     suiteTimerPausedAtMs: Number.isFinite(Number(session.suiteTimerPausedAtMs)) ? Number(session.suiteTimerPausedAtMs) : null,
                     suiteTimerRunning: session.suiteTimerRunning !== false,
                     flowMode: session.flowMode || 'simulation',
+                    frequencyScope: session.frequencyScope || 'all',
                     autoAdvanceAfterSubmit: typeof session.autoAdvanceAfterSubmit === 'boolean'
                         ? session.autoAdvanceAfterSubmit
                         : true,
@@ -1275,25 +1822,320 @@
                         markedQuestions: Array.isArray(r.markedQuestions) ? r.markedQuestions.slice() : [],
                         rawData: this._sanitizeSuiteRawData(r.rawData)
                     })),
-                    startTime: session.startTime,
-                    activeExamId: session.activeExamId
+                    startTime: Number(session.startTime) || now,
+                    activeExamId: session.activeExamId || null,
+                    pendingAdvance: session.pendingAdvance && typeof session.pendingAdvance === 'object'
+                        ? this._cloneSuitePlainObject(session.pendingAdvance)
+                        : null,
+                    windowName: session.windowName || 'ielts-suite-mode-tab',
+                    lastUpdate: session.lastUpdate,
+                    revision: session.revision,
+                    draftRevision: Math.max(0, Number(session.draftRevision) || 0),
+                    finalizeOperationId: session.finalizeOperationId || null,
+                    finalizeRecord: session.finalizeRecord
+                        ? this._cloneSuitePlainObject(session.finalizeRecord)
+                        : null
                 };
-                global.AppData.recovery.windowSession.save('simulation', snapshot);
-            } catch (_) { /* file:// may not support */ }
-        },
-
-        _restoreSessionFromStorage() {
-            try {
-                const snapshot = global.AppData.recovery.windowSession.get('simulation');
-                if (!snapshot || !snapshot.id || !Array.isArray(snapshot.sequence)) return null;
                 return snapshot;
-            } catch (_) { return null; }
+            } catch (error) {
+                console.warn('[SuitePractice] Unable to build suite recovery snapshot:', error);
+                return null;
+            }
         },
 
-        _clearSessionStorage() {
+        _mirrorSuiteRecoverySnapshot(snapshot) {
+            if (!snapshot || !global.AppData?.recovery?.windowSession) return false;
             try {
+                return global.AppData.recovery.windowSession.save('simulation', snapshot) !== false;
+            } catch (error) {
+                console.warn('[SuitePractice] Suite recovery window mirror failed:', error);
+                return false;
+            }
+        },
+
+        _mirrorSessionToStorage(session) {
+            return this._mirrorSuiteRecoverySnapshot(this._buildSuiteRecoverySnapshot(session));
+        },
+
+        async _commitSuiteRecovery(session, options = {}) {
+            if (!session || !session.id || session._suiteRecoveryClosed === true) return false;
+            const previous = session._suiteRecoveryCommitTail && typeof session._suiteRecoveryCommitTail.then === 'function'
+                ? session._suiteRecoveryCommitTail
+                : Promise.resolve();
+            const commit = previous.catch(() => undefined).then(async () => {
+                if (session._suiteRecoveryClosed === true) return false;
+                const recovery = global.AppData && global.AppData.recovery;
+                if (!recovery || typeof recovery.saveActiveSession !== 'function') {
+                    throw new Error('AppData recovery.saveActiveSession is unavailable');
+                }
+                const snapshot = this._buildSuiteRecoverySnapshot(session);
+                if (!snapshot) throw new Error('Suite recovery snapshot could not be built');
+                const snapshotRevision = Number(snapshot.revision) || 0;
+                const receipt = await recovery.saveActiveSession(snapshot, {
+                    operationId: `suite-recovery:${String(session.id)}:${snapshotRevision}`
+                });
+                if (!receipt || receipt.committed !== true) {
+                    throw new Error('Suite recovery commit was not confirmed');
+                }
+                this._mirrorSuiteRecoverySnapshot(snapshot);
+                return true;
+            });
+            session._suiteRecoveryCommitTail = commit;
+            try {
+                return await commit;
+            } catch (error) {
+                console.warn('[SuitePractice] Durable suite recovery write failed:', error);
+                if (options.notify !== false) {
+                    window.showMessage && window.showMessage('Suite progress could not be saved. This action was paused; allow site storage and try again.', 'error');
+                }
+                return false;
+            } finally {
+                if (session._suiteRecoveryCommitTail === commit) {
+                    delete session._suiteRecoveryCommitTail;
+                }
+            }
+        },
+
+        async _discardPersistentSuiteRecovery(session) {
+            if (!session || !session.id) return false;
+            session._suiteRecoveryClosed = true;
+            const pending = session._suiteRecoveryCommitTail;
+            if (pending && typeof pending.then === 'function') {
+                try {
+                    await pending;
+                } catch (_) {}
+            }
+            const recovery = global.AppData && global.AppData.recovery;
+            if (!recovery || typeof recovery.discardActiveSession !== 'function') {
+                session._suiteRecoveryClosed = false;
+                return false;
+            }
+            try {
+                const receipt = await recovery.discardActiveSession(String(session.id), {
+                    operationId: `suite-recovery:${String(session.id)}:discard`
+                });
+                if (!receipt || receipt.committed !== true) {
+                    throw new Error('Suite recovery discard was not confirmed');
+                }
+                return true;
+            } catch (error) {
+                session._suiteRecoveryClosed = false;
+                console.warn('[SuitePractice] Durable suite recovery discard failed:', error);
+                window.showMessage && window.showMessage('The unfinished suite could not be removed from storage. Please try again.', 'error');
+                return false;
+            }
+        },
+
+        _restoreSessionFromStorage(providedSnapshot = null) {
+            const clearInvalidWindowSnapshot = () => {
+                if (providedSnapshot == null) this._clearSessionStorage();
+            };
+            try {
+                const snapshot = providedSnapshot
+                    || global.AppData?.recovery?.windowSession?.get?.('simulation')
+                    || null;
+                if (!snapshot || typeof snapshot !== 'object' || !snapshot.id) return null;
+                if (snapshot.schema !== 'suite-session-v2' || Number(snapshot.version) !== 2) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const statusValue = String(snapshot.status || 'active').trim().toLowerCase();
+                if (!['initializing', 'active', 'finalizing'].includes(statusValue)) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const rawSequence = Array.isArray(snapshot.sequence)
+                    ? snapshot.sequence
+                    : (Array.isArray(snapshot.suiteSequence) ? snapshot.suiteSequence : []);
+                const sequence = rawSequence.map((entry) => {
+                    if (!entry || typeof entry !== 'object') return null;
+                    const exam = entry.exam && typeof entry.exam === 'object' ? entry.exam : entry;
+                    const examId = String(entry.examId ?? exam.id ?? '').trim();
+                    if (!examId) return null;
+                    return {
+                        ...this._cloneSuitePlainObject(entry),
+                        examId,
+                        exam: { ...this._cloneSuitePlainObject(exam), id: exam.id || examId }
+                    };
+                }).filter(Boolean);
+                const sequenceIds = sequence.map((entry) => String(entry.examId));
+                const flowMode = String(snapshot.flowMode || 'simulation').trim().toLowerCase();
+                const timerMode = String(snapshot.suiteTimerMode || 'countdown').trim().toLowerCase();
+                const timerLimit = Number(snapshot.suiteTimerLimitSeconds);
+                if (
+                    !sequence.length
+                    || new Set(sequenceIds).size !== sequenceIds.length
+                    || !['classic', 'simulation', 'stationary'].includes(flowMode)
+                    || !['countdown', 'elapsed'].includes(timerMode)
+                    || !Number.isFinite(timerLimit)
+                    || timerLimit <= 0
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const rawIndex = Number(snapshot.currentIndex);
+                if (!Number.isInteger(rawIndex) || rawIndex < 0 || rawIndex > sequence.length) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const results = Array.isArray(snapshot.results)
+                    ? this._cloneSuitePlainObject(snapshot.results)
+                    : [];
+                if (results.some((entry) => !this._isValidSuiteRecoveryResult(entry, sequenceIds))) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                const expectedOperationId = `practice-suite:${String(snapshot.id)}:finalize`;
+                if (snapshot.finalizeOperationId && snapshot.finalizeOperationId !== expectedOperationId) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                if (snapshot.finalizeRecord) {
+                    const finalizeRecord = snapshot.finalizeRecord;
+                    if (!this._isValidSuiteFinalizeRecord({
+                        id: snapshot.id,
+                        sequence,
+                        results
+                    }, finalizeRecord)) {
+                        clearInvalidWindowSnapshot();
+                        return null;
+                    }
+                }
+                const autoAdvance = snapshot.autoAdvanceAfterSubmit !== false;
+                const activeId = snapshot.activeExamId != null ? String(snapshot.activeExamId).trim() : '';
+                const activeIndex = activeId
+                    ? sequence.findIndex((entry) => String(entry.examId) === activeId)
+                    : -1;
+                const resultIds = results
+                    .map((entry) => entry && String(entry.examId || '').trim())
+                    .filter(Boolean);
+                const terminalSnapshot = statusValue === 'finalizing' || rawIndex === sequence.length;
+                if (
+                    new Set(resultIds).size !== resultIds.length
+                    || resultIds.some((examId) => !sequenceIds.includes(examId))
+                    || (terminalSnapshot && (
+                        resultIds.length !== sequenceIds.length
+                        || sequenceIds.some((examId) => !resultIds.includes(examId))
+                    ))
+                    || (statusValue !== 'finalizing' && activeId && activeIndex < 0)
+                    || (terminalSnapshot && rawIndex !== sequence.length)
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                if (
+                    statusValue !== 'finalizing'
+                    && activeIndex >= 0
+                    && activeIndex !== rawIndex
+                    && !(autoAdvance && rawIndex === activeIndex + 1 && results.some((entry) => entry && String(entry.examId) === activeId))
+                ) {
+                    clearInvalidWindowSnapshot();
+                    return null;
+                }
+                let currentIndex = rawIndex;
+                let status = statusValue;
+                if (status === 'finalizing' || currentIndex === sequence.length) {
+                    status = 'finalizing';
+                    currentIndex = sequence.length;
+                } else if (
+                    autoAdvance
+                    && activeIndex >= 0
+                    && currentIndex === activeIndex
+                    && results.some((entry) => entry && String(entry.examId) === activeId)
+                    && currentIndex + 1 < sequence.length
+                ) {
+                    currentIndex += 1;
+                }
+                const activeExamId = status === 'finalizing'
+                    ? null
+                    : (sequence[currentIndex] && sequence[currentIndex].examId) || activeId || sequence[0].examId;
+                const now = Date.now();
+                return {
+                    id: String(snapshot.id),
+                    status,
+                    startTime: Number(snapshot.startTime) || now,
+                    sequence,
+                    currentIndex,
+                    results,
+                    draftsByExam: snapshot.draftsByExam && typeof snapshot.draftsByExam === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.draftsByExam)
+                        : {},
+                    elapsedByExam: snapshot.elapsedByExam && typeof snapshot.elapsedByExam === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.elapsedByExam)
+                        : {},
+                    globalTimerAnchorMs: Number(snapshot.globalTimerAnchorMs) || Number(snapshot.startTime) || now,
+                    suiteTimerAnchorMs: Number(snapshot.suiteTimerAnchorMs) || Number(snapshot.globalTimerAnchorMs) || Number(snapshot.startTime) || now,
+                    suiteTimerMode: timerMode,
+                    suiteTimerLimitSeconds: timerLimit,
+                    suiteTimerPausedOffsetMs: Math.max(0, Number(snapshot.suiteTimerPausedOffsetMs) || 0),
+                    suiteTimerPausedAtMs: Number.isFinite(Number(snapshot.suiteTimerPausedAtMs)) ? Number(snapshot.suiteTimerPausedAtMs) : null,
+                    suiteTimerRunning: snapshot.suiteTimerRunning !== false,
+                    flowMode,
+                    frequencyScope: snapshot.frequencyScope || 'all',
+                    autoAdvanceAfterSubmit: autoAdvance,
+                    pendingAdvance: snapshot.pendingAdvance && typeof snapshot.pendingAdvance === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.pendingAdvance)
+                        : null,
+                    activeExamId,
+                    windowRef: null,
+                    windowName: snapshot.windowName || 'ielts-suite-mode-tab',
+                    lastUpdate: Number.isFinite(Number(snapshot.lastUpdate)) ? Number(snapshot.lastUpdate) : now,
+                    revision: Math.max(0, Number(snapshot.revision) || 0),
+                    draftRevision: Math.max(0, Number(snapshot.draftRevision) || 0),
+                    finalizeOperationId: snapshot.finalizeOperationId || (snapshot.finalizeRecord ? expectedOperationId : null),
+                    finalizeRecord: snapshot.finalizeRecord && typeof snapshot.finalizeRecord === 'object'
+                        ? this._cloneSuitePlainObject(snapshot.finalizeRecord)
+                        : null,
+                    _restoredFromStorage: true
+                };
+            } catch (error) {
+                console.warn('[SuitePractice] 套题恢复快照读取失败:', error);
+                clearInvalidWindowSnapshot();
+                return null;
+            }
+        },
+
+        _clearSessionStorage(session = null) {
+            try {
+                if (session && global.AppData?.recovery?.windowSession
+                    && typeof global.AppData.recovery.windowSession.get === 'function') {
+                    const snapshot = global.AppData.recovery.windowSession.get('simulation');
+                    if (snapshot && snapshot.id && String(snapshot.id) !== String(session.id)) {
+                        return false;
+                    }
+                }
                 global.AppData.recovery.windowSession.discard('simulation');
+                return true;
             } catch (_) { /* ignore */ }
+            return false;
+        },
+
+        async _discardStoredSuiteSession(session) {
+            if (!session) return false;
+            if (!await this._discardPersistentSuiteRecovery(session)) return false;
+            if (this.suiteExamMap && Array.isArray(session.sequence)) {
+                session.sequence.forEach((entry) => {
+                    if (entry && entry.examId != null
+                        && this.suiteExamMap.get(String(entry.examId)) === session.id) {
+                        this.suiteExamMap.delete(String(entry.examId));
+                    }
+                });
+            }
+            if (this.currentSuiteSession === session) this.currentSuiteSession = null;
+            this._clearSessionStorage(session);
+            return true;
+        },
+
+        _notifySuiteResumeAvailable(session) {
+            if (!session || this._suiteResumeNoticeShown) return;
+            this._suiteResumeNoticeShown = true;
+            const activeEntry = Array.isArray(session.sequence)
+                ? session.sequence.find((entry) => entry && String(entry.examId) === String(session.activeExamId))
+                : null;
+            const title = activeEntry && activeEntry.exam && activeEntry.exam.title
+                ? activeEntry.exam.title
+                : (session.activeExamId || '当前篇章');
+            window.showMessage && window.showMessage(`检测到未完成套题：${title}。请选择继续或放弃。`, 'info');
         },
 
         _syncSuiteTimerFromPayload(session, data = {}) {
@@ -1319,18 +2161,31 @@
                 const existingOffsetMs = Math.max(0, Number(session.suiteTimerPausedOffsetMs) || 0);
                 session.suiteTimerPausedOffsetMs = Math.max(existingOffsetMs, Math.max(0, pausedOffsetMs));
             }
-            const running = timerSnapshot ? timerSnapshot.running : data.suiteTimerRunning;
-            session.suiteTimerRunning = running !== false;
-            const pausedAtMs = Number(
-                (timerSnapshot && timerSnapshot.pausedAtMs)
-                ?? data.suiteTimerPausedAtMs
-                ?? data.pausedAtMs
+            const hasExplicitRunning = Boolean(
+                (timerSnapshot && Object.prototype.hasOwnProperty.call(timerSnapshot, 'running'))
+                || Object.prototype.hasOwnProperty.call(data, 'suiteTimerRunning')
             );
-            session.suiteTimerPausedAtMs = (
-                session.suiteTimerRunning === false
-                && Number.isFinite(pausedAtMs)
-                && pausedAtMs > 0
-            ) ? Math.floor(pausedAtMs) : null;
+            const hasExplicitPausedAt = Boolean(
+                (timerSnapshot && Object.prototype.hasOwnProperty.call(timerSnapshot, 'pausedAtMs'))
+                || Object.prototype.hasOwnProperty.call(data, 'suiteTimerPausedAtMs')
+                || Object.prototype.hasOwnProperty.call(data, 'pausedAtMs')
+            );
+            if (hasExplicitRunning || hasExplicitPausedAt) {
+                const pausedAtMs = Number(
+                    (timerSnapshot && timerSnapshot.pausedAtMs)
+                    ?? data.suiteTimerPausedAtMs
+                    ?? data.pausedAtMs
+                );
+                const running = hasExplicitRunning
+                    ? (timerSnapshot ? timerSnapshot.running : data.suiteTimerRunning)
+                    : !(Number.isFinite(pausedAtMs) && pausedAtMs > 0);
+                session.suiteTimerRunning = running !== false;
+                session.suiteTimerPausedAtMs = (
+                    session.suiteTimerRunning === false
+                    && Number.isFinite(pausedAtMs)
+                    && pausedAtMs > 0
+                ) ? Math.floor(pausedAtMs) : null;
+            }
         },
 
         _computeSuiteElapsedSeconds(session, referenceNow = Date.now()) {
@@ -1407,6 +2262,9 @@
                     examId,
                     sessionId: windowInfo && windowInfo.expectedSessionId ? windowInfo.expectedSessionId : null,
                     windowSessionToken: windowInfo && windowInfo.windowSessionToken ? windowInfo.windowSessionToken : null,
+                    windowSessionGeneration: windowInfo && Number.isInteger(windowInfo.sessionGeneration)
+                        ? windowInfo.sessionGeneration
+                        : 0,
                     messageIssuedAtMs,
                     suiteSequence: this._buildSuiteSequencePayload(session),
                     currentIndex: idx,
@@ -1511,10 +2369,18 @@
                 const targetEntry = session.sequence[targetIdx];
                 if (!targetEntry || !targetEntry.examId) return false;
 
+                const previousIndex = session.currentIndex;
+                const previousActiveExamId = session.activeExamId;
                 session.currentIndex = targetIdx;
                 session.activeExamId = targetEntry.examId;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'simulation-navigate' })) {
+                    session.currentIndex = previousIndex;
+                    session.activeExamId = previousActiveExamId;
+                    return false;
+                }
 
-                const targetWindow = await this.openExam(targetEntry.examId, {
+                const launchContext = await this.openExam(targetEntry.examId, {
                     examDefinition: targetEntry.exam,
                     target: 'tab',
                     windowName: session.windowName || 'ielts-suite-mode-tab',
@@ -1524,13 +2390,21 @@
                     suiteTimerLimitSeconds: Number.isFinite(Number(session.suiteTimerLimitSeconds)) ? Number(session.suiteTimerLimitSeconds) : 3600,
                     sequenceIndex: targetIdx,
                     sequenceTotal: session.sequence.length,
-                    reuseWindow: sourceWindow && !sourceWindow.closed ? sourceWindow : undefined
+                    reuseWindow: sourceWindow && !sourceWindow.closed ? sourceWindow : undefined,
+                    returnLaunchContext: true
                 });
+                const targetWindow = launchContext && launchContext.window ? launchContext.window : launchContext;
+                const registration = launchContext && launchContext.registration ? launchContext.registration : null;
 
                 if (!targetWindow || targetWindow.closed) return false;
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(targetEntry.examId, registration)) {
+                    return false;
+                }
 
                 session.windowRef = targetWindow;
-                this._mirrorSessionToStorage(session);
+                session._activeLaunchRegistration = registration;
                 const reusedSourceWindow = Boolean(
                     sourceWindow
                     && !sourceWindow.closed
@@ -2090,13 +2964,70 @@
             return aggregated;
         },
 
+        async _finalizeSuiteRecordWithGate(session, options = {}) {
+            if (!session) return false;
+            if (session._finalizePromise && typeof session._finalizePromise.then === 'function') {
+                return session._finalizePromise;
+            }
+            const finalizePromise = this.finalizeSuiteRecord(session, options);
+            session._finalizePromise = finalizePromise;
+            try {
+                return await finalizePromise;
+            } finally {
+                if (session._finalizePromise === finalizePromise) {
+                    session._finalizePromise = null;
+                }
+            }
+        },
+
         async finalizeSuiteRecord(session, options = {}) {
-            if (!session || !session.results || !session.results.length) {
-                await this._teardownSuiteSession(session);
+            if (!session || !Array.isArray(session.sequence) || !session.sequence.length) {
+                return false;
+            }
+
+            const sequenceIds = session.sequence
+                .map((entry) => entry && String(entry.examId || '').trim())
+                .filter(Boolean);
+            const results = Array.isArray(session.results) ? session.results : [];
+            const resultIds = results
+                .map((entry) => entry && String(entry.examId || '').trim())
+                .filter(Boolean);
+            const invalidResultIndex = results.findIndex((entry) => !this._isValidSuiteRecoveryResult(entry, sequenceIds));
+            const invalidResultExamId = invalidResultIndex >= 0 && results[invalidResultIndex]
+                ? String(results[invalidResultIndex].examId || '').trim()
+                : '';
+            const invalidSequenceIndex = invalidResultExamId ? sequenceIds.indexOf(invalidResultExamId) : -1;
+            const missingResultIndex = session.sequence.findIndex((entry) => (
+                entry && !resultIds.includes(String(entry.examId))
+            ));
+            const completeResults = Boolean(
+                sequenceIds.length === session.sequence.length
+                && resultIds.length === sequenceIds.length
+                && new Set(resultIds).size === resultIds.length
+                && invalidResultIndex < 0
+                && sequenceIds.every((examId) => resultIds.includes(examId))
+            );
+            if (!completeResults) {
+                const recoveryIndex = invalidSequenceIndex >= 0 ? invalidSequenceIndex : missingResultIndex;
+                const safeIndex = recoveryIndex >= 0
+                    ? recoveryIndex
+                    : Math.min(Math.max(0, Number(session.currentIndex) || 0), session.sequence.length - 1);
+                session.status = 'active';
+                session.currentIndex = safeIndex;
+                session.activeExamId = session.sequence[safeIndex] && session.sequence[safeIndex].examId || null;
+                session.finalizeOperationId = null;
+                session.finalizeRecord = null;
+                session.lastUpdate = Date.now();
+                await this._commitSuiteRecovery(session, { notify: false, reason: 'incomplete-finalize' });
+                window.showMessage && window.showMessage('套题结果不完整，请完成缺失篇章后再提交。', 'warning');
                 return false;
             }
 
             session.status = 'finalizing';
+            session.currentIndex = session.sequence.length;
+            session.activeExamId = null;
+            session.lastUpdate = Date.now();
+            if (!await this._commitSuiteRecovery(session, { reason: 'finalize-start' })) return false;
 
             let committed = false;
             try {
@@ -2170,7 +3101,7 @@
                 const dateLabel = this._formatSuiteDateLabel(startTime);
                 const displayTitle = dateLabel + '套题练习' + suiteSequence;
 
-                const record = {
+                const builtRecord = {
                     id: session.id,
                     examId: 'suite-' + session.id,
                     title: displayTitle,
@@ -2213,22 +3144,29 @@
                     sessionId: session.id
                 };
 
+                const expectedOperationId = `practice-suite:${String(session.id)}:finalize`;
+                session.finalizeOperationId = expectedOperationId;
+                const persistedRecord = session.finalizeRecord && this._isValidSuiteFinalizeRecord(session, session.finalizeRecord)
+                    ? this._cloneSuitePlainObject(session.finalizeRecord)
+                    : builtRecord;
+                const record = persistedRecord;
+                record.operationId = expectedOperationId;
+                session.finalizeRecord = this._cloneSuitePlainObject(record);
+                if (!await this._commitSuiteRecovery(session, { reason: 'finalize-record' })) return false;
+
                 await this._saveSuitePracticeRecord(record);
                 committed = true;
                 session.status = 'completed';
             } catch (error) {
                 console.error('[SuitePractice] 保存套题记录失败:', error);
                 try {
-                    window.showMessage && window.showMessage('套题记录保存失败，系统将尝试恢复到普通模式。', 'error');
+                    window.showMessage && window.showMessage('套题记录保存失败，恢复快照已保留，请稍后重试。', 'error');
                 } catch (notificationError) {
                     console.warn('[SuitePractice] 显示套题保存失败通知时出错:', notificationError);
                 }
-                try {
-                    await this._savePartialSuiteAsIndividual(session);
-                } catch (fallbackError) {
-                    console.warn('[SuitePractice] 聚合记录未保存，单篇恢复也失败:', fallbackError);
-                }
-                session.status = options.deferTeardown ? 'active' : 'error';
+                session.status = 'finalizing';
+                session.lastUpdate = Date.now();
+                await this._commitSuiteRecovery(session, { notify: false, reason: 'finalize-error' });
             }
 
             if (committed) {
@@ -2241,7 +3179,7 @@
                 });
             }
 
-            if (!options.deferTeardown) {
+            if (committed && !options.deferTeardown) {
                 await this._runSuitePostCommitStep('清理套题会话窗口', () => this._teardownSuiteSession(session));
             }
             return committed;
@@ -2536,7 +3474,10 @@
             );
 
             try {
-                if (this.currentSuiteSession && this.currentSuiteSession.status === 'active') {
+                if (this.currentSuiteSession && this.currentSuiteSession.status === 'completed') {
+                    if (!await this._teardownSuiteSession(this.currentSuiteSession)) return false;
+                }
+                if (this.currentSuiteSession && ['active', 'initializing', 'finalizing'].includes(this.currentSuiteSession.status)) {
                     window.showMessage && window.showMessage('套题练习正在进行中，请先完成当前套题。', 'warning');
                     return false;
                 }
@@ -2563,9 +3504,10 @@
                 const timerAnchorMs = Date.now();
                 const suiteTimerMode = 'countdown';
                 const suiteTimerLimitSeconds = 3600;
+                const firstEntry = normalizedSequence[0];
                 const session = {
                     id: suiteSessionId,
-                    status: 'initializing',
+                    status: 'active',
                     startTime: timerAnchorMs,
                     sequence: normalizedSequence,
                     currentIndex: 0,
@@ -2582,19 +3524,25 @@
                     flowMode,
                     frequencyScope,
                     autoAdvanceAfterSubmit: lockedAutoAdvance,
+                    activeExamId: firstEntry.examId,
                     windowRef: null,
                     windowName: suiteWindowName
                 };
 
                 this.currentSuiteSession = session;
+                session.lastUpdate = Date.now();
+                if (!await this._commitSuiteRecovery(session, { reason: 'suite-start' })) {
+                    if (this.currentSuiteSession === session) this.currentSuiteSession = null;
+                    this._clearSessionStorage(session);
+                    return false;
+                }
                 this._registerSuiteSequence(session);
 
-                const firstEntry = normalizedSequence[0];
                 window.showMessage && window.showMessage(launchLabel + ' 已启动，正在打开第一篇。', 'info');
 
-                let examWindow = null;
+                let launchContext = null;
                 try {
-                    examWindow = await this.openExam(firstEntry.examId, {
+                    launchContext = await this.openExam(firstEntry.examId, {
                         examDefinition: firstEntry.exam,
                         target: 'tab',
                         windowName: suiteWindowName,
@@ -2603,21 +3551,39 @@
                         suiteTimerMode,
                         suiteTimerLimitSeconds,
                         sequenceIndex: 0,
-                        sequenceTotal: normalizedSequence.length
+                        sequenceTotal: normalizedSequence.length,
+                        returnLaunchContext: true
                     });
                 } catch (openError) {
                     console.error('[SuitePractice] 打开首篇失败:', openError);
-                    examWindow = null;
+                    launchContext = null;
                 }
 
+                const examWindow = launchContext && launchContext.window
+                    ? launchContext.window
+                    : launchContext;
+                const registration = launchContext && launchContext.registration
+                    ? launchContext.registration
+                    : null;
                 if (!examWindow || examWindow.closed) {
-                    throw new Error('first_exam_window_unavailable');
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    window.showMessage && window.showMessage('首篇窗口未能打开，套题已安全保存；允许弹窗后可继续。', 'warning');
+                    return false;
+                }
+                if (registration
+                    && typeof this._isExamSessionRegistrationCurrent === 'function'
+                    && !this._isExamSessionRegistrationCurrent(firstEntry.examId, registration)) {
+                    session.windowRef = null;
+                    session._restoredFromStorage = true;
+                    return false;
                 }
 
                 session.windowRef = examWindow;
+                session._activeLaunchRegistration = registration;
                 this._ensureSuiteWindowGuard(session, session.windowRef);
-                session.status = 'active';
-                session.activeExamId = firstEntry.examId;
+                session._restoredFromStorage = false;
+                session.lastUpdate = Date.now();
                 this._focusSuiteWindow(session.windowRef);
                 if (flowMode === 'simulation') {
                     this._sendSimulationContext(session, firstEntry.examId, session.windowRef);
@@ -2626,9 +3592,6 @@
             } catch (error) {
                 console.error('[SuitePractice] 启动失败:', error);
                 window.showMessage && window.showMessage('套题练习启动失败，请稍后重试。', 'error');
-                if (this.currentSuiteSession) {
-                    await this._abortSuiteSession(this.currentSuiteSession, { reason: 'startup_failed' });
-                }
                 return false;
             }
         },
@@ -2723,6 +3686,143 @@
             };
         },
 
+        _isValidSuiteScoreInfo(scoreInfo) {
+            if (!scoreInfo || typeof scoreInfo !== 'object' || Array.isArray(scoreInfo)) return false;
+            const correct = Number(scoreInfo.correct);
+            const total = Number(scoreInfo.total);
+            const accuracy = Number(scoreInfo.accuracy);
+            const percentage = Number(scoreInfo.percentage);
+            return Boolean(
+                Number.isFinite(correct)
+                && Number.isFinite(total)
+                && Number.isFinite(accuracy)
+                && Number.isFinite(percentage)
+                && correct >= 0
+                && total >= 0
+                && correct <= total
+                && accuracy >= 0
+                && accuracy <= 1
+                && percentage >= 0
+                && percentage <= 100
+            );
+        },
+
+        _isValidSuiteRecoveryResult(entry, sequenceIds = []) {
+            if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+            const examId = String(entry.examId || '').trim();
+            const duration = Number(entry.duration);
+            return Boolean(
+                examId
+                && (!sequenceIds.length || sequenceIds.includes(examId))
+                && Number.isFinite(duration)
+                && duration >= 0
+                && this._isValidSuiteScoreInfo(entry.scoreInfo)
+                && entry.answers
+                && typeof entry.answers === 'object'
+                && entry.answerComparison
+                && typeof entry.answerComparison === 'object'
+            );
+        },
+
+        _isValidSuiteFinalizeEntry(entry, sequenceIds = []) {
+            return Boolean(
+                this._isValidSuiteRecoveryResult(entry, sequenceIds)
+                && Array.isArray(entry.markedQuestions)
+                && Array.isArray(entry.highlights)
+                && typeof entry.noteText === 'string'
+                && Array.isArray(entry.notes)
+                && Array.isArray(entry.noteOutlines)
+                && Number.isFinite(Number(entry.scrollY))
+            );
+        },
+
+        _isValidSuiteFinalizeRecord(session, record) {
+            if (!session || !record || typeof record !== 'object') return false;
+            const sequenceIds = Array.isArray(session.sequence)
+                ? session.sequence.map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean)
+                : [];
+            const recordEntries = Array.isArray(record.suiteEntries) ? record.suiteEntries : [];
+            const recordIds = recordEntries
+                .map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean);
+            const results = Array.isArray(session.results) ? session.results : [];
+            const resultIds = results.map((entry) => entry && String(entry.examId || '').trim()).filter(Boolean);
+            const expectedAnswers = {};
+            const expectedComparison = {};
+            let expectedCorrect = 0;
+            let expectedTotal = 0;
+            results.forEach((entry) => {
+                const examId = String(entry && entry.examId || '').trim();
+                const prefix = examId ? `${examId}::` : '';
+                expectedCorrect += Number(entry && entry.scoreInfo && entry.scoreInfo.correct) || 0;
+                expectedTotal += Number(entry && entry.scoreInfo && entry.scoreInfo.total) || 0;
+                Object.entries(entry && entry.answers && typeof entry.answers === 'object' ? entry.answers : {})
+                    .forEach(([questionId, answer]) => {
+                        expectedAnswers[prefix + questionId] = answer;
+                    });
+                Object.entries(entry && entry.answerComparison && typeof entry.answerComparison === 'object' ? entry.answerComparison : {})
+                    .forEach(([questionId, comparison]) => {
+                        expectedComparison[prefix + questionId] = comparison;
+                    });
+            });
+            const expectedAccuracy = expectedTotal > 0 ? expectedCorrect / expectedTotal : 0;
+            const expectedPercentage = Math.round(expectedAccuracy * 100);
+            const scoreInfo = record.scoreInfo;
+            const numericMatches = (left, right) => Number.isFinite(Number(left)) && Number(left) === Number(right);
+            return Boolean(
+                session.id
+                && String(record.id || '') === String(session.id)
+                && String(record.sessionId || '') === String(session.id)
+                && sequenceIds.length > 0
+                && record.examId === `suite-${String(session.id)}`
+                && record.type === 'reading'
+                && record.suiteMode === true
+                && record.frequency === 'suite'
+                && typeof record.title === 'string'
+                && typeof record.date === 'string'
+                && typeof record.startTime === 'string'
+                && typeof record.endTime === 'string'
+                && Number.isFinite(Number(record.duration))
+                && Number(record.duration) >= 0
+                && this._isValidSuiteScoreInfo(scoreInfo)
+                && numericMatches(record.totalQuestions, expectedTotal)
+                && numericMatches(record.correctAnswers, expectedCorrect)
+                && numericMatches(scoreInfo.correct, expectedCorrect)
+                && numericMatches(scoreInfo.total, expectedTotal)
+                && Math.abs(Number(scoreInfo.accuracy) - expectedAccuracy) < 1e-9
+                && Number(scoreInfo.percentage) === expectedPercentage
+                && this._suiteValuesEqual(record.answers, expectedAnswers)
+                && this._suiteValuesEqual(record.answerComparison, expectedComparison)
+                && recordEntries.length === sequenceIds.length
+                && recordIds.length === sequenceIds.length
+                && new Set(recordIds).size === recordIds.length
+                && recordIds.every((examId, index) => examId === sequenceIds[index])
+                && resultIds.length === sequenceIds.length
+                && new Set(resultIds).size === resultIds.length
+                && resultIds.every((examId) => sequenceIds.includes(examId))
+                && recordEntries.every((entry, index) => {
+                    const result = results.find((candidate) => String(candidate && candidate.examId || '').trim() === sequenceIds[index]);
+                    return this._isValidSuiteFinalizeEntry(entry, sequenceIds)
+                        && result
+                        && numericMatches(entry.duration, result.duration)
+                        && this._suiteValuesEqual(entry.scoreInfo, result.scoreInfo)
+                        && this._suiteValuesEqual(entry.answers, result.answers)
+                        && this._suiteValuesEqual(entry.answerComparison, result.answerComparison);
+                })
+                && record.metadata
+                && typeof record.metadata === 'object'
+                && String(record.metadata.suiteSessionId || '') === String(session.id)
+                && Number(record.metadata.suiteEntryCount) === sequenceIds.length
+                && record.realData
+                && typeof record.realData === 'object'
+                && record.realData.source === 'suite_mode'
+                && numericMatches(record.realData.correct, expectedCorrect)
+                && numericMatches(record.realData.total, expectedTotal)
+                && numericMatches(record.realData.duration, record.duration)
+                && typeof record.operationId === 'string'
+                && record.operationId === `practice-suite:${String(session.id)}:finalize`
+            );
+        },
+
         async _saveSuitePracticeRecord(record) {
             const childSessionIds = [];
             (Array.isArray(record && record.suiteEntries) ? record.suiteEntries : []).forEach((entry) => {
@@ -2734,9 +3834,6 @@
                 record,
                 childSessionIds,
                 operationId: record.operationId
-                    || (record.submissionId
-                        ? `practice-suite:${String(record.sessionId || 'session')}:${String(record.submissionId)}`
-                        : undefined)
             });
             if (!receipt || receipt.committed !== true) {
                 const error = new Error('Suite aggregate commit was not confirmed');
@@ -2865,24 +3962,6 @@
             return count + 1;
         },
 
-        async _savePartialSuiteAsIndividual(session) {
-            if (!session || !session.results || !session.results.length) {
-                return;
-            }
-
-            for (const entry of session.results) {
-                try {
-                    await this.saveRealPracticeData(entry.examId, this._buildSuiteEntryIndividualPayload(session, entry), { forceIndividualSave: true });
-                    this.updateExamStatus && this.updateExamStatus(entry.examId, 'completed');
-                } catch (error) {
-                    console.error('[SuitePractice] 保存单篇记录失败:', error);
-                }
-            }
-
-            await this._updatePracticeRecordsState();
-            this.refreshOverviewData && this.refreshOverviewData();
-        },
-
         _focusSuiteWindow(targetWindow) {
             if (!targetWindow || targetWindow.closed) {
                 return;
@@ -2917,13 +3996,30 @@
 
         async _teardownSuiteSession(session) {
             if (!session) {
-                return;
+                return false;
             }
+            if (session._teardownPromise && typeof session._teardownPromise.then === 'function') {
+                return session._teardownPromise;
+            }
+            const teardownPromise = this._teardownSuiteSessionInternal(session);
+            session._teardownPromise = teardownPromise;
+            try {
+                return await teardownPromise;
+            } finally {
+                if (session._teardownPromise === teardownPromise) delete session._teardownPromise;
+            }
+        },
+
+        async _teardownSuiteSessionInternal(session) {
+            if (this.currentSuiteSession !== session) return false;
 
             if (session.submitReceiptTeardownTimer) {
                 clearTimeout(session.submitReceiptTeardownTimer);
                 session.submitReceiptTeardownTimer = null;
             }
+
+            if (!await this._discardPersistentSuiteRecovery(session)) return false;
+            if (this.currentSuiteSession !== session) return false;
 
             this._clearSuiteHandshakes();
 
@@ -2949,7 +4045,11 @@
             }
 
             if (this.suiteExamMap) {
-                session.sequence && session.sequence.forEach(item => this.suiteExamMap.delete(item.examId));
+                session.sequence && session.sequence.forEach(item => {
+                    if (item && this.suiteExamMap.get(item.examId) === session.id) {
+                        this.suiteExamMap.delete(item.examId);
+                    }
+                });
             }
 
             if (this.currentSuiteSession && this.currentSuiteSession.id === session.id) {
@@ -2960,36 +4060,23 @@
             if (typeof this._clearSuiteHandshakes === 'function') {
                 this._clearSuiteHandshakes();
             }
-            this._clearSessionStorage();
+            this._clearSessionStorage(session);
+            return true;
         },
 
         async _abortSuiteSession(session, options = {}) {
             if (!session) {
-                return;
+                return false;
             }
 
+            const previousStatus = session.status;
             session.status = 'aborted';
 
             this._clearSuiteHandshakes();
 
-            const skipExamId = options.skipExamId;
-            if (session.results && session.results.length) {
-                for (const entry of session.results) {
-                    if (skipExamId && entry.examId === skipExamId) {
-                        continue;
-                    }
-                    try {
-                        await this.saveRealPracticeData(entry.examId, this._buildSuiteEntryIndividualPayload(session, entry), { forceIndividualSave: true });
-                        this.updateExamStatus && this.updateExamStatus(entry.examId, 'completed');
-                    } catch (error) {
-                        console.error('[SuitePractice] 套题中断时保存记录失败:', error);
-                    }
-                }
-                await this._updatePracticeRecordsState();
-                this.refreshOverviewData && this.refreshOverviewData();
-            }
-
-            await this._teardownSuiteSession(session);
+            const tornDown = await this._teardownSuiteSession(session);
+            if (!tornDown) session.status = previousStatus;
+            return tornDown;
         },
 
         _openNamedSuiteWindow(windowName, session = null) {

--- a/js/core/practiceRecorder.js
+++ b/js/core/practiceRecorder.js
@@ -363,7 +363,8 @@ class PracticeRecorder {
      */
     async restoreActiveSessions() {
         const raw = await window.AppData.recovery.listActiveSessions();
-        const storedSessions = Array.isArray(raw) ? raw : [];
+        const storedSessions = (Array.isArray(raw) ? raw : [])
+            .filter((sessionData) => sessionData.schema !== 'suite-session-v2');
 
         storedSessions
             .slice()

--- a/js/presentation/app-actions.js
+++ b/js/presentation/app-actions.js
@@ -116,7 +116,10 @@
     // Phase 3: 套题/随机练习/导出功能
     // ============================================================================
 
+    var suitePracticeLaunchPromise = null;
+
     function startSuitePractice() {
+        if (suitePracticeLaunchPromise) return suitePracticeLaunchPromise;
         function getSuitePreferenceUtils() {
             return global.SuitePreferenceUtils || null;
         }
@@ -293,38 +296,109 @@
             });
         }
 
+        function promptSuiteRecoveryChoice(candidate) {
+            return new Promise(function resolveRecoveryChoice(resolve) {
+                if (!global.document || !global.document.body) {
+                    resolve(null);
+                    return;
+                }
+                var existing = global.document.getElementById('suite-recovery-choice-modal');
+                if (existing && existing.parentNode) {
+                    existing.parentNode.removeChild(existing);
+                }
+                var completedCount = Math.max(0, Number(candidate && candidate.completedCount) || 0);
+                var total = Math.max(0, Number(candidate && candidate.total) || 0);
+                var escapedTitle = String(candidate && candidate.title || '当前篇章')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+                var host = global.document.createElement('div');
+                host.id = 'suite-recovery-choice-modal';
+                host.style.cssText = 'position:fixed;inset:0;background:rgba(15,23,42,0.55);display:flex;align-items:center;justify-content:center;z-index:10000;padding:16px;';
+                host.innerHTML = [
+                    '<div role="dialog" aria-modal="true" aria-labelledby="suite-recovery-title" style="width:min(440px,100%);background:var(--color-white, #fff);border:1px solid var(--color-gray-200, #e2e8f0);border-radius:8px;padding:24px;box-shadow:var(--shadow-xl, 0 20px 25px -5px rgba(0,0,0,0.1));font-family:var(--font-family-primary, sans-serif);">',
+                    '<h3 id="suite-recovery-title" style="margin:0 0 8px;font-size:20px;font-weight:700;color:var(--color-gray-900, #0f172a);letter-spacing:0;">发现未完成套题</h3>',
+                    '<p style="margin:0 0 6px;font-size:14px;line-height:1.6;color:var(--color-gray-700, #334155);">' + escapedTitle + '</p>',
+                    '<p style="margin:0 0 20px;font-size:13px;line-height:1.6;color:var(--color-gray-500, #64748b);">已完成 ' + completedCount + ' / ' + total + ' 篇。放弃后将删除这套未完成进度，但不会生成单篇记录。</p>',
+                    '<div style="display:flex;flex-wrap:wrap;justify-content:flex-end;gap:10px;">',
+                    '<button type="button" data-suite-recovery-choice="cancel" style="padding:10px 14px;border:1px solid var(--color-gray-300, #cbd5e1);border-radius:8px;background:var(--color-white, #fff);color:var(--color-gray-700, #334155);font-weight:600;cursor:pointer;">取消</button>',
+                    '<button type="button" data-suite-recovery-choice="discard" style="padding:10px 14px;border:1px solid #dc2626;border-radius:8px;background:var(--color-white, #fff);color:#b91c1c;font-weight:600;cursor:pointer;">放弃并新建</button>',
+                    '<button type="button" data-suite-recovery-choice="continue" style="padding:10px 14px;border:1px solid var(--color-brand-primary, #4f46e5);border-radius:8px;background:var(--color-brand-primary, #4f46e5);color:#fff;font-weight:600;cursor:pointer;">继续上次套题</button>',
+                    '</div>',
+                    '</div>'
+                ].join('');
+                host.addEventListener('click', function onRecoveryChoice(event) {
+                    var target = event.target && event.target.closest
+                        ? event.target.closest('button[data-suite-recovery-choice]')
+                        : null;
+                    if (!target) return;
+                    var choice = target.getAttribute('data-suite-recovery-choice');
+                    if (host.parentNode) host.parentNode.removeChild(host);
+                    resolve(choice === 'continue' || choice === 'discard' ? choice : null);
+                });
+                global.document.body.appendChild(host);
+            });
+        }
+
         var ensureSuiteReady = (global.AppEntry && typeof global.AppEntry.ensureSessionSuiteReady === 'function')
             ? global.AppEntry.ensureSessionSuiteReady()
             : ensurePracticeSuite();
 
-        return Promise.resolve(ensureSuiteReady).then(function afterReady() {
-            return promptSuiteModeSelection().then(function handleMode(selection) {
-                if (!selection || !selection.flowMode) {
-                    return undefined;
-                }
-                var appInstance = global.app;
-                if (appInstance && typeof appInstance.startSuitePractice === 'function') {
-                    try {
-                        return appInstance.startSuitePractice({
-                            flowMode: selection.flowMode,
-                            frequencyScope: selection.frequencyScope
-                        });
-                    } catch (error) {
-                        console.error('[AppActions] 套题模式启动失败', error);
-                        if (typeof global.showMessage === 'function') {
-                            global.showMessage('套题模式启动失败，请稍后重试', 'error');
-                        }
+        var launchPromise = Promise.resolve(ensureSuiteReady).then(function afterReady() {
+            var appInstance = global.app;
+            var launchNewSuite = function launchNewSuite() {
+                return promptSuiteModeSelection().then(function handleMode(selection) {
+                    if (!selection || !selection.flowMode) {
                         return undefined;
                     }
-                }
+                    if (appInstance && typeof appInstance.startSuitePractice === 'function') {
+                        try {
+                            return appInstance.startSuitePractice({
+                                flowMode: selection.flowMode,
+                                frequencyScope: selection.frequencyScope
+                            });
+                        } catch (error) {
+                            console.error('[AppActions] 套题模式启动失败', error);
+                            if (typeof global.showMessage === 'function') {
+                                global.showMessage('套题模式启动失败，请稍后重试', 'error');
+                            }
+                            return undefined;
+                        }
+                    }
 
-                var fallbackNotice = '套题模式尚未初始化，请完成加载后再试。';
-                if (typeof global.showMessage === 'function') {
-                    global.showMessage(fallbackNotice, 'warning');
-                } else if (typeof alert === 'function') {
-                    alert(fallbackNotice);
-                }
-                return undefined;
+                    var fallbackNotice = '套题模式尚未初始化，请完成加载后再试。';
+                    if (typeof global.showMessage === 'function') {
+                        global.showMessage(fallbackNotice, 'warning');
+                    } else if (typeof alert === 'function') {
+                        alert(fallbackNotice);
+                    }
+                    return undefined;
+                });
+            };
+
+            if (!appInstance || typeof appInstance.getSuiteRecoveryCandidate !== 'function') {
+                return launchNewSuite();
+            }
+            return Promise.resolve(appInstance.getSuiteRecoveryCandidate()).then(function handleRecoveryCandidate(candidate) {
+                if (!candidate) return launchNewSuite();
+                return promptSuiteRecoveryChoice(candidate).then(function handleRecoveryChoice(choice) {
+                    if (choice === 'continue') {
+                        return appInstance.startSuitePractice({
+                            recoveryAction: 'continue',
+                            recoverySessionId: candidate.id
+                        });
+                    }
+                    if (choice === 'discard') {
+                        if (typeof appInstance.abandonSuiteRecovery !== 'function') return undefined;
+                        return Promise.resolve(appInstance.abandonSuiteRecovery(candidate.id)).then(function afterAbandon(abandoned) {
+                            if (!abandoned) return undefined;
+                            return launchNewSuite();
+                        });
+                    }
+                    return undefined;
+                });
             });
         }).catch(function handleSuiteError(error) {
             console.error('[AppActions] 套题模块加载失败:', error);
@@ -332,6 +406,12 @@
                 global.showMessage('套题模块加载失败，请稍后重试', 'error');
             }
             return undefined;
+        });
+        suitePracticeLaunchPromise = launchPromise;
+        return launchPromise.finally(function clearSuitePracticeLaunchPromise() {
+            if (suitePracticeLaunchPromise === launchPromise) {
+                suitePracticeLaunchPromise = null;
+            }
         });
     }
 

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -158,7 +158,8 @@
         parentOrigin: '',
         parentOriginIsOpaque: false,
         windowSessionToken: '',
-        windowSessionIssuedAtMs: 0
+        windowSessionIssuedAtMs: 0,
+        windowSessionGeneration: 0
     };
 
     const dom = {
@@ -419,6 +420,10 @@
         var displaySeconds;
         var elapsed = getPageElapsedSeconds();
         var limitSeconds;
+        const isSuiteTimer = Boolean(state.suiteSessionId);
+        const suiteTimerMode = isSuiteTimer && state.suiteTimerMode === 'elapsed'
+            ? 'elapsed'
+            : (isSuiteTimer ? 'countdown' : '');
         const rawLimitSeconds = Number(state.suiteTimerLimitSeconds);
         if (Number.isFinite(rawLimitSeconds) && rawLimitSeconds > 0) {
             limitSeconds = Math.floor(rawLimitSeconds);
@@ -439,21 +444,26 @@
             }
             var remainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
             timer.textContent = remainingMinutes + ' minutes remaining';
+        } else if (suiteTimerMode === 'countdown') {
+            displaySeconds = Math.max(0, Number(limitSeconds || 0) - elapsed);
+            var suiteRemainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
+            timer.textContent = suiteRemainingMinutes + ' minutes remaining';
+        } else if (suiteTimerMode === 'elapsed') {
+            displaySeconds = elapsed;
+            timer.textContent = formatTimerSeconds(displaySeconds);
         } else if (preferences.mode === 'countdown') {
             const countdownSeconds = minutesToSeconds(preferences.countdownMinutes, 60);
             displaySeconds = Math.max(0, countdownSeconds - elapsed);
             timer.textContent = formatTimerSeconds(displaySeconds);
-        } else if (state.suiteSessionId && Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0) {
-            displaySeconds = Math.max(0, limitSeconds - elapsed);
-            var remainingMinutes = Math.max(0, Math.ceil(displaySeconds / 60));
-            timer.textContent = remainingMinutes + ' minutes remaining';
         } else {
             displaySeconds = elapsed;
             timer.textContent = formatTimerSeconds(displaySeconds);
         }
         var hasEndlessCountdown = state.endlessCountdownEndTime && Number.isFinite(state.endlessCountdownEndTime);
-        var countdownExpired = preferences.mode === 'countdown' && !hasEndlessCountdown && displaySeconds <= 0;
-        var limitExpired = Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds);
+        var countdownExpired = !isSuiteTimer && preferences.mode === 'countdown' && !hasEndlessCountdown && displaySeconds <= 0;
+        var limitExpired = suiteTimerMode === 'countdown'
+            ? Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds)
+            : (!isSuiteTimer && Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0 && elapsed >= Number(limitSeconds));
         var expired = Boolean(countdownExpired || limitExpired);
         state.timerExpired = expired;
         if (expired) {
@@ -462,12 +472,18 @@
         timer.classList.toggle('paused', !interaction.timerRunning && !hasEndlessCountdown);
         timer.classList.toggle('timer-expired', expired);
         if (timer.dataset) {
-            timer.dataset.timerMode = preferences.mode;
+            timer.dataset.timerMode = suiteTimerMode || preferences.mode;
             timer.dataset.expiryAction = preferences.expiryAction;
         }
         timer.style.opacity = (interaction.timerRunning || hasEndlessCountdown) ? '1' : '0.5';
         var _warnRemaining = !hasEndlessCountdown
-            && (preferences.mode === 'countdown' || (Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0))
+            && (
+                suiteTimerMode === 'countdown'
+                || (!isSuiteTimer && (
+                    preferences.mode === 'countdown'
+                    || (Number.isFinite(Number(limitSeconds)) && Number(limitSeconds) > 0)
+                ))
+            )
             && Number.isFinite(Number(displaySeconds))
             ? Math.max(0, Number(displaySeconds))
             : null;
@@ -1269,8 +1285,8 @@
         const baseUpdatedAt = Number(baseDraft && baseDraft.updatedAt);
         const nextUpdatedAt = Number(nextDraft && nextDraft.updatedAt);
         return Number.isFinite(baseUpdatedAt)
-            && Number.isFinite(nextUpdatedAt)
-            && nextUpdatedAt < baseUpdatedAt;
+            && baseUpdatedAt > 0
+            && (!Number.isFinite(nextUpdatedAt) || nextUpdatedAt <= baseUpdatedAt);
     }
 
     function mergeDraft(baseDraft, nextDraft) {
@@ -5559,8 +5575,44 @@
         return true;
     }
 
+    function capturePendingSubmissionOwnership(data = {}) {
+        if (!matchesPendingSubmission(data)) return null;
+        const generation = Number(state.windowSessionGeneration);
+        return {
+            parentWindow: state.parentWindow || null,
+            examId: String(state.examId || ''),
+            sessionId: String(state.sessionId || ''),
+            suiteSessionId: String(state.suiteSessionId || ''),
+            windowSessionToken: normalizeWindowSessionToken(state.windowSessionToken),
+            windowSessionGeneration: Number.isInteger(generation) && generation > 0 ? generation : 0,
+            submissionId: String(state.submissionId || ''),
+            finalSuiteSubmission: Boolean(
+                state.simulationMode
+                && state.simulationCtx
+                && state.simulationCtx.isLast
+                && state.suiteSessionId
+            )
+        };
+    }
+
+    function retainsSubmissionOwnership(ownership) {
+        if (!ownership || state.submissionStatus !== 'submitted') return false;
+        const generation = Number(state.windowSessionGeneration);
+        const currentGeneration = Number.isInteger(generation) && generation > 0 ? generation : 0;
+        return Boolean(
+            state.parentWindow === ownership.parentWindow
+            && String(state.examId || '') === ownership.examId
+            && String(state.sessionId || '') === ownership.sessionId
+            && String(state.suiteSessionId || '') === ownership.suiteSessionId
+            && normalizeWindowSessionToken(state.windowSessionToken) === ownership.windowSessionToken
+            && currentGeneration === ownership.windowSessionGeneration
+            && String(state.submissionId || '') === ownership.submissionId
+        );
+    }
+
     async function acceptSubmissionAcknowledgement(data = {}) {
-        if (!matchesPendingSubmission(data)) {
+        const ownership = capturePendingSubmissionOwnership(data);
+        if (!ownership) {
             return false;
         }
         const presentation = state.pendingSubmissionPresentation;
@@ -5570,6 +5622,9 @@
             state.lastResults = presentation.results;
             renderResults(presentation.results);
             await renderExplanations();
+            if (!retainsSubmissionOwnership(ownership)) {
+                return false;
+            }
             applyHighlights(Array.isArray(presentation.highlights) ? presentation.highlights : []);
             refreshNoteHighlightAttributes();
             restoreMissingNoteAnchors();
@@ -5577,11 +5632,21 @@
             enhanceReviewHighlights();
             updateNavStatuses(presentation.results);
         }
+        if (!retainsSubmissionOwnership(ownership)) {
+            return false;
+        }
         state.pendingSubmissionPresentation = null;
-        if (state.simulationMode && state.simulationCtx && state.simulationCtx.isLast) {
+        if (ownership.finalSuiteSubmission) {
             stopSimulationDraftSync();
             clearSimulationDraftMirror();
             state.simulationDraftFingerprint = '';
+            if (state.suiteSessionId && typeof global.close === 'function') {
+                try {
+                    global.close();
+                } catch (_) {
+                    // The host teardown remains the fallback when the browser refuses self-close.
+                }
+            }
         }
         return true;
     }
@@ -6031,6 +6096,7 @@
                 suiteTimerMode: state.suiteTimerMode,
                 suiteTimerLimitSeconds: state.suiteTimerLimitSeconds,
                 windowSessionToken: state.windowSessionToken || null,
+                windowSessionGeneration: Number.isInteger(state.windowSessionGeneration) ? state.windowSessionGeneration : 0,
                 messageIssuedAtMs,
                 source: MESSAGE_SOURCE
             }, payload || {}),
@@ -6077,6 +6143,8 @@
         const currentIssuedAtMs = Number.isFinite(Number(state.windowSessionIssuedAtMs))
             ? Number(state.windowSessionIssuedAtMs)
             : 0;
+        const incomingGeneration = Number(data && data.windowSessionGeneration);
+        const currentGeneration = Number(state.windowSessionGeneration);
 
         if (sourceWindow && state.parentWindow && sourceWindow !== state.parentWindow && currentToken) {
             return false;
@@ -6090,7 +6158,19 @@
         if (incomingToken === currentToken) {
             return true;
         }
-        if (incomingIssuedAtMs && currentIssuedAtMs && incomingIssuedAtMs >= currentIssuedAtMs) {
+        if (Number.isInteger(incomingGeneration) && incomingGeneration > 0) {
+            if (Number.isInteger(currentGeneration) && currentGeneration > 0) {
+                return incomingGeneration > currentGeneration;
+            }
+            return true;
+        }
+        if (Number.isInteger(currentGeneration) && currentGeneration > 0) {
+            return false;
+        }
+        // A timestamp alone cannot establish ordering when two registrations
+        // occur in the same millisecond.  Without a generation, keep the
+        // current token rather than allowing an ambiguous message to replace it.
+        if (incomingIssuedAtMs && currentIssuedAtMs && incomingIssuedAtMs > currentIssuedAtMs) {
             return true;
         }
         return false;
@@ -6099,6 +6179,7 @@
     function adoptWindowSessionMessage(data = {}, sourceWindow = null) {
         const incomingToken = normalizeWindowSessionToken(data && data.windowSessionToken);
         const incomingIssuedAtMs = readMessageIssuedAtMs(data);
+        const incomingGeneration = Number(data && data.windowSessionGeneration);
         if (incomingToken) {
             state.windowSessionToken = incomingToken;
         }
@@ -6106,6 +6187,9 @@
             state.windowSessionIssuedAtMs = incomingIssuedAtMs;
         } else if (incomingToken && !state.windowSessionIssuedAtMs) {
             state.windowSessionIssuedAtMs = Date.now();
+        }
+        if (Number.isInteger(incomingGeneration) && incomingGeneration > 0) {
+            state.windowSessionGeneration = incomingGeneration;
         }
     }
 
@@ -6358,7 +6442,7 @@
                 updatedAt: Date.now()
             });
         } catch (_) {
-            // ignore sessionStorage failures in restricted environments
+            // AppData v2 recovery is best-effort during page teardown.
         }
     }
 
@@ -6388,7 +6472,7 @@
         try {
             global.AppData.recovery.windowSession.discard(name);
         } catch (_) {
-            // ignore sessionStorage failures in restricted environments
+            // AppData v2 recovery is best-effort during page teardown.
         }
     }
 
@@ -6449,6 +6533,7 @@
             draft: mirroredDraft,
             draftUpdatedAt: Number.isFinite(Number(mirroredDraft.updatedAt)) ? Number(mirroredDraft.updatedAt) : Date.now(),
             elapsed: getPageElapsedSeconds(),
+            timerSnapshot: getPracticeTimerSnapshot(),
             reason
         });
     }
@@ -6474,6 +6559,10 @@
     }
 
     function flushReadingDraftOnLifecycle(reason = 'pagehide') {
+        if (state.simulationMode && state.suiteSessionId) {
+            syncSimulationDraftSnapshot(reason);
+            return;
+        }
         if (canSyncReadingDraft()) {
             syncReadingDraftSnapshot(reason);
             return;
@@ -6515,7 +6604,9 @@
             examId: state.examId,
             draft: mirroredDraft,
             draftUpdatedAt: Number.isFinite(Number(mirroredDraft.updatedAt)) ? Number(mirroredDraft.updatedAt) : Date.now(),
-            elapsed: getPageElapsedSeconds()
+            elapsed: getPageElapsedSeconds(),
+            timerSnapshot: getPracticeTimerSnapshot(),
+            reason
         });
     }
 


### PR DESCRIPTION
## Summary

- persist a suite recovery snapshot before opening the first passage
- persist each passage result before sending a positive ACK or advancing
- present explicit Continue / Abandon recovery choices
- close the child page only after the final persisted ACK
- bind asynchronous launch, reset, injection, and ACK work to the exact local window registration

This is the minimal single-window alternative described in #98. It targets `opensource` and intentionally excludes Web Locks, cross-tab leases, recovery fences/tombstones, entity CAS, and other multi-writer coordination.

## Root cause

Suite state was mirrored in `sessionStorage` before the first page opened, but the durable AppData recovery entity could lag behind navigation and ACKs. A refresh or `file://` navigation could therefore lose the suite, and delayed callbacks could act on a reused local window.

## Validation

- `node scripts/build-bundles.mjs --check`
- `node developer/tests/js/suiteSessionRecoveryV2.test.js`
- `node developer/tests/js/suiteModeRegression.test.js`
- `node developer/tests/js/suiteModeFlow.test.js`
- `node developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js`
- `node developer/tests/js/practiceRecorder.test.js`
- `node developer/tests/js/appDataV2.test.js`
- changed-JavaScript syntax checks and `git diff --check`