### PR TITLE
Add global question search and category switching

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8656,8 +8656,8 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
     font-variant-numeric: tabular-nums;
 }
 
-.question-bank-quick-picker__scopes > button:hover,
-.question-bank-quick-scope:hover,
+.question-bank-quick-picker__scopes > button:hover:not(:disabled),
+.question-bank-quick-scope:hover:not(:disabled),
 .question-bank-quick-picker__scopes > button[aria-pressed="true"],
 .question-bank-quick-picker__scopes > button[aria-current="true"],
 .question-bank-quick-scope.active {
@@ -8665,6 +8665,14 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
     border-color: color-mix(in srgb, var(--question-bank-quick-accent) 52%, var(--question-bank-quick-border-strong));
     box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
     transform: translateY(-1px);
+}
+
+.question-bank-quick-picker__scopes > button:disabled,
+.question-bank-quick-scope:disabled,
+.question-bank-quick-picker__results > button:disabled,
+.question-bank-quick-result:disabled {
+    opacity: 0.58;
+    cursor: wait;
 }
 
 .question-bank-quick-picker__results {
@@ -8705,11 +8713,11 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
         transform 180ms ease;
 }
 
-.question-bank-quick-picker__results > [role="option"]:hover,
+.question-bank-quick-picker__results > [role="option"]:hover:not(:disabled),
 .question-bank-quick-picker__results > [role="option"][aria-selected="true"],
-.question-bank-quick-picker__results > button:hover,
+.question-bank-quick-picker__results > button:hover:not(:disabled),
 .question-bank-quick-picker__results > a:hover,
-.question-bank-quick-result:hover,
+.question-bank-quick-result:hover:not(:disabled),
 .question-bank-quick-result[aria-selected="true"] {
     background: var(--question-bank-quick-surface-strong);
     border-color: color-mix(in srgb, var(--question-bank-quick-accent) 46%, transparent);

--- a/css/main.css
+++ b/css/main.css
@@ -8314,4 +8314,572 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
     }
 }
 
+/* ============================================================
+   Question bank quick picker
+   ============================================================ */
 
+.question-bank-quick-trigger {
+    appearance: none;
+    -webkit-appearance: none;
+    position: relative;
+    z-index: 2;
+    flex: 0 0 auto;
+    align-self: stretch;
+    min-height: 40px;
+    padding: 8px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.72);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.42);
+    color: rgba(30, 41, 59, 0.84);
+    box-shadow:
+        inset 0 1px 1px rgba(255, 255, 255, 0.82),
+        0 4px 12px rgba(15, 23, 42, 0.06);
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 750;
+    line-height: 1;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+        color 180ms ease,
+        background-color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+}
+
+.question-bank-quick-trigger:hover,
+.question-bank-quick-trigger[aria-expanded="true"] {
+    background: rgba(255, 255, 255, 0.72);
+    border-color: rgba(255, 255, 255, 0.92);
+    color: #0f172a;
+    box-shadow:
+        inset 0 1px 1px rgba(255, 255, 255, 0.95),
+        0 8px 18px rgba(15, 23, 42, 0.1);
+    transform: translateY(-1px);
+}
+
+.question-bank-quick-trigger:focus-visible {
+    outline: 3px solid var(--color-brand-primary);
+    outline-offset: 2px;
+}
+
+.question-bank-quick-picker {
+    --question-bank-quick-surface: rgba(255, 255, 255, 0.9);
+    --question-bank-quick-surface-strong: rgba(255, 255, 255, 0.98);
+    --question-bank-quick-surface-muted: rgba(241, 245, 249, 0.76);
+    --question-bank-quick-border: rgba(255, 255, 255, 0.76);
+    --question-bank-quick-border-strong: rgba(148, 163, 184, 0.34);
+    --question-bank-quick-text: #172033;
+    --question-bank-quick-muted: rgba(51, 65, 85, 0.7);
+    --question-bank-quick-accent: var(--shui-accent, var(--color-brand-primary));
+    --question-bank-quick-focus: var(--question-bank-quick-accent);
+    --question-bank-quick-anchor-top: clamp(104px, 17vh, 176px);
+    position: fixed;
+    inset: 0;
+    z-index: 9000;
+    display: grid;
+    align-items: start;
+    justify-items: center;
+    overflow: auto;
+    overscroll-behavior: contain;
+    padding: var(--question-bank-quick-anchor-top) 20px 28px;
+    background: rgba(15, 23, 42, 0.2);
+    backdrop-filter: blur(10px) saturate(120%);
+    -webkit-backdrop-filter: blur(10px) saturate(120%);
+}
+
+.question-bank-quick-picker[hidden],
+.question-bank-quick-picker__results[hidden] {
+    display: none !important;
+}
+
+.question-bank-quick-picker__dialog {
+    width: min(680px, 100%);
+    max-height: calc(100dvh - var(--question-bank-quick-anchor-top) - 28px);
+    overflow: auto;
+    color: var(--question-bank-quick-text);
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.28), transparent 46%),
+        var(--question-bank-quick-surface);
+    border: 1px solid var(--question-bank-quick-border);
+    border-radius: 28px;
+    box-shadow:
+        0 30px 80px rgba(15, 23, 42, 0.24),
+        inset 0 1px 1px rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(28px) saturate(155%);
+    -webkit-backdrop-filter: blur(28px) saturate(155%);
+    padding: clamp(20px, 3vw, 30px);
+    scrollbar-width: thin;
+    scrollbar-color: rgba(100, 116, 139, 0.34) transparent;
+    animation: questionBankQuickPickerEnter 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes questionBankQuickPickerEnter {
+    from {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.985);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.question-bank-quick-picker__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.question-bank-quick-picker__heading-group {
+    min-width: 0;
+}
+
+.question-bank-quick-picker__eyebrow {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--question-bank-quick-accent);
+    font-size: 0.7rem;
+    font-weight: 850;
+    letter-spacing: 0.16em;
+}
+
+.question-bank-quick-picker__heading-group h2 {
+    margin: 0;
+    color: var(--question-bank-quick-text);
+    font-size: clamp(1.3rem, 2.5vw, 1.65rem);
+    line-height: 1.2;
+}
+
+.question-bank-quick-picker__heading-group p {
+    max-width: 48ch;
+    margin: 7px 0 0;
+    color: var(--question-bank-quick-muted);
+    font-size: 0.9rem;
+    line-height: 1.55;
+}
+
+.question-bank-quick-picker__close {
+    appearance: none;
+    -webkit-appearance: none;
+    flex: 0 0 56px;
+    width: 56px;
+    height: 44px;
+    padding: 0;
+    border: 1px solid var(--question-bank-quick-border-strong);
+    border-radius: 999px;
+    background: var(--question-bank-quick-surface-muted);
+    color: var(--question-bank-quick-muted);
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 800;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+        color 180ms ease,
+        background-color 180ms ease,
+        border-color 180ms ease,
+        transform 180ms ease;
+}
+
+.question-bank-quick-picker__close:hover {
+    background: var(--question-bank-quick-surface-strong);
+    border-color: var(--question-bank-quick-accent);
+    color: var(--question-bank-quick-text);
+    transform: translateY(-1px);
+}
+
+.question-bank-quick-picker__close:focus-visible,
+.question-bank-quick-picker__search-field input:focus-visible,
+.question-bank-quick-picker__scopes > button:focus-visible,
+.question-bank-quick-picker__results > [role="option"]:focus-visible,
+.question-bank-quick-picker__results > button:focus-visible,
+.question-bank-quick-picker__results > a:focus-visible {
+    outline: 3px solid var(--question-bank-quick-focus);
+    outline-offset: 2px;
+}
+
+.question-bank-quick-picker__search-field {
+    display: grid;
+    gap: 8px;
+    margin-top: 22px;
+}
+
+.question-bank-quick-picker__search-field label {
+    color: var(--question-bank-quick-text);
+    font-size: 0.82rem;
+    font-weight: 800;
+}
+
+.question-bank-quick-picker__search-field input {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 100%;
+    min-height: 52px;
+    padding: 0 20px;
+    border: 1px solid var(--question-bank-quick-border-strong);
+    border-radius: 999px;
+    outline: none;
+    background: var(--question-bank-quick-surface-strong);
+    color: var(--question-bank-quick-text);
+    box-shadow:
+        0 12px 26px rgba(15, 23, 42, 0.07),
+        inset 0 1px 1px rgba(255, 255, 255, 0.88);
+    font: inherit;
+    font-size: 1rem;
+    font-weight: 650;
+    transition:
+        background-color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.question-bank-quick-picker__search-field input::placeholder {
+    color: var(--question-bank-quick-muted);
+    opacity: 0.72;
+}
+
+.question-bank-quick-picker__search-field input:hover {
+    border-color: color-mix(in srgb, var(--question-bank-quick-accent) 42%, var(--question-bank-quick-border-strong));
+}
+
+.question-bank-quick-picker__search-field input:focus-visible {
+    border-color: var(--question-bank-quick-accent);
+    box-shadow:
+        0 14px 30px rgba(15, 23, 42, 0.1),
+        0 0 0 4px var(--question-bank-quick-focus);
+}
+
+.question-bank-quick-picker__status {
+    min-height: 1.4em;
+    margin: 10px 2px 0;
+    color: var(--question-bank-quick-muted);
+    font-size: 0.8rem;
+    line-height: 1.4;
+}
+
+.question-bank-quick-picker__status[data-state="error"] {
+    color: #b91c1c;
+}
+
+.question-bank-quick-picker__status[data-state="success"] {
+    color: #047857;
+}
+
+.question-bank-quick-picker__section {
+    margin-top: 18px;
+    padding-top: 18px;
+    border-top: 1px solid var(--question-bank-quick-border-strong);
+}
+
+.question-bank-quick-picker__section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 11px;
+}
+
+.question-bank-quick-picker__section-head h3 {
+    margin: 0;
+    color: var(--question-bank-quick-text);
+    font-size: 0.96rem;
+}
+
+.question-bank-quick-picker__section-head span {
+    color: var(--question-bank-quick-muted);
+    font-size: 0.76rem;
+}
+
+.question-bank-quick-picker__scopes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(126px, 1fr));
+    gap: 9px;
+}
+
+.question-bank-quick-picker__scopes[aria-busy="true"] {
+    opacity: 0.72;
+}
+
+.question-bank-quick-picker__placeholder {
+    grid-column: 1 / -1;
+    margin: 0;
+    padding: 14px 16px;
+    border: 1px dashed var(--question-bank-quick-border-strong);
+    border-radius: 16px;
+    color: var(--question-bank-quick-muted);
+    background: var(--question-bank-quick-surface-muted);
+    font-size: 0.86rem;
+    text-align: center;
+}
+
+.question-bank-quick-picker__scopes > button,
+.question-bank-quick-scope {
+    appearance: none;
+    -webkit-appearance: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    padding: 9px 14px;
+    border: 1px solid var(--question-bank-quick-border-strong);
+    border-radius: 15px;
+    background: var(--question-bank-quick-surface-muted);
+    color: var(--question-bank-quick-text);
+    font: inherit;
+    font-size: 0.86rem;
+    font-weight: 750;
+    line-height: 1.25;
+    text-align: left;
+    cursor: pointer;
+    transition:
+        color 180ms ease,
+        background-color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+}
+
+.question-bank-quick-picker__scope-label {
+    min-width: 0;
+}
+
+.question-bank-quick-picker__scope-count {
+    flex: 0 0 auto;
+    color: var(--question-bank-quick-muted);
+    font-size: 0.78em;
+    font-variant-numeric: tabular-nums;
+}
+
+.question-bank-quick-picker__scopes > button:hover,
+.question-bank-quick-scope:hover,
+.question-bank-quick-picker__scopes > button[aria-pressed="true"],
+.question-bank-quick-picker__scopes > button[aria-current="true"],
+.question-bank-quick-scope.active {
+    background: var(--question-bank-quick-surface-strong);
+    border-color: color-mix(in srgb, var(--question-bank-quick-accent) 52%, var(--question-bank-quick-border-strong));
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
+}
+
+.question-bank-quick-picker__results {
+    display: grid;
+    gap: 8px;
+    max-height: min(320px, 42dvh);
+    margin-top: 18px;
+    padding-top: 18px;
+    overflow-y: auto;
+    border-top: 1px solid var(--question-bank-quick-border-strong);
+    scrollbar-width: thin;
+    scrollbar-color: rgba(100, 116, 139, 0.34) transparent;
+}
+
+.question-bank-quick-picker__results > [role="option"],
+.question-bank-quick-picker__results > button,
+.question-bank-quick-picker__results > a,
+.question-bank-quick-result {
+    appearance: none;
+    -webkit-appearance: none;
+    display: grid;
+    gap: 4px;
+    width: 100%;
+    min-height: 52px;
+    padding: 11px 14px;
+    border: 1px solid transparent;
+    border-radius: 15px;
+    background: var(--question-bank-quick-surface-muted);
+    color: var(--question-bank-quick-text);
+    font: inherit;
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+        background-color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+}
+
+.question-bank-quick-picker__results > [role="option"]:hover,
+.question-bank-quick-picker__results > [role="option"][aria-selected="true"],
+.question-bank-quick-picker__results > button:hover,
+.question-bank-quick-picker__results > a:hover,
+.question-bank-quick-result:hover,
+.question-bank-quick-result[aria-selected="true"] {
+    background: var(--question-bank-quick-surface-strong);
+    border-color: color-mix(in srgb, var(--question-bank-quick-accent) 46%, transparent);
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
+}
+
+.question-bank-quick-result__title {
+    overflow: hidden;
+    font-weight: 760;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.question-bank-quick-result__meta {
+    color: var(--question-bank-quick-muted);
+    font-size: 0.76rem;
+}
+
+body.bloom-dark-mode .question-bank-quick-trigger,
+body.blue-dark-mode .question-bank-quick-trigger,
+body[data-bg-theme="ascii-flower"] .question-bank-quick-trigger {
+    border-color: rgba(255, 255, 255, 0.13);
+    background: rgba(255, 255, 255, 0.07);
+    color: rgba(248, 250, 252, 0.84);
+    box-shadow:
+        inset 0 1px 1px rgba(255, 255, 255, 0.08),
+        0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+body.bloom-dark-mode .question-bank-quick-trigger:hover,
+body.bloom-dark-mode .question-bank-quick-trigger[aria-expanded="true"],
+body.blue-dark-mode .question-bank-quick-trigger:hover,
+body.blue-dark-mode .question-bank-quick-trigger[aria-expanded="true"],
+body[data-bg-theme="ascii-flower"] .question-bank-quick-trigger:hover,
+body[data-bg-theme="ascii-flower"] .question-bank-quick-trigger[aria-expanded="true"] {
+    border-color: rgba(255, 255, 255, 0.28);
+    background: rgba(255, 255, 255, 0.14);
+    color: #ffffff;
+}
+
+body.bloom-dark-mode .question-bank-quick-picker,
+body.blue-dark-mode .question-bank-quick-picker,
+body[data-bg-theme="ascii-flower"] .question-bank-quick-picker {
+    --question-bank-quick-surface: rgba(15, 23, 42, 0.92);
+    --question-bank-quick-surface-strong: rgba(30, 41, 59, 0.96);
+    --question-bank-quick-surface-muted: rgba(51, 65, 85, 0.48);
+    --question-bank-quick-border: rgba(255, 255, 255, 0.16);
+    --question-bank-quick-border-strong: rgba(148, 163, 184, 0.26);
+    --question-bank-quick-text: #f8fafc;
+    --question-bank-quick-muted: rgba(203, 213, 225, 0.76);
+    background: rgba(2, 6, 23, 0.52);
+}
+
+body.bloom-dark-mode .question-bank-quick-picker__dialog,
+body.blue-dark-mode .question-bank-quick-picker__dialog,
+body[data-bg-theme="ascii-flower"] .question-bank-quick-picker__dialog {
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.07), transparent 46%),
+        var(--question-bank-quick-surface);
+    box-shadow:
+        0 34px 90px rgba(0, 0, 0, 0.52),
+        inset 0 1px 1px rgba(255, 255, 255, 0.08);
+}
+
+body.bloom-dark-mode .question-bank-quick-picker__search-field input,
+body.blue-dark-mode .question-bank-quick-picker__search-field input,
+body[data-bg-theme="ascii-flower"] .question-bank-quick-picker__search-field input {
+    box-shadow:
+        0 12px 28px rgba(0, 0, 0, 0.24),
+        inset 0 1px 1px rgba(255, 255, 255, 0.06);
+}
+
+body.bloom-dark-mode .question-bank-quick-picker__status[data-state="error"],
+body.blue-dark-mode .question-bank-quick-picker__status[data-state="error"],
+body[data-bg-theme="ascii-flower"] .question-bank-quick-picker__status[data-state="error"] {
+    color: #fca5a5;
+}
+
+body.bloom-dark-mode .question-bank-quick-picker__status[data-state="success"],
+body.blue-dark-mode .question-bank-quick-picker__status[data-state="success"],
+body[data-bg-theme="ascii-flower"] .question-bank-quick-picker__status[data-state="success"] {
+    color: #6ee7b7;
+}
+
+@media (max-width: 768px) {
+    .hero-nav .question-bank-quick-trigger {
+        width: 100%;
+        max-width: 300px;
+        min-height: 44px;
+        align-self: center;
+        padding: 11px 18px;
+        font-size: 0.88rem;
+    }
+
+    .question-bank-quick-picker {
+        align-items: end;
+        padding: 16px;
+    }
+
+    .question-bank-quick-picker__dialog {
+        width: 100%;
+        max-height: min(84dvh, 720px);
+        border-radius: 28px 28px 20px 20px;
+        padding: 22px;
+    }
+
+    .question-bank-quick-picker__scopes {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .question-bank-quick-picker__results {
+        max-height: min(300px, 36dvh);
+    }
+}
+
+@media (max-width: 480px) {
+    .question-bank-quick-picker {
+        padding: 0;
+    }
+
+    .question-bank-quick-picker__dialog {
+        max-height: 92dvh;
+        border-radius: 26px 26px 0 0;
+        padding: 20px 16px calc(18px + env(safe-area-inset-bottom));
+    }
+
+    .question-bank-quick-picker__header {
+        gap: 12px;
+    }
+
+    .question-bank-quick-picker__heading-group p {
+        font-size: 0.84rem;
+    }
+
+    .question-bank-quick-picker__search-field input {
+        min-height: 50px;
+        padding-inline: 17px;
+        font-size: 16px;
+    }
+
+    .question-bank-quick-picker__section-head {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 3px;
+    }
+
+    .question-bank-quick-picker__scopes > button,
+    .question-bank-quick-scope {
+        min-height: 48px;
+    }
+
+    .question-bank-quick-picker__results > [role="option"],
+    .question-bank-quick-picker__results > button,
+    .question-bank-quick-picker__results > a,
+    .question-bank-quick-result {
+        min-height: 48px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .question-bank-quick-trigger,
+    .question-bank-quick-picker__dialog,
+    .question-bank-quick-picker__close,
+    .question-bank-quick-picker__search-field input,
+    .question-bank-quick-picker__scopes > button,
+    .question-bank-quick-picker__results > [role="option"],
+    .question-bank-quick-picker__results > button,
+    .question-bank-quick-picker__results > a {
+        animation: none !important;
+        transition: none !important;
+    }
+}

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -66,7 +66,7 @@ const documentStub = {
 const rendered = [];
 const browseState = { category: 'all', type: 'all' };
 const resolverQueue = [];
-const quietConsole = { log() {}, warn() {}, error() {} };
+const quietConsole = { log() {}, info() {}, warn() {}, error() {} };
 const sandbox = {
     console: quietConsole,
     document: documentStub,
@@ -103,6 +103,16 @@ const sandbox = {
     getCurrentExamType() { return browseState.type; },
     setBrowseTitle() {},
     formatBrowseTitle(category, type) { return `${category}:${type}`; },
+    normalizeCategoryKey(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized || normalized.toLowerCase() === 'all') return 'all';
+        const embedded = normalized.match(/\b(P[1-4])\b/i);
+        return embedded ? embedded[1].toUpperCase() : normalized;
+    },
+    normalizeExamType(value) {
+        const normalized = String(value || '').trim().toLowerCase();
+        return normalized === 'reading' || normalized === 'listening' ? normalized : 'all';
+    },
     getPersistedBrowseFilter() { return null; },
     async resolveActiveLibraryIndex() {
         const next = resolverQueue.shift();
@@ -179,7 +189,114 @@ assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening'], '最终列表�
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'all').ariaPressed, 'true');
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'reading').ariaPressed, 'false');
 
+const customCategoryIndex = [
+    { id: 'custom-reading', title: 'Imported Custom', type: 'reading', category: 'Custom' },
+    { id: 'p1-reading', title: 'Built-in P1', type: 'reading', category: 'P1' }
+];
+const customCategoryResolution = deferred();
+resolverQueue.push(customCategoryResolution);
+const customCategoryFilter = sandbox.applyBrowseFilter('Custom', 'reading');
+customCategoryResolution.resolve(customCategoryIndex);
+await customCategoryFilter;
+
+assert.strictEqual(
+    browseState.category,
+    'Custom',
+    'quick-picker navigation must preserve non-P1-P4 categories such as imported Custom'
+);
+assert.deepStrictEqual(
+    Array.from(sandbox.getBrowseFilteredExamBase(customCategoryIndex), (exam) => exam.id),
+    ['custom-reading'],
+    'the preserved custom category must filter the Browse list instead of falling back to all reading exams'
+);
+
+const decoratedCategoryIndex = [
+    { id: 'p1-mock', title: 'Imported P1 Mock', type: 'reading', category: 'P1 Mock' },
+    { id: 'p1-mock-lower', title: 'Imported lowercase mock', type: 'reading', category: 'p1 mock' },
+    { id: 'p1-reading', title: 'Built-in P1', type: 'reading', category: 'P1' }
+];
+const decoratedCategoryResolution = deferred();
+resolverQueue.push(decoratedCategoryResolution);
+const decoratedCategoryFilter = sandbox.applyBrowseFilter('P1 Mock', 'reading');
+decoratedCategoryResolution.resolve(decoratedCategoryIndex);
+await decoratedCategoryFilter;
+
+assert.strictEqual(
+    browseState.category,
+    'P1 Mock',
+    'an exact active-index category must take precedence over embedded P1-P4 legacy normalization'
+);
+assert.deepStrictEqual(
+    Array.from(sandbox.getBrowseFilteredExamBase(decoratedCategoryIndex), (exam) => exam.id),
+    ['p1-mock'],
+    'a dynamically rendered decorated category must open its exact Browse subset'
+);
+
+const lowercaseCategoryResolution = deferred();
+resolverQueue.push(lowercaseCategoryResolution);
+const lowercaseCategoryFilter = sandbox.applyBrowseFilter('p1 mock', 'reading');
+lowercaseCategoryResolution.resolve(decoratedCategoryIndex);
+await lowercaseCategoryFilter;
+assert.strictEqual(
+    browseState.category,
+    'p1 mock',
+    'case-sensitive exact matches must win when an active index contains case-distinct categories'
+);
+assert.deepStrictEqual(
+    Array.from(sandbox.getBrowseFilteredExamBase(decoratedCategoryIndex), (exam) => exam.id),
+    ['p1-mock-lower'],
+    'case-distinct category scopes must not collapse into the first compatibility match'
+);
+
+const existingBrowseStateManager = { source: 'lazy-prefetch' };
+let browseStateManagerConstructionCount = 0;
+let navigationInitialView = null;
+const originalQuerySelector = documentStub.querySelector;
+documentStub.querySelector = function querySelector(selector) {
+    if (selector === '.view.active') {
+        return { id: 'browse-view' };
+    }
+    return originalQuerySelector.call(this, selector);
+};
+sandbox.browseStateManager = existingBrowseStateManager;
+sandbox.BrowseStateManager = function BrowseStateManager() {
+    browseStateManagerConstructionCount += 1;
+};
+sandbox.NavigationController = {
+    ensure(options) {
+        navigationInitialView = options.initialView;
+        return {};
+    }
+};
+sandbox.LibraryManager = {
+    getInstance() {
+        return {
+            async loadActiveLibrary() {}
+        };
+    }
+};
+sandbox.setupBrowsePreferenceUI = function setupBrowsePreferenceUI() {};
+
+await sandbox.initializeLegacyComponents();
+documentStub.querySelector = originalQuerySelector;
+
+assert.strictEqual(
+    browseStateManagerConstructionCount,
+    0,
+    'app initialization must reuse the manager already created by lazy Browse prefetch'
+);
+assert.strictEqual(
+    sandbox.browseStateManager,
+    existingBrowseStateManager,
+    'app initialization must preserve the prefetched BrowseStateManager singleton'
+);
+assert.strictEqual(
+    navigationInitialView,
+    'browse',
+    'second-stage navigation initialization must preserve the currently active Browse view'
+);
+
 console.log(JSON.stringify({
     status: 'pass',
-    detail: 'browse search and type filters use latest-wins rendering'
+    detail: 'browse filters use latest-wins rendering, preserve custom categories, and keep lazy initialization idempotent'
 }, null, 2));

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -1,0 +1,652 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const mainSource = fs.readFileSync(path.join(repoRoot, 'js/main.js'), 'utf8');
+
+function loadScript(relativePath, context) {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    vm.runInContext(source, context, { filename: relativePath });
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+async function waitForCondition(predicate, message, rounds = 100) {
+    for (let index = 0; index < rounds; index += 1) {
+        if (predicate()) {
+            return;
+        }
+        await Promise.resolve();
+    }
+    assert.fail(message);
+}
+
+function installProductionBrowseControlsSetup(windowStub) {
+    const start = mainSource.indexOf('let browseControlsSeeded = false;');
+    const end = mainSource.indexOf('async function persistBrowsePreference', start);
+    assert.notEqual(start, -1, 'main.js should expose the browse-controls seed block');
+    assert.notEqual(end, -1, 'main.js should keep persistBrowsePreference after the seed block');
+
+    const sandbox = {
+        window: windowStub,
+        console: windowStub.console || console,
+        Promise
+    };
+    const context = vm.createContext(sandbox);
+    vm.runInContext(`
+        function setupBrowseSortControl() {}
+        function setupBrowseFrequencyFilterControl() {}
+        ${mainSource.slice(start, end)}
+        window.__productionSetupBrowseControls = setupBrowseControls;
+    `, context, { filename: 'js/main.js#browse-controls-seed' });
+    return windowStub.__productionSetupBrowseControls;
+}
+
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(value) { values.add(value); },
+        remove(value) { values.delete(value); },
+        toggle(value, enabled) {
+            if (enabled) values.add(value);
+            else values.delete(value);
+        },
+        contains(value) { return values.has(value); }
+    };
+}
+
+function createButton(dataset, active = false) {
+    return {
+        dataset: Object.assign({}, dataset),
+        classList: createClassList(active ? ['active'] : []),
+        ariaPressed: active ? 'true' : 'false',
+        setAttribute(name, value) {
+            if (name === 'aria-pressed') this.ariaPressed = value;
+        }
+    };
+}
+
+function createHarness(options = {}) {
+    const documentListeners = new Map();
+    const windowListeners = new Map();
+    const dispatchedEvents = [];
+    const loaderCalls = [];
+    const renderedFilterIndexes = [];
+    const filterStateCalls = [];
+    const titleCalls = [];
+    const preferencePatches = [];
+    let flushBrowsePreferenceCalls = 0;
+    const resolverQueue = Array.isArray(options.resolverQueue) ? options.resolverQueue.slice() : [];
+    const defaultIndex = Array.isArray(options.activeIndex)
+        ? options.activeIndex
+        : [{ id: 'p2-active', title: 'Active P2', category: 'P2', type: 'reading' }];
+
+    const searchInput = { value: 'ocean' };
+    const searchClearButton = { hidden: false };
+    const typeButtons = [
+        createButton({ filterId: 'all', filterType: 'all' }),
+        createButton({ filterId: 'reading', filterType: 'reading' }, true),
+        createButton({ filterId: 'listening', filterType: 'listening' })
+    ];
+    const frequencyButtons = [
+        createButton({ frequencyFilter: 'high' }, true),
+        createButton({ frequencyFilter: 'medium' })
+    ];
+    const typeContainer = {
+        querySelectorAll() { return typeButtons; }
+    };
+    const frequencyContainer = {
+        querySelectorAll() { return frequencyButtons; }
+    };
+
+    const documentStub = {
+        readyState: 'complete',
+        body: {},
+        addEventListener(type, handler) {
+            if (!documentListeners.has(type)) documentListeners.set(type, []);
+            documentListeners.get(type).push(handler);
+        },
+        dispatchEvent(event) {
+            dispatchedEvents.push(event);
+        },
+        getElementById(id) {
+            if (id === 'exam-search-input') return searchInput;
+            if (id === 'search-clear-btn') return searchClearButton;
+            if (id === 'type-filter-buttons') return typeContainer;
+            if (id === 'browse-frequency-filter-buttons') return frequencyContainer;
+            return null;
+        },
+        querySelector(selector) {
+            if (selector === '.search-input') return searchInput;
+            return null;
+        },
+        querySelectorAll() { return []; },
+        createElement() {
+            return {
+                classList: createClassList(),
+                dataset: {},
+                style: {},
+                appendChild() {},
+                removeChild() {},
+                addEventListener() {},
+                setAttribute() {},
+                querySelector() { return null; },
+                querySelectorAll() { return []; }
+            };
+        },
+        createTextNode(value) {
+            return { textContent: String(value || '') };
+        }
+    };
+
+    let browseRequestId = 0;
+    let clearedAutoScroll = 0;
+    let resetToDefaultCalls = 0;
+    const browseController = {
+        currentMode: 'frequency-p1',
+        activeFilter: 'high',
+        filterInteractionId: 3,
+        clearPendingBrowseAutoScroll() {
+            clearedAutoScroll += 1;
+        },
+        resetToDefault() {
+            resetToDefaultCalls += 1;
+            throw new Error('resetToDefault must not run during atomic reset');
+        },
+        renderFilterButtons(index) {
+            renderedFilterIndexes.push(Array.from(index, (exam) => exam.id));
+        }
+    };
+
+    const quietConsole = { log() {}, warn() {}, error() {}, info() {} };
+    const windowStub = {
+        console: quietConsole,
+        document: documentStub,
+        AppData: {
+            ready: Promise.resolve(),
+            preferences: {
+                async getBrowse() {
+                    return typeof options.getBrowse === 'function'
+                        ? options.getBrowse()
+                        : null;
+                },
+                async patchBrowse(value) {
+                    preferencePatches.push(JSON.parse(JSON.stringify(value)));
+                    if (typeof options.patchBrowse === 'function') {
+                        return options.patchBrowse(value);
+                    }
+                    return value;
+                }
+            }
+        },
+        browseController,
+        __browseFilterMode: 'frequency-p1',
+        __browsePath: 'ListeningPractice/100 P1',
+        __browseFrequencyFilter: 'high',
+        __readingMemorizeBrowseMode: true,
+        __browseMemorizeFilterMode: 'reading-memorize',
+        addEventListener(type, handler) {
+            if (!windowListeners.has(type)) windowListeners.set(type, []);
+            windowListeners.get(type).push(handler);
+        },
+        removeEventListener() {},
+        setBrowseFilterState(category, type) {
+            filterStateCalls.push({ category, type });
+        },
+        setBrowseTitle(value) {
+            titleCalls.push(value);
+        },
+        updateBrowseFrequencyButtons(value) {
+            this.__browseFrequencyFilter = value;
+            frequencyButtons.forEach((button) => {
+                const active = button.dataset.frequencyFilter === value;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-pressed', active ? 'true' : 'false');
+            });
+        },
+        setReadingMemorizeBrowseMode(value) {
+            this.__readingMemorizeBrowseMode = value;
+        },
+        syncReadingMemorizeBrowseModeUI() {},
+        flushBrowsePreferenceWrites() {
+            flushBrowsePreferenceCalls += 1;
+            if (typeof options.flushBrowsePreferenceWrites === 'function') {
+                return options.flushBrowsePreferenceWrites();
+            }
+            return Promise.resolve();
+        },
+        async setupBrowseControls() {
+            if (typeof options.setupBrowseControls === 'function') {
+                return options.setupBrowseControls(this);
+            }
+        },
+        __beginBrowseResultsRequest() {
+            browseRequestId += 1;
+            return browseRequestId;
+        },
+        __isBrowseResultsRequestCurrent(requestId) {
+            return requestId === browseRequestId;
+        },
+        resolveActiveLibraryIndex() {
+            const queued = resolverQueue.shift();
+            return queued ? queued.promise : Promise.resolve(defaultIndex);
+        },
+        loadExamList(indexOverride, renderRequestId) {
+            loaderCalls.push({
+                indexOverride,
+                ids: Array.isArray(indexOverride) ? Array.from(indexOverride, (exam) => exam.id) : null,
+                renderRequestId
+            });
+            if (options.loaderError) {
+                return Promise.reject(options.loaderError);
+            }
+            if (Object.prototype.hasOwnProperty.call(options, 'loaderResult')) {
+                return Promise.resolve(options.loaderResult);
+            }
+            return Promise.resolve(indexOverride);
+        }
+    };
+
+    const sandbox = {
+        window: windowStub,
+        document: documentStub,
+        console: quietConsole,
+        CustomEvent: class CustomEvent {
+            constructor(type, init = {}) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        },
+        Node: function Node() {},
+        Event: class Event {},
+        Promise,
+        Set,
+        Map,
+        Date,
+        Math,
+        JSON,
+        setTimeout,
+        clearTimeout
+    };
+    sandbox.globalThis = windowStub;
+    sandbox.self = windowStub;
+    const context = vm.createContext(sandbox);
+
+    loadScript('js/components/BrowseStateManager.js', context);
+    const stateManager = new windowStub.BrowseStateManager();
+    stateManager.currentFilter = 'P2';
+    stateManager.state.currentCategory = 'P2';
+    stateManager.state.currentFrequency = 'high';
+    stateManager.state.filters = { frequency: 'high', status: 'started', difficulty: 'hard' };
+    stateManager.state.searchQuery = 'ocean';
+    loadScript('js/app/examActions.js', context);
+
+    return {
+        window: windowStub,
+        stateManager,
+        searchInput,
+        searchClearButton,
+        typeButtons,
+        frequencyButtons,
+        loaderCalls,
+        renderedFilterIndexes,
+        filterStateCalls,
+        titleCalls,
+        preferencePatches,
+        context,
+        getFlushBrowsePreferenceCalls: () => flushBrowsePreferenceCalls,
+        getClearedAutoScroll: () => clearedAutoScroll,
+        getResetToDefaultCalls: () => resetToDefaultCalls
+    };
+}
+
+test('ordinary Browse navigation records history without resetting BrowseStateManager', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    let resetCalls = 0;
+    harness.stateManager.resetToAllExams = () => {
+        resetCalls += 1;
+    };
+
+    harness.stateManager.handleBrowseNavigation();
+
+    assert.equal(resetCalls, 0);
+    assert.equal(harness.stateManager.currentFilter, 'P2');
+    assert.equal(harness.stateManager.state.searchQuery, 'ocean');
+    assert.equal(harness.stateManager.getBrowseHistory().at(-1).action, 'navigate_to_browse');
+    assert.equal(harness.stateManager.getBrowseHistory().at(-1).filter, 'P2');
+});
+
+test('repeat Browse reset atomically clears UI/state and reloads the active index through the global adapter', async () => {
+    const activeIndex = [{ id: 'p3-active', title: 'Active P3', category: 'P3', type: 'reading' }];
+    const harness = createHarness({ activeIndex });
+    await harness.stateManager.ready;
+
+    await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.deepEqual(harness.loaderCalls[0].ids, ['p3-active']);
+    assert.notDeepEqual(harness.loaderCalls[0].indexOverride, []);
+    assert.equal(harness.getResetToDefaultCalls(), 0, 'reset must not trigger the controller filtering pipeline');
+    assert.equal(harness.getClearedAutoScroll(), 1);
+    assert.equal(harness.window.browseController.currentMode, 'default');
+    assert.equal(harness.window.browseController.activeFilter, 'all');
+    assert.equal(harness.window.browseController.filterInteractionId, 4);
+    assert.deepEqual(harness.renderedFilterIndexes, [['p3-active']]);
+    assert.deepEqual(harness.filterStateCalls.at(-1), { category: 'all', type: 'all' });
+    assert.equal(harness.searchInput.value, '');
+    assert.equal(harness.searchClearButton.hidden, true);
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browsePath, null);
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.window.__readingMemorizeBrowseMode, false);
+    assert.equal(harness.window.__browseMemorizeFilterMode, null);
+    assert.equal(harness.stateManager.currentFilter, 'all');
+    assert.equal(harness.stateManager.state.currentCategory, null);
+    assert.equal(harness.stateManager.state.currentFrequency, null);
+    assert.equal(harness.stateManager.state.searchQuery, '');
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.stateManager.state.filters)),
+        { frequency: 'all', status: 'all', difficulty: 'all' }
+    );
+    assert.equal(harness.typeButtons[0].classList.contains('active'), true);
+    assert.equal(harness.typeButtons[0].ariaPressed, 'true');
+    assert.equal(harness.typeButtons[1].classList.contains('active'), false);
+    assert(harness.frequencyButtons.every((button) => button.ariaPressed === 'false'));
+    assert.equal(harness.titleCalls.at(-1), '题库列表');
+    assert.equal(
+        harness.preferencePatches.some((patch) => patch.frequencyFilter === 'all'),
+        true,
+        'repeat reset must persist the cleared top-level frequency preference'
+    );
+});
+
+test('repeat reset waits for browse controls to restore preferences before clearing them', async () => {
+    const controlsReady = deferred();
+    const harness = createHarness({
+        async setupBrowseControls(windowStub) {
+            await controlsReady.promise;
+            windowStub.__browseFrequencyFilter = 'high';
+        }
+    });
+    await harness.stateManager.ready;
+
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await Promise.resolve();
+    assert.equal(harness.loaderCalls.length, 0);
+
+    controlsReady.resolve();
+    await reset;
+
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.equal(
+        harness.preferencePatches.some((patch) => patch.frequencyFilter === 'all'),
+        true
+    );
+});
+
+test('concurrent browse-control setup calls share the in-flight preference hydration', async () => {
+    const hydration = deferred();
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    let preferenceReads = 0;
+    harness.window.AppData.preferences.getBrowse = () => {
+        preferenceReads += 1;
+        return hydration.promise;
+    };
+    harness.window.setupBrowseControls = installProductionBrowseControlsSetup(harness.window);
+
+    const earlierSetup = harness.window.setupBrowseControls();
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks();
+
+    assert.equal(preferenceReads, 1, 'reset must join the existing hydration instead of starting a second read');
+    assert.equal(harness.loaderCalls.length, 0);
+
+    hydration.resolve({ sortMode: 'difficulty-desc', frequencyFilter: 'high' });
+    await Promise.all([earlierSetup, reset]);
+
+    assert.equal(preferenceReads, 1);
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.loaderCalls.length, 1);
+});
+
+test('repeat reset renders before durable preference writes settle, then awaits their completion', async () => {
+    const frequencyPersistence = deferred();
+    const lastFilterPersistence = deferred();
+    const harness = createHarness({
+        patchBrowse(value) {
+            return value && value.frequencyFilter === 'all'
+                ? frequencyPersistence.promise
+                : value;
+        },
+        flushBrowsePreferenceWrites() {
+            assert.deepEqual(harness.filterStateCalls.at(-1), { category: 'all', type: 'all' });
+            return lastFilterPersistence.promise;
+        }
+    });
+    await harness.stateManager.ready;
+
+    let settled = false;
+    const reset = harness.window.ExamActions.resetBrowseViewToAll().then((value) => {
+        settled = true;
+        return value;
+    });
+    await waitForCondition(
+        () => harness.loaderCalls.length === 1,
+        'the list reload should start without waiting for persistence'
+    );
+
+    assert.equal(harness.loaderCalls.length, 1, 'storage latency must not block the list reload');
+    assert.equal(settled, false, 'reset should still expose a durability completion boundary');
+    assert.equal(harness.getFlushBrowsePreferenceCalls(), 1);
+
+    frequencyPersistence.resolve();
+    await flushMicrotasks();
+    assert.equal(settled, false, 'lastFilter durability must also complete before reset resolves');
+
+    lastFilterPersistence.resolve();
+    await reset;
+    assert.equal(settled, true);
+});
+
+test('a superseded reset still waits for the durable writes it started', async () => {
+    const render = deferred();
+    const frequencyPersistence = deferred();
+    const lastFilterPersistence = deferred();
+    const harness = createHarness({
+        loaderResult: render.promise,
+        patchBrowse(value) {
+            return value && value.frequencyFilter === 'all'
+                ? frequencyPersistence.promise
+                : value;
+        },
+        flushBrowsePreferenceWrites() {
+            return lastFilterPersistence.promise;
+        }
+    });
+    await harness.stateManager.ready;
+
+    let settled = false;
+    const reset = harness.window.ExamActions.resetBrowseViewToAll().then((value) => {
+        settled = true;
+        return value;
+    });
+    await waitForCondition(
+        () => harness.loaderCalls.length === 1,
+        'the reset render should start before its persistence completes'
+    );
+
+    harness.window.__beginBrowseResultsRequest();
+    render.resolve([{ id: 'stale-render' }]);
+    await flushMicrotasks();
+    assert.equal(settled, false, 'supersession must not bypass the durability boundary');
+
+    frequencyPersistence.resolve();
+    await flushMicrotasks();
+    assert.equal(settled, false, 'lastFilter persistence must still be awaited after supersession');
+
+    lastFilterPersistence.resolve();
+    assert.equal(await reset, false);
+    assert.equal(settled, true);
+});
+
+test('repeat reset waits for BrowseStateManager restoration so saved search and filters cannot return', async () => {
+    const restoredBrowse = deferred();
+    const harness = createHarness({
+        getBrowse() {
+            return restoredBrowse.promise;
+        }
+    });
+
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await Promise.resolve();
+    assert.equal(harness.loaderCalls.length, 0);
+
+    restoredBrowse.resolve({
+        stateManager: {
+            previousFilter: 'P1',
+            browseHistory: [],
+            state: {
+                currentCategory: 'P1',
+                currentFrequency: 'high',
+                filters: { frequency: 'high', status: 'started', difficulty: 'hard' },
+                searchQuery: 'restored query'
+            }
+        }
+    });
+    await reset;
+
+    assert.equal(harness.stateManager.state.searchQuery, '');
+    assert.equal(harness.stateManager.state.currentCategory, null);
+    assert.equal(harness.stateManager.state.currentFrequency, null);
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.stateManager.state.filters)),
+        { frequency: 'all', status: 'all', difficulty: 'all' }
+    );
+    assert.equal(harness.loaderCalls.length, 1);
+});
+
+test('only the latest asynchronous repeat reset may update state or render', async () => {
+    const first = deferred();
+    const second = deferred();
+    const harness = createHarness({ resolverQueue: [first, second] });
+    await harness.stateManager.ready;
+
+    const staleReset = harness.window.ExamActions.resetBrowseViewToAll();
+    const latestReset = harness.window.ExamActions.resetBrowseViewToAll();
+    second.resolve([{ id: 'latest-index', category: 'P1', type: 'reading' }]);
+    await latestReset;
+    first.resolve([{ id: 'stale-index', category: 'P2', type: 'reading' }]);
+    const staleResult = await staleReset;
+
+    assert.equal(staleResult, false);
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.deepEqual(harness.loaderCalls[0].ids, ['latest-index']);
+    assert.deepEqual(harness.renderedFilterIndexes, [['latest-index']]);
+});
+
+test('an empty prefetch is delegated as unresolved and the adapter result resynchronizes filter buttons', async () => {
+    const harness = createHarness({
+        activeIndex: [],
+        loaderResult: [{ id: 'adapter-index', category: 'P4', type: 'listening' }]
+    });
+    await harness.stateManager.ready;
+
+    await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.equal(harness.loaderCalls[0].indexOverride, null);
+    assert.equal(harness.loaderCalls[0].ids, null);
+    assert.deepEqual(harness.renderedFilterIndexes, [[], ['adapter-index']]);
+});
+
+test('a global adapter failure is contained by repeat reset instead of becoming an unhandled rejection', async () => {
+    const harness = createHarness({ loaderError: new Error('adapter failed') });
+    await harness.stateManager.ready;
+
+    const result = await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(result, false);
+    assert.equal(harness.loaderCalls.length, 1);
+});
+
+test('an unexpected reset-state exception is contained by the public async boundary', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    harness.stateManager.resetToAllExams = () => {
+        throw new Error('unexpected state failure');
+    };
+
+    const result = await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(result, false);
+    assert.equal(harness.loaderCalls.length, 0);
+});
+
+test('repeat reset invalidates a captured pending Browse activation filter', async () => {
+    const activation = deferred();
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    const appliedFilters = [];
+    const pendingFilter = {
+        category: 'P3',
+        type: 'reading',
+        filterMode: null,
+        path: null
+    };
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.initializeBrowseView = () => activation.promise;
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+
+    app.onViewActivated('browse');
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    assert.equal(harness.window.__pendingBrowseFilter, undefined);
+    const replacementPendingFilter = {
+        category: 'P4',
+        type: 'listening',
+        filterMode: null,
+        path: null
+    };
+    harness.window.__pendingBrowseFilter = replacementPendingFilter;
+    await reset;
+
+    activation.resolve();
+    await flushMicrotasks();
+
+    assert.deepEqual(appliedFilters, [], 'captured activation must not restore the category after reset');
+    assert.strictEqual(
+        harness.window.__pendingBrowseFilter,
+        replacementPendingFilter,
+        'the stale activation cleanup must retain a newer pending intent'
+    );
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+});

--- a/developer/tests/js/e2e/indexSnapshot.js
+++ b/developer/tests/js/e2e/indexSnapshot.js
@@ -126,6 +126,17 @@ window.__APP_INDEX_HTML_SNAPSHOT__ = `<!doctype html>
                     📚 题库浏览
                 </button>
                 <button
+                    class="question-bank-quick-trigger"
+                    id="question-bank-quick-trigger"
+                    type="button"
+                    aria-label="题库速查：全局搜索或切换题目分类"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                    aria-controls="question-bank-quick-picker"
+                >
+                    题库速查
+                </button>
+                <button
                     class="nav-btn hero-nav__btn"
                     type="button"
                     data-view="practice"
@@ -147,6 +158,106 @@ window.__APP_INDEX_HTML_SNAPSHOT__ = `<!doctype html>
                     ⚙️ 设置
                 </button>
             </nav>
+
+            <section
+                class="question-bank-quick-picker"
+                id="question-bank-quick-picker"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="question-bank-quick-title"
+                aria-describedby="question-bank-quick-status"
+                hidden
+            >
+                <div
+                    class="question-bank-quick-picker__dialog"
+                    tabindex="-1"
+                >
+                    <header class="question-bank-quick-picker__header">
+                        <div class="question-bank-quick-picker__heading-group">
+                            <span
+                                class="question-bank-quick-picker__eyebrow"
+                                aria-hidden="true"
+                                >QUICK FIND</span
+                            >
+                            <h2 id="question-bank-quick-title">
+                                全局题库速查
+                            </h2>
+                            <p>
+                                搜索当前题库的全部题目，或直接切换题目分类。
+                            </p>
+                        </div>
+                        <button
+                            class="question-bank-quick-picker__close"
+                            id="question-bank-quick-close"
+                            type="button"
+                            aria-label="关闭题库速查"
+                        >
+                            关闭
+                        </button>
+                    </header>
+
+                    <div class="question-bank-quick-picker__search-field">
+                        <label for="question-bank-quick-search"
+                            >全局搜索</label
+                        >
+                        <input
+                            id="question-bank-quick-search"
+                            type="search"
+                            inputmode="search"
+                            enterkeyhint="search"
+                            autocomplete="off"
+                            spellcheck="false"
+                            placeholder="搜索题目标题、分类或关键字…"
+                            role="combobox"
+                            aria-autocomplete="list"
+                            aria-expanded="false"
+                            aria-controls="question-bank-quick-results"
+                            aria-describedby="question-bank-quick-status"
+                        />
+                    </div>
+
+                    <p
+                        class="question-bank-quick-picker__status"
+                        id="question-bank-quick-status"
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                    >
+                        选择分类可直接进入题库浏览。
+                    </p>
+
+                    <section
+                        class="question-bank-quick-picker__section"
+                        aria-labelledby="question-bank-quick-scopes-title"
+                    >
+                        <div class="question-bank-quick-picker__section-head">
+                            <h3 id="question-bank-quick-scopes-title">
+                                题目分类
+                            </h3>
+                            <span>无需返回总览</span>
+                        </div>
+                        <div
+                            class="question-bank-quick-picker__scopes"
+                            id="question-bank-quick-scopes"
+                            role="group"
+                            aria-label="可用题目分类"
+                            aria-busy="true"
+                        >
+                            <p class="question-bank-quick-picker__placeholder">
+                                正在读取题目分类…
+                            </p>
+                        </div>
+                    </section>
+
+                    <div
+                        class="question-bank-quick-picker__results"
+                        id="question-bank-quick-results"
+                        role="listbox"
+                        aria-label="全局搜索结果"
+                        hidden
+                    ></div>
+                </div>
+            </section>
 
             <!-- 总览页面 -->
             <div id="overview-view" class="view active hero-panel hero-section">

--- a/developer/tests/js/e2e/questionBankQuickPickerSmoke.test.js
+++ b/developer/tests/js/e2e/questionBankQuickPickerSmoke.test.js
@@ -242,19 +242,27 @@ test('real index bundle mounts the quick picker and routes search/scope actions'
     ];
     await page.evaluate((examIndex) => {
         window.__quickPickerSmokeCalls = [];
+        window.__resolveQuickPickerBrowse = null;
         window.__browseFilter = { category: 'P1', type: 'reading' };
         window.resolveActiveLibraryIndex = async () => examIndex;
-        window.ensureBrowseGroup = async () => {
+        window.ensureBrowseGroup = () => {
             window.__quickPickerSmokeCalls.push(['ensure']);
-            return true;
+            return new Promise((resolve) => {
+                window.__resolveQuickPickerBrowse = () => resolve(true);
+            });
         };
         window.app = window.app || {};
         window.app.browseCategory = (category, type) => {
             window.__quickPickerSmokeCalls.push(['browseCategory', category, type]);
             return true;
         };
-        window.app.openExam = (examId) => {
-            window.__quickPickerSmokeCalls.push(['openExam', examId]);
+        window.app.openExam = (examId, launchOptions) => {
+            window.__quickPickerSmokeCalls.push([
+                'openExam',
+                examId,
+                launchOptions?.examDefinition?.id || null,
+                navigator.userActivation?.isActive === true
+            ]);
             return true;
         };
     }, fixture);
@@ -289,10 +297,23 @@ test('real index bundle mounts the quick picker and routes search/scope actions'
         'search must ignore the current P1 browse filter and return cross-category matches'
     );
 
-    await results.locator('button[data-exam-id="listening-p2"]').click();
+    const listeningResult = results.locator('button[data-exam-id="listening-p2"]');
+    assert.equal(await listeningResult.isEnabled(), false, 'launches must stay disabled while Browse is loading');
+    await page.evaluate(() => window.__resolveQuickPickerBrowse?.());
+    await page.waitForFunction(
+        () => document.querySelector(
+            '#question-bank-quick-results button[data-exam-id="listening-p2"]'
+        )?.disabled === false,
+        null,
+        { timeout: 5_000 }
+    );
+    await listeningResult.click();
     await page.waitForFunction(
         () => window.__quickPickerSmokeCalls.some(
-            (call) => call[0] === 'openExam' && call[1] === 'listening-p2'
+            (call) => call[0] === 'openExam'
+                && call[1] === 'listening-p2'
+                && call[2] === 'listening-p2'
+                && call[3] === true
         ),
         null,
         { timeout: 5_000 }
@@ -318,8 +339,7 @@ test('real index bundle mounts the quick picker and routes search/scope actions'
     const calls = await page.evaluate(() => window.__quickPickerSmokeCalls);
     assert.deepEqual(calls, [
         ['ensure'],
-        ['openExam', 'listening-p2'],
-        ['ensure'],
+        ['openExam', 'listening-p2', 'listening-p2', true],
         ['browseCategory', 'P3', 'reading']
     ]);
     assert.equal(await panel.getAttribute('hidden'), '', 'successful scope navigation must close the picker');

--- a/developer/tests/js/e2e/questionBankQuickPickerSmoke.test.js
+++ b/developer/tests/js/e2e/questionBankQuickPickerSmoke.test.js
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const uiShellBundlePath = path.join(repoRoot, 'js', 'bundles', 'ui-shell.bundle.js');
+
+const CONTENT_TYPES = Object.freeze({
+    '.css': 'text/css; charset=utf-8',
+    '.html': 'text/html; charset=utf-8',
+    '.ico': 'image/x-icon',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.js': 'text/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.woff2': 'font/woff2'
+});
+
+function timeoutAfter(milliseconds, label) {
+    return new Promise((_, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`${label} timed out after ${milliseconds}ms`));
+        }, milliseconds);
+        if (typeof timer.unref === 'function') {
+            timer.unref();
+        }
+    });
+}
+
+async function within(promise, milliseconds, label) {
+    return Promise.race([promise, timeoutAfter(milliseconds, label)]);
+}
+
+function resolveStaticPath(requestUrl) {
+    let pathname;
+    try {
+        pathname = decodeURIComponent(new URL(requestUrl, 'http://127.0.0.1').pathname);
+    } catch (_) {
+        return null;
+    }
+    const relativePath = pathname === '/'
+        ? 'index.html'
+        : pathname.replace(/^\/+/, '');
+    if (!relativePath || relativePath.includes('\0')) {
+        return null;
+    }
+
+    const resolved = path.resolve(repoRoot, relativePath);
+    const rootPrefix = repoRoot.endsWith(path.sep) ? repoRoot : `${repoRoot}${path.sep}`;
+    if (resolved !== repoRoot && !resolved.startsWith(rootPrefix)) {
+        return null;
+    }
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+        return null;
+    }
+
+    const realRoot = fs.realpathSync(repoRoot);
+    const realPath = fs.realpathSync(resolved);
+    const realRootPrefix = realRoot.endsWith(path.sep) ? realRoot : `${realRoot}${path.sep}`;
+    return realPath === realRoot || realPath.startsWith(realRootPrefix) ? realPath : null;
+}
+
+async function startStaticServer() {
+    const server = http.createServer((request, response) => {
+        const filePath = resolveStaticPath(request.url || '/');
+        if (!filePath) {
+            response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+            response.end('Not found');
+            return;
+        }
+        const contentType = CONTENT_TYPES[path.extname(filePath).toLowerCase()]
+            || 'application/octet-stream';
+        response.writeHead(200, {
+            'Cache-Control': 'no-store',
+            'Content-Type': contentType
+        });
+        if (request.method === 'HEAD') {
+            response.end();
+            return;
+        }
+        const stream = fs.createReadStream(filePath);
+        stream.on('error', () => response.destroy());
+        stream.pipe(response);
+    });
+
+    await within(new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+        });
+    }), 5_000, 'static server listen');
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        server.close();
+        throw new Error('Static server did not expose a TCP port');
+    }
+    return {
+        server,
+        indexUrl: `http://127.0.0.1:${address.port}/index.html?test_env=1`
+    };
+}
+
+async function closeStaticServer(server) {
+    if (!server || !server.listening) {
+        return;
+    }
+    if (typeof server.closeAllConnections === 'function') {
+        server.closeAllConnections();
+    }
+    await within(new Promise((resolve) => {
+        server.close(() => resolve());
+    }), 3_000, 'static server close');
+}
+
+function resolveBrowserExecutable() {
+    const repoBrowserRoot = path.join(
+        repoRoot,
+        'developer',
+        'tests',
+        'e2e',
+        '.pw-browsers',
+        'browsers'
+    );
+    const candidates = [
+        chromium.executablePath(),
+        path.join(repoBrowserRoot, 'chromium_headless_shell-1194', 'chrome-win', 'headless_shell.exe'),
+        path.join(repoBrowserRoot, 'chromium_headless_shell-1194', 'chrome-linux', 'headless_shell'),
+        path.join(repoBrowserRoot, 'chromium_headless_shell-1194', 'chrome-mac', 'headless_shell'),
+        'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+        'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/usr/bin/google-chrome',
+        '/usr/bin/chromium',
+        '/usr/bin/chromium-browser'
+    ];
+    return candidates.find((candidate) => candidate && fs.existsSync(candidate));
+}
+
+async function launchChromium() {
+    const executablePath = resolveBrowserExecutable();
+    const options = {
+        headless: true,
+        args: ['--allow-file-access-from-files'],
+        timeout: 30_000
+    };
+    if (executablePath) {
+        options.executablePath = executablePath;
+    }
+    return chromium.launch(options);
+}
+
+async function shutdownChromium(browser) {
+    await browser.close();
+}
+
+async function dismissBlockingOverlays(page) {
+    const accepted = await page.evaluate(async () => {
+        if (!window.LicenseModal || typeof window.LicenseModal.accept !== 'function') {
+            throw new Error('LicenseModal.accept is unavailable');
+        }
+        return window.LicenseModal.accept();
+    });
+    assert.equal(accepted, true, 'GPL license consent must be committed before UI interactions');
+    await page.waitForFunction(
+        () => !document.getElementById('license-modal')?.classList.contains('show'),
+        null,
+        { timeout: 5_000 }
+    );
+
+    const overlay = page.locator('#library-loader-overlay');
+    if (await overlay.count() && await overlay.isVisible()) {
+        const closeButton = overlay.locator("[data-library-action='close']").first();
+        assert.equal(await closeButton.isVisible(), true, 'library loader close button must be visible');
+        await closeButton.click();
+        await overlay.waitFor({ state: 'hidden', timeout: 5_000 });
+    }
+}
+
+test('real index bundle mounts the quick picker and routes search/scope actions', { timeout: 180_000 }, async (t) => {
+    const bundleSource = fs.readFileSync(uiShellBundlePath, 'utf8');
+    assert.match(
+        bundleSource,
+        /\/\* ===== js\/components\/questionBankQuickPicker\.js ===== \*\//,
+        'the generated UI shell bundle must contain the quick-picker source'
+    );
+
+    const staticRuntime = await startStaticServer();
+    let browser = null;
+    let page = null;
+    t.after(async () => {
+        if (browser) {
+            await shutdownChromium(browser);
+        }
+        await closeStaticServer(staticRuntime.server);
+    });
+
+    browser = await launchChromium();
+
+    page = await within(
+        browser.newPage({ viewport: { width: 1280, height: 900 } }),
+        30_000,
+        'browser.newPage'
+    );
+    await within(
+        page.goto(staticRuntime.indexUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 }),
+        35_000,
+        'page.goto(index.html)'
+    );
+    await page.waitForFunction(
+        () => {
+            const api = window.QuestionBankQuickPicker;
+            const instance = api && typeof api.getInstance === 'function' ? api.getInstance() : null;
+            return !!(instance && instance._mounted);
+        },
+        null,
+        { timeout: 10_000 }
+    );
+    await page.waitForLoadState('load', { timeout: 30_000 });
+    await page.waitForFunction(
+        () => window.app?.isInitialized === true,
+        null,
+        { timeout: 60_000 }
+    );
+    await dismissBlockingOverlays(page);
+
+    const fixture = [
+        { id: 'reading-p1', type: 'reading', category: 'P1', title: 'Ocean Life' },
+        { id: 'reading-p3', type: 'reading', category: 'P3', title: 'Target Passage' },
+        { id: 'listening-p2', type: 'listening', category: 'P2', title: 'Target Audio' }
+    ];
+    await page.evaluate((examIndex) => {
+        window.__quickPickerSmokeCalls = [];
+        window.__browseFilter = { category: 'P1', type: 'reading' };
+        window.resolveActiveLibraryIndex = async () => examIndex;
+        window.ensureBrowseGroup = async () => {
+            window.__quickPickerSmokeCalls.push(['ensure']);
+            return true;
+        };
+        window.app = window.app || {};
+        window.app.browseCategory = (category, type) => {
+            window.__quickPickerSmokeCalls.push(['browseCategory', category, type]);
+            return true;
+        };
+        window.app.openExam = (examId) => {
+            window.__quickPickerSmokeCalls.push(['openExam', examId]);
+            return true;
+        };
+    }, fixture);
+
+    const trigger = page.locator('#question-bank-quick-trigger');
+    const panel = page.locator('#question-bank-quick-picker');
+    const search = page.locator('#question-bank-quick-search');
+    const results = page.locator('#question-bank-quick-results');
+
+    assert.equal(await trigger.isVisible(), true, 'the real trigger must be visible');
+    assert.equal(await trigger.isEnabled(), true, 'the real trigger must be enabled');
+    await trigger.click();
+    await page.waitForFunction(
+        () => {
+            const picker = document.getElementById('question-bank-quick-picker');
+            const scopes = document.getElementById('question-bank-quick-scopes');
+            return !!(picker && !picker.hidden && scopes && scopes.getAttribute('aria-busy') === 'false');
+        },
+        null,
+        { timeout: 10_000 }
+    );
+    assert.equal(await panel.getAttribute('hidden'), null, 'the real trigger must open the mounted picker');
+
+    assert.equal(await search.isVisible(), true, 'the global-search input must be visible');
+    await search.fill('target');
+    const matchedIds = await results
+        .locator('button[data-question-bank-action="open-exam"]')
+        .evaluateAll((buttons) => buttons.map((button) => button.getAttribute('data-exam-id')));
+    assert.deepEqual(
+        matchedIds,
+        ['reading-p3', 'listening-p2'],
+        'search must ignore the current P1 browse filter and return cross-category matches'
+    );
+
+    await results.locator('button[data-exam-id="listening-p2"]').click();
+    await page.waitForFunction(
+        () => window.__quickPickerSmokeCalls.some(
+            (call) => call[0] === 'openExam' && call[1] === 'listening-p2'
+        ),
+        null,
+        { timeout: 5_000 }
+    );
+
+    await trigger.click();
+    await page.waitForFunction(
+        () => document.getElementById('question-bank-quick-scopes')?.getAttribute('aria-busy') === 'false',
+        null,
+        { timeout: 10_000 }
+    );
+    await page.locator(
+        '#question-bank-quick-scopes button[data-type="reading"][data-category="P3"]'
+    ).click();
+    await page.waitForFunction(
+        () => window.__quickPickerSmokeCalls.some(
+            (call) => call[0] === 'browseCategory' && call[1] === 'P3' && call[2] === 'reading'
+        ),
+        null,
+        { timeout: 5_000 }
+    );
+
+    const calls = await page.evaluate(() => window.__quickPickerSmokeCalls);
+    assert.deepEqual(calls, [
+        ['ensure'],
+        ['openExam', 'listening-p2'],
+        ['ensure'],
+        ['browseCategory', 'P3', 'reading']
+    ]);
+    assert.equal(await panel.getAttribute('hidden'), '', 'successful scope navigation must close the picker');
+});

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -249,6 +249,133 @@ async function testColdBrowseProxyRestoresPreferences(harness) {
     });
 }
 
+async function testColdBrowseRuntimeInitializesNavigationAndStateManager() {
+    const harness = createHarness();
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    const fallbackHandler = function fallbackNavigation() {};
+    let fallbackRemovals = 0;
+    const navRoot = {
+        _legacyNavHandler: fallbackHandler,
+        removeEventListener(type, handler) {
+            if (type === 'click' && handler === fallbackHandler) {
+                fallbackRemovals += 1;
+            }
+        }
+    };
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.main-nav') {
+            return navRoot;
+        }
+        if (selector === '.view.active') {
+            return { id: 'browse-view' };
+        }
+        return originalQuerySelector(selector);
+    };
+
+    let navigationEnsureCalls = 0;
+    let navigationOptions = null;
+    let stateManagerCreations = 0;
+    let repeatResets = 0;
+    harness.windowStub.NavigationController = {
+        ensure(options) {
+            navigationEnsureCalls += 1;
+            if (typeof harness.windowStub.ensureLegacyNavigationController !== 'function') {
+                return null;
+            }
+            navigationOptions = options;
+            return harness.windowStub.ensureLegacyNavigationController(options);
+        }
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.ensureLegacyNavigationController = function ensureLegacyNavigationController() {
+                return { mounted: true };
+            };
+            harness.windowStub.BrowseStateManager = function BrowseStateManager() {
+                stateManagerCreations += 1;
+                this.ready = Promise.resolve();
+                harness.windowStub.browseStateManager = this;
+            };
+            harness.windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+                repeatResets += 1;
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    loadScript('js/presentation/app-actions.js', harness.context);
+    await harness.windowStub.AppActions.preloadBrowseView();
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+
+    assert.strictEqual(navigationEnsureCalls, 2, '导航应在冷启动和 Browse 懒加载完成后各尝试初始化一次');
+    assert.strictEqual(stateManagerCreations, 1, 'BrowseStateManager 应在懒加载完成后仅实例化一次');
+    assert(harness.windowStub.browseStateManager, '冷启动 Browse 应暴露全局状态管理器实例');
+    assert.strictEqual(fallbackRemovals, 1, '真实导航控制器挂载后应移除临时 fallback click handler');
+    assert.strictEqual(navRoot._legacyNavHandler, undefined, 'fallback handler 标记应在升级后清理');
+    assert(navigationOptions && typeof navigationOptions.onRepeatNavigate === 'function');
+    assert.strictEqual(navigationOptions.initialView, 'browse', '导航升级必须保留 fallback 已激活的 Browse 高亮');
+
+    navigationOptions.onRepeatNavigate('browse');
+    assert.strictEqual(repeatResets, 1, '懒加载后的首个重复 Browse 点击应直接进入 reset handler');
+    recordResult('browse 冷加载后补齐导航与状态管理器', true, {
+        navigationEnsureCalls,
+        stateManagerCreations,
+        fallbackRemovals,
+        repeatResets
+    });
+}
+
+async function testSessionSuiteFinalizesBrowseDependencyOnce() {
+    const harness = createHarness();
+    let navigationEnsureCalls = 0;
+    let stateManagerCreations = 0;
+    harness.windowStub.NavigationController = {
+        ensure() {
+            navigationEnsureCalls += 1;
+            if (typeof harness.windowStub.ensureLegacyNavigationController !== 'function') {
+                return null;
+            }
+            return harness.windowStub.ensureLegacyNavigationController();
+        }
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.ensureLegacyNavigationController = function ensureLegacyNavigationController() {
+                return { mounted: true };
+            };
+            harness.windowStub.BrowseStateManager = function BrowseStateManager() {
+                stateManagerCreations += 1;
+                harness.windowStub.browseStateManager = this;
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await Promise.all([
+        harness.windowStub.AppEntry.ensureSessionSuiteReady(),
+        harness.windowStub.AppEntry.ensureSessionSuiteReady()
+    ]);
+
+    assert.strictEqual(
+        harness.ensureCalls.filter((name) => name === 'browse-runtime').length,
+        1,
+        'session-suite startup must finalize its Browse dependency through the cached Browse entrypoint'
+    );
+    assert(harness.ensureCalls.includes('practice-suite'), 'session-suite startup must still preload practice-suite');
+    assert(harness.ensureCalls.includes('session-suite'), 'session-suite runtime itself must still load');
+    assert.strictEqual(navigationEnsureCalls, 2, 'navigation should initialize at shell boot and once after Browse loads');
+    assert.strictEqual(stateManagerCreations, 1, 'concurrent session startup must create one BrowseStateManager');
+    recordResult('session-suite 依赖统一完成 Browse 初始化', true, {
+        ensureCalls: harness.ensureCalls,
+        navigationEnsureCalls,
+        stateManagerCreations
+    });
+}
+
 async function testMoreViewActivationLoadsTools(harness) {
     let moreToolsLoads = 0;
     harness.windowStub.AppEntry = {
@@ -384,6 +511,8 @@ async function main() {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
         await testColdBrowseProxyRestoresPreferences(createHarness());
+        await testColdBrowseRuntimeInitializesNavigationAndStateManager();
+        await testSessionSuiteFinalizesBrowseDependencyOnce();
         await testMoreViewActivationLoadsTools(createHarness());
         await testSuiteRecoveryRequiresExplicitContinueChoice();
         await testSuiteRecoveryAbandonThenStartsFreshSuite();

--- a/developer/tests/js/questionBankQuickPicker.test.js
+++ b/developer/tests/js/questionBankQuickPicker.test.js
@@ -1,0 +1,726 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const componentSource = fs.readFileSync(
+    path.join(repoRoot, 'js', 'components', 'questionBankQuickPicker.js'),
+    'utf8'
+);
+const indexSource = fs.readFileSync(path.join(repoRoot, 'index.html'), 'utf8');
+const mainCssSource = fs.readFileSync(path.join(repoRoot, 'css', 'main.css'), 'utf8');
+
+function plain(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+class FakeStyle {
+    constructor() {
+        this.values = Object.create(null);
+    }
+
+    setProperty(name, value) {
+        this.values[name] = String(value);
+    }
+
+    removeProperty(name) {
+        delete this.values[name];
+    }
+
+    getPropertyValue(name) {
+        return this.values[name] || '';
+    }
+}
+
+function allDescendants(root) {
+    const output = [];
+    (root.children || []).forEach((child) => {
+        output.push(child, ...allDescendants(child));
+    });
+    return output;
+}
+
+function matchesSimpleSelector(element, selector) {
+    const trimmed = selector.trim();
+    if (trimmed.startsWith('#')) {
+        return element.id === trimmed.slice(1);
+    }
+    if (trimmed.startsWith('.')) {
+        return String(element.className || '').split(/\s+/).includes(trimmed.slice(1));
+    }
+    const attribute = trimmed.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+    if (attribute) {
+        const value = element.getAttribute(attribute[1]);
+        return attribute[2] === undefined ? value !== null : value === attribute[2];
+    }
+    return element.tagName.toLowerCase() === trimmed.toLowerCase();
+}
+
+class FakeElement {
+    constructor(tagName, documentRef) {
+        this.tagName = String(tagName || 'div').toUpperCase();
+        this.ownerDocument = documentRef;
+        this.parentNode = null;
+        this.children = [];
+        this.listeners = new Map();
+        this.attributes = new Map();
+        this.dataset = {};
+        this.style = new FakeStyle();
+        this.hidden = false;
+        this.disabled = false;
+        this.className = '';
+        this.id = '';
+        this.type = '';
+        this.value = '';
+        this.textContent = '';
+        this.rect = { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+        this.scrollCalls = 0;
+    }
+
+    get firstChild() {
+        return this.children[0] || null;
+    }
+
+    addEventListener(type, handler) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, []);
+        }
+        this.listeners.get(type).push(handler);
+    }
+
+    removeEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        this.listeners.set(type, handlers.filter((candidate) => candidate !== handler));
+    }
+
+    fire(type, event = {}) {
+        if (!event.target) {
+            event.target = this;
+        }
+        (this.listeners.get(type) || []).forEach((handler) => handler(event));
+    }
+
+    setAttribute(name, value) {
+        const stringValue = String(value);
+        this.attributes.set(name, stringValue);
+        if (name === 'id') {
+            this.id = stringValue;
+        }
+        if (name.startsWith('data-')) {
+            const dataName = name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+            this.dataset[dataName] = stringValue;
+        }
+    }
+
+    getAttribute(name) {
+        if (name === 'id' && this.id) {
+            return this.id;
+        }
+        return this.attributes.has(name) ? this.attributes.get(name) : null;
+    }
+
+    removeAttribute(name) {
+        this.attributes.delete(name);
+        if (name.startsWith('data-')) {
+            const dataName = name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+            delete this.dataset[dataName];
+        }
+    }
+
+    appendChild(child) {
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    }
+
+    removeChild(child) {
+        const index = this.children.indexOf(child);
+        if (index >= 0) {
+            this.children.splice(index, 1);
+            child.parentNode = null;
+        }
+        return child;
+    }
+
+    replaceChildren(...children) {
+        this.children.forEach((child) => {
+            child.parentNode = null;
+        });
+        this.children = [];
+        children.forEach((child) => this.appendChild(child));
+    }
+
+    contains(candidate) {
+        if (candidate === this) {
+            return true;
+        }
+        return this.children.some((child) => child.contains(candidate));
+    }
+
+    querySelectorAll(selector) {
+        const descendants = allDescendants(this);
+        if (selector.includes('button:not([disabled])')) {
+            return descendants.filter((element) => {
+                const focusableTag = ['BUTTON', 'INPUT', 'A'].includes(element.tagName);
+                const explicitTabIndex = element.getAttribute('tabindex');
+                return !element.hidden && !element.disabled
+                    && (focusableTag || (explicitTabIndex !== null && explicitTabIndex !== '-1'));
+            });
+        }
+        const selectors = selector.split(',');
+        return descendants.filter((element) => selectors.some((item) => matchesSimpleSelector(element, item)));
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+
+    focus() {
+        this.ownerDocument.activeElement = this;
+    }
+
+    getBoundingClientRect() {
+        return { ...this.rect };
+    }
+
+    scrollIntoView() {
+        this.scrollCalls += 1;
+    }
+}
+
+class FakeDocument {
+    constructor() {
+        this.readyState = 'loading';
+        this.listeners = new Map();
+        this.selectorMap = new Map();
+        this.idMap = new Map();
+        this.documentElement = { clientWidth: 1200, clientHeight: 800 };
+        this.body = new FakeElement('body', this);
+        this.activeElement = this.body;
+    }
+
+    createElement(tagName) {
+        return new FakeElement(tagName, this);
+    }
+
+    register(selector, element) {
+        this.selectorMap.set(selector, element);
+        if (selector.startsWith('#')) {
+            element.id = selector.slice(1);
+            this.idMap.set(element.id, element);
+        }
+        return element;
+    }
+
+    querySelector(selector) {
+        if (this.selectorMap.has(selector)) {
+            return this.selectorMap.get(selector);
+        }
+        return this.body.querySelector(selector);
+    }
+
+    getElementById(id) {
+        return this.idMap.get(id) || null;
+    }
+
+    addEventListener(type, handler) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, []);
+        }
+        this.listeners.get(type).push(handler);
+    }
+
+    removeEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        this.listeners.set(type, handlers.filter((candidate) => candidate !== handler));
+    }
+
+    fire(type, event = {}) {
+        (this.listeners.get(type) || []).forEach((handler) => handler(event));
+    }
+}
+
+function createHarness(options = {}) {
+    const documentStub = new FakeDocument();
+    const trigger = documentStub.register('#question-bank-quick-trigger', documentStub.createElement('button'));
+    const panel = documentStub.register('#question-bank-quick-picker', documentStub.createElement('section'));
+    const dialog = documentStub.register('.question-bank-quick-picker__dialog', documentStub.createElement('div'));
+    const title = documentStub.register('#question-bank-quick-title', documentStub.createElement('h2'));
+    const close = documentStub.register('#question-bank-quick-close', documentStub.createElement('button'));
+    const search = documentStub.register('#question-bank-quick-search', documentStub.createElement('input'));
+    const status = documentStub.register('#question-bank-quick-status', documentStub.createElement('p'));
+    const scopes = documentStub.register('#question-bank-quick-scopes', documentStub.createElement('div'));
+    const results = documentStub.register('#question-bank-quick-results', documentStub.createElement('div'));
+    trigger.rect = { left: 620, right: 760, top: 90, bottom: 134, width: 140, height: 44 };
+    panel.appendChild(dialog);
+    [title, close, search, status, scopes, results].forEach((element) => dialog.appendChild(element));
+    documentStub.body.appendChild(trigger);
+    documentStub.body.appendChild(panel);
+
+    const windowListeners = new Map();
+    const animationFrames = [];
+    const warnings = [];
+    const windowStub = {
+        document: documentStub,
+        innerWidth: 1200,
+        innerHeight: 800,
+        console: {
+            log() {},
+            warn(...args) {
+                warnings.push(args);
+            }
+        },
+        resolveActiveLibraryIndex: options.resolveActiveLibraryIndex || (() => Promise.resolve([])),
+        addEventListener(type, handler) {
+            if (!windowListeners.has(type)) {
+                windowListeners.set(type, []);
+            }
+            windowListeners.get(type).push(handler);
+        },
+        removeEventListener(type, handler) {
+            const handlers = windowListeners.get(type) || [];
+            windowListeners.set(type, handlers.filter((candidate) => candidate !== handler));
+        },
+        requestAnimationFrame(callback) {
+            animationFrames.push(callback);
+            return animationFrames.length;
+        }
+    };
+    windowStub.window = windowStub;
+    windowStub.globalThis = windowStub;
+
+    const sandbox = {
+        window: windowStub,
+        document: documentStub,
+        console: windowStub.console,
+        globalThis: windowStub,
+        Promise,
+        setTimeout,
+        clearTimeout
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(componentSource, sandbox, {
+        filename: 'js/components/questionBankQuickPicker.js'
+    });
+    const api = windowStub.QuestionBankQuickPicker;
+    const picker = api.create({ document: documentStub, global: windowStub, resultLimit: 10 });
+    assert.equal(picker.mount(), true);
+
+    return {
+        api,
+        picker,
+        windowStub,
+        documentStub,
+        warnings,
+        elements: { trigger, panel, dialog, title, close, search, status, scopes, results },
+        flushAnimationFrames() {
+            while (animationFrames.length) {
+                animationFrames.shift()();
+            }
+        },
+        fireWindow(type, event = {}) {
+            (windowListeners.get(type) || []).forEach((handler) => handler(event));
+        }
+    };
+}
+
+const activeIndex = [
+    { id: 'r-p1', category: 'P1', type: 'reading', title: 'Ocean Life', path: 'Reading/One' },
+    { id: 'r-p3', category: 'P3', type: 'reading', title: 'Target Passage', path: 'Reading/Three' },
+    { id: 'r-p3-extra', category: 'P3', type: 'reading', title: 'Another Target', tags: ['science'] },
+    { id: 'l-p1', category: 'P1', type: 'listening', title: 'Target Audio', filename: 'audio-one.html' },
+    { id: 'custom', category: 'Custom', type: 'speaking', title: 'Community Interview' }
+];
+
+test('trigger naming and focus/scope styles preserve visible, discernible controls', () => {
+    const triggerMarkup = indexSource.match(
+        /<button(?=[^>]*\bid="question-bank-quick-trigger")[^>]*>[\s\S]*?<\/button>/
+    );
+    assert(triggerMarkup, 'quick-picker trigger markup must exist');
+    const ariaLabel = triggerMarkup[0].match(/\baria-label="([^"]+)"/);
+    assert(ariaLabel && ariaLabel[1].includes('题库速查'), 'accessible name must include the visible trigger label');
+
+    assert.match(
+        mainCssSource,
+        /--question-bank-quick-focus:\s*var\(--question-bank-quick-accent\)/,
+        'picker focus indicators must use the solid accent instead of a low-contrast transparent mix'
+    );
+    assert.match(
+        mainCssSource,
+        /\.question-bank-quick-trigger:focus-visible\s*\{[^}]*outline:\s*3px solid var\(--color-brand-primary\)/s
+    );
+    const scopeRule = mainCssSource.match(
+        /\.question-bank-quick-picker__scopes\s*>\s*button,\s*\.question-bank-quick-scope\s*\{([^}]*)\}/s
+    );
+    assert(scopeRule, 'scope button CSS rule must exist');
+    assert.match(scopeRule[1], /display:\s*flex/);
+    assert.match(scopeRule[1], /gap:\s*10px/);
+});
+
+test('pure search uses the full supplied active index and tokenized normalized text', () => {
+    const { api, windowStub } = createHarness();
+    windowStub.__browseFilter = { category: 'P1', type: 'reading' };
+    windowStub.getCurrentCategory = () => {
+        throw new Error('browse filter must not be consulted');
+    };
+
+    assert.deepEqual(
+        api.filterExams(activeIndex, 'target passage').map((exam) => exam.id),
+        ['r-p3']
+    );
+    assert.deepEqual(
+        api.filterExams(activeIndex, 'ＴＡＲＧＥＴ 听力').map((exam) => exam.id),
+        ['l-p1']
+    );
+    assert.deepEqual(api.filterExams(activeIndex, '').map((exam) => exam.id), activeIndex.map((exam) => exam.id));
+});
+
+test('deriveScopes keeps supported categories separate and omits unsupported Browse scopes', () => {
+    const { api } = createHarness();
+    const scopes = plain(api.deriveScopes(activeIndex));
+
+    assert.deepEqual(scopes.types.map(({ type, count }) => [type, count]), [
+        ['reading', 3],
+        ['listening', 1]
+    ]);
+    assert.deepEqual(scopes.categories.map(({ key, count }) => [key, count]), [
+        ['reading::P1', 1],
+        ['reading::P3', 2],
+        ['listening::P1', 1]
+    ]);
+});
+
+test('position helpers clamp popovers and compute a desktop modal anchor', () => {
+    const { api } = createHarness();
+    const position = plain(api.computePanelPosition(
+        { left: 950, right: 990, top: 720, bottom: 760 },
+        { width: 400, height: 300 },
+        { width: 1000, height: 800 }
+    ));
+
+    assert.equal(position.placement, 'top');
+    assert.equal(position.left, 588);
+    assert.ok(position.top >= 12);
+    assert.equal(api.computeAnchorTop({ bottom: 120 }, { height: 800 }), 130);
+    assert.equal(api.computeAnchorTop({ bottom: 780 }, { height: 800 }), 548);
+});
+
+test('open renders loading, dynamic flat scopes, global results, and keyboard selection', async () => {
+    let resolveIndex;
+    const pendingIndex = new Promise((resolve) => {
+        resolveIndex = resolve;
+    });
+    const harness = createHarness({ resolveActiveLibraryIndex: () => pendingIndex });
+    const { picker, elements, documentStub } = harness;
+    elements.trigger.focus();
+
+    const opening = picker.open();
+    assert.equal(elements.panel.hidden, false);
+    assert.equal(elements.trigger.getAttribute('aria-expanded'), 'true');
+    assert.equal(elements.scopes.getAttribute('aria-busy'), 'true');
+    assert.equal(elements.status.dataset.state, 'loading');
+    assert.equal(documentStub.activeElement, elements.search);
+
+    resolveIndex(activeIndex);
+    await opening;
+    assert.equal(elements.scopes.getAttribute('aria-busy'), 'false');
+    assert.equal(elements.scopes.children.length, 1 + 2 + 3);
+    elements.scopes.children.forEach((button) => {
+        assert.equal(button.tagName, 'BUTTON');
+        assert.match(button.className, /question-bank-quick-scope/);
+        assert.doesNotMatch(button.className, /(?:^|\s)nav-btn(?:\s|$)/);
+    });
+
+    elements.search.value = 'target';
+    elements.search.fire('input');
+    assert.equal(elements.results.hidden, false);
+    assert.deepEqual(picker.matches.map((exam) => exam.id), ['r-p3', 'r-p3-extra', 'l-p1']);
+    assert.equal(picker.resultElements.length, 3);
+    assert.equal(picker.resultElements[0].getAttribute('role'), 'option');
+    assert.ok(picker.resultElements[0].id);
+
+    let prevented = false;
+    elements.search.fire('keydown', {
+        key: 'ArrowDown',
+        preventDefault() {
+            prevented = true;
+        }
+    });
+    assert.equal(prevented, true);
+    assert.equal(picker.resultElements[0].getAttribute('aria-selected'), 'true');
+    assert.equal(elements.search.getAttribute('aria-activedescendant'), picker.resultElements[0].id);
+
+    ['Home', 'End'].forEach((key) => {
+        let textEditingPrevented = false;
+        elements.search.fire('keydown', {
+            key,
+            preventDefault() {
+                textEditingPrevented = true;
+            }
+        });
+        assert.equal(textEditingPrevented, false, `${key} must retain its native text-caret behavior`);
+        assert.equal(picker.activeResultIndex, 0);
+    });
+
+    elements.search.fire('keydown', {
+        key: 'End',
+        keyCode: 229,
+        isComposing: true,
+        preventDefault() {
+            throw new Error('IME composition must not move or open a result');
+        }
+    });
+    assert.equal(picker.activeResultIndex, 0);
+
+    picker.resultElements[0].focus();
+    elements.results.fire('keydown', {
+        target: picker.resultElements[0],
+        key: 'End',
+        preventDefault() {}
+    });
+    assert.equal(documentStub.activeElement, picker.resultElements[2]);
+    assert.equal(picker.resultElements[2].getAttribute('aria-selected'), 'true');
+
+    elements.search.value = 'no-such-question';
+    elements.search.fire('input');
+    assert.equal(elements.results.hidden, true);
+    assert.equal(elements.search.getAttribute('aria-expanded'), 'false');
+    assert.equal(elements.results.children.length, 0, 'an empty listbox must not contain a non-option placeholder');
+    assert.equal(elements.status.dataset.state, 'empty');
+});
+
+test('reopening drops the previous library snapshot while the next index is pending', async () => {
+    const nextIndex = deferred();
+    let resolverCall = 0;
+    const harness = createHarness({
+        resolveActiveLibraryIndex() {
+            resolverCall += 1;
+            return resolverCall === 1
+                ? Promise.resolve([{ id: 'old-exam', category: 'P1', type: 'reading', title: 'Legacy Target' }])
+                : nextIndex.promise;
+        }
+    });
+    const { picker, elements } = harness;
+
+    await picker.open();
+    elements.search.value = 'legacy';
+    elements.search.fire('input');
+    assert.deepEqual(picker.matches.map((exam) => exam.id), ['old-exam']);
+    assert.equal(picker.resultElements.length, 1);
+
+    picker.close();
+    const reopening = picker.open();
+    assert.deepEqual(plain(picker.index), []);
+    assert.deepEqual(plain(picker.matches), []);
+    assert.equal(elements.results.hidden, true);
+
+    elements.search.fire('input');
+    assert.deepEqual(plain(picker.matches), []);
+    assert.equal(picker.resultElements.length, 0);
+    assert.equal(elements.results.hidden, true, 'typing during refresh must not reveal the old library');
+
+    nextIndex.resolve([{ id: 'new-exam', category: 'P2', type: 'reading', title: 'Fresh Target' }]);
+    await reopening;
+    assert.deepEqual(picker.index.map((exam) => exam.id), ['new-exam']);
+    assert.deepEqual(plain(picker.matches), [], 'the retained query must not match the old snapshot after refresh');
+});
+
+test('settling an action from a closed session cannot close or overwrite a reopened picker', async () => {
+    const successfulAction = deferred();
+    const successfulActionStarted = deferred();
+    const rejectedAction = deferred();
+    const rejectedActionStarted = deferred();
+    let actionCall = 0;
+    const harness = createHarness({ resolveActiveLibraryIndex: () => Promise.resolve(activeIndex) });
+    const { picker, windowStub, elements, warnings } = harness;
+    windowStub.ensureBrowseGroup = () => Promise.resolve();
+    windowStub.app = {
+        openExam() {
+            actionCall += 1;
+            if (actionCall === 1) {
+                successfulActionStarted.resolve();
+                return successfulAction.promise;
+            }
+            rejectedActionStarted.resolve();
+            return rejectedAction.promise;
+        }
+    };
+
+    await picker.open();
+    const staleSuccess = picker.openExam('r-p1');
+    await successfulActionStarted.promise;
+    picker.close();
+    await picker.open();
+    const readyStatusAfterSuccessReopen = elements.status.textContent;
+    assert.equal(picker._actionPending, false, 'closing must release the action lock for the next session');
+
+    successfulAction.resolve({ window: {} });
+    assert.equal(await staleSuccess, false);
+    assert.equal(picker.isOpen, true);
+    assert.equal(elements.panel.hidden, false);
+    assert.equal(elements.status.textContent, readyStatusAfterSuccessReopen);
+
+    const staleFailure = picker.openExam('r-p3');
+    await rejectedActionStarted.promise;
+    picker.close();
+    await picker.open();
+    const readyStatusAfterFailureReopen = elements.status.textContent;
+    const warningCount = warnings.length;
+
+    rejectedAction.reject(new Error('stale open failed'));
+    assert.equal(await staleFailure, false);
+    assert.equal(picker.isOpen, true);
+    assert.equal(elements.panel.hidden, false);
+    assert.equal(elements.status.textContent, readyStatusAfterFailureReopen);
+    assert.equal(warnings.length, warningCount, 'a stale rejection must not report against the new session');
+});
+
+test('category and exam actions await Browse, clear stale search, and call app APIs', async () => {
+    const calls = [];
+    const harness = createHarness({ resolveActiveLibraryIndex: () => Promise.resolve(activeIndex) });
+    const { picker, windowStub, documentStub, elements } = harness;
+    const browseSearch = documentStub.register('#exam-search-input', documentStub.createElement('input'));
+    const browseClear = documentStub.register('#search-clear-btn', documentStub.createElement('button'));
+    browseSearch.value = 'old filter';
+    browseClear.hidden = false;
+    windowStub.ensureBrowseGroup = async () => {
+        calls.push('ensure');
+    };
+    windowStub.browseStateManager = {
+        clearSearchState() {
+            calls.push('clear');
+        }
+    };
+    windowStub.app = {
+        browseCategory(category, type) {
+            calls.push(`browse:${category}:${type}`);
+        },
+        openExam(examId) {
+            calls.push(`open:${examId}`);
+            return { closed: false };
+        }
+    };
+
+    elements.trigger.focus();
+    await picker.open();
+    assert.equal(await picker.browseScope('reading', 'P3'), true);
+    assert.deepEqual(calls, ['ensure', 'clear', 'browse:P3:reading']);
+    assert.equal(browseSearch.value, '');
+    assert.equal(browseClear.hidden, true);
+    assert.equal(elements.panel.hidden, true);
+    assert.equal(documentStub.activeElement, elements.trigger);
+
+    calls.length = 0;
+    elements.trigger.focus();
+    await picker.open();
+    assert.equal(await picker.openExam('l-p1'), true);
+    assert.deepEqual(calls, ['ensure', 'open:l-p1']);
+
+    calls.length = 0;
+    await picker.open();
+    windowStub.app.openExam = (examId) => {
+        calls.push(`open:${examId}`);
+        return null;
+    };
+    assert.equal(await picker.openExam('l-p1'), false);
+    assert.deepEqual(calls, ['ensure', 'open:l-p1']);
+    assert.equal(picker.isOpen, true, 'a null production launch result must preserve the search context');
+    assert.equal(elements.panel.hidden, false);
+    assert.equal(elements.status.dataset.state, 'error');
+});
+
+test('empty and rejected active indexes expose stable empty/error states', async () => {
+    const emptyHarness = createHarness({ resolveActiveLibraryIndex: () => Promise.resolve([]) });
+    await emptyHarness.picker.open();
+    assert.equal(emptyHarness.elements.status.dataset.state, 'empty');
+    assert.equal(emptyHarness.elements.results.hidden, true);
+    assert.equal(emptyHarness.elements.scopes.getAttribute('aria-busy'), 'false');
+
+    const errorHarness = createHarness({
+        resolveActiveLibraryIndex: () => Promise.reject(new Error('index failed'))
+    });
+    await errorHarness.picker.open();
+    assert.equal(errorHarness.elements.status.dataset.state, 'error');
+    assert.equal(errorHarness.elements.results.hidden, true);
+    assert.equal(errorHarness.warnings.length, 1);
+});
+
+test('backdrop, outside click, Escape, focus trap, and resize preserve modal behavior', async () => {
+    const harness = createHarness({ resolveActiveLibraryIndex: () => Promise.resolve(activeIndex) });
+    const { picker, documentStub, windowStub, elements } = harness;
+    elements.trigger.focus();
+    await picker.open();
+
+    assert.equal(elements.panel.style.getPropertyValue('--question-bank-quick-anchor-top'), '144px');
+    documentStub.fire('pointerdown', { target: elements.dialog });
+    assert.equal(picker.isOpen, true, 'clicking inside the dialog must keep it open');
+    documentStub.fire('pointerdown', { target: elements.panel });
+    assert.equal(picker.isOpen, false, 'clicking the backdrop must close it');
+    assert.equal(documentStub.activeElement, elements.trigger);
+
+    await picker.open();
+    elements.search.value = 'target';
+    picker.renderResults('target');
+    const focusables = elements.dialog.querySelectorAll(
+        'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+    );
+    focusables.at(-1).focus();
+    let tabPrevented = false;
+    documentStub.fire('keydown', {
+        key: 'Tab',
+        shiftKey: false,
+        preventDefault() {
+            tabPrevented = true;
+        }
+    });
+    assert.equal(tabPrevented, true);
+    assert.equal(documentStub.activeElement, focusables[0]);
+
+    elements.trigger.rect.bottom = 200;
+    harness.fireWindow('resize');
+    harness.flushAnimationFrames();
+    assert.equal(elements.panel.style.getPropertyValue('--question-bank-quick-anchor-top'), '210px');
+    windowStub.innerWidth = 600;
+    harness.fireWindow('resize');
+    harness.flushAnimationFrames();
+    assert.equal(elements.panel.style.getPropertyValue('--question-bank-quick-anchor-top'), '');
+
+    let composingEscapePrevented = false;
+    documentStub.fire('keydown', {
+        key: 'Escape',
+        keyCode: 229,
+        isComposing: true,
+        preventDefault() {
+            composingEscapePrevented = true;
+        }
+    });
+    assert.equal(composingEscapePrevented, false, 'IME Escape must retain composition behavior');
+    assert.equal(picker.isOpen, true, 'IME Escape must not close the picker');
+
+    let escapePrevented = false;
+    documentStub.fire('keydown', {
+        key: 'Escape',
+        preventDefault() {
+            escapePrevented = true;
+        }
+    });
+    assert.equal(escapePrevented, true);
+    assert.equal(elements.panel.hidden, true);
+    assert.equal(elements.trigger.getAttribute('aria-expanded'), 'false');
+});

--- a/developer/tests/js/questionBankQuickPicker.test.js
+++ b/developer/tests/js/questionBankQuickPicker.test.js
@@ -287,6 +287,7 @@ function createHarness(options = {}) {
             }
         },
         resolveActiveLibraryIndex: options.resolveActiveLibraryIndex || (() => Promise.resolve([])),
+        ensureBrowseGroup: options.ensureBrowseGroup || (() => Promise.resolve(true)),
         addEventListener(type, handler) {
             if (!windowListeners.has(type)) {
                 windowListeners.set(type, []);
@@ -591,7 +592,7 @@ test('settling an action from a closed session cannot close or overwrite a reope
     assert.equal(warnings.length, warningCount, 'a stale rejection must not report against the new session');
 });
 
-test('category and exam actions await Browse, clear stale search, and call app APIs', async () => {
+test('category and exam actions use the preloaded Browse runtime and call app APIs', async () => {
     const calls = [];
     const harness = createHarness({ resolveActiveLibraryIndex: () => Promise.resolve(activeIndex) });
     const { picker, windowStub, documentStub, elements } = harness;
@@ -611,8 +612,9 @@ test('category and exam actions await Browse, clear stale search, and call app A
         browseCategory(category, type) {
             calls.push(`browse:${category}:${type}`);
         },
-        openExam(examId) {
+        openExam(examId, launchOptions) {
             calls.push(`open:${examId}`);
+            calls.push(`definition:${launchOptions?.examDefinition?.id || 'missing'}`);
             return { closed: false };
         }
     };
@@ -630,19 +632,98 @@ test('category and exam actions await Browse, clear stale search, and call app A
     elements.trigger.focus();
     await picker.open();
     assert.equal(await picker.openExam('l-p1'), true);
-    assert.deepEqual(calls, ['ensure', 'open:l-p1']);
+    assert.deepEqual(calls, ['open:l-p1', 'definition:l-p1']);
 
     calls.length = 0;
     await picker.open();
-    windowStub.app.openExam = (examId) => {
+    windowStub.app.openExam = (examId, launchOptions) => {
         calls.push(`open:${examId}`);
+        calls.push(`definition:${launchOptions?.examDefinition?.id || 'missing'}`);
         return null;
     };
     assert.equal(await picker.openExam('l-p1'), false);
-    assert.deepEqual(calls, ['ensure', 'open:l-p1']);
+    assert.deepEqual(calls, ['open:l-p1', 'definition:l-p1']);
     assert.equal(picker.isOpen, true, 'a null production launch result must preserve the search context');
     assert.equal(elements.panel.hidden, false);
     assert.equal(elements.status.dataset.state, 'error');
+});
+
+test('opening preloads Browse and keeps launch controls disabled until user activation can be preserved', async () => {
+    const runtimeReady = deferred();
+    let ensureCalls = 0;
+    let activationActive = false;
+    let activationSeenByOpenExam = null;
+    const harness = createHarness({
+        resolveActiveLibraryIndex: () => Promise.resolve(activeIndex),
+        ensureBrowseGroup() {
+            ensureCalls += 1;
+            return runtimeReady.promise;
+        }
+    });
+    const { picker, windowStub, elements } = harness;
+    windowStub.app = {
+        openExam(examId, launchOptions) {
+            activationSeenByOpenExam = activationActive;
+            assert.equal(examId, 'l-p1');
+            assert.equal(launchOptions.examDefinition.id, 'l-p1');
+            return { closed: false };
+        }
+    };
+
+    const opening = picker.open();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ensureCalls, 1, 'opening the picker must start Browse loading before an action');
+    elements.search.value = 'target audio';
+    elements.search.fire('input');
+    assert.equal(picker.resultElements.length, 1);
+    assert.equal(picker.resultElements[0].disabled, true);
+    elements.scopes.children.forEach((button) => assert.equal(button.disabled, true));
+    assert.equal(await picker.openExam('l-p1'), false, 'programmatic activation must be rejected while loading');
+    assert.equal(activationSeenByOpenExam, null);
+
+    runtimeReady.resolve(true);
+    await opening;
+    assert.equal(picker.resultElements[0].disabled, false);
+    elements.scopes.children.forEach((button) => assert.equal(button.disabled, false));
+
+    activationActive = true;
+    const launched = picker.openExam('l-p1');
+    activationActive = false;
+    assert.equal(activationSeenByOpenExam, true, 'app.openExam must run synchronously inside the user event');
+    assert.equal(await launched, true);
+    assert.equal(ensureCalls, 1, 'the click must not re-enter the lazy loader');
+});
+
+test('a failed Browse preload stays non-interactive and retries cleanly after reopening', async () => {
+    let ensureCalls = 0;
+    const harness = createHarness({
+        resolveActiveLibraryIndex: () => Promise.resolve(activeIndex),
+        ensureBrowseGroup() {
+            ensureCalls += 1;
+            return ensureCalls === 1
+                ? Promise.reject(new Error('temporary loader failure'))
+                : Promise.resolve(true);
+        }
+    });
+    const { picker, elements, warnings } = harness;
+
+    await picker.open();
+    assert.equal(ensureCalls, 1);
+    assert.equal(picker._browseReady, false);
+    assert.equal(elements.panel.getAttribute('aria-busy'), 'false');
+    elements.scopes.children.forEach((button) => assert.equal(button.disabled, true));
+    assert.equal(elements.status.dataset.state, 'error');
+    assert.equal(warnings.length, 1);
+    elements.search.value = 'target';
+    elements.search.fire('input');
+    assert.equal(elements.status.dataset.state, 'error', 'typing must not hide the loader failure');
+    assert.match(elements.status.textContent, /加载失败/);
+
+    picker.close();
+    await picker.open();
+    assert.equal(ensureCalls, 2, 'reopening after a rejection must retry the lazy loader');
+    assert.equal(picker._browseReady, true);
+    elements.scopes.children.forEach((button) => assert.equal(button.disabled, false));
 });
 
 test('empty and rejected active indexes expose stable empty/error states', async () => {

--- a/index.html
+++ b/index.html
@@ -106,6 +106,17 @@
                     📚 题库浏览
                 </button>
                 <button
+                    class="question-bank-quick-trigger"
+                    id="question-bank-quick-trigger"
+                    type="button"
+                    aria-label="题库速查：全局搜索或切换题目分类"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                    aria-controls="question-bank-quick-picker"
+                >
+                    题库速查
+                </button>
+                <button
                     class="nav-btn hero-nav__btn"
                     type="button"
                     data-view="practice"
@@ -127,6 +138,106 @@
                     ⚙️ 设置
                 </button>
             </nav>
+
+            <section
+                class="question-bank-quick-picker"
+                id="question-bank-quick-picker"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="question-bank-quick-title"
+                aria-describedby="question-bank-quick-status"
+                hidden
+            >
+                <div
+                    class="question-bank-quick-picker__dialog"
+                    tabindex="-1"
+                >
+                    <header class="question-bank-quick-picker__header">
+                        <div class="question-bank-quick-picker__heading-group">
+                            <span
+                                class="question-bank-quick-picker__eyebrow"
+                                aria-hidden="true"
+                                >QUICK FIND</span
+                            >
+                            <h2 id="question-bank-quick-title">
+                                全局题库速查
+                            </h2>
+                            <p>
+                                搜索当前题库的全部题目，或直接切换题目分类。
+                            </p>
+                        </div>
+                        <button
+                            class="question-bank-quick-picker__close"
+                            id="question-bank-quick-close"
+                            type="button"
+                            aria-label="关闭题库速查"
+                        >
+                            关闭
+                        </button>
+                    </header>
+
+                    <div class="question-bank-quick-picker__search-field">
+                        <label for="question-bank-quick-search"
+                            >全局搜索</label
+                        >
+                        <input
+                            id="question-bank-quick-search"
+                            type="search"
+                            inputmode="search"
+                            enterkeyhint="search"
+                            autocomplete="off"
+                            spellcheck="false"
+                            placeholder="搜索题目标题、分类或关键字…"
+                            role="combobox"
+                            aria-autocomplete="list"
+                            aria-expanded="false"
+                            aria-controls="question-bank-quick-results"
+                            aria-describedby="question-bank-quick-status"
+                        />
+                    </div>
+
+                    <p
+                        class="question-bank-quick-picker__status"
+                        id="question-bank-quick-status"
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                    >
+                        选择分类可直接进入题库浏览。
+                    </p>
+
+                    <section
+                        class="question-bank-quick-picker__section"
+                        aria-labelledby="question-bank-quick-scopes-title"
+                    >
+                        <div class="question-bank-quick-picker__section-head">
+                            <h3 id="question-bank-quick-scopes-title">
+                                题目分类
+                            </h3>
+                            <span>无需返回总览</span>
+                        </div>
+                        <div
+                            class="question-bank-quick-picker__scopes"
+                            id="question-bank-quick-scopes"
+                            role="group"
+                            aria-label="可用题目分类"
+                            aria-busy="true"
+                        >
+                            <p class="question-bank-quick-picker__placeholder">
+                                正在读取题目分类…
+                            </p>
+                        </div>
+                    </section>
+
+                    <div
+                        class="question-bank-quick-picker__results"
+                        id="question-bank-quick-results"
+                        role="listbox"
+                        aria-label="全局搜索结果"
+                        hidden
+                    ></div>
+                </div>
+            </section>
 
             <!-- 总览页面 -->
             <div id="overview-view" class="view active hero-panel hero-section">

--- a/js/app.js
+++ b/js/app.js
@@ -650,17 +650,25 @@ class ExamSystemApp {
                     break;
                 case 'browse':
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
-                        const { category, type, filterMode, path } = window.__pendingBrowseFilter;
+                        const pendingFilter = window.__pendingBrowseFilter;
+                        const { category, type, filterMode, path } = pendingFilter;
                         Promise.resolve(
                             typeof window.initializeBrowseView === 'function'
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
-                        ).then(() => window.applyBrowseFilter(category, type, filterMode, path))
+                        ).then(() => {
+                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                                return undefined;
+                            }
+                            return window.applyBrowseFilter(category, type, filterMode, path);
+                        })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                delete window.__pendingBrowseFilter;
+                                if (window.__pendingBrowseFilter === pendingFilter) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {
                         window.initializeBrowseView();

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -923,50 +923,232 @@
         return examsToShow;
     }
 
-    /**
-     * 重置浏览视图
-     */
-    function resetBrowseViewToAll() {
-        clearReadingMemorizeBrowseMode();
-        // 1. 清除频率模式标记（关键修复）
-        if (typeof global.__browseFilterMode !== 'undefined') {
-            global.__browseFilterMode = 'default';
+    let browseResetInteractionId = 0;
+
+    function isBrowseResetCurrent(interactionId, renderRequestId) {
+        if (interactionId !== browseResetInteractionId) {
+            return false;
         }
-        if (typeof global.__browsePath !== 'undefined') {
-            global.__browsePath = null;
+        return renderRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(renderRequestId);
+    }
+
+    function clearBrowseSearchUI() {
+        if (global.browseStateManager && typeof global.browseStateManager.clearSearchState === 'function') {
+            global.browseStateManager.clearSearchState();
+            return;
+        }
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    }
+
+    function syncBrowseFilterUI(examIndex) {
+        const controller = global.browseController;
+        if (controller) {
+            controller.currentMode = 'default';
+            controller.activeFilter = 'all';
+            if (typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            }
         }
 
-        // 2. 重置 browseController 到默认模式
-        if (global.browseController) {
-            global.browseController.clearPendingBrowseAutoScroll();
+        const typeContainer = document.getElementById('type-filter-buttons');
+        if (typeContainer && typeof typeContainer.querySelectorAll === 'function') {
+            typeContainer.querySelectorAll('.shui-segmented-btn').forEach((button) => {
+                const filterId = button.dataset && (button.dataset.filterId || button.dataset.filterType);
+                const active = filterId === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
 
-            // 恢复默认模式（消除频率模式）
-            if (typeof global.browseController.resetToDefault === 'function') {
-                global.browseController.resetToDefault();
-            } else {
-                // 降级：手动重置
-                global.browseController.currentMode = 'default';
-                global.browseController.activeFilter = 'all';
-            }
-
-            const currentCategory = global.browseController.getCurrentCategory();
-            const currentType = global.browseController.getCurrentExamType();
-
-            if (currentCategory === 'all' && currentType === 'all') {
-                if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-                loadExamList();
-                return;
-            }
-
-            global.browseController.setBrowseFilterState('all', 'all');
+        if (typeof global.updateBrowseFrequencyButtons === 'function') {
+            global.updateBrowseFrequencyButtons('all');
         } else {
-            // 降级
-            if (typeof global.clearPendingBrowseAutoScroll === 'function') global.clearPendingBrowseAutoScroll();
-            if (typeof global.setBrowseFilterState === 'function') global.setBrowseFilterState('all', 'all');
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    if (button.classList && typeof button.classList.remove === 'function') {
+                        button.classList.remove('active');
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', 'false');
+                    }
+                });
+            }
+        }
+    }
+
+    async function prepareBrowseReset() {
+        const pending = [];
+        const manager = global.browseStateManager;
+        if (manager && manager.ready && typeof manager.ready.then === 'function') {
+            pending.push(Promise.resolve(manager.ready).catch((error) => {
+                console.warn('[ExamActions] 等待浏览状态恢复失败:', error);
+            }));
+        }
+        if (typeof global.setupBrowseControls === 'function') {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+                console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
+            }));
+        }
+        if (pending.length > 0) {
+            await Promise.all(pending);
+        }
+    }
+
+    async function persistBrowseFrequencyReset() {
+        const preferences = global.AppData && global.AppData.preferences;
+        if (!preferences || typeof preferences.patchBrowse !== 'function') {
+            return;
+        }
+        try {
+            await preferences.patchBrowse({ frequencyFilter: 'all' });
+        } catch (error) {
+            console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+        }
+    }
+
+    function beginBrowseResetPersistence() {
+        const pending = [persistBrowseFrequencyReset()];
+        if (typeof global.flushBrowsePreferenceWrites === 'function') {
+            pending.push(Promise.resolve().then(() => global.flushBrowsePreferenceWrites()).catch((error) => {
+                console.warn('[ExamActions] 等待浏览筛选偏好写入失败:', error);
+            }));
+        }
+        return Promise.all(pending);
+    }
+
+    function applyBrowseResetState(examIndex) {
+        clearReadingMemorizeBrowseMode();
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+
+        if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
+            global.browseStateManager.resetToAllExams();
+        } else {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            }
+            clearBrowseSearchUI();
         }
 
-        if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-        loadExamList();
+        syncBrowseFilterUI(examIndex);
+        if (typeof global.setBrowseTitle === 'function') {
+            global.setBrowseTitle('题库列表');
+        }
+    }
+
+    /**
+     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
+     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     */
+    async function performBrowseViewResetToAll() {
+        const interactionId = ++browseResetInteractionId;
+        if (global.__pendingBrowseFilter) {
+            delete global.__pendingBrowseFilter;
+        }
+        const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+            ? global.__beginBrowseResultsRequest()
+            : null;
+
+        if (global.browseController) {
+            if (typeof global.browseController.filterInteractionId === 'number') {
+                global.browseController.filterInteractionId += 1;
+            }
+            if (typeof global.browseController.clearPendingBrowseAutoScroll === 'function') {
+                global.browseController.clearPendingBrowseAutoScroll();
+            }
+        } else if (typeof global.clearPendingBrowseAutoScroll === 'function') {
+            global.clearPendingBrowseAutoScroll();
+        }
+
+        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+            ? global.resolveActiveLibraryIndex
+            : global.resolveActiveExamIndex;
+        const indexPromise = typeof resolver === 'function'
+            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                Array.isArray(resolved) ? resolved : null
+            )).catch((error) => {
+                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                return null;
+            })
+            : Promise.resolve(null);
+        const [examIndex] = await Promise.all([
+            indexPromise,
+            prepareBrowseReset()
+        ]);
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        applyBrowseResetState(examIndex);
+
+        const globalLoader = global.loadExamList;
+        if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
+            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
+            let renderPromise;
+            try {
+                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+            } catch (error) {
+                renderPromise = Promise.reject(error);
+            }
+            const persistencePromise = beginBrowseResetPersistence();
+            try {
+                const result = await renderPromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    await persistencePromise;
+                    return false;
+                }
+                // null/[] 预取会让适配器重新解析；用其最终快照刷新默认模式按钮。
+                if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                    && Array.isArray(result)) {
+                    syncBrowseFilterUI(result);
+                }
+                await persistencePromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    return false;
+                }
+                return result;
+            } catch (error) {
+                console.warn('[ExamActions] 重置浏览视图加载失败:', error);
+                await persistencePromise;
+                return false;
+            }
+        }
+
+        if (Array.isArray(examIndex) && examIndex.length > 0) {
+            const result = loadExamList(examIndex);
+            await beginBrowseResetPersistence();
+            return result;
+        }
+
+        await beginBrowseResetPersistence();
+        console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
+        return false;
+    }
+
+    async function resetBrowseViewToAll() {
+        try {
+            return await performBrowseViewResetToAll();
+        } catch (error) {
+            console.warn('[ExamActions] 重置浏览视图失败:', error);
+            return false;
+        }
     }
 
     /**

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -274,6 +274,21 @@
         }
     }
 
+    function ensureBrowseStateManager() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[MainEntry] 初始化浏览状态管理器失败:', error);
+            return null;
+        }
+    }
+
     function synchronizeActiveBrowseViewAfterLoad() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
@@ -286,7 +301,7 @@
                 return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             })
             .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter) {
+                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
                 return global.applyBrowseFilter(
@@ -307,6 +322,13 @@
         if (!browseGroupPromise) {
             browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
                 reapplyAppMixins();
+                // NavigationController is part of the shell, while its legacy
+                // implementation and BrowseStateManager arrive with Browse.
+                // Retry their idempotent initialization after the lazy group is
+                // present so cold quick-picker entry has the same runtime as a
+                // preloaded Browse view.
+                initializeNavigationShell();
+                ensureBrowseStateManager();
                 if (typeof global.setupBrowsePreferenceUI === 'function') {
                     try {
                         global.setupBrowsePreferenceUI();
@@ -343,6 +365,7 @@
     function ensureSessionSuiteReady() {
         if (!sessionSuitePromise) {
             sessionSuitePromise = Promise.all([
+                ensureBrowseGroup(),
                 ensurePracticeSuiteGroup(),
                 ensureLazyGroup(SESSION_GROUP)
             ]).then(function afterSuiteLoaded() {
@@ -384,12 +407,13 @@
     }
 
     function initializeNavigationShell() {
+        var controller = null;
         try {
             if (global.NavigationController && typeof global.NavigationController.ensure === 'function') {
-                global.NavigationController.ensure({
+                controller = global.NavigationController.ensure({
                     containerSelector: '.main-nav',
                     activeClass: 'active',
-                    initialView: 'overview',
+                    initialView: getActiveViewName() || 'overview',
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
@@ -410,6 +434,19 @@
         } catch (error) {
             console.warn('[MainEntry] 初始化导航失败:', error);
         }
+        if (controller && typeof document !== 'undefined') {
+            var navRoot = document.querySelector('.main-nav');
+            var fallbackHandler = navRoot && navRoot._legacyNavHandler;
+            if (typeof fallbackHandler === 'function' && typeof navRoot.removeEventListener === 'function') {
+                navRoot.removeEventListener('click', fallbackHandler);
+                try {
+                    delete navRoot._legacyNavHandler;
+                } catch (_) {
+                    navRoot._legacyNavHandler = null;
+                }
+            }
+        }
+        return controller;
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5071,50 +5071,232 @@
         return examsToShow;
     }
 
-    /**
-     * 重置浏览视图
-     */
-    function resetBrowseViewToAll() {
-        clearReadingMemorizeBrowseMode();
-        // 1. 清除频率模式标记（关键修复）
-        if (typeof global.__browseFilterMode !== 'undefined') {
-            global.__browseFilterMode = 'default';
+    let browseResetInteractionId = 0;
+
+    function isBrowseResetCurrent(interactionId, renderRequestId) {
+        if (interactionId !== browseResetInteractionId) {
+            return false;
         }
-        if (typeof global.__browsePath !== 'undefined') {
-            global.__browsePath = null;
+        return renderRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(renderRequestId);
+    }
+
+    function clearBrowseSearchUI() {
+        if (global.browseStateManager && typeof global.browseStateManager.clearSearchState === 'function') {
+            global.browseStateManager.clearSearchState();
+            return;
+        }
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    }
+
+    function syncBrowseFilterUI(examIndex) {
+        const controller = global.browseController;
+        if (controller) {
+            controller.currentMode = 'default';
+            controller.activeFilter = 'all';
+            if (typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            }
         }
 
-        // 2. 重置 browseController 到默认模式
-        if (global.browseController) {
-            global.browseController.clearPendingBrowseAutoScroll();
+        const typeContainer = document.getElementById('type-filter-buttons');
+        if (typeContainer && typeof typeContainer.querySelectorAll === 'function') {
+            typeContainer.querySelectorAll('.shui-segmented-btn').forEach((button) => {
+                const filterId = button.dataset && (button.dataset.filterId || button.dataset.filterType);
+                const active = filterId === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
 
-            // 恢复默认模式（消除频率模式）
-            if (typeof global.browseController.resetToDefault === 'function') {
-                global.browseController.resetToDefault();
-            } else {
-                // 降级：手动重置
-                global.browseController.currentMode = 'default';
-                global.browseController.activeFilter = 'all';
-            }
-
-            const currentCategory = global.browseController.getCurrentCategory();
-            const currentType = global.browseController.getCurrentExamType();
-
-            if (currentCategory === 'all' && currentType === 'all') {
-                if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-                loadExamList();
-                return;
-            }
-
-            global.browseController.setBrowseFilterState('all', 'all');
+        if (typeof global.updateBrowseFrequencyButtons === 'function') {
+            global.updateBrowseFrequencyButtons('all');
         } else {
-            // 降级
-            if (typeof global.clearPendingBrowseAutoScroll === 'function') global.clearPendingBrowseAutoScroll();
-            if (typeof global.setBrowseFilterState === 'function') global.setBrowseFilterState('all', 'all');
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    if (button.classList && typeof button.classList.remove === 'function') {
+                        button.classList.remove('active');
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', 'false');
+                    }
+                });
+            }
+        }
+    }
+
+    async function prepareBrowseReset() {
+        const pending = [];
+        const manager = global.browseStateManager;
+        if (manager && manager.ready && typeof manager.ready.then === 'function') {
+            pending.push(Promise.resolve(manager.ready).catch((error) => {
+                console.warn('[ExamActions] 等待浏览状态恢复失败:', error);
+            }));
+        }
+        if (typeof global.setupBrowseControls === 'function') {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+                console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
+            }));
+        }
+        if (pending.length > 0) {
+            await Promise.all(pending);
+        }
+    }
+
+    async function persistBrowseFrequencyReset() {
+        const preferences = global.AppData && global.AppData.preferences;
+        if (!preferences || typeof preferences.patchBrowse !== 'function') {
+            return;
+        }
+        try {
+            await preferences.patchBrowse({ frequencyFilter: 'all' });
+        } catch (error) {
+            console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+        }
+    }
+
+    function beginBrowseResetPersistence() {
+        const pending = [persistBrowseFrequencyReset()];
+        if (typeof global.flushBrowsePreferenceWrites === 'function') {
+            pending.push(Promise.resolve().then(() => global.flushBrowsePreferenceWrites()).catch((error) => {
+                console.warn('[ExamActions] 等待浏览筛选偏好写入失败:', error);
+            }));
+        }
+        return Promise.all(pending);
+    }
+
+    function applyBrowseResetState(examIndex) {
+        clearReadingMemorizeBrowseMode();
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+
+        if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
+            global.browseStateManager.resetToAllExams();
+        } else {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            }
+            clearBrowseSearchUI();
         }
 
-        if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-        loadExamList();
+        syncBrowseFilterUI(examIndex);
+        if (typeof global.setBrowseTitle === 'function') {
+            global.setBrowseTitle('题库列表');
+        }
+    }
+
+    /**
+     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
+     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     */
+    async function performBrowseViewResetToAll() {
+        const interactionId = ++browseResetInteractionId;
+        if (global.__pendingBrowseFilter) {
+            delete global.__pendingBrowseFilter;
+        }
+        const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+            ? global.__beginBrowseResultsRequest()
+            : null;
+
+        if (global.browseController) {
+            if (typeof global.browseController.filterInteractionId === 'number') {
+                global.browseController.filterInteractionId += 1;
+            }
+            if (typeof global.browseController.clearPendingBrowseAutoScroll === 'function') {
+                global.browseController.clearPendingBrowseAutoScroll();
+            }
+        } else if (typeof global.clearPendingBrowseAutoScroll === 'function') {
+            global.clearPendingBrowseAutoScroll();
+        }
+
+        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+            ? global.resolveActiveLibraryIndex
+            : global.resolveActiveExamIndex;
+        const indexPromise = typeof resolver === 'function'
+            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                Array.isArray(resolved) ? resolved : null
+            )).catch((error) => {
+                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                return null;
+            })
+            : Promise.resolve(null);
+        const [examIndex] = await Promise.all([
+            indexPromise,
+            prepareBrowseReset()
+        ]);
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        applyBrowseResetState(examIndex);
+
+        const globalLoader = global.loadExamList;
+        if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
+            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
+            let renderPromise;
+            try {
+                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+            } catch (error) {
+                renderPromise = Promise.reject(error);
+            }
+            const persistencePromise = beginBrowseResetPersistence();
+            try {
+                const result = await renderPromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    await persistencePromise;
+                    return false;
+                }
+                // null/[] 预取会让适配器重新解析；用其最终快照刷新默认模式按钮。
+                if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                    && Array.isArray(result)) {
+                    syncBrowseFilterUI(result);
+                }
+                await persistencePromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    return false;
+                }
+                return result;
+            } catch (error) {
+                console.warn('[ExamActions] 重置浏览视图加载失败:', error);
+                await persistencePromise;
+                return false;
+            }
+        }
+
+        if (Array.isArray(examIndex) && examIndex.length > 0) {
+            const result = loadExamList(examIndex);
+            await beginBrowseResetPersistence();
+            return result;
+        }
+
+        await beginBrowseResetPersistence();
+        console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
+        return false;
+    }
+
+    async function resetBrowseViewToAll() {
+        try {
+            return await performBrowseViewResetToAll();
+        } catch (error) {
+            console.warn('[ExamActions] 重置浏览视图失败:', error);
+            return false;
+        }
     }
 
     /**
@@ -14496,19 +14678,16 @@ class BrowseStateManager {
      * 处理浏览导航
      */
     handleBrowseNavigation() {
-        console.log('[BrowseStateManager] 处理浏览导航，重置为显示所有考试');
+        console.log('[BrowseStateManager] 记录题库浏览导航');
 
-        if (typeof window.clearPendingBrowseAutoScroll === 'function') {
-            try { window.clearPendingBrowseAutoScroll(); } catch (_) {}
-        }
-
-        // 重置到全部考试视图
-        this.resetToAllExams();
+        // 导航控制器单独区分“进入 Browse”和“重复点击 Browse”。
+        // 普通进入时应保留待处理的分类与持久化偏好；只有重复
+        // 导航才由 ExamActions.resetBrowseViewToAll 执行一次原子重置。
 
         // 记录导航历史
         this.addToHistory({
             action: 'navigate_to_browse',
-            filter: 'all',
+            filter: this.currentFilter,
             timestamp: Date.now()
         });
     }
@@ -14718,6 +14897,11 @@ class BrowseStateManager {
         this.setState({
             currentCategory: null,
             currentFrequency: null,
+            filters: {
+                frequency: 'all',
+                status: 'all',
+                difficulty: 'all'
+            },
             searchQuery: '',
             pagination: {
                 page: 1,
@@ -14767,9 +14951,14 @@ class BrowseStateManager {
      * 清除搜索状态
      */
     clearSearchState() {
-        const searchInput = document.querySelector('.search-input');
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
         if (searchInput) {
             searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
         }
     }
 
@@ -17170,7 +17359,11 @@ async function initializeLegacyComponents() {
     try { showMessage('系统准备就绪', 'success'); } catch (_) { }
 
     try {
-        ensureLegacyNavigation({ initialView: 'overview' });
+        const activeView = document.querySelector('.view.active');
+        const activeViewName = activeView && activeView.id
+            ? activeView.id.replace(/-view$/, '')
+            : 'overview';
+        ensureLegacyNavigation({ initialView: activeViewName });
     } catch (error) {
         console.warn('[Navigation] 初始化导航控制器失败:', error);
     }
@@ -17183,8 +17376,8 @@ async function initializeLegacyComponents() {
         console.log('[System] PDF处理器已初始化');
     }
     if (window.BrowseStateManager) {
-        browseStateManager = new BrowseStateManager();
-        console.log('[System] 浏览状态管理器已初始化');
+        browseStateManager = window.browseStateManager || new window.BrowseStateManager();
+        console.log('[System] 浏览状态管理器已就绪');
     }
     // 性能优化器已拆到 diagnostics-tools；浏览页保留无依赖降级路径。
     if (window.PerformanceOptimizer) {
@@ -19030,11 +19223,25 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             filterMode = null;
             path = null;
         }
-        // 归一化输入：兼容 "P1 阅读"/"P2 听力" 这类文案
+        // 归一化输入：活动索引中的精确分类优先，避免 "P1 Mock" 等
+        // 自定义分类被旧的嵌入式 P1-P4 兼容规则缩写成 "P1"。
         const raw = String(category || 'all');
-        let normalizedCategory = 'all';
-        const m = raw.match(/\bP[1-4]\b/i);
-        if (m) normalizedCategory = m[0].toUpperCase();
+        const trimmedCategory = raw.trim();
+        const exactCategoryEntry = trimmedCategory && trimmedCategory.toLowerCase() !== 'all'
+            ? indexSnapshot.find((exam) => exam && typeof exam.category === 'string'
+                && exam.category.trim() === trimmedCategory)
+            : null;
+        const compatibleCategoryEntry = exactCategoryEntry || (
+            trimmedCategory && trimmedCategory.toLowerCase() !== 'all'
+                ? indexSnapshot.find((exam) => exam && typeof exam.category === 'string'
+                    && exam.category.trim().toLocaleLowerCase() === trimmedCategory.toLocaleLowerCase())
+                : null
+        );
+        const normalizedCategory = compatibleCategoryEntry
+            ? compatibleCategoryEntry.category.trim()
+            : (typeof window.normalizeCategoryKey === 'function'
+                ? window.normalizeCategoryKey(raw)
+                : trimmedCategory || 'all');
 
         // 若未显式给出类型，从文案或题库推断
         if (!type || type === 'all') {
@@ -19193,22 +19400,33 @@ function refreshBrowseResults() {
 }
 
 let browseControlsSeeded = false;
+let browseControlsSeedPromise = null;
 async function setupBrowseControls() {
     if (!browseControlsSeeded) {
-        try {
-            const browse = await window.AppData.preferences.getBrowse();
-            if (browse) {
-                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
-            }
-        } catch (_) { /* defaults remain active */ }
-        browseControlsSeeded = true;
+        if (!browseControlsSeedPromise) {
+            browseControlsSeedPromise = (async () => {
+                try {
+                    const browse = await window.AppData.preferences.getBrowse();
+                    if (browse) {
+                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                    }
+                } catch (_) { /* defaults remain active */ }
+                browseControlsSeeded = true;
+            })();
+        }
+        await browseControlsSeedPromise;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
 }
 
 async function persistBrowsePreference(patch) {
+    if (window.AppData && window.AppData.preferences
+        && typeof window.AppData.preferences.patchBrowse === 'function') {
+        await window.AppData.preferences.patchBrowse(patch);
+        return;
+    }
     const current = await window.AppData.preferences.getBrowse() || {};
     await window.AppData.preferences.setBrowse(Object.assign({}, current, patch));
 }
@@ -19236,6 +19454,7 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
+    window.__browseFrequencyFilter = activeFilter;
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return;

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2261,17 +2261,25 @@ class ExamSystemApp {
                     break;
                 case 'browse':
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
-                        const { category, type, filterMode, path } = window.__pendingBrowseFilter;
+                        const pendingFilter = window.__pendingBrowseFilter;
+                        const { category, type, filterMode, path } = pendingFilter;
                         Promise.resolve(
                             typeof window.initializeBrowseView === 'function'
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
-                        ).then(() => window.applyBrowseFilter(category, type, filterMode, path))
+                        ).then(() => {
+                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                                return undefined;
+                            }
+                            return window.applyBrowseFilter(category, type, filterMode, path);
+                        })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                delete window.__pendingBrowseFilter;
+                                if (window.__pendingBrowseFilter === pendingFilter) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {
                         window.initializeBrowseView();

--- a/js/bundles/runtime-entry.bundle.js
+++ b/js/bundles/runtime-entry.bundle.js
@@ -1352,6 +1352,7 @@
     var prefetchTriggered = false;
     var attachedPrefetchHandlers = false;
     var browsePrefetchTriggered = false;
+    var browsePrefetchPromise = null;
     var morePrefetchTriggered = false;
 
     function ensurePracticeSuite() {
@@ -1359,6 +1360,19 @@
             return Promise.resolve();
         }
         return global.AppLazyLoader.ensureGroup('practice-suite');
+    }
+
+    function ensureBrowseRuntime() {
+        if (global.AppEntry && typeof global.AppEntry.ensureBrowseGroup === 'function') {
+            return Promise.resolve(global.AppEntry.ensureBrowseGroup());
+        }
+        if (typeof global.ensureBrowseGroup === 'function') {
+            return Promise.resolve(global.ensureBrowseGroup());
+        }
+        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+            return Promise.resolve(global.AppLazyLoader.ensureGroup('browse-runtime'));
+        }
+        return Promise.resolve();
     }
 
     function exportPracticeMarkdown() {
@@ -1401,14 +1415,15 @@
 
     function triggerBrowsePrefetch() {
         if (browsePrefetchTriggered) {
-            return;
+            return browsePrefetchPromise || Promise.resolve();
         }
         browsePrefetchTriggered = true;
-        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
-            global.AppLazyLoader.ensureGroup('browse-runtime').catch(function swallow(error) {
-                console.warn('[AppActions] 浏览模块预加载失败:', error);
-            });
-        }
+        browsePrefetchPromise = ensureBrowseRuntime().catch(function swallow(error) {
+            browsePrefetchTriggered = false;
+            browsePrefetchPromise = null;
+            console.warn('[AppActions] 浏览模块预加载失败:', error);
+        });
+        return browsePrefetchPromise;
     }
 
     function triggerMorePrefetch() {
@@ -1848,8 +1863,8 @@
         var tasks = [];
         if (loader) {
             tasks.push(loader.ensureGroup('exam-data'));
-            tasks.push(loader.ensureGroup('browse-runtime').catch(function () { return undefined; }));
         }
+        tasks.push(ensureBrowseRuntime().catch(function () { return undefined; }));
         return Promise.all(tasks).then(function () {
             return undefined;
         });

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1236,6 +1236,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         this._positionFrame = null;
         this._restoreFocus = null;
         this._actionPending = false;
+        this._browseReady = false;
+        this._browseLoading = false;
+        this._browseLoadError = null;
+        this._browsePreloadPromise = null;
 
         this._onTriggerClick = this._handleTriggerClick.bind(this);
         this._onCloseClick = this._handleCloseClick.bind(this);
@@ -1530,10 +1534,11 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         setAttribute(this.elements.trigger, 'aria-expanded', 'true');
         this.position();
         this._renderLoading();
+        var browseReady = this._preloadBrowseGroup();
         if (typeof this.elements.search.focus === 'function') {
             this.elements.search.focus();
         }
-        return this.refresh().then(function opened() {
+        return Promise.all([this.refresh(), browseReady]).then(function opened() {
             return true;
         });
     };
@@ -1612,6 +1617,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             self.scopes = deriveScopes(self.index);
             self.renderScopes();
             self.renderResults(self.elements.search.value);
+            self._syncBrowseActionAvailability();
+            if (self._browseLoadError) {
+                self._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            } else if (self._browseLoading) {
+                self._setStatus('题库功能正在加载，搜索结果将在加载完成后可打开。', 'loading');
+            }
             self.position();
             return self.index;
         }).catch(function indexFailed(error) {
@@ -1625,6 +1636,18 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     QuestionBankQuickPicker.prototype._setStatus = function setStatusText(text, state) {
         this.elements.status.textContent = text;
         setState(this.elements.status, state || 'ready');
+    };
+
+    QuestionBankQuickPicker.prototype._setBrowseAwareStatus = function setBrowseAwareStatus(text, state) {
+        if (this._browseLoadError) {
+            this._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            return;
+        }
+        if (this._browseLoading) {
+            this._setStatus('题库功能正在加载，搜索结果将在加载完成后可打开。', 'loading');
+            return;
+        }
+        this._setStatus(text, state);
     };
 
     QuestionBankQuickPicker.prototype._renderLoading = function renderLoading() {
@@ -1679,6 +1702,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var button = this.document.createElement('button');
         button.type = 'button';
         button.className = 'question-bank-quick-picker__scope question-bank-quick-scope';
+        button.disabled = !this._browseReady;
         setAttribute(button, ACTION_ATTRIBUTE, 'browse-scope');
         setAttribute(button, 'data-type', type);
         setAttribute(button, 'data-category', category);
@@ -1743,6 +1767,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var button = this.document.createElement('button');
         button.type = 'button';
         button.className = 'question-bank-quick-picker__result question-bank-quick-result';
+        button.disabled = !this._browseReady;
         setAttribute(button, ACTION_ATTRIBUTE, 'open-exam');
         setAttribute(button, 'data-exam-id', examId);
         setAttribute(button, 'role', 'option');
@@ -1781,7 +1806,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             this.matches = [];
             this.elements.results.hidden = true;
             setAttribute(this.elements.search, 'aria-expanded', 'false');
-            this._setStatus(
+            this._setBrowseAwareStatus(
                 '已加载 ' + this.index.length + ' 道题；选择分类，或输入关键词全局搜索。',
                 'ready'
             );
@@ -1792,7 +1817,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         if (this.matches.length === 0) {
             this.elements.results.hidden = true;
             setAttribute(this.elements.search, 'aria-expanded', 'false');
-            this._setStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
+            this._setBrowseAwareStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
             return [];
         }
 
@@ -1810,7 +1835,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var suffix = this.matches.length > this.resultLimit
             ? '，显示前 ' + this.resultLimit + ' 道'
             : '';
-        this._setStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
+        this._setBrowseAwareStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
         return this.matches.slice();
     };
 
@@ -1825,6 +1850,77 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             return Promise.reject(new Error('ensureBrowseGroup is unavailable'));
         }
         return Promise.resolve(loader.call(owner));
+    };
+
+    QuestionBankQuickPicker.prototype._syncBrowseActionAvailability = function syncBrowseActionAvailability() {
+        var disabled = !this._browseReady;
+        var containers = [this.elements.scopes, this.elements.results];
+        containers.forEach(function updateContainer(container) {
+            if (!container || typeof container.querySelectorAll !== 'function') {
+                return;
+            }
+            Array.prototype.slice.call(container.querySelectorAll('[' + ACTION_ATTRIBUTE + ']') || [])
+                .forEach(function updateAction(action) {
+                    action.disabled = disabled;
+                });
+        });
+        if (this.elements.panel) {
+            setAttribute(this.elements.panel, 'aria-busy', this._browseLoading ? 'true' : 'false');
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._preloadBrowseGroup = function preloadBrowseGroup() {
+        if (this._browseReady) {
+            this._syncBrowseActionAvailability();
+            return Promise.resolve(true);
+        }
+        if (this._browsePreloadPromise) {
+            return this._browsePreloadPromise;
+        }
+
+        var self = this;
+        var started;
+        this._browseLoading = true;
+        this._browseLoadError = null;
+        this._syncBrowseActionAvailability();
+        try {
+            // Invoke the loader immediately when the panel opens. Result and
+            // scope controls stay disabled until it settles, so their eventual
+            // click handlers never spend transient user activation on loading.
+            started = this._ensureBrowseGroup();
+        } catch (error) {
+            started = Promise.reject(error);
+        }
+
+        var preload = Promise.resolve(started).then(function browseLoaded() {
+            self._browseReady = true;
+            self._browseLoading = false;
+            self._browseLoadError = null;
+            self._syncBrowseActionAvailability();
+            if (self.isOpen && self.index.length > 0) {
+                self.renderResults(self.elements.search.value);
+            }
+            return true;
+        }).catch(function browseLoadFailed(error) {
+            self._browseReady = false;
+            self._browseLoading = false;
+            self._browseLoadError = error;
+            self._syncBrowseActionAvailability();
+            if (self.isOpen) {
+                self._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            }
+            if (self.global.console && typeof self.global.console.warn === 'function') {
+                self.global.console.warn('[QuestionBankQuickPicker] Failed to preload Browse:', error);
+            }
+            return false;
+        });
+        this._browsePreloadPromise = preload;
+        preload.then(function clearPreload() {
+            if (self._browsePreloadPromise === preload) {
+                self._browsePreloadPromise = null;
+            }
+        });
+        return preload;
     };
 
     QuestionBankQuickPicker.prototype._clearBrowseSearchState = function clearBrowseSearchState() {
@@ -1852,7 +1948,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     };
 
     QuestionBankQuickPicker.prototype.browseScope = function browseScope(type, category) {
-        if (this._actionPending) {
+        if (this._actionPending || !this.isOpen || !this._browseReady) {
+            if (this.isOpen && !this._browseReady) {
+                this._setStatus('题库功能仍在加载，请稍候。', 'loading');
+            }
             return Promise.resolve(false);
         }
         var safeType = normalizeScopeValue(type, 'all');
@@ -1861,18 +1960,18 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var actionVersion = ++this._actionVersion;
         this._actionPending = true;
         this._setStatus('正在打开题目分类…', 'loading');
-        return this._ensureBrowseGroup().then(function browseReady() {
-            if (!self.isOpen || actionVersion !== self._actionVersion) {
-                return false;
-            }
+        var categoryAction;
+        try {
             if (!self.global.app || typeof self.global.app.browseCategory !== 'function') {
                 throw new Error('app.browseCategory is unavailable');
             }
             self._clearBrowseSearchState();
-            return Promise.resolve(self.global.app.browseCategory(safeCategory, safeType)).then(function categoryDispatched() {
-                return true;
-            });
-        }).then(function categoryOpened(opened) {
+            categoryAction = self.global.app.browseCategory(safeCategory, safeType);
+        } catch (error) {
+            categoryAction = Promise.reject(error);
+        }
+        return Promise.resolve(categoryAction).then(function categoryOpened() {
+            var opened = true;
             if (opened !== true || !self.isOpen || actionVersion !== self._actionVersion) {
                 return false;
             }
@@ -1896,27 +1995,38 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 
     QuestionBankQuickPicker.prototype.openExam = function openExam(examId) {
         var safeExamId = normalizeScopeValue(examId, '');
-        if (!safeExamId || this._actionPending) {
+        if (!safeExamId || this._actionPending || !this.isOpen || !this._browseReady) {
+            if (this.isOpen && !this._browseReady) {
+                this._setStatus('题库功能仍在加载，请稍候。', 'loading');
+            }
             return Promise.resolve(false);
         }
         var self = this;
+        var examDefinition = this.index.find(function findExam(exam) {
+            return normalizeScopeValue(exam && (exam.id || exam.examId), '') === safeExamId;
+        });
         var actionVersion = ++this._actionVersion;
         this._actionPending = true;
         this._setStatus('正在打开题目…', 'loading');
-        return this._ensureBrowseGroup().then(function browseReady() {
-            if (!self.isOpen || actionVersion !== self._actionVersion) {
-                return false;
-            }
+        var examAction;
+        try {
             if (!self.global.app || typeof self.global.app.openExam !== 'function') {
                 throw new Error('app.openExam is unavailable');
             }
-            return Promise.resolve(self.global.app.openExam(safeExamId)).then(function examDispatched(launchTarget) {
-                // ExamSystemApp.openExam resolves to the opened Window (or a
-                // launch-context object when requested) on success, and to
-                // undefined/null when the exam cannot be launched.
-                return Boolean(launchTarget);
-            });
-        }).then(function examOpened(opened) {
+            // Calling app.openExam synchronously preserves the click's transient
+            // activation. Supplying the selected snapshot also skips its normal
+            // asynchronous index lookup before window.open.
+            examAction = self.global.app.openExam(safeExamId, examDefinition
+                ? { examDefinition: examDefinition }
+                : {});
+        } catch (error) {
+            examAction = Promise.reject(error);
+        }
+        return Promise.resolve(examAction).then(function examOpened(launchTarget) {
+            // ExamSystemApp.openExam resolves to the opened Window (or a
+            // launch-context object when requested) on success, and to
+            // undefined/null when the exam cannot be launched.
+            var opened = Boolean(launchTarget);
             if (!self.isOpen || actionVersion !== self._actionVersion) {
                 return false;
             }

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -918,6 +918,1070 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 })(typeof window !== 'undefined' ? window : this);
 
 
+/* ===== js/components/questionBankQuickPicker.js ===== */
+/**
+ * Top-bar question-bank quick picker.
+ *
+ * The picker deliberately searches a snapshot returned by
+ * resolveActiveLibraryIndex(). It does not read the browse view's current
+ * category/type state, so a search remains global even while Browse is
+ * filtered. Navigation still goes through the existing lazy Browse group and
+ * app methods, keeping a single source of truth for opening exams and filters.
+ */
+(function registerQuestionBankQuickPicker(global) {
+    'use strict';
+
+    var SELECTORS = {
+        trigger: '#question-bank-quick-trigger',
+        panel: '#question-bank-quick-picker',
+        dialog: '.question-bank-quick-picker__dialog',
+        title: '#question-bank-quick-title',
+        close: '#question-bank-quick-close',
+        search: '#question-bank-quick-search',
+        status: '#question-bank-quick-status',
+        scopes: '#question-bank-quick-scopes',
+        results: '#question-bank-quick-results'
+    };
+    var ACTION_ATTRIBUTE = 'data-question-bank-action';
+    var DEFAULT_RESULT_LIMIT = 20;
+    var TYPE_LABELS = {
+        reading: '阅读',
+        listening: '听力'
+    };
+
+    function normalizeSearchText(value) {
+        var normalized = value === null || value === undefined ? '' : String(value);
+        if (typeof normalized.normalize === 'function') {
+            try {
+                normalized = normalized.normalize('NFKC');
+            } catch (_) { }
+        }
+        return normalized.toLocaleLowerCase().replace(/\s+/g, ' ').trim();
+    }
+
+    function normalizeScopeValue(value, fallback) {
+        var normalized = value === null || value === undefined ? '' : String(value).trim();
+        return normalized || fallback;
+    }
+
+    function getTypeLabel(type) {
+        var normalized = normalizeScopeValue(type, 'other');
+        return TYPE_LABELS[normalized.toLocaleLowerCase()] || normalized;
+    }
+
+    function flattenSearchValue(value) {
+        if (Array.isArray(value)) {
+            return value.join(' ');
+        }
+        if (value && typeof value === 'object') {
+            return Object.keys(value).map(function mapSearchValue(key) {
+                return value[key];
+            }).join(' ');
+        }
+        return value;
+    }
+
+    function createExamSearchText(exam) {
+        if (!exam || typeof exam !== 'object') {
+            return '';
+        }
+        var fields = [
+            exam.id,
+            exam.examId,
+            exam.dataKey,
+            exam.title,
+            exam.category,
+            exam.type,
+            getTypeLabel(exam.type),
+            exam.frequency,
+            exam.path,
+            exam.filename,
+            exam.pdfFilename,
+            exam.sourceKind,
+            flattenSearchValue(exam.keywords),
+            flattenSearchValue(exam.tags),
+            exam.searchText
+        ];
+        return normalizeSearchText(fields.filter(function filterSearchField(value) {
+            return value !== null && value !== undefined && String(value).trim() !== '';
+        }).join(' '));
+    }
+
+    /**
+     * Filter an explicitly supplied active-library snapshot. No global browse
+     * state is consulted here; this is the invariant that makes search global.
+     */
+    function filterExams(exams, query) {
+        var source = Array.isArray(exams) ? exams : [];
+        var tokens = normalizeSearchText(query).split(' ').filter(Boolean);
+        var validExams = source.filter(function filterExam(exam) {
+            return !!exam && typeof exam === 'object';
+        });
+        if (tokens.length === 0) {
+            return validExams.slice();
+        }
+        return validExams.filter(function matchExam(exam) {
+            var haystack = createExamSearchText(exam);
+            return tokens.every(function matchToken(token) {
+                return haystack.indexOf(token) !== -1;
+            });
+        });
+    }
+
+    function compareNatural(left, right) {
+        return String(left).localeCompare(String(right), undefined, {
+            numeric: true,
+            sensitivity: 'base'
+        });
+    }
+
+    function compareTypes(left, right) {
+        var priority = { reading: 0, listening: 1 };
+        var leftKey = String(left).toLocaleLowerCase();
+        var rightKey = String(right).toLocaleLowerCase();
+        var leftPriority = Object.prototype.hasOwnProperty.call(priority, leftKey)
+            ? priority[leftKey]
+            : 2;
+        var rightPriority = Object.prototype.hasOwnProperty.call(priority, rightKey)
+            ? priority[rightKey]
+            : 2;
+        return leftPriority - rightPriority || compareNatural(left, right);
+    }
+
+    /**
+     * Derive every Browse-supported type and type/category pair from the
+     * active index. The pair key includes type so identically named categories
+     * in two sections never collapse into one target. Exams with other types
+     * remain available to global search without exposing a scope that Browse
+     * cannot represent.
+     */
+    function deriveScopes(exams) {
+        var typeCounts = Object.create(null);
+        var categoryCounts = Object.create(null);
+        var categoryValues = Object.create(null);
+
+        (Array.isArray(exams) ? exams : []).forEach(function countScope(exam) {
+            if (!exam || typeof exam !== 'object') {
+                return;
+            }
+            var type = normalizeScopeValue(exam.type, '').toLocaleLowerCase();
+            if (type !== 'reading' && type !== 'listening') {
+                return;
+            }
+            var category = normalizeScopeValue(exam.category, '');
+            typeCounts[type] = (typeCounts[type] || 0) + 1;
+            if (!category) {
+                return;
+            }
+            var key = type + '\u0000' + category;
+            categoryCounts[key] = (categoryCounts[key] || 0) + 1;
+            categoryValues[key] = { type: type, category: category };
+        });
+
+        var types = Object.keys(typeCounts).sort(compareTypes).map(function mapType(type) {
+            return {
+                key: type,
+                type: type,
+                label: getTypeLabel(type),
+                count: typeCounts[type]
+            };
+        });
+        var categories = Object.keys(categoryCounts).map(function mapCategory(key) {
+            var values = categoryValues[key];
+            return {
+                key: values.type + '::' + values.category,
+                type: values.type,
+                category: values.category,
+                label: values.category,
+                count: categoryCounts[key]
+            };
+        }).sort(function sortCategory(left, right) {
+            return compareTypes(left.type, right.type)
+                || compareNatural(left.category, right.category);
+        });
+
+        return { types: types, categories: categories };
+    }
+
+    function finiteNumber(value, fallback) {
+        return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+    }
+
+    /**
+     * Calculate a fixed-position popover location. The result is viewport
+     * clamped and flips above the trigger when that side has materially more
+     * room.
+     */
+    function computePanelPosition(triggerRect, panelRect, viewport, options) {
+        var opts = options || {};
+        var margin = Math.max(0, finiteNumber(opts.margin, 12));
+        var gap = Math.max(0, finiteNumber(opts.gap, 8));
+        var viewportWidth = Math.max(0, finiteNumber(viewport && viewport.width, 0));
+        var viewportHeight = Math.max(0, finiteNumber(viewport && viewport.height, 0));
+        var trigger = triggerRect || {};
+        var triggerLeft = finiteNumber(trigger.left, margin);
+        var triggerRight = finiteNumber(trigger.right, triggerLeft);
+        var triggerTop = finiteNumber(trigger.top, margin);
+        var triggerBottom = finiteNumber(trigger.bottom, triggerTop);
+        var maxWidth = Math.max(0, viewportWidth - margin * 2);
+        var panelWidth = Math.min(
+            Math.max(0, finiteNumber(panelRect && panelRect.width, Math.min(520, maxWidth))),
+            maxWidth
+        );
+        var panelHeight = Math.max(0, finiteNumber(panelRect && panelRect.height, 420));
+        var belowSpace = Math.max(0, viewportHeight - triggerBottom - gap - margin);
+        var aboveSpace = Math.max(0, triggerTop - gap - margin);
+        var placement = belowSpace >= Math.min(panelHeight, 240) || belowSpace >= aboveSpace
+            ? 'bottom'
+            : 'top';
+        var availableHeight = placement === 'bottom' ? belowSpace : aboveSpace;
+        var maxHeight = Math.max(0, availableHeight);
+        var visibleHeight = Math.min(panelHeight, maxHeight);
+        var top = placement === 'bottom'
+            ? triggerBottom + gap
+            : triggerTop - gap - visibleHeight;
+        var preferredLeft = triggerRight - panelWidth;
+        var greatestLeft = Math.max(margin, viewportWidth - margin - panelWidth);
+        var left = Math.min(Math.max(preferredLeft, margin), greatestLeft);
+
+        return {
+            left: Math.round(left),
+            top: Math.round(Math.max(margin, top)),
+            maxWidth: Math.round(maxWidth),
+            maxHeight: Math.round(maxHeight),
+            placement: placement
+        };
+    }
+
+    function computeAnchorTop(triggerRect, viewport, options) {
+        var opts = options || {};
+        var gap = Math.max(0, finiteNumber(opts.gap, 10));
+        var margin = Math.max(0, finiteNumber(opts.margin, 12));
+        var minimumDialogSpace = Math.max(0, finiteNumber(opts.minimumDialogSpace, 240));
+        var triggerBottom = finiteNumber(triggerRect && triggerRect.bottom, margin);
+        var viewportHeight = Math.max(0, finiteNumber(viewport && viewport.height, 0));
+        var greatestTop = Math.max(margin, viewportHeight - minimumDialogSpace - margin);
+        return Math.round(Math.min(Math.max(triggerBottom + gap, margin), greatestTop));
+    }
+
+    function clearElement(element) {
+        if (!element) {
+            return;
+        }
+        if (typeof element.replaceChildren === 'function') {
+            element.replaceChildren();
+            return;
+        }
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function setAttribute(element, name, value) {
+        if (element && typeof element.setAttribute === 'function') {
+            element.setAttribute(name, String(value));
+        }
+    }
+
+    function setState(element, state) {
+        if (!element) {
+            return;
+        }
+        if (element.dataset) {
+            element.dataset.state = state;
+        } else {
+            setAttribute(element, 'data-state', state);
+        }
+    }
+
+    function createTextElement(documentRef, tagName, className, text) {
+        var element = documentRef.createElement(tagName);
+        element.className = className || '';
+        element.textContent = text;
+        return element;
+    }
+
+    function findActionTarget(start, container) {
+        var current = start;
+        while (current) {
+            if (typeof current.getAttribute === 'function' && current.getAttribute(ACTION_ATTRIBUTE)) {
+                return !container || current === container || (typeof container.contains === 'function' && container.contains(current))
+                    ? current
+                    : null;
+            }
+            if (current === container) {
+                break;
+            }
+            current = current.parentNode;
+        }
+        return null;
+    }
+
+    function QuestionBankQuickPicker(options) {
+        var opts = options || {};
+        this.global = opts.global || global;
+        this.document = opts.document || this.global.document || null;
+        this.selectors = Object.assign({}, SELECTORS, opts.selectors || {});
+        this.resultLimit = Math.max(1, Number(opts.resultLimit) || DEFAULT_RESULT_LIMIT);
+        this.elements = {};
+        this.index = [];
+        this.scopes = { types: [], categories: [] };
+        this.matches = [];
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.isOpen = false;
+        this._mounted = false;
+        this._loadVersion = 0;
+        this._actionVersion = 0;
+        this._positionFrame = null;
+        this._restoreFocus = null;
+        this._actionPending = false;
+
+        this._onTriggerClick = this._handleTriggerClick.bind(this);
+        this._onCloseClick = this._handleCloseClick.bind(this);
+        this._onSearchInput = this._handleSearchInput.bind(this);
+        this._onSearchKeydown = this._handleSearchKeydown.bind(this);
+        this._onScopesClick = this._handleScopesClick.bind(this);
+        this._onResultsClick = this._handleResultsClick.bind(this);
+        this._onResultsKeydown = this._handleResultsKeydown.bind(this);
+        this._onDocumentPointerDown = this._handleDocumentPointerDown.bind(this);
+        this._onDocumentKeydown = this._handleDocumentKeydown.bind(this);
+        this._onViewportChange = this._handleViewportChange.bind(this);
+    }
+
+    QuestionBankQuickPicker.prototype._query = function query(selector) {
+        return this.document && typeof this.document.querySelector === 'function'
+            ? this.document.querySelector(selector)
+            : null;
+    };
+
+    QuestionBankQuickPicker.prototype.mount = function mount() {
+        if (this._mounted) {
+            return true;
+        }
+        if (!this.document) {
+            return false;
+        }
+        this.elements = {
+            trigger: this._query(this.selectors.trigger),
+            panel: this._query(this.selectors.panel),
+            dialog: this._query(this.selectors.dialog),
+            title: this._query(this.selectors.title),
+            close: this._query(this.selectors.close),
+            search: this._query(this.selectors.search),
+            status: this._query(this.selectors.status),
+            scopes: this._query(this.selectors.scopes),
+            results: this._query(this.selectors.results)
+        };
+        var required = ['trigger', 'panel', 'dialog', 'close', 'search', 'status', 'scopes', 'results'];
+        if (required.some(function missingElement(name) { return !this.elements[name]; }, this)) {
+            return false;
+        }
+
+        this.elements.trigger.addEventListener('click', this._onTriggerClick);
+        this.elements.close.addEventListener('click', this._onCloseClick);
+        this.elements.search.addEventListener('input', this._onSearchInput);
+        this.elements.search.addEventListener('keydown', this._onSearchKeydown);
+        this.elements.scopes.addEventListener('click', this._onScopesClick);
+        this.elements.results.addEventListener('click', this._onResultsClick);
+        this.elements.results.addEventListener('keydown', this._onResultsKeydown);
+        this.document.addEventListener('pointerdown', this._onDocumentPointerDown);
+        this.document.addEventListener('keydown', this._onDocumentKeydown);
+        if (typeof this.global.addEventListener === 'function') {
+            this.global.addEventListener('resize', this._onViewportChange);
+            this.global.addEventListener('scroll', this._onViewportChange, true);
+        }
+
+        setAttribute(this.elements.trigger, 'aria-expanded', 'false');
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        this.elements.panel.hidden = true;
+        this._mounted = true;
+        return true;
+    };
+
+    QuestionBankQuickPicker.prototype.destroy = function destroy() {
+        if (!this._mounted) {
+            return;
+        }
+        this.close({ restoreFocus: false });
+        this.elements.trigger.removeEventListener('click', this._onTriggerClick);
+        this.elements.close.removeEventListener('click', this._onCloseClick);
+        this.elements.search.removeEventListener('input', this._onSearchInput);
+        this.elements.search.removeEventListener('keydown', this._onSearchKeydown);
+        this.elements.scopes.removeEventListener('click', this._onScopesClick);
+        this.elements.results.removeEventListener('click', this._onResultsClick);
+        this.elements.results.removeEventListener('keydown', this._onResultsKeydown);
+        this.document.removeEventListener('pointerdown', this._onDocumentPointerDown);
+        this.document.removeEventListener('keydown', this._onDocumentKeydown);
+        if (typeof this.global.removeEventListener === 'function') {
+            this.global.removeEventListener('resize', this._onViewportChange);
+            this.global.removeEventListener('scroll', this._onViewportChange, true);
+        }
+        this._mounted = false;
+    };
+
+    QuestionBankQuickPicker.prototype._handleTriggerClick = function handleTriggerClick(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.toggle();
+    };
+
+    QuestionBankQuickPicker.prototype._handleCloseClick = function handleCloseClick(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.close();
+    };
+
+    QuestionBankQuickPicker.prototype._handleSearchInput = function handleSearchInput() {
+        this.renderResults(this.elements.search.value);
+    };
+
+    QuestionBankQuickPicker.prototype._handleSearchKeydown = function handleSearchKeydown(event) {
+        if (event && (event.isComposing || event.keyCode === 229)) {
+            return;
+        }
+        if (!event || this.elements.results.hidden) {
+            return;
+        }
+        var nextIndex = this.activeResultIndex;
+        if (event.key === 'ArrowDown') {
+            nextIndex = nextIndex < 0 ? 0 : nextIndex + 1;
+        } else if (event.key === 'ArrowUp') {
+            nextIndex = nextIndex < 0 ? this.resultElements.length - 1 : nextIndex - 1;
+        } else if (event.key === 'Enter' && this.activeResultIndex >= 0) {
+            event.preventDefault();
+            this.openExam(this.resultElements[this.activeResultIndex].getAttribute('data-exam-id'));
+            return;
+        } else {
+            return;
+        }
+        event.preventDefault();
+        this._setActiveResult(nextIndex, false);
+    };
+
+    QuestionBankQuickPicker.prototype._handleScopesClick = function handleScopesClick(event) {
+        var target = findActionTarget(event && event.target, this.elements.scopes);
+        if (!target || target.getAttribute(ACTION_ATTRIBUTE) !== 'browse-scope') {
+            return;
+        }
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.browseScope(target.getAttribute('data-type'), target.getAttribute('data-category'));
+    };
+
+    QuestionBankQuickPicker.prototype._handleResultsClick = function handleResultsClick(event) {
+        var target = findActionTarget(event && event.target, this.elements.results);
+        if (!target || target.getAttribute(ACTION_ATTRIBUTE) !== 'open-exam') {
+            return;
+        }
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.openExam(target.getAttribute('data-exam-id'));
+    };
+
+    QuestionBankQuickPicker.prototype._handleResultsKeydown = function handleResultsKeydown(event) {
+        if (!event || this.resultElements.length === 0) {
+            return;
+        }
+        var currentIndex = this.resultElements.indexOf(event.target);
+        if (currentIndex < 0) {
+            return;
+        }
+        var nextIndex = currentIndex;
+        if (event.key === 'ArrowDown') {
+            nextIndex = currentIndex + 1;
+        } else if (event.key === 'ArrowUp') {
+            nextIndex = currentIndex - 1;
+        } else if (event.key === 'Home') {
+            nextIndex = 0;
+        } else if (event.key === 'End') {
+            nextIndex = this.resultElements.length - 1;
+        } else if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.openExam(event.target.getAttribute('data-exam-id'));
+            return;
+        } else {
+            return;
+        }
+        event.preventDefault();
+        this._setActiveResult(nextIndex, true);
+    };
+
+    QuestionBankQuickPicker.prototype._setActiveResult = function setActiveResult(index, moveFocus) {
+        if (this.resultElements.length === 0) {
+            this.activeResultIndex = -1;
+            if (typeof this.elements.search.removeAttribute === 'function') {
+                this.elements.search.removeAttribute('aria-activedescendant');
+            }
+            return;
+        }
+        var length = this.resultElements.length;
+        var safeIndex = ((index % length) + length) % length;
+        this.activeResultIndex = safeIndex;
+        this.resultElements.forEach(function updateSelected(element, elementIndex) {
+            setAttribute(element, 'aria-selected', elementIndex === safeIndex ? 'true' : 'false');
+        });
+        var active = this.resultElements[safeIndex];
+        setAttribute(this.elements.search, 'aria-activedescendant', active.id);
+        if (typeof active.scrollIntoView === 'function') {
+            try {
+                active.scrollIntoView({ block: 'nearest' });
+            } catch (_) { }
+        }
+        if (moveFocus && typeof active.focus === 'function') {
+            active.focus();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleDocumentPointerDown = function handleDocumentPointerDown(event) {
+        if (!this.isOpen) {
+            return;
+        }
+        var target = event && event.target;
+        var insideDialog = target && typeof this.elements.dialog.contains === 'function'
+            ? this.elements.dialog.contains(target)
+            : target === this.elements.dialog;
+        var insideTrigger = target && typeof this.elements.trigger.contains === 'function'
+            ? this.elements.trigger.contains(target)
+            : target === this.elements.trigger;
+        if (!insideDialog && !insideTrigger) {
+            this.close();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleDocumentKeydown = function handleDocumentKeydown(event) {
+        if (!this.isOpen || !event) {
+            return;
+        }
+        if (event.isComposing || event.keyCode === 229) {
+            return;
+        }
+        if (event.key === 'Escape') {
+            if (typeof event.preventDefault === 'function') {
+                event.preventDefault();
+            }
+            this.close();
+            return;
+        }
+        if (event.key === 'Tab') {
+            this._trapFocus(event);
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._trapFocus = function trapFocus(event) {
+        if (!this.elements.dialog || typeof this.elements.dialog.querySelectorAll !== 'function') {
+            return;
+        }
+        var candidates = Array.prototype.slice.call(this.elements.dialog.querySelectorAll(
+            'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+        ) || []).filter(function visibleCandidate(element) {
+            return !element.hidden;
+        });
+        if (candidates.length === 0) {
+            return;
+        }
+        var first = candidates[0];
+        var last = candidates[candidates.length - 1];
+        var active = this.document.activeElement;
+        if (event.shiftKey && (active === first || !this.elements.dialog.contains(active))) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && (active === last || !this.elements.dialog.contains(active))) {
+            event.preventDefault();
+            first.focus();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleViewportChange = function handleViewportChange() {
+        if (!this.isOpen || this._positionFrame !== null) {
+            return;
+        }
+        var self = this;
+        var schedule = typeof this.global.requestAnimationFrame === 'function'
+            ? this.global.requestAnimationFrame.bind(this.global)
+            : function fallbackFrame(callback) { return setTimeout(callback, 0); };
+        this._positionFrame = schedule(function repositionPicker() {
+            self._positionFrame = null;
+            if (self.isOpen) {
+                self.position();
+            }
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.toggle = function toggle() {
+        if (this.isOpen) {
+            this.close();
+            return Promise.resolve(false);
+        }
+        return this.open();
+    };
+
+    QuestionBankQuickPicker.prototype.open = function open() {
+        if (!this.mount()) {
+            return Promise.resolve(false);
+        }
+        this._restoreFocus = this.document.activeElement || this.elements.trigger;
+        this.isOpen = true;
+        this.elements.panel.hidden = false;
+        setAttribute(this.elements.trigger, 'aria-expanded', 'true');
+        this.position();
+        this._renderLoading();
+        if (typeof this.elements.search.focus === 'function') {
+            this.elements.search.focus();
+        }
+        return this.refresh().then(function opened() {
+            return true;
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.close = function close(options) {
+        if (!this._mounted) {
+            return;
+        }
+        var opts = options || {};
+        this.isOpen = false;
+        this._loadVersion += 1;
+        this._actionVersion += 1;
+        this._actionPending = false;
+        this.elements.panel.hidden = true;
+        setAttribute(this.elements.trigger, 'aria-expanded', 'false');
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+        if (opts.restoreFocus !== false) {
+            var focusTarget = this._restoreFocus && typeof this._restoreFocus.focus === 'function'
+                ? this._restoreFocus
+                : this.elements.trigger;
+            if (focusTarget && typeof focusTarget.focus === 'function') {
+                focusTarget.focus();
+            }
+        }
+        this._restoreFocus = null;
+    };
+
+    QuestionBankQuickPicker.prototype.position = function position() {
+        if (!this.isOpen || !this.elements.trigger || !this.elements.panel) {
+            return null;
+        }
+        var triggerRect = typeof this.elements.trigger.getBoundingClientRect === 'function'
+            ? this.elements.trigger.getBoundingClientRect()
+            : {};
+        var viewport = {
+            width: finiteNumber(this.global.innerWidth, this.document.documentElement && this.document.documentElement.clientWidth || 0),
+            height: finiteNumber(this.global.innerHeight, this.document.documentElement && this.document.documentElement.clientHeight || 0)
+        };
+        var anchorTop = computeAnchorTop(triggerRect, viewport);
+        var style = this.elements.panel.style || {};
+        if (viewport.width <= 768) {
+            if (typeof style.removeProperty === 'function') {
+                style.removeProperty('--question-bank-quick-anchor-top');
+            } else {
+                style['--question-bank-quick-anchor-top'] = '';
+            }
+            return { anchorTop: null };
+        }
+        if (typeof style.setProperty === 'function') {
+            style.setProperty('--question-bank-quick-anchor-top', anchorTop + 'px');
+        } else {
+            style['--question-bank-quick-anchor-top'] = anchorTop + 'px';
+        }
+        return { anchorTop: anchorTop };
+    };
+
+    QuestionBankQuickPicker.prototype.refresh = function refresh() {
+        var resolver = this.global.resolveActiveLibraryIndex;
+        var version = ++this._loadVersion;
+        var self = this;
+        this._renderLoading();
+        if (typeof resolver !== 'function') {
+            this._renderError(new Error('resolveActiveLibraryIndex is unavailable'));
+            return Promise.resolve([]);
+        }
+        return Promise.resolve().then(function resolveIndex() {
+            return resolver.call(self.global);
+        }).then(function indexResolved(index) {
+            if (!self.isOpen || version !== self._loadVersion) {
+                return [];
+            }
+            self.index = Array.isArray(index) ? index.slice() : [];
+            self.scopes = deriveScopes(self.index);
+            self.renderScopes();
+            self.renderResults(self.elements.search.value);
+            self.position();
+            return self.index;
+        }).catch(function indexFailed(error) {
+            if (self.isOpen && version === self._loadVersion) {
+                self._renderError(error);
+            }
+            return [];
+        });
+    };
+
+    QuestionBankQuickPicker.prototype._setStatus = function setStatusText(text, state) {
+        this.elements.status.textContent = text;
+        setState(this.elements.status, state || 'ready');
+    };
+
+    QuestionBankQuickPicker.prototype._renderLoading = function renderLoading() {
+        // A reopened picker may be resolving a different active library. Drop
+        // the previous snapshot immediately so input events during that wait
+        // cannot reveal or launch stale results.
+        this.index = [];
+        this.scopes = { types: [], categories: [] };
+        this.matches = [];
+        this._setStatus('正在读取当前活动题库…', 'loading');
+        setAttribute(this.elements.scopes, 'aria-busy', 'true');
+        clearElement(this.elements.scopes);
+        this.elements.scopes.appendChild(createTextElement(
+            this.document,
+            'p',
+            'question-bank-quick-picker__placeholder',
+            '正在读取题目分类…'
+        ));
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.elements.results.hidden = true;
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._renderError = function renderError(error) {
+        this.index = [];
+        this.matches = [];
+        this._setStatus('无法读取当前活动题库，请稍后重试。', 'error');
+        setAttribute(this.elements.scopes, 'aria-busy', 'false');
+        clearElement(this.elements.scopes);
+        this.elements.scopes.appendChild(createTextElement(
+            this.document,
+            'p',
+            'question-bank-quick-picker__placeholder question-bank-quick-picker__placeholder--error',
+            '题库分类加载失败。'
+        ));
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.elements.results.hidden = true;
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (this.global.console && typeof this.global.console.warn === 'function') {
+            this.global.console.warn('[QuestionBankQuickPicker] Failed to load active index:', error);
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._createScopeButton = function createScopeButton(type, category, label, count) {
+        var button = this.document.createElement('button');
+        button.type = 'button';
+        button.className = 'question-bank-quick-picker__scope question-bank-quick-scope';
+        setAttribute(button, ACTION_ATTRIBUTE, 'browse-scope');
+        setAttribute(button, 'data-type', type);
+        setAttribute(button, 'data-category', category);
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__scope-label',
+            label
+        ));
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__scope-count',
+            String(count)
+        ));
+        return button;
+    };
+
+    QuestionBankQuickPicker.prototype.renderScopes = function renderScopes() {
+        clearElement(this.elements.scopes);
+        setAttribute(this.elements.scopes, 'aria-busy', 'false');
+        if (this.index.length === 0) {
+            this.elements.scopes.appendChild(createTextElement(
+                this.document,
+                'p',
+                'question-bank-quick-picker__placeholder',
+                '当前活动题库没有可用题目。'
+            ));
+            this._setStatus('当前活动题库没有可用题目。', 'empty');
+            return;
+        }
+
+        this.elements.scopes.appendChild(this._createScopeButton(
+            'all',
+            'all',
+            '全部题目',
+            this.index.length
+        ));
+        var self = this;
+        this.scopes.types.forEach(function renderType(typeScope) {
+            self.elements.scopes.appendChild(self._createScopeButton(
+                typeScope.type,
+                'all',
+                '全部' + typeScope.label,
+                typeScope.count
+            ));
+            self.scopes.categories.filter(function inType(categoryScope) {
+                return categoryScope.type === typeScope.type;
+            }).forEach(function renderCategory(categoryScope) {
+                self.elements.scopes.appendChild(self._createScopeButton(
+                    categoryScope.type,
+                    categoryScope.category,
+                    typeScope.label + ' · ' + categoryScope.label,
+                    categoryScope.count
+                ));
+            });
+        });
+    };
+
+    QuestionBankQuickPicker.prototype._createResultButton = function createResultButton(exam, index) {
+        var examId = normalizeScopeValue(exam.id || exam.examId, '');
+        var button = this.document.createElement('button');
+        button.type = 'button';
+        button.className = 'question-bank-quick-picker__result question-bank-quick-result';
+        setAttribute(button, ACTION_ATTRIBUTE, 'open-exam');
+        setAttribute(button, 'data-exam-id', examId);
+        setAttribute(button, 'role', 'option');
+        setAttribute(button, 'aria-selected', 'false');
+        button.id = 'question-bank-quick-result-' + String(index) + '-' + examId.replace(/[^A-Za-z0-9_-]+/g, '-');
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__result-title question-bank-quick-result__title',
+            normalizeScopeValue(exam.title, examId || '未命名题目')
+        ));
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__result-meta question-bank-quick-result__meta',
+            getTypeLabel(exam.type) + ' · ' + normalizeScopeValue(exam.category, '未分类')
+        ));
+        return button;
+    };
+
+    QuestionBankQuickPicker.prototype.renderResults = function renderResults(query) {
+        var normalizedQuery = normalizeSearchText(query);
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+        if (this.index.length === 0) {
+            this.matches = [];
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            return [];
+        }
+        if (!normalizedQuery) {
+            this.matches = [];
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            this._setStatus(
+                '已加载 ' + this.index.length + ' 道题；选择分类，或输入关键词全局搜索。',
+                'ready'
+            );
+            return [];
+        }
+
+        this.matches = filterExams(this.index, normalizedQuery);
+        if (this.matches.length === 0) {
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            this._setStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
+            return [];
+        }
+
+        this.elements.results.hidden = false;
+        setAttribute(this.elements.search, 'aria-expanded', 'true');
+
+        var self = this;
+        this.matches.slice(0, this.resultLimit).forEach(function renderResult(exam, index) {
+            if (exam.id || exam.examId) {
+                var result = self._createResultButton(exam, index);
+                self.resultElements.push(result);
+                self.elements.results.appendChild(result);
+            }
+        });
+        var suffix = this.matches.length > this.resultLimit
+            ? '，显示前 ' + this.resultLimit + ' 道'
+            : '';
+        this._setStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
+        return this.matches.slice();
+    };
+
+    QuestionBankQuickPicker.prototype._ensureBrowseGroup = function ensureBrowseGroupReady() {
+        var owner = this.global;
+        var loader = this.global.ensureBrowseGroup;
+        if (typeof loader !== 'function' && this.global.AppEntry) {
+            owner = this.global.AppEntry;
+            loader = owner.ensureBrowseGroup;
+        }
+        if (typeof loader !== 'function') {
+            return Promise.reject(new Error('ensureBrowseGroup is unavailable'));
+        }
+        return Promise.resolve(loader.call(owner));
+    };
+
+    QuestionBankQuickPicker.prototype._clearBrowseSearchState = function clearBrowseSearchState() {
+        var manager = this.global.browseStateManager;
+        if (manager && typeof manager.clearSearchState === 'function') {
+            try {
+                manager.clearSearchState();
+            } catch (_) { }
+        }
+        var searchInput = this.document && typeof this.document.getElementById === 'function'
+            ? this.document.getElementById('exam-search-input')
+            : null;
+        if (!searchInput && this.document && typeof this.document.querySelector === 'function') {
+            searchInput = this.document.querySelector('.search-input');
+        }
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        var clearButton = this.document && typeof this.document.getElementById === 'function'
+            ? this.document.getElementById('search-clear-btn')
+            : null;
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    };
+
+    QuestionBankQuickPicker.prototype.browseScope = function browseScope(type, category) {
+        if (this._actionPending) {
+            return Promise.resolve(false);
+        }
+        var safeType = normalizeScopeValue(type, 'all');
+        var safeCategory = normalizeScopeValue(category, 'all');
+        var self = this;
+        var actionVersion = ++this._actionVersion;
+        this._actionPending = true;
+        this._setStatus('正在打开题目分类…', 'loading');
+        return this._ensureBrowseGroup().then(function browseReady() {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (!self.global.app || typeof self.global.app.browseCategory !== 'function') {
+                throw new Error('app.browseCategory is unavailable');
+            }
+            self._clearBrowseSearchState();
+            return Promise.resolve(self.global.app.browseCategory(safeCategory, safeType)).then(function categoryDispatched() {
+                return true;
+            });
+        }).then(function categoryOpened(opened) {
+            if (opened !== true || !self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            self.close();
+            return true;
+        }).catch(function categoryFailed(error) {
+            if (self.isOpen && actionVersion === self._actionVersion) {
+                self._setStatus('无法打开该题目分类，请稍后重试。', 'error');
+                if (self.global.console && typeof self.global.console.warn === 'function') {
+                    self.global.console.warn('[QuestionBankQuickPicker] Failed to browse category:', error);
+                }
+            }
+            return false;
+        }).then(function clearPending(result) {
+            if (actionVersion === self._actionVersion) {
+                self._actionPending = false;
+            }
+            return result;
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.openExam = function openExam(examId) {
+        var safeExamId = normalizeScopeValue(examId, '');
+        if (!safeExamId || this._actionPending) {
+            return Promise.resolve(false);
+        }
+        var self = this;
+        var actionVersion = ++this._actionVersion;
+        this._actionPending = true;
+        this._setStatus('正在打开题目…', 'loading');
+        return this._ensureBrowseGroup().then(function browseReady() {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (!self.global.app || typeof self.global.app.openExam !== 'function') {
+                throw new Error('app.openExam is unavailable');
+            }
+            return Promise.resolve(self.global.app.openExam(safeExamId)).then(function examDispatched(launchTarget) {
+                // ExamSystemApp.openExam resolves to the opened Window (or a
+                // launch-context object when requested) on success, and to
+                // undefined/null when the exam cannot be launched.
+                return Boolean(launchTarget);
+            });
+        }).then(function examOpened(opened) {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (opened !== true) {
+                self._setStatus('无法打开该题目，请稍后重试。', 'error');
+                return false;
+            }
+            self.close();
+            return true;
+        }).catch(function examFailed(error) {
+            if (self.isOpen && actionVersion === self._actionVersion) {
+                self._setStatus('无法打开该题目，请稍后重试。', 'error');
+                if (self.global.console && typeof self.global.console.warn === 'function') {
+                    self.global.console.warn('[QuestionBankQuickPicker] Failed to open exam:', error);
+                }
+            }
+            return false;
+        }).then(function clearPending(result) {
+            if (actionVersion === self._actionVersion) {
+                self._actionPending = false;
+            }
+            return result;
+        });
+    };
+
+    var singleton = null;
+    var api = {
+        SELECTORS: Object.assign({}, SELECTORS),
+        normalizeSearchText: normalizeSearchText,
+        createExamSearchText: createExamSearchText,
+        filterExams: filterExams,
+        deriveScopes: deriveScopes,
+        computePanelPosition: computePanelPosition,
+        computeAnchorTop: computeAnchorTop,
+        getTypeLabel: getTypeLabel,
+        Controller: QuestionBankQuickPicker,
+        create: function create(options) {
+            return new QuestionBankQuickPicker(options);
+        },
+        init: function init(options) {
+            if (!singleton) {
+                singleton = new QuestionBankQuickPicker(options);
+            }
+            singleton.mount();
+            return singleton;
+        },
+        getInstance: function getInstance() {
+            return singleton;
+        }
+    };
+
+    global.QuestionBankQuickPicker = api;
+
+    if (global.document) {
+        if (global.document.readyState === 'loading') {
+            global.document.addEventListener('DOMContentLoaded', function initQuickPicker() {
+                api.init();
+            }, { once: true });
+        } else {
+            api.init();
+        }
+    }
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
 /* ===== js/presentation/message-center.js ===== */
 (function (global) {
     'use strict';
@@ -1731,6 +2795,21 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
     }
 
+    function ensureBrowseStateManager() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[MainEntry] 初始化浏览状态管理器失败:', error);
+            return null;
+        }
+    }
+
     function synchronizeActiveBrowseViewAfterLoad() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
@@ -1743,7 +2822,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             })
             .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter) {
+                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
                 return global.applyBrowseFilter(
@@ -1764,6 +2843,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         if (!browseGroupPromise) {
             browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
                 reapplyAppMixins();
+                // NavigationController is part of the shell, while its legacy
+                // implementation and BrowseStateManager arrive with Browse.
+                // Retry their idempotent initialization after the lazy group is
+                // present so cold quick-picker entry has the same runtime as a
+                // preloaded Browse view.
+                initializeNavigationShell();
+                ensureBrowseStateManager();
                 if (typeof global.setupBrowsePreferenceUI === 'function') {
                     try {
                         global.setupBrowsePreferenceUI();
@@ -1800,6 +2886,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     function ensureSessionSuiteReady() {
         if (!sessionSuitePromise) {
             sessionSuitePromise = Promise.all([
+                ensureBrowseGroup(),
                 ensurePracticeSuiteGroup(),
                 ensureLazyGroup(SESSION_GROUP)
             ]).then(function afterSuiteLoaded() {
@@ -1841,12 +2928,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     function initializeNavigationShell() {
+        var controller = null;
         try {
             if (global.NavigationController && typeof global.NavigationController.ensure === 'function') {
-                global.NavigationController.ensure({
+                controller = global.NavigationController.ensure({
                     containerSelector: '.main-nav',
                     activeClass: 'active',
-                    initialView: 'overview',
+                    initialView: getActiveViewName() || 'overview',
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
@@ -1867,6 +2955,19 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         } catch (error) {
             console.warn('[MainEntry] 初始化导航失败:', error);
         }
+        if (controller && typeof document !== 'undefined') {
+            var navRoot = document.querySelector('.main-nav');
+            var fallbackHandler = navRoot && navRoot._legacyNavHandler;
+            if (typeof fallbackHandler === 'function' && typeof navRoot.removeEventListener === 'function') {
+                navRoot.removeEventListener('click', fallbackHandler);
+                try {
+                    delete navRoot._legacyNavHandler;
+                } catch (_) {
+                    navRoot._legacyNavHandler = null;
+                }
+            }
+        }
+        return controller;
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {
@@ -3308,6 +4409,7 @@ function ensureSettings() {
     "js/services/overviewStats.js",
     "js/views/overviewView.js",
     "js/presentation/navigation-controller.js",
+    "js/components/questionBankQuickPicker.js",
     "js/presentation/message-center.js",
     "js/utils/practiceTimerPreferences.js",
     "js/components/practiceSettingsPanel.js",

--- a/js/components/BrowseStateManager.js
+++ b/js/components/BrowseStateManager.js
@@ -86,19 +86,16 @@ class BrowseStateManager {
      * 处理浏览导航
      */
     handleBrowseNavigation() {
-        console.log('[BrowseStateManager] 处理浏览导航，重置为显示所有考试');
+        console.log('[BrowseStateManager] 记录题库浏览导航');
 
-        if (typeof window.clearPendingBrowseAutoScroll === 'function') {
-            try { window.clearPendingBrowseAutoScroll(); } catch (_) {}
-        }
-
-        // 重置到全部考试视图
-        this.resetToAllExams();
+        // 导航控制器单独区分“进入 Browse”和“重复点击 Browse”。
+        // 普通进入时应保留待处理的分类与持久化偏好；只有重复
+        // 导航才由 ExamActions.resetBrowseViewToAll 执行一次原子重置。
 
         // 记录导航历史
         this.addToHistory({
             action: 'navigate_to_browse',
-            filter: 'all',
+            filter: this.currentFilter,
             timestamp: Date.now()
         });
     }
@@ -308,6 +305,11 @@ class BrowseStateManager {
         this.setState({
             currentCategory: null,
             currentFrequency: null,
+            filters: {
+                frequency: 'all',
+                status: 'all',
+                difficulty: 'all'
+            },
             searchQuery: '',
             pagination: {
                 page: 1,
@@ -357,9 +359,14 @@ class BrowseStateManager {
      * 清除搜索状态
      */
     clearSearchState() {
-        const searchInput = document.querySelector('.search-input');
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
         if (searchInput) {
             searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
         }
     }
 

--- a/js/components/questionBankQuickPicker.js
+++ b/js/components/questionBankQuickPicker.js
@@ -315,6 +315,10 @@
         this._positionFrame = null;
         this._restoreFocus = null;
         this._actionPending = false;
+        this._browseReady = false;
+        this._browseLoading = false;
+        this._browseLoadError = null;
+        this._browsePreloadPromise = null;
 
         this._onTriggerClick = this._handleTriggerClick.bind(this);
         this._onCloseClick = this._handleCloseClick.bind(this);
@@ -609,10 +613,11 @@
         setAttribute(this.elements.trigger, 'aria-expanded', 'true');
         this.position();
         this._renderLoading();
+        var browseReady = this._preloadBrowseGroup();
         if (typeof this.elements.search.focus === 'function') {
             this.elements.search.focus();
         }
-        return this.refresh().then(function opened() {
+        return Promise.all([this.refresh(), browseReady]).then(function opened() {
             return true;
         });
     };
@@ -691,6 +696,12 @@
             self.scopes = deriveScopes(self.index);
             self.renderScopes();
             self.renderResults(self.elements.search.value);
+            self._syncBrowseActionAvailability();
+            if (self._browseLoadError) {
+                self._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            } else if (self._browseLoading) {
+                self._setStatus('题库功能正在加载，搜索结果将在加载完成后可打开。', 'loading');
+            }
             self.position();
             return self.index;
         }).catch(function indexFailed(error) {
@@ -704,6 +715,18 @@
     QuestionBankQuickPicker.prototype._setStatus = function setStatusText(text, state) {
         this.elements.status.textContent = text;
         setState(this.elements.status, state || 'ready');
+    };
+
+    QuestionBankQuickPicker.prototype._setBrowseAwareStatus = function setBrowseAwareStatus(text, state) {
+        if (this._browseLoadError) {
+            this._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            return;
+        }
+        if (this._browseLoading) {
+            this._setStatus('题库功能正在加载，搜索结果将在加载完成后可打开。', 'loading');
+            return;
+        }
+        this._setStatus(text, state);
     };
 
     QuestionBankQuickPicker.prototype._renderLoading = function renderLoading() {
@@ -758,6 +781,7 @@
         var button = this.document.createElement('button');
         button.type = 'button';
         button.className = 'question-bank-quick-picker__scope question-bank-quick-scope';
+        button.disabled = !this._browseReady;
         setAttribute(button, ACTION_ATTRIBUTE, 'browse-scope');
         setAttribute(button, 'data-type', type);
         setAttribute(button, 'data-category', category);
@@ -822,6 +846,7 @@
         var button = this.document.createElement('button');
         button.type = 'button';
         button.className = 'question-bank-quick-picker__result question-bank-quick-result';
+        button.disabled = !this._browseReady;
         setAttribute(button, ACTION_ATTRIBUTE, 'open-exam');
         setAttribute(button, 'data-exam-id', examId);
         setAttribute(button, 'role', 'option');
@@ -860,7 +885,7 @@
             this.matches = [];
             this.elements.results.hidden = true;
             setAttribute(this.elements.search, 'aria-expanded', 'false');
-            this._setStatus(
+            this._setBrowseAwareStatus(
                 '已加载 ' + this.index.length + ' 道题；选择分类，或输入关键词全局搜索。',
                 'ready'
             );
@@ -871,7 +896,7 @@
         if (this.matches.length === 0) {
             this.elements.results.hidden = true;
             setAttribute(this.elements.search, 'aria-expanded', 'false');
-            this._setStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
+            this._setBrowseAwareStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
             return [];
         }
 
@@ -889,7 +914,7 @@
         var suffix = this.matches.length > this.resultLimit
             ? '，显示前 ' + this.resultLimit + ' 道'
             : '';
-        this._setStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
+        this._setBrowseAwareStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
         return this.matches.slice();
     };
 
@@ -904,6 +929,77 @@
             return Promise.reject(new Error('ensureBrowseGroup is unavailable'));
         }
         return Promise.resolve(loader.call(owner));
+    };
+
+    QuestionBankQuickPicker.prototype._syncBrowseActionAvailability = function syncBrowseActionAvailability() {
+        var disabled = !this._browseReady;
+        var containers = [this.elements.scopes, this.elements.results];
+        containers.forEach(function updateContainer(container) {
+            if (!container || typeof container.querySelectorAll !== 'function') {
+                return;
+            }
+            Array.prototype.slice.call(container.querySelectorAll('[' + ACTION_ATTRIBUTE + ']') || [])
+                .forEach(function updateAction(action) {
+                    action.disabled = disabled;
+                });
+        });
+        if (this.elements.panel) {
+            setAttribute(this.elements.panel, 'aria-busy', this._browseLoading ? 'true' : 'false');
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._preloadBrowseGroup = function preloadBrowseGroup() {
+        if (this._browseReady) {
+            this._syncBrowseActionAvailability();
+            return Promise.resolve(true);
+        }
+        if (this._browsePreloadPromise) {
+            return this._browsePreloadPromise;
+        }
+
+        var self = this;
+        var started;
+        this._browseLoading = true;
+        this._browseLoadError = null;
+        this._syncBrowseActionAvailability();
+        try {
+            // Invoke the loader immediately when the panel opens. Result and
+            // scope controls stay disabled until it settles, so their eventual
+            // click handlers never spend transient user activation on loading.
+            started = this._ensureBrowseGroup();
+        } catch (error) {
+            started = Promise.reject(error);
+        }
+
+        var preload = Promise.resolve(started).then(function browseLoaded() {
+            self._browseReady = true;
+            self._browseLoading = false;
+            self._browseLoadError = null;
+            self._syncBrowseActionAvailability();
+            if (self.isOpen && self.index.length > 0) {
+                self.renderResults(self.elements.search.value);
+            }
+            return true;
+        }).catch(function browseLoadFailed(error) {
+            self._browseReady = false;
+            self._browseLoading = false;
+            self._browseLoadError = error;
+            self._syncBrowseActionAvailability();
+            if (self.isOpen) {
+                self._setStatus('题库功能加载失败，请关闭后重试。', 'error');
+            }
+            if (self.global.console && typeof self.global.console.warn === 'function') {
+                self.global.console.warn('[QuestionBankQuickPicker] Failed to preload Browse:', error);
+            }
+            return false;
+        });
+        this._browsePreloadPromise = preload;
+        preload.then(function clearPreload() {
+            if (self._browsePreloadPromise === preload) {
+                self._browsePreloadPromise = null;
+            }
+        });
+        return preload;
     };
 
     QuestionBankQuickPicker.prototype._clearBrowseSearchState = function clearBrowseSearchState() {
@@ -931,7 +1027,10 @@
     };
 
     QuestionBankQuickPicker.prototype.browseScope = function browseScope(type, category) {
-        if (this._actionPending) {
+        if (this._actionPending || !this.isOpen || !this._browseReady) {
+            if (this.isOpen && !this._browseReady) {
+                this._setStatus('题库功能仍在加载，请稍候。', 'loading');
+            }
             return Promise.resolve(false);
         }
         var safeType = normalizeScopeValue(type, 'all');
@@ -940,18 +1039,18 @@
         var actionVersion = ++this._actionVersion;
         this._actionPending = true;
         this._setStatus('正在打开题目分类…', 'loading');
-        return this._ensureBrowseGroup().then(function browseReady() {
-            if (!self.isOpen || actionVersion !== self._actionVersion) {
-                return false;
-            }
+        var categoryAction;
+        try {
             if (!self.global.app || typeof self.global.app.browseCategory !== 'function') {
                 throw new Error('app.browseCategory is unavailable');
             }
             self._clearBrowseSearchState();
-            return Promise.resolve(self.global.app.browseCategory(safeCategory, safeType)).then(function categoryDispatched() {
-                return true;
-            });
-        }).then(function categoryOpened(opened) {
+            categoryAction = self.global.app.browseCategory(safeCategory, safeType);
+        } catch (error) {
+            categoryAction = Promise.reject(error);
+        }
+        return Promise.resolve(categoryAction).then(function categoryOpened() {
+            var opened = true;
             if (opened !== true || !self.isOpen || actionVersion !== self._actionVersion) {
                 return false;
             }
@@ -975,27 +1074,38 @@
 
     QuestionBankQuickPicker.prototype.openExam = function openExam(examId) {
         var safeExamId = normalizeScopeValue(examId, '');
-        if (!safeExamId || this._actionPending) {
+        if (!safeExamId || this._actionPending || !this.isOpen || !this._browseReady) {
+            if (this.isOpen && !this._browseReady) {
+                this._setStatus('题库功能仍在加载，请稍候。', 'loading');
+            }
             return Promise.resolve(false);
         }
         var self = this;
+        var examDefinition = this.index.find(function findExam(exam) {
+            return normalizeScopeValue(exam && (exam.id || exam.examId), '') === safeExamId;
+        });
         var actionVersion = ++this._actionVersion;
         this._actionPending = true;
         this._setStatus('正在打开题目…', 'loading');
-        return this._ensureBrowseGroup().then(function browseReady() {
-            if (!self.isOpen || actionVersion !== self._actionVersion) {
-                return false;
-            }
+        var examAction;
+        try {
             if (!self.global.app || typeof self.global.app.openExam !== 'function') {
                 throw new Error('app.openExam is unavailable');
             }
-            return Promise.resolve(self.global.app.openExam(safeExamId)).then(function examDispatched(launchTarget) {
-                // ExamSystemApp.openExam resolves to the opened Window (or a
-                // launch-context object when requested) on success, and to
-                // undefined/null when the exam cannot be launched.
-                return Boolean(launchTarget);
-            });
-        }).then(function examOpened(opened) {
+            // Calling app.openExam synchronously preserves the click's transient
+            // activation. Supplying the selected snapshot also skips its normal
+            // asynchronous index lookup before window.open.
+            examAction = self.global.app.openExam(safeExamId, examDefinition
+                ? { examDefinition: examDefinition }
+                : {});
+        } catch (error) {
+            examAction = Promise.reject(error);
+        }
+        return Promise.resolve(examAction).then(function examOpened(launchTarget) {
+            // ExamSystemApp.openExam resolves to the opened Window (or a
+            // launch-context object when requested) on success, and to
+            // undefined/null when the exam cannot be launched.
+            var opened = Boolean(launchTarget);
             if (!self.isOpen || actionVersion !== self._actionVersion) {
                 return false;
             }

--- a/js/components/questionBankQuickPicker.js
+++ b/js/components/questionBankQuickPicker.js
@@ -1,0 +1,1061 @@
+/**
+ * Top-bar question-bank quick picker.
+ *
+ * The picker deliberately searches a snapshot returned by
+ * resolveActiveLibraryIndex(). It does not read the browse view's current
+ * category/type state, so a search remains global even while Browse is
+ * filtered. Navigation still goes through the existing lazy Browse group and
+ * app methods, keeping a single source of truth for opening exams and filters.
+ */
+(function registerQuestionBankQuickPicker(global) {
+    'use strict';
+
+    var SELECTORS = {
+        trigger: '#question-bank-quick-trigger',
+        panel: '#question-bank-quick-picker',
+        dialog: '.question-bank-quick-picker__dialog',
+        title: '#question-bank-quick-title',
+        close: '#question-bank-quick-close',
+        search: '#question-bank-quick-search',
+        status: '#question-bank-quick-status',
+        scopes: '#question-bank-quick-scopes',
+        results: '#question-bank-quick-results'
+    };
+    var ACTION_ATTRIBUTE = 'data-question-bank-action';
+    var DEFAULT_RESULT_LIMIT = 20;
+    var TYPE_LABELS = {
+        reading: '阅读',
+        listening: '听力'
+    };
+
+    function normalizeSearchText(value) {
+        var normalized = value === null || value === undefined ? '' : String(value);
+        if (typeof normalized.normalize === 'function') {
+            try {
+                normalized = normalized.normalize('NFKC');
+            } catch (_) { }
+        }
+        return normalized.toLocaleLowerCase().replace(/\s+/g, ' ').trim();
+    }
+
+    function normalizeScopeValue(value, fallback) {
+        var normalized = value === null || value === undefined ? '' : String(value).trim();
+        return normalized || fallback;
+    }
+
+    function getTypeLabel(type) {
+        var normalized = normalizeScopeValue(type, 'other');
+        return TYPE_LABELS[normalized.toLocaleLowerCase()] || normalized;
+    }
+
+    function flattenSearchValue(value) {
+        if (Array.isArray(value)) {
+            return value.join(' ');
+        }
+        if (value && typeof value === 'object') {
+            return Object.keys(value).map(function mapSearchValue(key) {
+                return value[key];
+            }).join(' ');
+        }
+        return value;
+    }
+
+    function createExamSearchText(exam) {
+        if (!exam || typeof exam !== 'object') {
+            return '';
+        }
+        var fields = [
+            exam.id,
+            exam.examId,
+            exam.dataKey,
+            exam.title,
+            exam.category,
+            exam.type,
+            getTypeLabel(exam.type),
+            exam.frequency,
+            exam.path,
+            exam.filename,
+            exam.pdfFilename,
+            exam.sourceKind,
+            flattenSearchValue(exam.keywords),
+            flattenSearchValue(exam.tags),
+            exam.searchText
+        ];
+        return normalizeSearchText(fields.filter(function filterSearchField(value) {
+            return value !== null && value !== undefined && String(value).trim() !== '';
+        }).join(' '));
+    }
+
+    /**
+     * Filter an explicitly supplied active-library snapshot. No global browse
+     * state is consulted here; this is the invariant that makes search global.
+     */
+    function filterExams(exams, query) {
+        var source = Array.isArray(exams) ? exams : [];
+        var tokens = normalizeSearchText(query).split(' ').filter(Boolean);
+        var validExams = source.filter(function filterExam(exam) {
+            return !!exam && typeof exam === 'object';
+        });
+        if (tokens.length === 0) {
+            return validExams.slice();
+        }
+        return validExams.filter(function matchExam(exam) {
+            var haystack = createExamSearchText(exam);
+            return tokens.every(function matchToken(token) {
+                return haystack.indexOf(token) !== -1;
+            });
+        });
+    }
+
+    function compareNatural(left, right) {
+        return String(left).localeCompare(String(right), undefined, {
+            numeric: true,
+            sensitivity: 'base'
+        });
+    }
+
+    function compareTypes(left, right) {
+        var priority = { reading: 0, listening: 1 };
+        var leftKey = String(left).toLocaleLowerCase();
+        var rightKey = String(right).toLocaleLowerCase();
+        var leftPriority = Object.prototype.hasOwnProperty.call(priority, leftKey)
+            ? priority[leftKey]
+            : 2;
+        var rightPriority = Object.prototype.hasOwnProperty.call(priority, rightKey)
+            ? priority[rightKey]
+            : 2;
+        return leftPriority - rightPriority || compareNatural(left, right);
+    }
+
+    /**
+     * Derive every Browse-supported type and type/category pair from the
+     * active index. The pair key includes type so identically named categories
+     * in two sections never collapse into one target. Exams with other types
+     * remain available to global search without exposing a scope that Browse
+     * cannot represent.
+     */
+    function deriveScopes(exams) {
+        var typeCounts = Object.create(null);
+        var categoryCounts = Object.create(null);
+        var categoryValues = Object.create(null);
+
+        (Array.isArray(exams) ? exams : []).forEach(function countScope(exam) {
+            if (!exam || typeof exam !== 'object') {
+                return;
+            }
+            var type = normalizeScopeValue(exam.type, '').toLocaleLowerCase();
+            if (type !== 'reading' && type !== 'listening') {
+                return;
+            }
+            var category = normalizeScopeValue(exam.category, '');
+            typeCounts[type] = (typeCounts[type] || 0) + 1;
+            if (!category) {
+                return;
+            }
+            var key = type + '\u0000' + category;
+            categoryCounts[key] = (categoryCounts[key] || 0) + 1;
+            categoryValues[key] = { type: type, category: category };
+        });
+
+        var types = Object.keys(typeCounts).sort(compareTypes).map(function mapType(type) {
+            return {
+                key: type,
+                type: type,
+                label: getTypeLabel(type),
+                count: typeCounts[type]
+            };
+        });
+        var categories = Object.keys(categoryCounts).map(function mapCategory(key) {
+            var values = categoryValues[key];
+            return {
+                key: values.type + '::' + values.category,
+                type: values.type,
+                category: values.category,
+                label: values.category,
+                count: categoryCounts[key]
+            };
+        }).sort(function sortCategory(left, right) {
+            return compareTypes(left.type, right.type)
+                || compareNatural(left.category, right.category);
+        });
+
+        return { types: types, categories: categories };
+    }
+
+    function finiteNumber(value, fallback) {
+        return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+    }
+
+    /**
+     * Calculate a fixed-position popover location. The result is viewport
+     * clamped and flips above the trigger when that side has materially more
+     * room.
+     */
+    function computePanelPosition(triggerRect, panelRect, viewport, options) {
+        var opts = options || {};
+        var margin = Math.max(0, finiteNumber(opts.margin, 12));
+        var gap = Math.max(0, finiteNumber(opts.gap, 8));
+        var viewportWidth = Math.max(0, finiteNumber(viewport && viewport.width, 0));
+        var viewportHeight = Math.max(0, finiteNumber(viewport && viewport.height, 0));
+        var trigger = triggerRect || {};
+        var triggerLeft = finiteNumber(trigger.left, margin);
+        var triggerRight = finiteNumber(trigger.right, triggerLeft);
+        var triggerTop = finiteNumber(trigger.top, margin);
+        var triggerBottom = finiteNumber(trigger.bottom, triggerTop);
+        var maxWidth = Math.max(0, viewportWidth - margin * 2);
+        var panelWidth = Math.min(
+            Math.max(0, finiteNumber(panelRect && panelRect.width, Math.min(520, maxWidth))),
+            maxWidth
+        );
+        var panelHeight = Math.max(0, finiteNumber(panelRect && panelRect.height, 420));
+        var belowSpace = Math.max(0, viewportHeight - triggerBottom - gap - margin);
+        var aboveSpace = Math.max(0, triggerTop - gap - margin);
+        var placement = belowSpace >= Math.min(panelHeight, 240) || belowSpace >= aboveSpace
+            ? 'bottom'
+            : 'top';
+        var availableHeight = placement === 'bottom' ? belowSpace : aboveSpace;
+        var maxHeight = Math.max(0, availableHeight);
+        var visibleHeight = Math.min(panelHeight, maxHeight);
+        var top = placement === 'bottom'
+            ? triggerBottom + gap
+            : triggerTop - gap - visibleHeight;
+        var preferredLeft = triggerRight - panelWidth;
+        var greatestLeft = Math.max(margin, viewportWidth - margin - panelWidth);
+        var left = Math.min(Math.max(preferredLeft, margin), greatestLeft);
+
+        return {
+            left: Math.round(left),
+            top: Math.round(Math.max(margin, top)),
+            maxWidth: Math.round(maxWidth),
+            maxHeight: Math.round(maxHeight),
+            placement: placement
+        };
+    }
+
+    function computeAnchorTop(triggerRect, viewport, options) {
+        var opts = options || {};
+        var gap = Math.max(0, finiteNumber(opts.gap, 10));
+        var margin = Math.max(0, finiteNumber(opts.margin, 12));
+        var minimumDialogSpace = Math.max(0, finiteNumber(opts.minimumDialogSpace, 240));
+        var triggerBottom = finiteNumber(triggerRect && triggerRect.bottom, margin);
+        var viewportHeight = Math.max(0, finiteNumber(viewport && viewport.height, 0));
+        var greatestTop = Math.max(margin, viewportHeight - minimumDialogSpace - margin);
+        return Math.round(Math.min(Math.max(triggerBottom + gap, margin), greatestTop));
+    }
+
+    function clearElement(element) {
+        if (!element) {
+            return;
+        }
+        if (typeof element.replaceChildren === 'function') {
+            element.replaceChildren();
+            return;
+        }
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function setAttribute(element, name, value) {
+        if (element && typeof element.setAttribute === 'function') {
+            element.setAttribute(name, String(value));
+        }
+    }
+
+    function setState(element, state) {
+        if (!element) {
+            return;
+        }
+        if (element.dataset) {
+            element.dataset.state = state;
+        } else {
+            setAttribute(element, 'data-state', state);
+        }
+    }
+
+    function createTextElement(documentRef, tagName, className, text) {
+        var element = documentRef.createElement(tagName);
+        element.className = className || '';
+        element.textContent = text;
+        return element;
+    }
+
+    function findActionTarget(start, container) {
+        var current = start;
+        while (current) {
+            if (typeof current.getAttribute === 'function' && current.getAttribute(ACTION_ATTRIBUTE)) {
+                return !container || current === container || (typeof container.contains === 'function' && container.contains(current))
+                    ? current
+                    : null;
+            }
+            if (current === container) {
+                break;
+            }
+            current = current.parentNode;
+        }
+        return null;
+    }
+
+    function QuestionBankQuickPicker(options) {
+        var opts = options || {};
+        this.global = opts.global || global;
+        this.document = opts.document || this.global.document || null;
+        this.selectors = Object.assign({}, SELECTORS, opts.selectors || {});
+        this.resultLimit = Math.max(1, Number(opts.resultLimit) || DEFAULT_RESULT_LIMIT);
+        this.elements = {};
+        this.index = [];
+        this.scopes = { types: [], categories: [] };
+        this.matches = [];
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.isOpen = false;
+        this._mounted = false;
+        this._loadVersion = 0;
+        this._actionVersion = 0;
+        this._positionFrame = null;
+        this._restoreFocus = null;
+        this._actionPending = false;
+
+        this._onTriggerClick = this._handleTriggerClick.bind(this);
+        this._onCloseClick = this._handleCloseClick.bind(this);
+        this._onSearchInput = this._handleSearchInput.bind(this);
+        this._onSearchKeydown = this._handleSearchKeydown.bind(this);
+        this._onScopesClick = this._handleScopesClick.bind(this);
+        this._onResultsClick = this._handleResultsClick.bind(this);
+        this._onResultsKeydown = this._handleResultsKeydown.bind(this);
+        this._onDocumentPointerDown = this._handleDocumentPointerDown.bind(this);
+        this._onDocumentKeydown = this._handleDocumentKeydown.bind(this);
+        this._onViewportChange = this._handleViewportChange.bind(this);
+    }
+
+    QuestionBankQuickPicker.prototype._query = function query(selector) {
+        return this.document && typeof this.document.querySelector === 'function'
+            ? this.document.querySelector(selector)
+            : null;
+    };
+
+    QuestionBankQuickPicker.prototype.mount = function mount() {
+        if (this._mounted) {
+            return true;
+        }
+        if (!this.document) {
+            return false;
+        }
+        this.elements = {
+            trigger: this._query(this.selectors.trigger),
+            panel: this._query(this.selectors.panel),
+            dialog: this._query(this.selectors.dialog),
+            title: this._query(this.selectors.title),
+            close: this._query(this.selectors.close),
+            search: this._query(this.selectors.search),
+            status: this._query(this.selectors.status),
+            scopes: this._query(this.selectors.scopes),
+            results: this._query(this.selectors.results)
+        };
+        var required = ['trigger', 'panel', 'dialog', 'close', 'search', 'status', 'scopes', 'results'];
+        if (required.some(function missingElement(name) { return !this.elements[name]; }, this)) {
+            return false;
+        }
+
+        this.elements.trigger.addEventListener('click', this._onTriggerClick);
+        this.elements.close.addEventListener('click', this._onCloseClick);
+        this.elements.search.addEventListener('input', this._onSearchInput);
+        this.elements.search.addEventListener('keydown', this._onSearchKeydown);
+        this.elements.scopes.addEventListener('click', this._onScopesClick);
+        this.elements.results.addEventListener('click', this._onResultsClick);
+        this.elements.results.addEventListener('keydown', this._onResultsKeydown);
+        this.document.addEventListener('pointerdown', this._onDocumentPointerDown);
+        this.document.addEventListener('keydown', this._onDocumentKeydown);
+        if (typeof this.global.addEventListener === 'function') {
+            this.global.addEventListener('resize', this._onViewportChange);
+            this.global.addEventListener('scroll', this._onViewportChange, true);
+        }
+
+        setAttribute(this.elements.trigger, 'aria-expanded', 'false');
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        this.elements.panel.hidden = true;
+        this._mounted = true;
+        return true;
+    };
+
+    QuestionBankQuickPicker.prototype.destroy = function destroy() {
+        if (!this._mounted) {
+            return;
+        }
+        this.close({ restoreFocus: false });
+        this.elements.trigger.removeEventListener('click', this._onTriggerClick);
+        this.elements.close.removeEventListener('click', this._onCloseClick);
+        this.elements.search.removeEventListener('input', this._onSearchInput);
+        this.elements.search.removeEventListener('keydown', this._onSearchKeydown);
+        this.elements.scopes.removeEventListener('click', this._onScopesClick);
+        this.elements.results.removeEventListener('click', this._onResultsClick);
+        this.elements.results.removeEventListener('keydown', this._onResultsKeydown);
+        this.document.removeEventListener('pointerdown', this._onDocumentPointerDown);
+        this.document.removeEventListener('keydown', this._onDocumentKeydown);
+        if (typeof this.global.removeEventListener === 'function') {
+            this.global.removeEventListener('resize', this._onViewportChange);
+            this.global.removeEventListener('scroll', this._onViewportChange, true);
+        }
+        this._mounted = false;
+    };
+
+    QuestionBankQuickPicker.prototype._handleTriggerClick = function handleTriggerClick(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.toggle();
+    };
+
+    QuestionBankQuickPicker.prototype._handleCloseClick = function handleCloseClick(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.close();
+    };
+
+    QuestionBankQuickPicker.prototype._handleSearchInput = function handleSearchInput() {
+        this.renderResults(this.elements.search.value);
+    };
+
+    QuestionBankQuickPicker.prototype._handleSearchKeydown = function handleSearchKeydown(event) {
+        if (event && (event.isComposing || event.keyCode === 229)) {
+            return;
+        }
+        if (!event || this.elements.results.hidden) {
+            return;
+        }
+        var nextIndex = this.activeResultIndex;
+        if (event.key === 'ArrowDown') {
+            nextIndex = nextIndex < 0 ? 0 : nextIndex + 1;
+        } else if (event.key === 'ArrowUp') {
+            nextIndex = nextIndex < 0 ? this.resultElements.length - 1 : nextIndex - 1;
+        } else if (event.key === 'Enter' && this.activeResultIndex >= 0) {
+            event.preventDefault();
+            this.openExam(this.resultElements[this.activeResultIndex].getAttribute('data-exam-id'));
+            return;
+        } else {
+            return;
+        }
+        event.preventDefault();
+        this._setActiveResult(nextIndex, false);
+    };
+
+    QuestionBankQuickPicker.prototype._handleScopesClick = function handleScopesClick(event) {
+        var target = findActionTarget(event && event.target, this.elements.scopes);
+        if (!target || target.getAttribute(ACTION_ATTRIBUTE) !== 'browse-scope') {
+            return;
+        }
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.browseScope(target.getAttribute('data-type'), target.getAttribute('data-category'));
+    };
+
+    QuestionBankQuickPicker.prototype._handleResultsClick = function handleResultsClick(event) {
+        var target = findActionTarget(event && event.target, this.elements.results);
+        if (!target || target.getAttribute(ACTION_ATTRIBUTE) !== 'open-exam') {
+            return;
+        }
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        this.openExam(target.getAttribute('data-exam-id'));
+    };
+
+    QuestionBankQuickPicker.prototype._handleResultsKeydown = function handleResultsKeydown(event) {
+        if (!event || this.resultElements.length === 0) {
+            return;
+        }
+        var currentIndex = this.resultElements.indexOf(event.target);
+        if (currentIndex < 0) {
+            return;
+        }
+        var nextIndex = currentIndex;
+        if (event.key === 'ArrowDown') {
+            nextIndex = currentIndex + 1;
+        } else if (event.key === 'ArrowUp') {
+            nextIndex = currentIndex - 1;
+        } else if (event.key === 'Home') {
+            nextIndex = 0;
+        } else if (event.key === 'End') {
+            nextIndex = this.resultElements.length - 1;
+        } else if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.openExam(event.target.getAttribute('data-exam-id'));
+            return;
+        } else {
+            return;
+        }
+        event.preventDefault();
+        this._setActiveResult(nextIndex, true);
+    };
+
+    QuestionBankQuickPicker.prototype._setActiveResult = function setActiveResult(index, moveFocus) {
+        if (this.resultElements.length === 0) {
+            this.activeResultIndex = -1;
+            if (typeof this.elements.search.removeAttribute === 'function') {
+                this.elements.search.removeAttribute('aria-activedescendant');
+            }
+            return;
+        }
+        var length = this.resultElements.length;
+        var safeIndex = ((index % length) + length) % length;
+        this.activeResultIndex = safeIndex;
+        this.resultElements.forEach(function updateSelected(element, elementIndex) {
+            setAttribute(element, 'aria-selected', elementIndex === safeIndex ? 'true' : 'false');
+        });
+        var active = this.resultElements[safeIndex];
+        setAttribute(this.elements.search, 'aria-activedescendant', active.id);
+        if (typeof active.scrollIntoView === 'function') {
+            try {
+                active.scrollIntoView({ block: 'nearest' });
+            } catch (_) { }
+        }
+        if (moveFocus && typeof active.focus === 'function') {
+            active.focus();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleDocumentPointerDown = function handleDocumentPointerDown(event) {
+        if (!this.isOpen) {
+            return;
+        }
+        var target = event && event.target;
+        var insideDialog = target && typeof this.elements.dialog.contains === 'function'
+            ? this.elements.dialog.contains(target)
+            : target === this.elements.dialog;
+        var insideTrigger = target && typeof this.elements.trigger.contains === 'function'
+            ? this.elements.trigger.contains(target)
+            : target === this.elements.trigger;
+        if (!insideDialog && !insideTrigger) {
+            this.close();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleDocumentKeydown = function handleDocumentKeydown(event) {
+        if (!this.isOpen || !event) {
+            return;
+        }
+        if (event.isComposing || event.keyCode === 229) {
+            return;
+        }
+        if (event.key === 'Escape') {
+            if (typeof event.preventDefault === 'function') {
+                event.preventDefault();
+            }
+            this.close();
+            return;
+        }
+        if (event.key === 'Tab') {
+            this._trapFocus(event);
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._trapFocus = function trapFocus(event) {
+        if (!this.elements.dialog || typeof this.elements.dialog.querySelectorAll !== 'function') {
+            return;
+        }
+        var candidates = Array.prototype.slice.call(this.elements.dialog.querySelectorAll(
+            'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+        ) || []).filter(function visibleCandidate(element) {
+            return !element.hidden;
+        });
+        if (candidates.length === 0) {
+            return;
+        }
+        var first = candidates[0];
+        var last = candidates[candidates.length - 1];
+        var active = this.document.activeElement;
+        if (event.shiftKey && (active === first || !this.elements.dialog.contains(active))) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && (active === last || !this.elements.dialog.contains(active))) {
+            event.preventDefault();
+            first.focus();
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._handleViewportChange = function handleViewportChange() {
+        if (!this.isOpen || this._positionFrame !== null) {
+            return;
+        }
+        var self = this;
+        var schedule = typeof this.global.requestAnimationFrame === 'function'
+            ? this.global.requestAnimationFrame.bind(this.global)
+            : function fallbackFrame(callback) { return setTimeout(callback, 0); };
+        this._positionFrame = schedule(function repositionPicker() {
+            self._positionFrame = null;
+            if (self.isOpen) {
+                self.position();
+            }
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.toggle = function toggle() {
+        if (this.isOpen) {
+            this.close();
+            return Promise.resolve(false);
+        }
+        return this.open();
+    };
+
+    QuestionBankQuickPicker.prototype.open = function open() {
+        if (!this.mount()) {
+            return Promise.resolve(false);
+        }
+        this._restoreFocus = this.document.activeElement || this.elements.trigger;
+        this.isOpen = true;
+        this.elements.panel.hidden = false;
+        setAttribute(this.elements.trigger, 'aria-expanded', 'true');
+        this.position();
+        this._renderLoading();
+        if (typeof this.elements.search.focus === 'function') {
+            this.elements.search.focus();
+        }
+        return this.refresh().then(function opened() {
+            return true;
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.close = function close(options) {
+        if (!this._mounted) {
+            return;
+        }
+        var opts = options || {};
+        this.isOpen = false;
+        this._loadVersion += 1;
+        this._actionVersion += 1;
+        this._actionPending = false;
+        this.elements.panel.hidden = true;
+        setAttribute(this.elements.trigger, 'aria-expanded', 'false');
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+        if (opts.restoreFocus !== false) {
+            var focusTarget = this._restoreFocus && typeof this._restoreFocus.focus === 'function'
+                ? this._restoreFocus
+                : this.elements.trigger;
+            if (focusTarget && typeof focusTarget.focus === 'function') {
+                focusTarget.focus();
+            }
+        }
+        this._restoreFocus = null;
+    };
+
+    QuestionBankQuickPicker.prototype.position = function position() {
+        if (!this.isOpen || !this.elements.trigger || !this.elements.panel) {
+            return null;
+        }
+        var triggerRect = typeof this.elements.trigger.getBoundingClientRect === 'function'
+            ? this.elements.trigger.getBoundingClientRect()
+            : {};
+        var viewport = {
+            width: finiteNumber(this.global.innerWidth, this.document.documentElement && this.document.documentElement.clientWidth || 0),
+            height: finiteNumber(this.global.innerHeight, this.document.documentElement && this.document.documentElement.clientHeight || 0)
+        };
+        var anchorTop = computeAnchorTop(triggerRect, viewport);
+        var style = this.elements.panel.style || {};
+        if (viewport.width <= 768) {
+            if (typeof style.removeProperty === 'function') {
+                style.removeProperty('--question-bank-quick-anchor-top');
+            } else {
+                style['--question-bank-quick-anchor-top'] = '';
+            }
+            return { anchorTop: null };
+        }
+        if (typeof style.setProperty === 'function') {
+            style.setProperty('--question-bank-quick-anchor-top', anchorTop + 'px');
+        } else {
+            style['--question-bank-quick-anchor-top'] = anchorTop + 'px';
+        }
+        return { anchorTop: anchorTop };
+    };
+
+    QuestionBankQuickPicker.prototype.refresh = function refresh() {
+        var resolver = this.global.resolveActiveLibraryIndex;
+        var version = ++this._loadVersion;
+        var self = this;
+        this._renderLoading();
+        if (typeof resolver !== 'function') {
+            this._renderError(new Error('resolveActiveLibraryIndex is unavailable'));
+            return Promise.resolve([]);
+        }
+        return Promise.resolve().then(function resolveIndex() {
+            return resolver.call(self.global);
+        }).then(function indexResolved(index) {
+            if (!self.isOpen || version !== self._loadVersion) {
+                return [];
+            }
+            self.index = Array.isArray(index) ? index.slice() : [];
+            self.scopes = deriveScopes(self.index);
+            self.renderScopes();
+            self.renderResults(self.elements.search.value);
+            self.position();
+            return self.index;
+        }).catch(function indexFailed(error) {
+            if (self.isOpen && version === self._loadVersion) {
+                self._renderError(error);
+            }
+            return [];
+        });
+    };
+
+    QuestionBankQuickPicker.prototype._setStatus = function setStatusText(text, state) {
+        this.elements.status.textContent = text;
+        setState(this.elements.status, state || 'ready');
+    };
+
+    QuestionBankQuickPicker.prototype._renderLoading = function renderLoading() {
+        // A reopened picker may be resolving a different active library. Drop
+        // the previous snapshot immediately so input events during that wait
+        // cannot reveal or launch stale results.
+        this.index = [];
+        this.scopes = { types: [], categories: [] };
+        this.matches = [];
+        this._setStatus('正在读取当前活动题库…', 'loading');
+        setAttribute(this.elements.scopes, 'aria-busy', 'true');
+        clearElement(this.elements.scopes);
+        this.elements.scopes.appendChild(createTextElement(
+            this.document,
+            'p',
+            'question-bank-quick-picker__placeholder',
+            '正在读取题目分类…'
+        ));
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.elements.results.hidden = true;
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._renderError = function renderError(error) {
+        this.index = [];
+        this.matches = [];
+        this._setStatus('无法读取当前活动题库，请稍后重试。', 'error');
+        setAttribute(this.elements.scopes, 'aria-busy', 'false');
+        clearElement(this.elements.scopes);
+        this.elements.scopes.appendChild(createTextElement(
+            this.document,
+            'p',
+            'question-bank-quick-picker__placeholder question-bank-quick-picker__placeholder--error',
+            '题库分类加载失败。'
+        ));
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        this.elements.results.hidden = true;
+        setAttribute(this.elements.search, 'aria-expanded', 'false');
+        if (this.global.console && typeof this.global.console.warn === 'function') {
+            this.global.console.warn('[QuestionBankQuickPicker] Failed to load active index:', error);
+        }
+    };
+
+    QuestionBankQuickPicker.prototype._createScopeButton = function createScopeButton(type, category, label, count) {
+        var button = this.document.createElement('button');
+        button.type = 'button';
+        button.className = 'question-bank-quick-picker__scope question-bank-quick-scope';
+        setAttribute(button, ACTION_ATTRIBUTE, 'browse-scope');
+        setAttribute(button, 'data-type', type);
+        setAttribute(button, 'data-category', category);
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__scope-label',
+            label
+        ));
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__scope-count',
+            String(count)
+        ));
+        return button;
+    };
+
+    QuestionBankQuickPicker.prototype.renderScopes = function renderScopes() {
+        clearElement(this.elements.scopes);
+        setAttribute(this.elements.scopes, 'aria-busy', 'false');
+        if (this.index.length === 0) {
+            this.elements.scopes.appendChild(createTextElement(
+                this.document,
+                'p',
+                'question-bank-quick-picker__placeholder',
+                '当前活动题库没有可用题目。'
+            ));
+            this._setStatus('当前活动题库没有可用题目。', 'empty');
+            return;
+        }
+
+        this.elements.scopes.appendChild(this._createScopeButton(
+            'all',
+            'all',
+            '全部题目',
+            this.index.length
+        ));
+        var self = this;
+        this.scopes.types.forEach(function renderType(typeScope) {
+            self.elements.scopes.appendChild(self._createScopeButton(
+                typeScope.type,
+                'all',
+                '全部' + typeScope.label,
+                typeScope.count
+            ));
+            self.scopes.categories.filter(function inType(categoryScope) {
+                return categoryScope.type === typeScope.type;
+            }).forEach(function renderCategory(categoryScope) {
+                self.elements.scopes.appendChild(self._createScopeButton(
+                    categoryScope.type,
+                    categoryScope.category,
+                    typeScope.label + ' · ' + categoryScope.label,
+                    categoryScope.count
+                ));
+            });
+        });
+    };
+
+    QuestionBankQuickPicker.prototype._createResultButton = function createResultButton(exam, index) {
+        var examId = normalizeScopeValue(exam.id || exam.examId, '');
+        var button = this.document.createElement('button');
+        button.type = 'button';
+        button.className = 'question-bank-quick-picker__result question-bank-quick-result';
+        setAttribute(button, ACTION_ATTRIBUTE, 'open-exam');
+        setAttribute(button, 'data-exam-id', examId);
+        setAttribute(button, 'role', 'option');
+        setAttribute(button, 'aria-selected', 'false');
+        button.id = 'question-bank-quick-result-' + String(index) + '-' + examId.replace(/[^A-Za-z0-9_-]+/g, '-');
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__result-title question-bank-quick-result__title',
+            normalizeScopeValue(exam.title, examId || '未命名题目')
+        ));
+        button.appendChild(createTextElement(
+            this.document,
+            'span',
+            'question-bank-quick-picker__result-meta question-bank-quick-result__meta',
+            getTypeLabel(exam.type) + ' · ' + normalizeScopeValue(exam.category, '未分类')
+        ));
+        return button;
+    };
+
+    QuestionBankQuickPicker.prototype.renderResults = function renderResults(query) {
+        var normalizedQuery = normalizeSearchText(query);
+        clearElement(this.elements.results);
+        this.resultElements = [];
+        this.activeResultIndex = -1;
+        if (typeof this.elements.search.removeAttribute === 'function') {
+            this.elements.search.removeAttribute('aria-activedescendant');
+        }
+        if (this.index.length === 0) {
+            this.matches = [];
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            return [];
+        }
+        if (!normalizedQuery) {
+            this.matches = [];
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            this._setStatus(
+                '已加载 ' + this.index.length + ' 道题；选择分类，或输入关键词全局搜索。',
+                'ready'
+            );
+            return [];
+        }
+
+        this.matches = filterExams(this.index, normalizedQuery);
+        if (this.matches.length === 0) {
+            this.elements.results.hidden = true;
+            setAttribute(this.elements.search, 'aria-expanded', 'false');
+            this._setStatus('未找到与“' + String(query).trim() + '”匹配的题目。', 'empty');
+            return [];
+        }
+
+        this.elements.results.hidden = false;
+        setAttribute(this.elements.search, 'aria-expanded', 'true');
+
+        var self = this;
+        this.matches.slice(0, this.resultLimit).forEach(function renderResult(exam, index) {
+            if (exam.id || exam.examId) {
+                var result = self._createResultButton(exam, index);
+                self.resultElements.push(result);
+                self.elements.results.appendChild(result);
+            }
+        });
+        var suffix = this.matches.length > this.resultLimit
+            ? '，显示前 ' + this.resultLimit + ' 道'
+            : '';
+        this._setStatus('找到 ' + this.matches.length + ' 道匹配题目' + suffix + '。', 'results');
+        return this.matches.slice();
+    };
+
+    QuestionBankQuickPicker.prototype._ensureBrowseGroup = function ensureBrowseGroupReady() {
+        var owner = this.global;
+        var loader = this.global.ensureBrowseGroup;
+        if (typeof loader !== 'function' && this.global.AppEntry) {
+            owner = this.global.AppEntry;
+            loader = owner.ensureBrowseGroup;
+        }
+        if (typeof loader !== 'function') {
+            return Promise.reject(new Error('ensureBrowseGroup is unavailable'));
+        }
+        return Promise.resolve(loader.call(owner));
+    };
+
+    QuestionBankQuickPicker.prototype._clearBrowseSearchState = function clearBrowseSearchState() {
+        var manager = this.global.browseStateManager;
+        if (manager && typeof manager.clearSearchState === 'function') {
+            try {
+                manager.clearSearchState();
+            } catch (_) { }
+        }
+        var searchInput = this.document && typeof this.document.getElementById === 'function'
+            ? this.document.getElementById('exam-search-input')
+            : null;
+        if (!searchInput && this.document && typeof this.document.querySelector === 'function') {
+            searchInput = this.document.querySelector('.search-input');
+        }
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        var clearButton = this.document && typeof this.document.getElementById === 'function'
+            ? this.document.getElementById('search-clear-btn')
+            : null;
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    };
+
+    QuestionBankQuickPicker.prototype.browseScope = function browseScope(type, category) {
+        if (this._actionPending) {
+            return Promise.resolve(false);
+        }
+        var safeType = normalizeScopeValue(type, 'all');
+        var safeCategory = normalizeScopeValue(category, 'all');
+        var self = this;
+        var actionVersion = ++this._actionVersion;
+        this._actionPending = true;
+        this._setStatus('正在打开题目分类…', 'loading');
+        return this._ensureBrowseGroup().then(function browseReady() {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (!self.global.app || typeof self.global.app.browseCategory !== 'function') {
+                throw new Error('app.browseCategory is unavailable');
+            }
+            self._clearBrowseSearchState();
+            return Promise.resolve(self.global.app.browseCategory(safeCategory, safeType)).then(function categoryDispatched() {
+                return true;
+            });
+        }).then(function categoryOpened(opened) {
+            if (opened !== true || !self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            self.close();
+            return true;
+        }).catch(function categoryFailed(error) {
+            if (self.isOpen && actionVersion === self._actionVersion) {
+                self._setStatus('无法打开该题目分类，请稍后重试。', 'error');
+                if (self.global.console && typeof self.global.console.warn === 'function') {
+                    self.global.console.warn('[QuestionBankQuickPicker] Failed to browse category:', error);
+                }
+            }
+            return false;
+        }).then(function clearPending(result) {
+            if (actionVersion === self._actionVersion) {
+                self._actionPending = false;
+            }
+            return result;
+        });
+    };
+
+    QuestionBankQuickPicker.prototype.openExam = function openExam(examId) {
+        var safeExamId = normalizeScopeValue(examId, '');
+        if (!safeExamId || this._actionPending) {
+            return Promise.resolve(false);
+        }
+        var self = this;
+        var actionVersion = ++this._actionVersion;
+        this._actionPending = true;
+        this._setStatus('正在打开题目…', 'loading');
+        return this._ensureBrowseGroup().then(function browseReady() {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (!self.global.app || typeof self.global.app.openExam !== 'function') {
+                throw new Error('app.openExam is unavailable');
+            }
+            return Promise.resolve(self.global.app.openExam(safeExamId)).then(function examDispatched(launchTarget) {
+                // ExamSystemApp.openExam resolves to the opened Window (or a
+                // launch-context object when requested) on success, and to
+                // undefined/null when the exam cannot be launched.
+                return Boolean(launchTarget);
+            });
+        }).then(function examOpened(opened) {
+            if (!self.isOpen || actionVersion !== self._actionVersion) {
+                return false;
+            }
+            if (opened !== true) {
+                self._setStatus('无法打开该题目，请稍后重试。', 'error');
+                return false;
+            }
+            self.close();
+            return true;
+        }).catch(function examFailed(error) {
+            if (self.isOpen && actionVersion === self._actionVersion) {
+                self._setStatus('无法打开该题目，请稍后重试。', 'error');
+                if (self.global.console && typeof self.global.console.warn === 'function') {
+                    self.global.console.warn('[QuestionBankQuickPicker] Failed to open exam:', error);
+                }
+            }
+            return false;
+        }).then(function clearPending(result) {
+            if (actionVersion === self._actionVersion) {
+                self._actionPending = false;
+            }
+            return result;
+        });
+    };
+
+    var singleton = null;
+    var api = {
+        SELECTORS: Object.assign({}, SELECTORS),
+        normalizeSearchText: normalizeSearchText,
+        createExamSearchText: createExamSearchText,
+        filterExams: filterExams,
+        deriveScopes: deriveScopes,
+        computePanelPosition: computePanelPosition,
+        computeAnchorTop: computeAnchorTop,
+        getTypeLabel: getTypeLabel,
+        Controller: QuestionBankQuickPicker,
+        create: function create(options) {
+            return new QuestionBankQuickPicker(options);
+        },
+        init: function init(options) {
+            if (!singleton) {
+                singleton = new QuestionBankQuickPicker(options);
+            }
+            singleton.mount();
+            return singleton;
+        },
+        getInstance: function getInstance() {
+            return singleton;
+        }
+    };
+
+    global.QuestionBankQuickPicker = api;
+
+    if (global.document) {
+        if (global.document.readyState === 'loading') {
+            global.document.addEventListener('DOMContentLoaded', function initQuickPicker() {
+                api.init();
+            }, { once: true });
+        } else {
+            api.init();
+        }
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/main.js
+++ b/js/main.js
@@ -262,7 +262,11 @@ async function initializeLegacyComponents() {
     try { showMessage('系统准备就绪', 'success'); } catch (_) { }
 
     try {
-        ensureLegacyNavigation({ initialView: 'overview' });
+        const activeView = document.querySelector('.view.active');
+        const activeViewName = activeView && activeView.id
+            ? activeView.id.replace(/-view$/, '')
+            : 'overview';
+        ensureLegacyNavigation({ initialView: activeViewName });
     } catch (error) {
         console.warn('[Navigation] 初始化导航控制器失败:', error);
     }
@@ -275,8 +279,8 @@ async function initializeLegacyComponents() {
         console.log('[System] PDF处理器已初始化');
     }
     if (window.BrowseStateManager) {
-        browseStateManager = new BrowseStateManager();
-        console.log('[System] 浏览状态管理器已初始化');
+        browseStateManager = window.browseStateManager || new window.BrowseStateManager();
+        console.log('[System] 浏览状态管理器已就绪');
     }
     // 性能优化器已拆到 diagnostics-tools；浏览页保留无依赖降级路径。
     if (window.PerformanceOptimizer) {
@@ -2122,11 +2126,25 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             filterMode = null;
             path = null;
         }
-        // 归一化输入：兼容 "P1 阅读"/"P2 听力" 这类文案
+        // 归一化输入：活动索引中的精确分类优先，避免 "P1 Mock" 等
+        // 自定义分类被旧的嵌入式 P1-P4 兼容规则缩写成 "P1"。
         const raw = String(category || 'all');
-        let normalizedCategory = 'all';
-        const m = raw.match(/\bP[1-4]\b/i);
-        if (m) normalizedCategory = m[0].toUpperCase();
+        const trimmedCategory = raw.trim();
+        const exactCategoryEntry = trimmedCategory && trimmedCategory.toLowerCase() !== 'all'
+            ? indexSnapshot.find((exam) => exam && typeof exam.category === 'string'
+                && exam.category.trim() === trimmedCategory)
+            : null;
+        const compatibleCategoryEntry = exactCategoryEntry || (
+            trimmedCategory && trimmedCategory.toLowerCase() !== 'all'
+                ? indexSnapshot.find((exam) => exam && typeof exam.category === 'string'
+                    && exam.category.trim().toLocaleLowerCase() === trimmedCategory.toLocaleLowerCase())
+                : null
+        );
+        const normalizedCategory = compatibleCategoryEntry
+            ? compatibleCategoryEntry.category.trim()
+            : (typeof window.normalizeCategoryKey === 'function'
+                ? window.normalizeCategoryKey(raw)
+                : trimmedCategory || 'all');
 
         // 若未显式给出类型，从文案或题库推断
         if (!type || type === 'all') {
@@ -2285,22 +2303,33 @@ function refreshBrowseResults() {
 }
 
 let browseControlsSeeded = false;
+let browseControlsSeedPromise = null;
 async function setupBrowseControls() {
     if (!browseControlsSeeded) {
-        try {
-            const browse = await window.AppData.preferences.getBrowse();
-            if (browse) {
-                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
-            }
-        } catch (_) { /* defaults remain active */ }
-        browseControlsSeeded = true;
+        if (!browseControlsSeedPromise) {
+            browseControlsSeedPromise = (async () => {
+                try {
+                    const browse = await window.AppData.preferences.getBrowse();
+                    if (browse) {
+                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                    }
+                } catch (_) { /* defaults remain active */ }
+                browseControlsSeeded = true;
+            })();
+        }
+        await browseControlsSeedPromise;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
 }
 
 async function persistBrowsePreference(patch) {
+    if (window.AppData && window.AppData.preferences
+        && typeof window.AppData.preferences.patchBrowse === 'function') {
+        await window.AppData.preferences.patchBrowse(patch);
+        return;
+    }
     const current = await window.AppData.preferences.getBrowse() || {};
     await window.AppData.preferences.setBrowse(Object.assign({}, current, patch));
 }
@@ -2328,6 +2357,7 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
+    window.__browseFrequencyFilter = activeFilter;
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return;

--- a/js/presentation/app-actions.js
+++ b/js/presentation/app-actions.js
@@ -4,6 +4,7 @@
     var prefetchTriggered = false;
     var attachedPrefetchHandlers = false;
     var browsePrefetchTriggered = false;
+    var browsePrefetchPromise = null;
     var morePrefetchTriggered = false;
 
     function ensurePracticeSuite() {
@@ -11,6 +12,19 @@
             return Promise.resolve();
         }
         return global.AppLazyLoader.ensureGroup('practice-suite');
+    }
+
+    function ensureBrowseRuntime() {
+        if (global.AppEntry && typeof global.AppEntry.ensureBrowseGroup === 'function') {
+            return Promise.resolve(global.AppEntry.ensureBrowseGroup());
+        }
+        if (typeof global.ensureBrowseGroup === 'function') {
+            return Promise.resolve(global.ensureBrowseGroup());
+        }
+        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+            return Promise.resolve(global.AppLazyLoader.ensureGroup('browse-runtime'));
+        }
+        return Promise.resolve();
     }
 
     function exportPracticeMarkdown() {
@@ -53,14 +67,15 @@
 
     function triggerBrowsePrefetch() {
         if (browsePrefetchTriggered) {
-            return;
+            return browsePrefetchPromise || Promise.resolve();
         }
         browsePrefetchTriggered = true;
-        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
-            global.AppLazyLoader.ensureGroup('browse-runtime').catch(function swallow(error) {
-                console.warn('[AppActions] 浏览模块预加载失败:', error);
-            });
-        }
+        browsePrefetchPromise = ensureBrowseRuntime().catch(function swallow(error) {
+            browsePrefetchTriggered = false;
+            browsePrefetchPromise = null;
+            console.warn('[AppActions] 浏览模块预加载失败:', error);
+        });
+        return browsePrefetchPromise;
     }
 
     function triggerMorePrefetch() {
@@ -500,8 +515,8 @@
         var tasks = [];
         if (loader) {
             tasks.push(loader.ensureGroup('exam-data'));
-            tasks.push(loader.ensureGroup('browse-runtime').catch(function () { return undefined; }));
         }
+        tasks.push(ensureBrowseRuntime().catch(function () { return undefined; }));
         return Promise.all(tasks).then(function () {
             return undefined;
         });

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -36,6 +36,7 @@ const bundles = {
         'js/services/overviewStats.js',
         'js/views/overviewView.js',
         'js/presentation/navigation-controller.js',
+        'js/components/questionBankQuickPicker.js',
         'js/presentation/message-center.js',
         'js/utils/practiceTimerPreferences.js',
         'js/components/practiceSettingsPanel.js',


### PR DESCRIPTION
## Purpose

Fixes #110 by removing the need to return to Overview when searching or switching Question Bank categories.

## Implementation

- adds an accessible top-navigation quick picker with active-library global search and dynamic reading/listening category shortcuts
- routes category and exam actions through the existing lazy Browse lifecycle
- makes repeated Browse navigation reset filters and search atomically while preventing stale asynchronous state from restoring old results
- preserves exact custom category values and keeps generated bundles in sync

## Validation

- `node scripts/build-bundles.mjs --check`
- `node --test --test-concurrency=1 "tests/js/**/*.test.js"` from `developer` (95/95)
- `python -m unittest discover -s developer/tests/py -p "test_*.py"` (20/20)
- `python developer/tests/ci/check_reading_data_integrity.py`
- `python developer/tests/ci/run_static_suite.py`
- `python developer/tests/e2e/e2e_runner.py` (8/8)
- real Chromium quick-picker smoke with normal Playwright actionability checks

The single commit is PGP-signed and GitHub reports it as verified.