### PR TITLE
fix(reading): 单选题 A/B/C/D 选项纵向排列，修复 All in the family 排版错乱

### DIFF
--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -184,6 +184,34 @@
             margin-bottom: 12px;
         }
 
+        /* Single-choice (multiple choice) vertical layout fix */
+        .mc-question-item {
+            margin-bottom: 16px;
+        }
+
+        .mc-question-item > p {
+            margin: 0 0 8px;
+            line-height: 1.45;
+        }
+
+        label.mc-option {
+            display: flex;
+            align-items: flex-start;
+            gap: 8px;
+            margin: 0 0 8px;
+            cursor: pointer;
+            line-height: 1.5;
+        }
+
+        label.mc-option:last-child {
+            margin-bottom: 0;
+        }
+
+        label.mc-option input[type="radio"] {
+            flex-shrink: 0;
+            margin-top: 3px;
+        }
+
         .tfng-item {
             margin: 0 0 14px;
         }


### PR DESCRIPTION
## 问题
单选题（single_choice）的 A/B/C/D 选项因缺少布局样式而横向排列、排版错乱。

## 修复
在 assets/generated/reading-exams/reading-practice-unified.html 的 <style> 中补充 .mc-question-item 与 label.mc-option 的纵向 flex 布局样式，使每个选项独占一行、radio 与文字顶部对齐。

## 验证
本地起服务预览 reading-practice-unified.html?examId=p3-high-229，Q31-Q34 选项已正确纵向排列。