### PR TITLE
Add secondary reading highlight color

### DIFF
--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -793,6 +793,11 @@
             color: #fff;
         }
 
+        .hl[data-hl-level="secondary"] {
+            background-color: #e63b86;
+            color: #fff;
+        }
+
         /* Dark Mode variables */
         body.dark-mode {
             --panel: #1e293b;
@@ -819,6 +824,11 @@
 
         body.dark-mode .hl[data-hl-type="note"] {
             background-color: #0369d9;
+            color: #fff;
+        }
+
+        body.dark-mode .hl[data-hl-level="secondary"] {
+            background-color: #e63b86;
             color: #fff;
         }
 

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -4504,7 +4504,14 @@
         return node.dataset && node.dataset.hlType === 'note' ? 'note' : 'highlight';
     }
 
-    function applyHighlightKind(node, kind = 'highlight') {
+    function resolveHighlightLevel(node) {
+        if (!(node instanceof HTMLElement)) {
+            return 'primary';
+        }
+        return node.dataset && node.dataset.hlLevel === 'secondary' ? 'secondary' : 'primary';
+    }
+
+    function applyHighlightKind(node, kind = 'highlight', level = 'primary') {
         if (!(node instanceof HTMLElement)) {
             return;
         }
@@ -4513,6 +4520,11 @@
             node.dataset.hlType = 'note';
         } else {
             delete node.dataset.hlType;
+        }
+        if (level === 'secondary') {
+            node.dataset.hlLevel = 'secondary';
+        } else {
+            delete node.dataset.hlLevel;
         }
     }
 
@@ -4561,6 +4573,7 @@
                     scope,
                     text,
                     kind: resolveHighlightKind(node),
+                    level: resolveHighlightLevel(node),
                     noteId: node.dataset && node.dataset.noteId ? String(node.dataset.noteId) : '',
                     occurrence: seen,
                     start: startOffset,
@@ -4584,6 +4597,7 @@
             return;
         }
         const highlightKind = record.kind === 'note' ? 'note' : 'highlight';
+        const highlightLevel = record.level === 'secondary' ? 'secondary' : 'primary';
         const normalizedRecordText = normalizeComparableText(record.text);
         const startOffset = Number(
             Object.prototype.hasOwnProperty.call(record, 'start')
@@ -4634,7 +4648,7 @@
                 const offsetRange = resolveRangeFromOffsets(root, startOffset, endOffset);
                 if (offsetRange && !offsetRange.collapsed) {
                     const offsetSpan = document.createElement('span');
-                    applyHighlightKind(offsetSpan, highlightKind);
+                    applyHighlightKind(offsetSpan, highlightKind, highlightLevel);
                     if (record.noteId) {
                         offsetSpan.dataset.noteId = String(record.noteId);
                     }
@@ -4685,7 +4699,7 @@
             return false;
         }
         const span = document.createElement('span');
-        applyHighlightKind(span, highlightKind);
+        applyHighlightKind(span, highlightKind, highlightLevel);
         if (record.noteId) {
             span.dataset.noteId = String(record.noteId);
         }
@@ -6930,7 +6944,19 @@
             return;
         }
         const selection = global.getSelection();
-        if (!interaction.lastRange || interaction.lastRange.collapsed || interaction.currentHighlightNode) {
+        if (!interaction.lastRange || interaction.lastRange.collapsed) {
+            return;
+        }
+        if (kind === 'highlight' && interaction.currentHighlightNode instanceof HTMLElement) {
+            interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            selection?.removeAllRanges();
+            if (toolbar) toolbar.style.display = 'none';
+            interaction.lastRange = null;
+            interaction.currentHighlightNode = null;
+            syncReadingAnnotation('highlight');
+            return;
+        }
+        if (interaction.currentHighlightNode) {
             return;
         }
         const span = document.createElement('span');

--- a/js/runtime/readingHighlightShared.js
+++ b/js/runtime/readingHighlightShared.js
@@ -129,7 +129,14 @@
         return node.dataset && node.dataset.hlType === 'note' ? 'note' : 'highlight';
     }
 
-    function applyHighlightKind(node, kind = 'highlight') {
+    function resolveHighlightLevel(node) {
+        if (!(node instanceof HTMLElement)) {
+            return 'primary';
+        }
+        return node.dataset && node.dataset.hlLevel === 'secondary' ? 'secondary' : 'primary';
+    }
+
+    function applyHighlightKind(node, kind = 'highlight', level = 'primary') {
         if (!(node instanceof HTMLElement)) {
             return;
         }
@@ -138,6 +145,11 @@
             node.dataset.hlType = 'note';
         } else {
             delete node.dataset.hlType;
+        }
+        if (level === 'secondary') {
+            node.dataset.hlLevel = 'secondary';
+        } else {
+            delete node.dataset.hlLevel;
         }
     }
 
@@ -186,6 +198,7 @@
                     scope,
                     text,
                     kind: resolveHighlightKind(node),
+                    level: resolveHighlightLevel(node),
                     noteId: node.dataset && node.dataset.noteId ? String(node.dataset.noteId) : '',
                     occurrence: seen,
                     start: startOffset,
@@ -209,6 +222,7 @@
             return;
         }
         const highlightKind = record.kind === 'note' ? 'note' : 'highlight';
+        const highlightLevel = record.level === 'secondary' ? 'secondary' : 'primary';
         const normalizedRecordText = normalizeComparableText(record.text);
         const startOffset = Number(
             Object.prototype.hasOwnProperty.call(record, 'start')
@@ -259,7 +273,7 @@
                 const offsetRange = resolveRangeFromOffsets(root, startOffset, endOffset);
                 if (offsetRange && !offsetRange.collapsed) {
                     const offsetSpan = document.createElement('span');
-                    applyHighlightKind(offsetSpan, highlightKind);
+                    applyHighlightKind(offsetSpan, highlightKind, highlightLevel);
                     if (record.noteId) {
                         offsetSpan.dataset.noteId = String(record.noteId);
                     }
@@ -310,7 +324,7 @@
             return false;
         }
         const span = document.createElement('span');
-        applyHighlightKind(span, highlightKind);
+        applyHighlightKind(span, highlightKind, highlightLevel);
         if (record.noteId) {
             span.dataset.noteId = String(record.noteId);
         }

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -684,7 +684,19 @@
             return;
         }
         const selection = global.getSelection();
-        if (!interaction.lastRange || interaction.lastRange.collapsed || interaction.currentHighlightNode) {
+        if (!interaction.lastRange || interaction.lastRange.collapsed) {
+            return;
+        }
+        if (kind === 'highlight' && interaction.currentHighlightNode instanceof HTMLElement) {
+            interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            selection?.removeAllRanges();
+            if (toolbar) toolbar.style.display = 'none';
+            interaction.lastRange = null;
+            interaction.currentHighlightNode = null;
+            syncReadingAnnotation('highlight');
+            return;
+        }
+        if (interaction.currentHighlightNode) {
             return;
         }
         const span = document.createElement('span');


### PR DESCRIPTION
## Summary
- Add a secondary highlight state for reading-page highlights
- Turn an already-highlighted selection magenta on a second highlight action, matching the IELTS test behavior
- Persist and restore the secondary highlight level in reading highlight snapshots

## Scope
Only reading highlight behavior and the generated reading page bundle are changed. This PR does not include wrong-reason, backend, vocabulary-list, or practice-record changes.

## Validation
- Ran bundle build with `node scripts/build-bundles.mjs`
- Ran syntax checks for `js/runtime/readingHighlightShared.js`, `js/runtime/unifiedReadingPage.js`, and `js/bundles/reading-page.bundle.js`
- Ran `git diff --check`
- Verified in a local Edge/Playwright page check that secondary highlight state is snapshotted, restored, and rendered as `rgb(230, 59, 134)`