### PR TITLE
修复段落标题匹配题已用选项标灰禁用

### DIFF
--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -403,6 +403,15 @@
             border-style: solid;
         }
 
+        .drag-item.option-consumed {
+            opacity: 0.45;
+            cursor: not-allowed;
+            background: #f1f5f9;
+            border-color: #cbd5e1;
+            color: #94a3b8;
+            pointer-events: none;
+        }
+
         /* Draggable word styles for summary completion */
         .draggable-word {
             border: 1px solid #bfdbfe;

--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -403,7 +403,9 @@
             border-style: solid;
         }
 
-        .drag-item.option-consumed {
+        .drag-item.option-consumed,
+        .draggable-word.option-consumed,
+        .card.option-consumed {
             opacity: 0.45;
             cursor: not-allowed;
             background: #f1f5f9;

--- a/developer/tests/js/readingInteractionRegression.test.js
+++ b/developer/tests/js/readingInteractionRegression.test.js
@@ -125,6 +125,79 @@ async function testBrowserInteractions() {
         assert.deepEqual(replayChecks.split, [true, false, true]);
         assert.deepEqual(replayChecks.single, [true, false, true]);
 
+        const cardPoolChecks = await page.evaluate(() => {
+            const groups = document.getElementById('question-groups');
+            groups.innerHTML = `
+                <section class="unified-group" data-question-ids="q6,q7" data-allow-option-reuse="false">
+                    <div id="test-cardpool" class="cardpool">
+                        <div id="cardpool-A" class="card" data-value="A" draggable="true">A Alpha</div>
+                        <div id="cardpool-B" class="card" data-value="B" draggable="true">B Beta</div>
+                    </div>
+                    <div class="match-dropzone" data-question="q6"></div>
+                    <div class="match-dropzone" data-question="q7"></div>
+                </section>
+                <section class="unified-group" data-question-ids="q20,q21" data-allow-option-reuse="false">
+                    <div id="test-option-pool" class="option-pool">
+                        <div id="optionpool-C" class="card" data-value="C" draggable="true">C Gamma</div>
+                        <div id="optionpool-D" class="card" data-value="D" draggable="true">D Delta</div>
+                    </div>
+                    <div class="match-dropzone" data-question="q20"></div>
+                    <div class="match-dropzone" data-question="q21"></div>
+                </section>
+                <section class="unified-group" data-question-ids="q30" data-allow-option-reuse="true">
+                    <div id="test-reusable-option-pool" class="option-pool">
+                        <div id="optionpool-E" class="card" data-value="E" draggable="true">E Reusable</div>
+                    </div>
+                    <div class="match-dropzone" data-question="q30"></div>
+                </section>`;
+
+            const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+            hooks.setTestState({ readOnly: false, timerLocked: false });
+            const snapshot = (id) => {
+                const item = document.getElementById(id);
+                return {
+                    consumed: item.dataset.consumed || '',
+                    consumedClass: item.classList.contains('option-consumed'),
+                    draggable: item.getAttribute('draggable')
+                };
+            };
+
+            hooks.applyReplayAnswersToDom({ q6: 'A', q20: 'C', q30: 'E' });
+            const first = {
+                cardA: snapshot('cardpool-A'),
+                cardB: snapshot('cardpool-B'),
+                optionC: snapshot('optionpool-C'),
+                optionD: snapshot('optionpool-D'),
+                reusableE: snapshot('optionpool-E')
+            };
+
+            hooks.applyReplayAnswersToDom({ q6: 'B', q20: 'D', q30: 'E' });
+            const second = {
+                cardA: snapshot('cardpool-A'),
+                cardB: snapshot('cardpool-B'),
+                optionC: snapshot('optionpool-C'),
+                optionD: snapshot('optionpool-D'),
+                reusableE: snapshot('optionpool-E')
+            };
+            return { first, second };
+        });
+        assert.deepEqual(cardPoolChecks, {
+            first: {
+                cardA: { consumed: '1', consumedClass: true, draggable: 'false' },
+                cardB: { consumed: '', consumedClass: false, draggable: 'true' },
+                optionC: { consumed: '1', consumedClass: true, draggable: 'false' },
+                optionD: { consumed: '', consumedClass: false, draggable: 'true' },
+                reusableE: { consumed: '', consumedClass: false, draggable: 'true' }
+            },
+            second: {
+                cardA: { consumed: '', consumedClass: false, draggable: 'true' },
+                cardB: { consumed: '1', consumedClass: true, draggable: 'false' },
+                optionC: { consumed: '', consumedClass: false, draggable: 'true' },
+                optionD: { consumed: '1', consumedClass: true, draggable: 'false' },
+                reusableE: { consumed: '', consumedClass: false, draggable: 'true' }
+            }
+        });
+
         const unknownPresentation = await page.evaluate(() => {
             const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
             hooks.captureDom();
@@ -420,7 +493,7 @@ async function main() {
     await testBrowserInteractions();
     console.log(JSON.stringify({
         status: 'pass',
-        detail: 'reading duplicate highlights, grouped replay, unknown results and inline-suite locks covered'
+        detail: 'reading duplicate highlights, grouped/card-pool replay, unknown results and inline-suite locks covered'
     }));
 }
 

--- a/developer/tests/js/unifiedReadingLockRegression.test.js
+++ b/developer/tests/js/unifiedReadingLockRegression.test.js
@@ -134,6 +134,10 @@ async function run() {
   ok(/displayAnswerValue\(entry\.correctAnswer,\s*''\)/.test(unifiedPage), 'review_results_correct_answer_not_normalized', failed);
   ok(/setDropzoneAnswer\(dropzone,\s*value,\s*label\)/.test(unifiedPage), 'dropzone_replay_label_not_preserved', failed);
   ok(/value:\s*item\.dataset\.heading\s*\|\|\s*item\.dataset\.option\s*\|\|\s*item\.dataset\.key/.test(unifiedPage), 'drag_payload_ignores_data_key', failed);
+  ok(/POOL_CONTAINER_SELECTOR[^\n]*\.cardpool/.test(unifiedPage), 'cardpool_container_missing', failed);
+  ok(/POOL_CONTAINER_SELECTOR[^\n]*\.option-pool/.test(unifiedPage), 'option_pool_container_missing', failed);
+  ok(/\.card\.option-consumed\s*\{[\s\S]*?opacity:\s*0\.45/.test(unifiedPage), 'card_consumed_style_missing', failed);
+  ok(/\.card\.option-consumed\s*\{[\s\S]*?opacity:\s*0\.45/.test(unifiedHtml), 'unified_html_card_consumed_style_missing', failed);
   ok(/splitAnswerTokens\(rawValue\)\s*\.map\(\(entry\) => canonicalizeAnswerToken\(entry\)\)/.test(unifiedPage), 'replay_field_value_list_not_normalized', failed);
   ok(!/String\(rawValue == null \? '' : rawValue\)\.split/.test(unifiedPage), 'replay_raw_object_string_split_regressed', failed);
   ok(/--reading-left-pane-width/.test(unifiedHtml), 'missing_resizable_reading_pane_width_var', failed);

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -6258,6 +6258,7 @@
     const MEMORIZE_STYLE_ID = 'reading-memorize-style';
     const READING_NOTE_STYLE_ID = 'reading-note-style';
     const READING_DISPLAY_CONTROL_STYLE_ID = 'reading-display-control-style';
+    const OPTION_CONSUMED_STYLE_ID = 'reading-option-consumed-style';
     const PRACTICE_TIMER_BRIDGE_KEY = '__IELTS_PRACTICE_TIMER__';
     const PRACTICE_TIMER_EVENT = 'practiceTimerStateChange';
     const READING_CANDIDATE_CODE_PATTERN = /^\d{6}$/;
@@ -7940,6 +7941,23 @@
             body.hide-reading-highlights .hl:not([data-hl-type="note"]):not([data-note-id]){background:transparent!important;color:inherit!important;box-shadow:none!important;outline:none!important}
             body.reading-question-nav-collapsed .practice-nav{display:none}
             body.dark-mode .reading-display-toggle-group{background:#1e293b;border-color:#475569;color:#cbd5e1}
+        `;
+        document.head.appendChild(style);
+    }
+
+    function ensureOptionConsumedStyles() {
+        if (document.getElementById(OPTION_CONSUMED_STYLE_ID)) return;
+        const style = document.createElement('style');
+        style.id = OPTION_CONSUMED_STYLE_ID;
+        style.textContent = `
+            .drag-item.option-consumed {
+                opacity: 0.45 !important;
+                cursor: not-allowed !important;
+                background: #f1f5f9 !important;
+                border-color: #cbd5e1 !important;
+                color: #94a3b8 !important;
+                pointer-events: none !important;
+            }
         `;
         document.head.appendChild(style);
     }
@@ -10476,6 +10494,7 @@
 
     function clearDropzone(dropzone) {
         if (!dropzone) return;
+        const previousPayload = getDropzonePayload(dropzone);
         dropzone.dataset.answerValue = '';
         dropzone.dataset.answerLabel = '';
         // 清除判卷残留的标记，避免重置后旧颜色残留
@@ -10487,6 +10506,10 @@
             if (holder) {
                 holder.innerHTML = '';
             }
+        }
+        // 清空后恢复 pool 中对应选项的显示（不允许复用的题组）
+        if (previousPayload) {
+            restorePoolOption(dropzone, previousPayload);
         }
         updateDropzoneState(dropzone);
     }
@@ -10505,10 +10528,12 @@
     function buildDragPayload(item) {
         if (!item) return null;
         const sourceDropzone = item.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary');
+        const sourcePool = item.closest('.pool-items');
         return {
             value: item.dataset.heading || item.dataset.option || item.dataset.key || item.dataset.word || item.dataset.value || item.dataset.answerValue || item.textContent.trim(),
             label: item.dataset.answerLabel || item.dataset.word || item.dataset.value || item.textContent.trim(),
-            sourceDropzoneId: sourceDropzone?.dataset?.dropzoneId || ''
+            sourceDropzoneId: sourceDropzone?.dataset?.dropzoneId || '',
+            sourcePoolId: sourcePool?.id || item.dataset.originPool || ''
         };
     }
 
@@ -10543,6 +10568,11 @@
         }
         item.dataset.dragBound = '1';
         item.addEventListener('dragstart', (event) => {
+            // 已被使用的选项不可拖拽
+            if (item.classList.contains('option-consumed') || item.dataset.consumed === '1') {
+                event.preventDefault();
+                return;
+            }
             const payload = buildDragPayload(item);
             if (!payload || !payload.value) {
                 event.preventDefault();
@@ -10593,6 +10623,102 @@
         updateDropzoneState(dropzone);
     }
 
+    function resolveOptionGroupAndPool(dropzone, payload) {
+        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池
+        let group = null;
+        let pool = null;
+
+        // 1. 优先通过 payload.sourcePoolId 查找 pool
+        if (payload && payload.sourcePoolId) {
+            pool = document.getElementById(payload.sourcePoolId);
+            if (pool) {
+                group = pool.closest('.unified-group');
+            }
+        }
+
+        // 2. 尝试从 dropzone 向上查找 group（兼容非分栏布局）
+        if (!group && dropzone) {
+            group = dropzone.closest('.unified-group');
+            if (group) {
+                pool = group.querySelector('.pool-items');
+            }
+        }
+
+        // 3. 如果还没找到，通过 dropzone 关联的题目查找：找到页面上 allowOptionReuse=false 的 group
+        if (!group) {
+            group = document.querySelector('.unified-group[data-allow-option-reuse="false"]');
+            if (group) {
+                pool = group.querySelector('.pool-items');
+            }
+        }
+
+        // 4. 最后兜底：直接找第一个 pool
+        if (!pool) {
+            pool = document.querySelector('.pool-items');
+            if (pool) {
+                group = group || pool.closest('.unified-group');
+            }
+        }
+
+        return { group, pool };
+    }
+
+    function consumePoolOption(dropzone, payload) {
+        // 段落匹配等不允许复用的题组：选项拖走后在候选池标记为已使用（禁用+标灰），
+        // 便于用户直观看到哪些选项已被使用，且不可再次选择。
+        if (!dropzone || !payload || !payload.value) {
+            return;
+        }
+        const { group, pool } = resolveOptionGroupAndPool(dropzone, payload);
+        if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
+            return;
+        }
+        const consumedValue = canonicalizeAnswerToken(payload.value);
+        pool.querySelectorAll('.drag-item').forEach((item) => {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === consumedValue && !item.dataset.consumed) {
+                item.dataset.consumed = '1';
+                item.classList.add('option-consumed');
+                item.setAttribute('draggable', 'false');
+            }
+        });
+    }
+
+    function restorePoolOption(dropzone, payload) {
+        if (!dropzone || !payload || !payload.value) {
+            return;
+        }
+        const { group, pool } = resolveOptionGroupAndPool(dropzone, payload);
+        if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
+            return;
+        }
+        const restoredValue = canonicalizeAnswerToken(payload.value);
+        pool.querySelectorAll('.drag-item').forEach((item) => {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
+                // 仅当该选项未被其他 dropzone 使用时才恢复
+                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone
+                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone'));
+                const stillUsed = allDropzones.some((zone) => {
+                    const zonePayload = getDropzonePayload(zone);
+                    return zonePayload
+                        && canonicalizeAnswerToken(zonePayload.value) === itemValue;
+                });
+                if (!stillUsed) {
+                    delete item.dataset.consumed;
+                    item.classList.remove('option-consumed');
+                    item.setAttribute('draggable', 'true');
+                }
+            }
+        });
+    }
+
     function handleDropOnDropzone(dropzone, payload) {
         if (!dropzone || !payload || !payload.value) {
             return;
@@ -10606,6 +10732,10 @@
         }
         const previousPayload = getDropzonePayload(dropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
+        // 从 pool 拖入：消耗选项（若组不允许复用）
+        if (!sourceDropzone) {
+            consumePoolOption(dropzone, payload);
+        }
         if (sourceDropzone && sourceDropzone !== dropzone) {
             if (previousPayload && previousPayload.value) {
                 setDropzoneAnswer(sourceDropzone, previousPayload.value, previousPayload.label);
@@ -10624,11 +10754,17 @@
         if (!sourceDropzone) {
             return;
         }
+        // 先记录原答案，清空后恢复 pool 中的选项显示
+        const previousPayload = getDropzonePayload(sourceDropzone);
         clearDropzone(sourceDropzone);
+        if (previousPayload) {
+            restorePoolOption(sourceDropzone, previousPayload);
+        }
         updateNavStatuses();
     }
 
     function attachDragDrop() {
+        ensureOptionConsumedStyles();
         getDropzones().forEach((dropzone, index) => {
             if (!dropzone.dataset.dropzoneId) {
                 dropzone.dataset.dropzoneId = `dropzone-${index + 1}`;
@@ -10931,6 +11067,8 @@
         }
         const label = normalizeAnswerForReplay(rawValue, 'label') || value;
         setDropzoneAnswer(dropzone, value, label);
+        // 回放答案时也需要标记选项为已使用（不允许复用的题组）
+        consumePoolOption(dropzone, { value, label });
         return true;
     }
 
@@ -11908,7 +12046,9 @@
         const locked = Boolean(state.readOnly || state.timerLocked);
         document.querySelectorAll('.drag-item, .draggable-word, .card').forEach((item) => {
             if (!(item instanceof HTMLElement)) return;
-            item.setAttribute('draggable', locked ? 'false' : 'true');
+            // 如果选项已被使用（option-consumed），始终保持不可拖拽
+            const isConsumed = item.classList.contains('option-consumed') || item.dataset.consumed === '1';
+            item.setAttribute('draggable', locked || isConsumed ? 'false' : 'true');
             item.classList.toggle('drag-item-locked', locked);
         });
     }
@@ -13290,6 +13430,14 @@
         });
         getDropzones().forEach((dropzone) => {
             clearDropzone(dropzone);
+        });
+        // 兜底：确保所有选项池中的选项都恢复为可用状态
+        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
+            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                item.setAttribute('draggable', 'true');
+            }
         });
         // 清除选择题/表格判卷残留的绿/红标记
         document.querySelectorAll('.option-correct, .option-wrong, .correct, .wrong').forEach((node) => {

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -10695,6 +10695,15 @@
         if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
             return;
         }
+        // 限定到当前组的 questionIds：同一页面可能有多个不允许复用的题组
+        // 使用相同选项字母（如 p2-high-233 组2/组3 都用 A-E），
+        // 跨组扫描会误伤其他组的独立选项。
+        const groupQuestionIds = new Set(
+            String(group.dataset.questionIds || '')
+                .split(',')
+                .map((entry) => normalizeQuestionId(entry.trim()))
+                .filter(Boolean)
+        );
         const restoredValue = canonicalizeAnswerToken(payload.value);
         pool.querySelectorAll('.drag-item').forEach((item) => {
             const itemValue = canonicalizeAnswerToken(
@@ -10702,11 +10711,19 @@
                 || item.dataset.word || item.dataset.value || item.textContent
             );
             if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
-                // 仅当该选项未被其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone；
+                // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
+                // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
                 // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
-                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'));
-                const stillUsed = allDropzones.some((zone) => {
+                const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
+                    .filter((zone) => {
+                        const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
+                        const zoneIds = expandQuestionSequence(zoneQuestion);
+                        const normalizedZoneIds = zoneIds.length
+                            ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
+                            : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
+                        return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
+                    });
+                const stillUsed = groupDropzones.some((zone) => {
                     const zonePayload = getDropzonePayload(zone);
                     return zonePayload
                         && canonicalizeAnswerToken(zonePayload.value) === itemValue;

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -6259,6 +6259,10 @@
     const READING_NOTE_STYLE_ID = 'reading-note-style';
     const READING_DISPLAY_CONTROL_STYLE_ID = 'reading-display-control-style';
     const OPTION_CONSUMED_STYLE_ID = 'reading-option-consumed-style';
+    // 候选池容器/选项 class 不统一，统一选择器覆盖所有变体。
+    // .headings-pool 当前都包裹 .pool-items 但作为防御一并纳入。
+    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
+    const POOL_CONTAINER_SELECTOR = '.pool-items, #word-options, .options-pool, .option-pool, .cardpool, .headings-pool, .pool';
     const PRACTICE_TIMER_BRIDGE_KEY = '__IELTS_PRACTICE_TIMER__';
     const PRACTICE_TIMER_EVENT = 'practiceTimerStateChange';
     const READING_CANDIDATE_CODE_PATTERN = /^\d{6}$/;
@@ -7779,14 +7783,14 @@
     }
 
     function initDragPools() {
-        document.querySelectorAll('.pool-items').forEach((pool, index) => {
+        document.querySelectorAll(POOL_CONTAINER_SELECTOR).forEach((pool, index) => {
             if (!pool.id) {
                 pool.id = `practice-pool-${index}`;
             }
         });
-        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
+        document.querySelectorAll(`${POOL_CONTAINER_SELECTOR} ${POOL_ITEM_SELECTOR}`).forEach((item) => {
             if (!item.dataset.originPool) {
-                const pool = item.closest('.pool-items');
+                const pool = item.closest(POOL_CONTAINER_SELECTOR);
                 if (pool?.id) {
                     item.dataset.originPool = pool.id;
                 }
@@ -7950,7 +7954,9 @@
         const style = document.createElement('style');
         style.id = OPTION_CONSUMED_STYLE_ID;
         style.textContent = `
-            .drag-item.option-consumed {
+            .drag-item.option-consumed,
+            .draggable-word.option-consumed,
+            .card.option-consumed {
                 opacity: 0.45 !important;
                 cursor: not-allowed !important;
                 background: #f1f5f9 !important;
@@ -10528,7 +10534,7 @@
     function buildDragPayload(item) {
         if (!item) return null;
         const sourceDropzone = item.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary');
-        const sourcePool = item.closest('.pool-items');
+        const sourcePool = item.closest(POOL_CONTAINER_SELECTOR);
         return {
             value: item.dataset.heading || item.dataset.option || item.dataset.key || item.dataset.word || item.dataset.value || item.dataset.answerValue || item.textContent.trim(),
             label: item.dataset.answerLabel || item.dataset.word || item.dataset.value || item.textContent.trim(),
@@ -10547,7 +10553,8 @@
             return {
                 value: String(payload.value || payload.label || '').trim(),
                 label: String(payload.label || payload.value || '').trim(),
-                sourceDropzoneId: String(payload.sourceDropzoneId || '').trim()
+                sourceDropzoneId: String(payload.sourceDropzoneId || '').trim(),
+                sourcePoolId: String(payload.sourcePoolId || '').trim()
             };
         } catch (_) {
             const fallback = String(rawValue).trim();
@@ -10623,12 +10630,12 @@
         updateDropzoneState(dropzone);
     }
 
-    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
-
     function resolvePoolContainer(group) {
-        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool 均可能是
+        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool /
+        // .option-pool / .cardpool 均可能是（.option-pool 与 .options-pool 是不同 class，
+        // .cardpool 用于卡片匹配题，二者都必须覆盖）
         if (!group) return null;
-        return group.querySelector('.pool-items, #word-options, .options-pool, .pool');
+        return group.querySelector(POOL_CONTAINER_SELECTOR);
     }
 
     function resolveOptionGroupAndPool(dropzone, payload) {
@@ -10664,7 +10671,7 @@
 
         // 4. 最后兜底：直接找第一个 pool
         if (!pool) {
-            pool = document.querySelector('.pool-items, #word-options, .options-pool, .pool');
+            pool = document.querySelector(POOL_CONTAINER_SELECTOR);
             if (pool) {
                 group = group || pool.closest('.unified-group');
             }
@@ -10829,7 +10836,7 @@
         });
         document.addEventListener('dragover', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             if (!target) {
                 return;
@@ -10839,13 +10846,13 @@
         });
         document.addEventListener('dragleave', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             target?.classList?.remove('drag-over');
         });
         document.addEventListener('drop', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             if (!target) {
                 return;
@@ -10857,7 +10864,7 @@
             if (!payload) {
                 return;
             }
-            if (target.classList.contains('pool-items')) {
+            if (target.matches(POOL_CONTAINER_SELECTOR) || target.closest(POOL_CONTAINER_SELECTOR)) {
                 handleDropBackToPool(payload);
                 return;
             }

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -10623,44 +10623,70 @@
         updateDropzoneState(dropzone);
     }
 
+    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
+
+    function resolvePoolContainer(group) {
+        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool 均可能是
+        if (!group) return null;
+        return group.querySelector('.pool-items, #word-options, .options-pool, .pool');
+    }
+
     function resolveOptionGroupAndPool(dropzone, payload) {
-        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池
+        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池。
+        // 优先用 dropzone 定位所属组（consume/restore 针对放置/清空的答案区所属组，
+        // 跨组交换时不能用 payload 来源定位，否则会误伤源组），sourcePoolId 作兜底。
         let group = null;
         let pool = null;
 
-        // 1. 优先通过 payload.sourcePoolId 查找 pool
-        if (payload && payload.sourcePoolId) {
+        // 1. 优先从 dropzone 向上查找 group（目标/源答案区所属组）
+        if (dropzone) {
+            group = dropzone.closest('.unified-group');
+            if (group) {
+                pool = resolvePoolContainer(group);
+            }
+        }
+
+        // 2. 尝试通过 payload.sourcePoolId 查找 pool（兼容分栏下 closest 失效）
+        if (!group && payload && payload.sourcePoolId) {
             pool = document.getElementById(payload.sourcePoolId);
             if (pool) {
                 group = pool.closest('.unified-group');
             }
         }
 
-        // 2. 尝试从 dropzone 向上查找 group（兼容非分栏布局）
-        if (!group && dropzone) {
-            group = dropzone.closest('.unified-group');
-            if (group) {
-                pool = group.querySelector('.pool-items');
-            }
-        }
-
-        // 3. 如果还没找到，通过 dropzone 关联的题目查找：找到页面上 allowOptionReuse=false 的 group
+        // 3. 如果还没找到，找到页面上 allowOptionReuse=false 的 group
         if (!group) {
             group = document.querySelector('.unified-group[data-allow-option-reuse="false"]');
             if (group) {
-                pool = group.querySelector('.pool-items');
+                pool = resolvePoolContainer(group);
             }
         }
 
         // 4. 最后兜底：直接找第一个 pool
         if (!pool) {
-            pool = document.querySelector('.pool-items');
+            pool = document.querySelector('.pool-items, #word-options, .options-pool, .pool');
             if (pool) {
                 group = group || pool.closest('.unified-group');
             }
         }
 
         return { group, pool };
+    }
+
+    function findPoolItemByValue(pool, consumedValue) {
+        // 统一候选 item 类型：.drag-item（段落/匹配）、.draggable-word（选词填空）
+        if (!pool) return null;
+        const items = pool.querySelectorAll(POOL_ITEM_SELECTOR);
+        for (const item of items) {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === consumedValue) {
+                return item;
+            }
+        }
+        return null;
     }
 
     function consumePoolOption(dropzone, payload) {
@@ -10674,17 +10700,12 @@
             return;
         }
         const consumedValue = canonicalizeAnswerToken(payload.value);
-        pool.querySelectorAll('.drag-item').forEach((item) => {
-            const itemValue = canonicalizeAnswerToken(
-                item.dataset.heading || item.dataset.option || item.dataset.key
-                || item.dataset.word || item.dataset.value || item.textContent
-            );
-            if (itemValue && itemValue === consumedValue && !item.dataset.consumed) {
-                item.dataset.consumed = '1';
-                item.classList.add('option-consumed');
-                item.setAttribute('draggable', 'false');
-            }
-        });
+        const item = findPoolItemByValue(pool, consumedValue);
+        if (item && !item.dataset.consumed) {
+            item.dataset.consumed = '1';
+            item.classList.add('option-consumed');
+            item.setAttribute('draggable', 'false');
+        }
     }
 
     function restorePoolOption(dropzone, payload) {
@@ -10705,36 +10726,35 @@
                 .filter(Boolean)
         );
         const restoredValue = canonicalizeAnswerToken(payload.value);
-        pool.querySelectorAll('.drag-item').forEach((item) => {
-            const itemValue = canonicalizeAnswerToken(
-                item.dataset.heading || item.dataset.option || item.dataset.key
-                || item.dataset.word || item.dataset.value || item.textContent
-            );
-            if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
-                // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
-                // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
-                const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
-                    .filter((zone) => {
-                        const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
-                        const zoneIds = expandQuestionSequence(zoneQuestion);
-                        const normalizedZoneIds = zoneIds.length
-                            ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
-                            : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
-                        return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
-                    });
-                const stillUsed = groupDropzones.some((zone) => {
-                    const zonePayload = getDropzonePayload(zone);
-                    return zonePayload
-                        && canonicalizeAnswerToken(zonePayload.value) === itemValue;
+        const item = findPoolItemByValue(pool, restoredValue);
+        if (item && item.dataset.consumed) {
+            // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
+            // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
+            // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
+            const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
+                .filter((zone) => {
+                    const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
+                    const zoneIds = expandQuestionSequence(zoneQuestion);
+                    const normalizedZoneIds = zoneIds.length
+                        ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
+                        : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
+                    return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
                 });
-                if (!stillUsed) {
-                    delete item.dataset.consumed;
-                    item.classList.remove('option-consumed');
-                    item.setAttribute('draggable', 'true');
-                }
+            const stillUsed = groupDropzones.some((zone) => {
+                const zonePayload = getDropzonePayload(zone);
+                return zonePayload
+                    && canonicalizeAnswerToken(zonePayload.value) === restoredValue;
+            });
+            if (!stillUsed) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                // 恢复可用性时需保留当前交互锁：计时器锁定或只读状态下
+                // 不允许重新启用选项，否则可绕过锁定继续作答
+                const interactionLocked = Boolean(state.readOnly || state.timerLocked);
+                item.setAttribute('draggable', interactionLocked ? 'false' : 'true');
+                item.classList.toggle('drag-item-locked', interactionLocked);
             }
-        });
+        }
     }
 
     function handleDropOnDropzone(dropzone, payload) {
@@ -10749,21 +10769,28 @@
             return;
         }
         const previousPayload = getDropzonePayload(dropzone);
+        const sourcePreviousPayload = getDropzonePayload(sourceDropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
-        // 从 pool 拖入：消耗新选项（若组不允许复用）
-        if (!sourceDropzone) {
-            consumePoolOption(dropzone, payload);
-            // 替换已填答案时，旧选项已不再被该 dropzone 使用，恢复其在 pool 中的可用状态
-            if (previousPayload && previousPayload.value
-                && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
-                restorePoolOption(dropzone, previousPayload);
-            }
+
+        // 目标 dropzone：消耗新值；若原来有值且被替换，恢复原值（仅当不再被使用）
+        consumePoolOption(dropzone, payload);
+        if (previousPayload && previousPayload.value
+            && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
+            restorePoolOption(dropzone, previousPayload);
         }
+
         if (sourceDropzone && sourceDropzone !== dropzone) {
+            // 跨答案区拖动：先把目标旧值移入源 dropzone（消耗源组对应选项），
+            // 再恢复源旧值——此时源已更新，才能正确判断源旧值是否仍被使用
             if (previousPayload && previousPayload.value) {
                 setDropzoneAnswer(sourceDropzone, previousPayload.value, previousPayload.label);
+                consumePoolOption(sourceDropzone, previousPayload);
             } else {
                 clearDropzone(sourceDropzone);
+            }
+            // 源 dropzone 的旧值已被移走，恢复其在 pool 中的状态（仅当不再被使用）
+            if (sourcePreviousPayload && sourcePreviousPayload.value) {
+                restorePoolOption(sourceDropzone, sourcePreviousPayload);
             }
         }
         updateNavStatuses();
@@ -12018,6 +12045,9 @@
     }
 
     function applyReplayAnswersToDom(answers = {}) {
+        // 连续 replay 不同记录时，先重置所有候选池的已使用状态，
+        // 再按新记录的完整答案集重新消耗，避免新旧答案的选项都保持禁用
+        resetAllConsumedOptions();
         applyAnswersToDom(answers);
     }
 
@@ -13440,6 +13470,19 @@
         };
     }
 
+    function resetAllConsumedOptions() {
+        // 重置所有候选池选项的已使用状态（覆盖 .drag-item 和 .draggable-word）。
+        // 供重置和 replay 前调用，避免连续 replay 时新旧答案的选项都保持禁用。
+        document.querySelectorAll(`${POOL_ITEM_SELECTOR}`).forEach((item) => {
+            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                const interactionLocked = Boolean(state.readOnly || state.timerLocked);
+                item.setAttribute('draggable', interactionLocked ? 'false' : 'true');
+            }
+        });
+    }
+
     function clearCurrentAnswers() {
         document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach((input) => {
             input.checked = false;
@@ -13455,13 +13498,7 @@
             clearDropzone(dropzone);
         });
         // 兜底：确保所有选项池中的选项都恢复为可用状态
-        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
-            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
-                delete item.dataset.consumed;
-                item.classList.remove('option-consumed');
-                item.setAttribute('draggable', 'true');
-            }
-        });
+        resetAllConsumedOptions();
         // 清除选择题/表格判卷残留的绿/红标记
         document.querySelectorAll('.option-correct, .option-wrong, .correct, .wrong').forEach((node) => {
             node.classList.remove('option-correct', 'option-wrong', 'correct', 'wrong');

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -10703,8 +10703,9 @@
             );
             if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
                 // 仅当该选项未被其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone
-                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone'));
+                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone；
+                // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
+                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'));
                 const stillUsed = allDropzones.some((zone) => {
                     const zonePayload = getDropzonePayload(zone);
                     return zonePayload
@@ -10732,9 +10733,14 @@
         }
         const previousPayload = getDropzonePayload(dropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
-        // 从 pool 拖入：消耗选项（若组不允许复用）
+        // 从 pool 拖入：消耗新选项（若组不允许复用）
         if (!sourceDropzone) {
             consumePoolOption(dropzone, payload);
+            // 替换已填答案时，旧选项已不再被该 dropzone 使用，恢复其在 pool 中的可用状态
+            if (previousPayload && previousPayload.value
+                && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
+                restorePoolOption(dropzone, previousPayload);
+            }
         }
         if (sourceDropzone && sourceDropzone !== dropzone) {
             if (previousPayload && previousPayload.value) {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -13,6 +13,10 @@
     const READING_NOTE_STYLE_ID = 'reading-note-style';
     const READING_DISPLAY_CONTROL_STYLE_ID = 'reading-display-control-style';
     const OPTION_CONSUMED_STYLE_ID = 'reading-option-consumed-style';
+    // 候选池容器/选项 class 不统一，统一选择器覆盖所有变体。
+    // .headings-pool 当前都包裹 .pool-items 但作为防御一并纳入。
+    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
+    const POOL_CONTAINER_SELECTOR = '.pool-items, #word-options, .options-pool, .option-pool, .cardpool, .headings-pool, .pool';
     const PRACTICE_TIMER_BRIDGE_KEY = '__IELTS_PRACTICE_TIMER__';
     const PRACTICE_TIMER_EVENT = 'practiceTimerStateChange';
     const READING_CANDIDATE_CODE_PATTERN = /^\d{6}$/;
@@ -1533,14 +1537,14 @@
     }
 
     function initDragPools() {
-        document.querySelectorAll('.pool-items').forEach((pool, index) => {
+        document.querySelectorAll(POOL_CONTAINER_SELECTOR).forEach((pool, index) => {
             if (!pool.id) {
                 pool.id = `practice-pool-${index}`;
             }
         });
-        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
+        document.querySelectorAll(`${POOL_CONTAINER_SELECTOR} ${POOL_ITEM_SELECTOR}`).forEach((item) => {
             if (!item.dataset.originPool) {
-                const pool = item.closest('.pool-items');
+                const pool = item.closest(POOL_CONTAINER_SELECTOR);
                 if (pool?.id) {
                     item.dataset.originPool = pool.id;
                 }
@@ -1704,7 +1708,9 @@
         const style = document.createElement('style');
         style.id = OPTION_CONSUMED_STYLE_ID;
         style.textContent = `
-            .drag-item.option-consumed {
+            .drag-item.option-consumed,
+            .draggable-word.option-consumed,
+            .card.option-consumed {
                 opacity: 0.45 !important;
                 cursor: not-allowed !important;
                 background: #f1f5f9 !important;
@@ -4282,7 +4288,7 @@
     function buildDragPayload(item) {
         if (!item) return null;
         const sourceDropzone = item.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary');
-        const sourcePool = item.closest('.pool-items');
+        const sourcePool = item.closest(POOL_CONTAINER_SELECTOR);
         return {
             value: item.dataset.heading || item.dataset.option || item.dataset.key || item.dataset.word || item.dataset.value || item.dataset.answerValue || item.textContent.trim(),
             label: item.dataset.answerLabel || item.dataset.word || item.dataset.value || item.textContent.trim(),
@@ -4301,7 +4307,8 @@
             return {
                 value: String(payload.value || payload.label || '').trim(),
                 label: String(payload.label || payload.value || '').trim(),
-                sourceDropzoneId: String(payload.sourceDropzoneId || '').trim()
+                sourceDropzoneId: String(payload.sourceDropzoneId || '').trim(),
+                sourcePoolId: String(payload.sourcePoolId || '').trim()
             };
         } catch (_) {
             const fallback = String(rawValue).trim();
@@ -4377,12 +4384,12 @@
         updateDropzoneState(dropzone);
     }
 
-    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
-
     function resolvePoolContainer(group) {
-        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool 均可能是
+        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool /
+        // .option-pool / .cardpool 均可能是（.option-pool 与 .options-pool 是不同 class，
+        // .cardpool 用于卡片匹配题，二者都必须覆盖）
         if (!group) return null;
-        return group.querySelector('.pool-items, #word-options, .options-pool, .pool');
+        return group.querySelector(POOL_CONTAINER_SELECTOR);
     }
 
     function resolveOptionGroupAndPool(dropzone, payload) {
@@ -4418,7 +4425,7 @@
 
         // 4. 最后兜底：直接找第一个 pool
         if (!pool) {
-            pool = document.querySelector('.pool-items, #word-options, .options-pool, .pool');
+            pool = document.querySelector(POOL_CONTAINER_SELECTOR);
             if (pool) {
                 group = group || pool.closest('.unified-group');
             }
@@ -4583,7 +4590,7 @@
         });
         document.addEventListener('dragover', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             if (!target) {
                 return;
@@ -4593,13 +4600,13 @@
         });
         document.addEventListener('dragleave', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             target?.classList?.remove('drag-over');
         });
         document.addEventListener('drop', (event) => {
             const target = event.target instanceof HTMLElement
-                ? event.target.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary, .pool-items')
+                ? event.target.closest(`.paragraph-dropzone, .match-dropzone, .drop-target-summary, ${POOL_CONTAINER_SELECTOR}`)
                 : null;
             if (!target) {
                 return;
@@ -4611,7 +4618,7 @@
             if (!payload) {
                 return;
             }
-            if (target.classList.contains('pool-items')) {
+            if (target.matches(POOL_CONTAINER_SELECTOR) || target.closest(POOL_CONTAINER_SELECTOR)) {
                 handleDropBackToPool(payload);
                 return;
             }

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -12,6 +12,7 @@
     const MEMORIZE_STYLE_ID = 'reading-memorize-style';
     const READING_NOTE_STYLE_ID = 'reading-note-style';
     const READING_DISPLAY_CONTROL_STYLE_ID = 'reading-display-control-style';
+    const OPTION_CONSUMED_STYLE_ID = 'reading-option-consumed-style';
     const PRACTICE_TIMER_BRIDGE_KEY = '__IELTS_PRACTICE_TIMER__';
     const PRACTICE_TIMER_EVENT = 'practiceTimerStateChange';
     const READING_CANDIDATE_CODE_PATTERN = /^\d{6}$/;
@@ -1694,6 +1695,23 @@
             body.hide-reading-highlights .hl:not([data-hl-type="note"]):not([data-note-id]){background:transparent!important;color:inherit!important;box-shadow:none!important;outline:none!important}
             body.reading-question-nav-collapsed .practice-nav{display:none}
             body.dark-mode .reading-display-toggle-group{background:#1e293b;border-color:#475569;color:#cbd5e1}
+        `;
+        document.head.appendChild(style);
+    }
+
+    function ensureOptionConsumedStyles() {
+        if (document.getElementById(OPTION_CONSUMED_STYLE_ID)) return;
+        const style = document.createElement('style');
+        style.id = OPTION_CONSUMED_STYLE_ID;
+        style.textContent = `
+            .drag-item.option-consumed {
+                opacity: 0.45 !important;
+                cursor: not-allowed !important;
+                background: #f1f5f9 !important;
+                border-color: #cbd5e1 !important;
+                color: #94a3b8 !important;
+                pointer-events: none !important;
+            }
         `;
         document.head.appendChild(style);
     }
@@ -4230,6 +4248,7 @@
 
     function clearDropzone(dropzone) {
         if (!dropzone) return;
+        const previousPayload = getDropzonePayload(dropzone);
         dropzone.dataset.answerValue = '';
         dropzone.dataset.answerLabel = '';
         // 清除判卷残留的标记，避免重置后旧颜色残留
@@ -4241,6 +4260,10 @@
             if (holder) {
                 holder.innerHTML = '';
             }
+        }
+        // 清空后恢复 pool 中对应选项的显示（不允许复用的题组）
+        if (previousPayload) {
+            restorePoolOption(dropzone, previousPayload);
         }
         updateDropzoneState(dropzone);
     }
@@ -4259,10 +4282,12 @@
     function buildDragPayload(item) {
         if (!item) return null;
         const sourceDropzone = item.closest('.paragraph-dropzone, .match-dropzone, .drop-target-summary');
+        const sourcePool = item.closest('.pool-items');
         return {
             value: item.dataset.heading || item.dataset.option || item.dataset.key || item.dataset.word || item.dataset.value || item.dataset.answerValue || item.textContent.trim(),
             label: item.dataset.answerLabel || item.dataset.word || item.dataset.value || item.textContent.trim(),
-            sourceDropzoneId: sourceDropzone?.dataset?.dropzoneId || ''
+            sourceDropzoneId: sourceDropzone?.dataset?.dropzoneId || '',
+            sourcePoolId: sourcePool?.id || item.dataset.originPool || ''
         };
     }
 
@@ -4297,6 +4322,11 @@
         }
         item.dataset.dragBound = '1';
         item.addEventListener('dragstart', (event) => {
+            // 已被使用的选项不可拖拽
+            if (item.classList.contains('option-consumed') || item.dataset.consumed === '1') {
+                event.preventDefault();
+                return;
+            }
             const payload = buildDragPayload(item);
             if (!payload || !payload.value) {
                 event.preventDefault();
@@ -4347,6 +4377,102 @@
         updateDropzoneState(dropzone);
     }
 
+    function resolveOptionGroupAndPool(dropzone, payload) {
+        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池
+        let group = null;
+        let pool = null;
+
+        // 1. 优先通过 payload.sourcePoolId 查找 pool
+        if (payload && payload.sourcePoolId) {
+            pool = document.getElementById(payload.sourcePoolId);
+            if (pool) {
+                group = pool.closest('.unified-group');
+            }
+        }
+
+        // 2. 尝试从 dropzone 向上查找 group（兼容非分栏布局）
+        if (!group && dropzone) {
+            group = dropzone.closest('.unified-group');
+            if (group) {
+                pool = group.querySelector('.pool-items');
+            }
+        }
+
+        // 3. 如果还没找到，通过 dropzone 关联的题目查找：找到页面上 allowOptionReuse=false 的 group
+        if (!group) {
+            group = document.querySelector('.unified-group[data-allow-option-reuse="false"]');
+            if (group) {
+                pool = group.querySelector('.pool-items');
+            }
+        }
+
+        // 4. 最后兜底：直接找第一个 pool
+        if (!pool) {
+            pool = document.querySelector('.pool-items');
+            if (pool) {
+                group = group || pool.closest('.unified-group');
+            }
+        }
+
+        return { group, pool };
+    }
+
+    function consumePoolOption(dropzone, payload) {
+        // 段落匹配等不允许复用的题组：选项拖走后在候选池标记为已使用（禁用+标灰），
+        // 便于用户直观看到哪些选项已被使用，且不可再次选择。
+        if (!dropzone || !payload || !payload.value) {
+            return;
+        }
+        const { group, pool } = resolveOptionGroupAndPool(dropzone, payload);
+        if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
+            return;
+        }
+        const consumedValue = canonicalizeAnswerToken(payload.value);
+        pool.querySelectorAll('.drag-item').forEach((item) => {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === consumedValue && !item.dataset.consumed) {
+                item.dataset.consumed = '1';
+                item.classList.add('option-consumed');
+                item.setAttribute('draggable', 'false');
+            }
+        });
+    }
+
+    function restorePoolOption(dropzone, payload) {
+        if (!dropzone || !payload || !payload.value) {
+            return;
+        }
+        const { group, pool } = resolveOptionGroupAndPool(dropzone, payload);
+        if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
+            return;
+        }
+        const restoredValue = canonicalizeAnswerToken(payload.value);
+        pool.querySelectorAll('.drag-item').forEach((item) => {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
+                // 仅当该选项未被其他 dropzone 使用时才恢复
+                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone
+                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone'));
+                const stillUsed = allDropzones.some((zone) => {
+                    const zonePayload = getDropzonePayload(zone);
+                    return zonePayload
+                        && canonicalizeAnswerToken(zonePayload.value) === itemValue;
+                });
+                if (!stillUsed) {
+                    delete item.dataset.consumed;
+                    item.classList.remove('option-consumed');
+                    item.setAttribute('draggable', 'true');
+                }
+            }
+        });
+    }
+
     function handleDropOnDropzone(dropzone, payload) {
         if (!dropzone || !payload || !payload.value) {
             return;
@@ -4360,6 +4486,10 @@
         }
         const previousPayload = getDropzonePayload(dropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
+        // 从 pool 拖入：消耗选项（若组不允许复用）
+        if (!sourceDropzone) {
+            consumePoolOption(dropzone, payload);
+        }
         if (sourceDropzone && sourceDropzone !== dropzone) {
             if (previousPayload && previousPayload.value) {
                 setDropzoneAnswer(sourceDropzone, previousPayload.value, previousPayload.label);
@@ -4378,11 +4508,17 @@
         if (!sourceDropzone) {
             return;
         }
+        // 先记录原答案，清空后恢复 pool 中的选项显示
+        const previousPayload = getDropzonePayload(sourceDropzone);
         clearDropzone(sourceDropzone);
+        if (previousPayload) {
+            restorePoolOption(sourceDropzone, previousPayload);
+        }
         updateNavStatuses();
     }
 
     function attachDragDrop() {
+        ensureOptionConsumedStyles();
         getDropzones().forEach((dropzone, index) => {
             if (!dropzone.dataset.dropzoneId) {
                 dropzone.dataset.dropzoneId = `dropzone-${index + 1}`;
@@ -4685,6 +4821,8 @@
         }
         const label = normalizeAnswerForReplay(rawValue, 'label') || value;
         setDropzoneAnswer(dropzone, value, label);
+        // 回放答案时也需要标记选项为已使用（不允许复用的题组）
+        consumePoolOption(dropzone, { value, label });
         return true;
     }
 
@@ -5662,7 +5800,9 @@
         const locked = Boolean(state.readOnly || state.timerLocked);
         document.querySelectorAll('.drag-item, .draggable-word, .card').forEach((item) => {
             if (!(item instanceof HTMLElement)) return;
-            item.setAttribute('draggable', locked ? 'false' : 'true');
+            // 如果选项已被使用（option-consumed），始终保持不可拖拽
+            const isConsumed = item.classList.contains('option-consumed') || item.dataset.consumed === '1';
+            item.setAttribute('draggable', locked || isConsumed ? 'false' : 'true');
             item.classList.toggle('drag-item-locked', locked);
         });
     }
@@ -7044,6 +7184,14 @@
         });
         getDropzones().forEach((dropzone) => {
             clearDropzone(dropzone);
+        });
+        // 兜底：确保所有选项池中的选项都恢复为可用状态
+        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
+            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                item.setAttribute('draggable', 'true');
+            }
         });
         // 清除选择题/表格判卷残留的绿/红标记
         document.querySelectorAll('.option-correct, .option-wrong, .correct, .wrong').forEach((node) => {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -4457,8 +4457,9 @@
             );
             if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
                 // 仅当该选项未被其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone
-                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone'));
+                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone；
+                // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
+                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'));
                 const stillUsed = allDropzones.some((zone) => {
                     const zonePayload = getDropzonePayload(zone);
                     return zonePayload
@@ -4486,9 +4487,14 @@
         }
         const previousPayload = getDropzonePayload(dropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
-        // 从 pool 拖入：消耗选项（若组不允许复用）
+        // 从 pool 拖入：消耗新选项（若组不允许复用）
         if (!sourceDropzone) {
             consumePoolOption(dropzone, payload);
+            // 替换已填答案时，旧选项已不再被该 dropzone 使用，恢复其在 pool 中的可用状态
+            if (previousPayload && previousPayload.value
+                && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
+                restorePoolOption(dropzone, previousPayload);
+            }
         }
         if (sourceDropzone && sourceDropzone !== dropzone) {
             if (previousPayload && previousPayload.value) {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -4377,44 +4377,70 @@
         updateDropzoneState(dropzone);
     }
 
+    const POOL_ITEM_SELECTOR = '.drag-item, .draggable-word, .card';
+
+    function resolvePoolContainer(group) {
+        // 候选池容器 class 不统一：.pool-items / #word-options / .options-pool 均可能是
+        if (!group) return null;
+        return group.querySelector('.pool-items, #word-options, .options-pool, .pool');
+    }
+
     function resolveOptionGroupAndPool(dropzone, payload) {
-        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池
+        // 辅助函数：在左右分栏布局下也能找到正确的题组容器和选项池。
+        // 优先用 dropzone 定位所属组（consume/restore 针对放置/清空的答案区所属组，
+        // 跨组交换时不能用 payload 来源定位，否则会误伤源组），sourcePoolId 作兜底。
         let group = null;
         let pool = null;
 
-        // 1. 优先通过 payload.sourcePoolId 查找 pool
-        if (payload && payload.sourcePoolId) {
+        // 1. 优先从 dropzone 向上查找 group（目标/源答案区所属组）
+        if (dropzone) {
+            group = dropzone.closest('.unified-group');
+            if (group) {
+                pool = resolvePoolContainer(group);
+            }
+        }
+
+        // 2. 尝试通过 payload.sourcePoolId 查找 pool（兼容分栏下 closest 失效）
+        if (!group && payload && payload.sourcePoolId) {
             pool = document.getElementById(payload.sourcePoolId);
             if (pool) {
                 group = pool.closest('.unified-group');
             }
         }
 
-        // 2. 尝试从 dropzone 向上查找 group（兼容非分栏布局）
-        if (!group && dropzone) {
-            group = dropzone.closest('.unified-group');
-            if (group) {
-                pool = group.querySelector('.pool-items');
-            }
-        }
-
-        // 3. 如果还没找到，通过 dropzone 关联的题目查找：找到页面上 allowOptionReuse=false 的 group
+        // 3. 如果还没找到，找到页面上 allowOptionReuse=false 的 group
         if (!group) {
             group = document.querySelector('.unified-group[data-allow-option-reuse="false"]');
             if (group) {
-                pool = group.querySelector('.pool-items');
+                pool = resolvePoolContainer(group);
             }
         }
 
         // 4. 最后兜底：直接找第一个 pool
         if (!pool) {
-            pool = document.querySelector('.pool-items');
+            pool = document.querySelector('.pool-items, #word-options, .options-pool, .pool');
             if (pool) {
                 group = group || pool.closest('.unified-group');
             }
         }
 
         return { group, pool };
+    }
+
+    function findPoolItemByValue(pool, consumedValue) {
+        // 统一候选 item 类型：.drag-item（段落/匹配）、.draggable-word（选词填空）
+        if (!pool) return null;
+        const items = pool.querySelectorAll(POOL_ITEM_SELECTOR);
+        for (const item of items) {
+            const itemValue = canonicalizeAnswerToken(
+                item.dataset.heading || item.dataset.option || item.dataset.key
+                || item.dataset.word || item.dataset.value || item.textContent
+            );
+            if (itemValue && itemValue === consumedValue) {
+                return item;
+            }
+        }
+        return null;
     }
 
     function consumePoolOption(dropzone, payload) {
@@ -4428,17 +4454,12 @@
             return;
         }
         const consumedValue = canonicalizeAnswerToken(payload.value);
-        pool.querySelectorAll('.drag-item').forEach((item) => {
-            const itemValue = canonicalizeAnswerToken(
-                item.dataset.heading || item.dataset.option || item.dataset.key
-                || item.dataset.word || item.dataset.value || item.textContent
-            );
-            if (itemValue && itemValue === consumedValue && !item.dataset.consumed) {
-                item.dataset.consumed = '1';
-                item.classList.add('option-consumed');
-                item.setAttribute('draggable', 'false');
-            }
-        });
+        const item = findPoolItemByValue(pool, consumedValue);
+        if (item && !item.dataset.consumed) {
+            item.dataset.consumed = '1';
+            item.classList.add('option-consumed');
+            item.setAttribute('draggable', 'false');
+        }
     }
 
     function restorePoolOption(dropzone, payload) {
@@ -4459,36 +4480,35 @@
                 .filter(Boolean)
         );
         const restoredValue = canonicalizeAnswerToken(payload.value);
-        pool.querySelectorAll('.drag-item').forEach((item) => {
-            const itemValue = canonicalizeAnswerToken(
-                item.dataset.heading || item.dataset.option || item.dataset.key
-                || item.dataset.word || item.dataset.value || item.textContent
-            );
-            if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
-                // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
-                // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
-                const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
-                    .filter((zone) => {
-                        const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
-                        const zoneIds = expandQuestionSequence(zoneQuestion);
-                        const normalizedZoneIds = zoneIds.length
-                            ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
-                            : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
-                        return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
-                    });
-                const stillUsed = groupDropzones.some((zone) => {
-                    const zonePayload = getDropzonePayload(zone);
-                    return zonePayload
-                        && canonicalizeAnswerToken(zonePayload.value) === itemValue;
+        const item = findPoolItemByValue(pool, restoredValue);
+        if (item && item.dataset.consumed) {
+            // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
+            // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
+            // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
+            const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
+                .filter((zone) => {
+                    const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
+                    const zoneIds = expandQuestionSequence(zoneQuestion);
+                    const normalizedZoneIds = zoneIds.length
+                        ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
+                        : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
+                    return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
                 });
-                if (!stillUsed) {
-                    delete item.dataset.consumed;
-                    item.classList.remove('option-consumed');
-                    item.setAttribute('draggable', 'true');
-                }
+            const stillUsed = groupDropzones.some((zone) => {
+                const zonePayload = getDropzonePayload(zone);
+                return zonePayload
+                    && canonicalizeAnswerToken(zonePayload.value) === restoredValue;
+            });
+            if (!stillUsed) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                // 恢复可用性时需保留当前交互锁：计时器锁定或只读状态下
+                // 不允许重新启用选项，否则可绕过锁定继续作答
+                const interactionLocked = Boolean(state.readOnly || state.timerLocked);
+                item.setAttribute('draggable', interactionLocked ? 'false' : 'true');
+                item.classList.toggle('drag-item-locked', interactionLocked);
             }
-        });
+        }
     }
 
     function handleDropOnDropzone(dropzone, payload) {
@@ -4503,21 +4523,28 @@
             return;
         }
         const previousPayload = getDropzonePayload(dropzone);
+        const sourcePreviousPayload = getDropzonePayload(sourceDropzone);
         setDropzoneAnswer(dropzone, payload.value, payload.label);
-        // 从 pool 拖入：消耗新选项（若组不允许复用）
-        if (!sourceDropzone) {
-            consumePoolOption(dropzone, payload);
-            // 替换已填答案时，旧选项已不再被该 dropzone 使用，恢复其在 pool 中的可用状态
-            if (previousPayload && previousPayload.value
-                && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
-                restorePoolOption(dropzone, previousPayload);
-            }
+
+        // 目标 dropzone：消耗新值；若原来有值且被替换，恢复原值（仅当不再被使用）
+        consumePoolOption(dropzone, payload);
+        if (previousPayload && previousPayload.value
+            && canonicalizeAnswerToken(previousPayload.value) !== canonicalizeAnswerToken(payload.value)) {
+            restorePoolOption(dropzone, previousPayload);
         }
+
         if (sourceDropzone && sourceDropzone !== dropzone) {
+            // 跨答案区拖动：先把目标旧值移入源 dropzone（消耗源组对应选项），
+            // 再恢复源旧值——此时源已更新，才能正确判断源旧值是否仍被使用
             if (previousPayload && previousPayload.value) {
                 setDropzoneAnswer(sourceDropzone, previousPayload.value, previousPayload.label);
+                consumePoolOption(sourceDropzone, previousPayload);
             } else {
                 clearDropzone(sourceDropzone);
+            }
+            // 源 dropzone 的旧值已被移走，恢复其在 pool 中的状态（仅当不再被使用）
+            if (sourcePreviousPayload && sourcePreviousPayload.value) {
+                restorePoolOption(sourceDropzone, sourcePreviousPayload);
             }
         }
         updateNavStatuses();
@@ -5772,6 +5799,9 @@
     }
 
     function applyReplayAnswersToDom(answers = {}) {
+        // 连续 replay 不同记录时，先重置所有候选池的已使用状态，
+        // 再按新记录的完整答案集重新消耗，避免新旧答案的选项都保持禁用
+        resetAllConsumedOptions();
         applyAnswersToDom(answers);
     }
 
@@ -7194,6 +7224,19 @@
         };
     }
 
+    function resetAllConsumedOptions() {
+        // 重置所有候选池选项的已使用状态（覆盖 .drag-item 和 .draggable-word）。
+        // 供重置和 replay 前调用，避免连续 replay 时新旧答案的选项都保持禁用。
+        document.querySelectorAll(`${POOL_ITEM_SELECTOR}`).forEach((item) => {
+            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
+                delete item.dataset.consumed;
+                item.classList.remove('option-consumed');
+                const interactionLocked = Boolean(state.readOnly || state.timerLocked);
+                item.setAttribute('draggable', interactionLocked ? 'false' : 'true');
+            }
+        });
+    }
+
     function clearCurrentAnswers() {
         document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach((input) => {
             input.checked = false;
@@ -7209,13 +7252,7 @@
             clearDropzone(dropzone);
         });
         // 兜底：确保所有选项池中的选项都恢复为可用状态
-        document.querySelectorAll('.pool-items .drag-item').forEach((item) => {
-            if (item.dataset.consumed || item.classList.contains('option-consumed')) {
-                delete item.dataset.consumed;
-                item.classList.remove('option-consumed');
-                item.setAttribute('draggable', 'true');
-            }
-        });
+        resetAllConsumedOptions();
         // 清除选择题/表格判卷残留的绿/红标记
         document.querySelectorAll('.option-correct, .option-wrong, .correct, .wrong').forEach((node) => {
             node.classList.remove('option-correct', 'option-wrong', 'correct', 'wrong');

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -4449,6 +4449,15 @@
         if (!group || !pool || group.dataset.allowOptionReuse !== 'false') {
             return;
         }
+        // 限定到当前组的 questionIds：同一页面可能有多个不允许复用的题组
+        // 使用相同选项字母（如 p2-high-233 组2/组3 都用 A-E），
+        // 跨组扫描会误伤其他组的独立选项。
+        const groupQuestionIds = new Set(
+            String(group.dataset.questionIds || '')
+                .split(',')
+                .map((entry) => normalizeQuestionId(entry.trim()))
+                .filter(Boolean)
+        );
         const restoredValue = canonicalizeAnswerToken(payload.value);
         pool.querySelectorAll('.drag-item').forEach((item) => {
             const itemValue = canonicalizeAnswerToken(
@@ -4456,11 +4465,19 @@
                 || item.dataset.word || item.dataset.value || item.textContent
             );
             if (itemValue && itemValue === restoredValue && item.dataset.consumed) {
-                // 仅当该选项未被其他 dropzone 使用时才恢复
-                // 左右分栏布局下 dropzone 不在 group 内，需要查询所有 dropzone；
+                // 仅当该选项未被当前组的其他 dropzone 使用时才恢复
+                // 左右分栏布局下 dropzone 不在 group 内，需按 questionId 匹配；
                 // summary 填空题的答案也存在 .drop-target-summary 中，需一并检查
-                const allDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'));
-                const stillUsed = allDropzones.some((zone) => {
+                const groupDropzones = Array.from(document.querySelectorAll('.paragraph-dropzone, .match-dropzone, .drop-target-summary'))
+                    .filter((zone) => {
+                        const zoneQuestion = zone.dataset.question || zone.dataset.questionId || '';
+                        const zoneIds = expandQuestionSequence(zoneQuestion);
+                        const normalizedZoneIds = zoneIds.length
+                            ? zoneIds.map((id) => normalizeQuestionId(id)).filter(Boolean)
+                            : [normalizeQuestionId(zoneQuestion)].filter(Boolean);
+                        return normalizedZoneIds.some((id) => groupQuestionIds.has(id));
+                    });
+                const stillUsed = groupDropzones.some((zone) => {
                     const zonePayload = getDropzonePayload(zone);
                     return zonePayload
                         && canonicalizeAnswerToken(zonePayload.value) === itemValue;


### PR DESCRIPTION
## Summary

用户建议：段落标题匹配题（List of Headings）中，已用选项应从候选池消失/禁用，方便做题时直观看到哪些选项已被使用。

## Implementation

- 不允许选项复用的题组（allowOptionReuse=false），选项使用后在候选池标记为已使用：opacity 0.45 变灰、pointer-events none 不可选中、draggable false
- 取消使用（拖回候选池/清空答案）后自动恢复为可用状态
- 修复左右分栏布局下 group/pool 查找失效问题（原 closest 查找无法跨分栏）：
  新增 resolveOptionGroupAndPool 辅助函数，通过 sourcePoolId 优先查找，兼容分栏/非分栏布局
- buildDragPayload 携带 sourcePoolId，确保选项来源追踪正确
- disableDragInteractions 全局锁定时仍尊重已用选项的禁用状态
- 重置时兜底清理所有 option-consumed 状态
- 答案回放（草稿恢复）时同步标记选项为已使用
- bundle 已重新构建

## Validation

- 段落匹配题（如 p1-high-118 Questions 1-7）：拖选项到答案区后，候选池选项变灰禁用
- 拖回候选池/清空答案：选项恢复可用
- 左右分栏布局下功能正常
- 允许复用的题组（人名匹配）不受影响