### PR TITLE
Fix secondary highlight handling for partial selections

### DIFF
--- a/developer/tests/js/readingInteractionRegression.test.js
+++ b/developer/tests/js/readingInteractionRegression.test.js
@@ -62,7 +62,8 @@ async function testBrowserInteractions() {
         await page.setContent(`<!doctype html>
             <html><head></head><body>
                 <header><div class="header-right"></div></header>
-                <div id="highlight-root">alpha <span class="hl" data-note-id="note-1">repeat</span> middle <span class="hl" data-note-id="note-2">repeat</span> omega</div>
+                <div id="highlight-root">alpha <span class="hl" data-note-id="note-1">repeat</span><span class="hl" data-note-id="note-2" data-hl-level="secondary">repeat</span> omega</div>
+                <div id="inline-highlight-root"><span class="hl" data-hl-level="secondary"><em>AB</em>C<strong>DE</strong></span></div>
                 <input type="checkbox" name="q8-9" value="A">
                 <input type="checkbox" name="q8-9" value="B">
                 <input type="checkbox" name="q8-9" value="C">
@@ -76,6 +77,11 @@ async function testBrowserInteractions() {
                 <button id="submit-btn" type="button">Submit</button>
                 <button id="reset-btn" type="button">Reset</button>
                 <button id="exit-btn" type="button">Exit</button>
+                <div id="selbar" style="display: none">
+                    <button id="btnHL" type="button">Highlight</button>
+                    <button id="btnNote" type="button">Note</button>
+                    <button id="btnUH" type="button">Remove</button>
+                </div>
             </body></html>`);
 
         await page.addScriptTag({ content: read('js/runtime/readingHighlightShared.js') });
@@ -83,15 +89,41 @@ async function testBrowserInteractions() {
             const root = document.getElementById('highlight-root');
             const shared = window.__READING_HIGHLIGHT_SHARED__;
             const first = shared.snapshotHighlights({ left: root });
-            shared.restoreHighlights({ left: root }, first);
+            const restored = shared.restoreHighlights({ left: root }, first);
             const second = shared.snapshotHighlights({ left: root });
-            return { first, second };
+            const inlineRoot = document.getElementById('inline-highlight-root');
+            const inlineFirst = shared.snapshotHighlights({ left: inlineRoot });
+            const inlineRestored = shared.restoreHighlights({ left: inlineRoot }, inlineFirst);
+            const inlineSecond = shared.snapshotHighlights({ left: inlineRoot });
+            return {
+                first,
+                restored,
+                second,
+                inline: {
+                    first: inlineFirst,
+                    restored: inlineRestored,
+                    second: inlineSecond,
+                    html: inlineRoot.innerHTML
+                }
+            };
         });
         assert.equal(highlightSnapshot.first.length, 2, 'duplicate highlight text must snapshot both DOM ranges');
-        assert.deepEqual(highlightSnapshot.first.map((entry) => entry.start), [6, 20]);
+        assert.deepEqual(highlightSnapshot.first.map((entry) => entry.start), [6, 12]);
+        assert.deepEqual(highlightSnapshot.first.map((entry) => entry.end), [12, 18]);
         assert.deepEqual(highlightSnapshot.first.map((entry) => entry.noteId), ['note-1', 'note-2']);
-        assert.deepEqual(highlightSnapshot.second.map((entry) => entry.start), [6, 20]);
+        assert.deepEqual(highlightSnapshot.first.map((entry) => entry.level), ['primary', 'secondary']);
+        assert.equal(highlightSnapshot.restored, 2, 'adjacent primary and secondary highlights must both restore');
+        assert.deepEqual(highlightSnapshot.second.map((entry) => entry.start), [6, 12]);
+        assert.deepEqual(highlightSnapshot.second.map((entry) => entry.end), [12, 18]);
         assert.deepEqual(highlightSnapshot.second.map((entry) => entry.noteId), ['note-1', 'note-2']);
+        assert.deepEqual(highlightSnapshot.second.map((entry) => entry.level), ['primary', 'secondary']);
+        assert.equal(highlightSnapshot.inline.restored, 1, 'a highlight spanning inline markup must restore');
+        assert.deepEqual(highlightSnapshot.inline.first.map((entry) => [entry.start, entry.end, entry.level]), [[0, 5, 'secondary']]);
+        assert.deepEqual(highlightSnapshot.inline.second.map((entry) => [entry.start, entry.end, entry.level]), [[0, 5, 'secondary']]);
+        assert.equal(
+            highlightSnapshot.inline.html,
+            '<span class="hl" data-hl-level="secondary"><em>AB</em>C<strong>DE</strong></span>'
+        );
 
         await page.evaluate(() => {
             window.__IELTS_READING_PAGE_TEST_HOOKS__ = true;
@@ -99,6 +131,134 @@ async function testBrowserInteractions() {
         await page.addScriptTag({ content: read('js/utils/answerSanitizer.js') });
         await page.addScriptTag({ content: read('js/utils/answerMatchCore.js') });
         await page.addScriptTag({ content: read('js/runtime/unifiedReadingPage.js') });
+
+        const highlightSelectionChecks = await page.evaluate(() => {
+            const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+            const left = document.getElementById('left');
+            hooks.setTestState({
+                readOnly: false,
+                timerLocked: false,
+                submitted: false,
+                reviewMode: false,
+                memorizeMode: false
+            });
+            hooks.captureDom();
+
+            const runSelection = (html, configureRange) => {
+                left.innerHTML = html;
+                const highlights = Array.from(left.querySelectorAll('.hl'));
+                const range = document.createRange();
+                configureRange(range, highlights);
+                const selection = window.getSelection();
+                selection.removeAllRanges();
+                selection.addRange(range);
+                hooks.updateSelectionToolbar();
+                hooks.applySelectionHighlight('highlight');
+                const selectionState = hooks.getSelectionHighlightTestState();
+                const selectionRangeCount = selection.rangeCount;
+                const toolbarDisplay = document.getElementById('selbar').style.display;
+                selection.removeAllRanges();
+                return {
+                    html: left.innerHTML,
+                    text: left.textContent,
+                    highlightCount: left.querySelectorAll('.hl').length,
+                    levels: Array.from(left.querySelectorAll('.hl')).map((node) => node.dataset.hlLevel || 'primary'),
+                    selectionState,
+                    selectionRangeCount,
+                    toolbarDisplay
+                };
+            };
+
+            const single = 'plain <span class="hl">ABCDE</span> tail';
+            const partial = runSelection(single, (range, [highlight]) => {
+                range.setStart(highlight.firstChild, 1);
+                range.setEnd(highlight.firstChild, 4);
+            });
+            const mixedPartial = runSelection(single, (range, [highlight]) => {
+                range.setStart(left.firstChild, 2);
+                range.setEnd(highlight.firstChild, 3);
+            });
+            const mixedFull = runSelection(single, (range, [highlight]) => {
+                range.setStart(left.firstChild, 2);
+                range.setEnd(highlight.firstChild, highlight.firstChild.data.length);
+            });
+            const multiple = runSelection(
+                '<span class="hl">ABC</span> gap <span class="hl">DEF</span>',
+                (range, highlights) => {
+                    range.setStart(highlights[0].firstChild, 0);
+                    range.setEnd(highlights[1].firstChild, highlights[1].firstChild.data.length);
+                }
+            );
+            const secondary = runSelection(
+                '<span class="hl" data-hl-level="secondary">ABCDE</span>',
+                (range, [highlight]) => range.selectNodeContents(highlight)
+            );
+            const adjacentBoundary = runSelection(
+                '<span class="hl">A</span><span class="hl">B</span>',
+                (range, highlights) => {
+                    range.setStart(highlights[0].firstChild, 0);
+                    range.setEnd(highlights[1].firstChild, 0);
+                }
+            );
+            const exactTextRange = runSelection(single, (range, [highlight]) => {
+                range.setStart(highlight.firstChild, 0);
+                range.setEnd(highlight.firstChild, highlight.firstChild.data.length);
+            });
+            const exactNodeContents = runSelection(
+                'plain <span class="hl"><em>AB</em>C<strong>DE</strong></span> tail',
+                (range, [highlight]) => range.selectNodeContents(highlight)
+            );
+
+            return {
+                single,
+                partial,
+                mixedPartial,
+                mixedFull,
+                multiple,
+                secondary,
+                adjacentBoundary,
+                exactTextRange,
+                exactNodeContents
+            };
+        });
+        for (const result of [
+            highlightSelectionChecks.partial,
+            highlightSelectionChecks.mixedPartial,
+            highlightSelectionChecks.mixedFull
+        ]) {
+            assert.equal(result.html, highlightSelectionChecks.single, 'partial or mixed selections must leave the primary highlight unchanged');
+            assert.equal(result.highlightCount, 1, 'partial or mixed selections must not create nested highlights');
+            assert.deepEqual(result.levels, ['primary']);
+            assert.equal(result.text, 'plain ABCDE tail');
+            assert.equal(result.selectionRangeCount, 0, 'a rejected highlight action must clear the browser selection');
+            assert.equal(result.toolbarDisplay, 'none', 'a rejected highlight action must dismiss the selection toolbar');
+            assert.deepEqual(result.selectionState, {
+                hasLastRange: false,
+                hasCurrentHighlightNode: false
+            });
+        }
+        assert.equal(highlightSelectionChecks.multiple.highlightCount, 2, 'a selection crossing highlights must not merge or nest spans');
+        assert.deepEqual(highlightSelectionChecks.multiple.levels, ['primary', 'primary']);
+        assert.equal(highlightSelectionChecks.multiple.text, 'ABC gap DEF');
+        assert.equal(highlightSelectionChecks.secondary.highlightCount, 1);
+        assert.deepEqual(highlightSelectionChecks.secondary.levels, ['secondary'], 'an already-secondary highlight must remain unchanged');
+        assert.equal(highlightSelectionChecks.secondary.selectionRangeCount, 0);
+        assert.deepEqual(highlightSelectionChecks.secondary.selectionState, {
+            hasLastRange: false,
+            hasCurrentHighlightNode: false
+        });
+        assert.equal(highlightSelectionChecks.adjacentBoundary.highlightCount, 2);
+        assert.deepEqual(
+            highlightSelectionChecks.adjacentBoundary.levels,
+            ['secondary', 'primary'],
+            'boundary-only contact with an adjacent highlight must not block an exact promotion'
+        );
+        assert.equal(highlightSelectionChecks.exactTextRange.highlightCount, 1);
+        assert.deepEqual(highlightSelectionChecks.exactTextRange.levels, ['secondary'], 'an exact text-boundary selection must become secondary');
+        assert.equal(highlightSelectionChecks.exactTextRange.text, 'plain ABCDE tail');
+        assert.equal(highlightSelectionChecks.exactNodeContents.highlightCount, 1);
+        assert.deepEqual(highlightSelectionChecks.exactNodeContents.levels, ['secondary'], 'a full selection across nested inline markup must become secondary');
+        assert.equal(highlightSelectionChecks.exactNodeContents.text, 'plain ABCDE tail');
 
         const replayChecks = await page.evaluate(() => {
             const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -4464,6 +4464,40 @@
         });
     }
 
+    function expandRangeToFullySelectedBoundaries(range) {
+        if (!range || range.collapsed) {
+            return range;
+        }
+        const commonAncestor = range.commonAncestorContainer;
+        let startContainer = range.startContainer;
+        let startOffset = range.startOffset;
+        while (startContainer !== commonAncestor && startOffset === 0) {
+            const parent = startContainer.parentNode;
+            if (!parent) break;
+            startOffset = Array.prototype.indexOf.call(parent.childNodes, startContainer);
+            startContainer = parent;
+        }
+
+        let endContainer = range.endContainer;
+        let endOffset = range.endOffset;
+        let endLength = endContainer.nodeType === Node.TEXT_NODE
+            ? (endContainer.textContent || '').length
+            : endContainer.childNodes.length;
+        while (endContainer !== commonAncestor && endOffset === endLength) {
+            const parent = endContainer.parentNode;
+            if (!parent) break;
+            endOffset = Array.prototype.indexOf.call(parent.childNodes, endContainer) + 1;
+            endContainer = parent;
+            endLength = endContainer.nodeType === Node.TEXT_NODE
+                ? (endContainer.textContent || '').length
+                : endContainer.childNodes.length;
+        }
+
+        range.setStart(startContainer, startOffset);
+        range.setEnd(endContainer, endOffset);
+        return range;
+    }
+
     function resolveRangeFromOffsets(root, start, end) {
         const nodes = getTextNodes(root);
         let offset = 0;
@@ -4475,11 +4509,15 @@
             const node = nodes[index];
             const text = node.textContent || '';
             const nextOffset = offset + text.length;
-            if (!startNode && start >= offset && start <= nextOffset) {
+            if (
+                !startNode
+                && start >= offset
+                && (start < nextOffset || (index === nodes.length - 1 && start === nextOffset))
+            ) {
                 startNode = node;
                 startOffset = Math.max(0, start - offset);
             }
-            if (!endNode && end >= offset && end <= nextOffset) {
+            if (!endNode && end > offset && end <= nextOffset) {
                 endNode = node;
                 endOffset = Math.max(0, end - offset);
             }
@@ -4494,7 +4532,7 @@
         const range = document.createRange();
         range.setStart(startNode, startOffset);
         range.setEnd(endNode, endOffset);
-        return range;
+        return expandRangeToFullySelectedBoundaries(range);
     }
 
     function resolveHighlightKind(node) {
@@ -6871,6 +6909,89 @@
         });
     }
 
+    function getNonEmptyTextNodes(root) {
+        const textNodes = [];
+        if (!(root instanceof Node)) {
+            return textNodes;
+        }
+        const ownerDocument = root.ownerDocument || document;
+        const nodeFilter = ownerDocument.defaultView?.NodeFilter || global.NodeFilter;
+        if (!nodeFilter) {
+            return textNodes;
+        }
+        const walker = ownerDocument.createTreeWalker(root, nodeFilter.SHOW_TEXT);
+        let textNode = walker.nextNode();
+        while (textNode) {
+            if ((textNode.data || '').length > 0) {
+                textNodes.push(textNode);
+            }
+            textNode = walker.nextNode();
+        }
+        return textNodes;
+    }
+
+    function rangeHasPositiveTextOverlap(range, node) {
+        if (!range || range.collapsed || !(node instanceof Node)) {
+            return false;
+        }
+        const textNodes = getNonEmptyTextNodes(node);
+        if (!textNodes.length) {
+            return false;
+        }
+        const ownerDocument = node.ownerDocument || document;
+        const rangeType = ownerDocument.defaultView?.Range || global.Range;
+        if (!rangeType || typeof range.compareBoundaryPoints !== 'function') {
+            return false;
+        }
+        try {
+            const nodeTextRange = ownerDocument.createRange();
+            nodeTextRange.setStart(textNodes[0], 0);
+            const lastTextNode = textNodes[textNodes.length - 1];
+            nodeTextRange.setEnd(lastTextNode, lastTextNode.data.length);
+            return range.compareBoundaryPoints(rangeType.START_TO_END, nodeTextRange) > 0
+                && range.compareBoundaryPoints(rangeType.END_TO_START, nodeTextRange) < 0;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function isAtomicPrimaryHighlightSelection(range, highlightNode) {
+        if (
+            !range
+            || range.collapsed
+            || !(highlightNode instanceof HTMLElement)
+            || !highlightNode.matches('.hl')
+            || !highlightNode.isConnected
+            || highlightNode.dataset.hlLevel === 'secondary'
+            || typeof range.comparePoint !== 'function'
+        ) {
+            return false;
+        }
+
+        const textNodes = getNonEmptyTextNodes(highlightNode);
+        if (!textNodes.length) {
+            return false;
+        }
+
+        try {
+            const ownerDocument = highlightNode.ownerDocument || document;
+            const scope = highlightNode.closest('#left, #right') || ownerDocument;
+            const intersectedHighlights = Array.from(scope.querySelectorAll('.hl'))
+                .filter((node) => rangeHasPositiveTextOverlap(range, node));
+            if (intersectedHighlights.length !== 1 || intersectedHighlights[0] !== highlightNode) {
+                return false;
+            }
+
+            const firstTextNode = textNodes[0];
+            const lastTextNode = textNodes[textNodes.length - 1];
+            return range.comparePoint(firstTextNode, 0) === 0
+                && range.comparePoint(lastTextNode, lastTextNode.data.length) === 0
+                && range.toString() === String(highlightNode.textContent || '');
+        } catch (_) {
+            return false;
+        }
+    }
+
     function updateSelectionToolbar() {
         const toolbar = document.getElementById('selbar');
         if (!toolbar) return;
@@ -6907,13 +7028,7 @@
                 const hls = containerElement.querySelectorAll('.hl');
                 for (let i = 0; i < hls.length; i++) {
                     const hl = hls[i];
-                    let intersects = false;
-                    if (typeof range.intersectsNode === 'function') {
-                        intersects = range.intersectsNode(hl);
-                    } else if (selection && typeof selection.containsNode === 'function') {
-                        intersects = selection.containsNode(hl, true);
-                    }
-                    if (intersects) {
+                    if (rangeHasPositiveTextOverlap(range, hl)) {
                         hasHighlight = true;
                         finalHighlightNode = hl;
                         break;
@@ -6948,12 +7063,20 @@
             return;
         }
         if (kind === 'highlight' && interaction.currentHighlightNode instanceof HTMLElement) {
-            interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            const shouldPromote = isAtomicPrimaryHighlightSelection(
+                interaction.lastRange,
+                interaction.currentHighlightNode
+            );
+            if (shouldPromote) {
+                interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            }
             selection?.removeAllRanges();
             if (toolbar) toolbar.style.display = 'none';
             interaction.lastRange = null;
             interaction.currentHighlightNode = null;
-            syncReadingAnnotation('highlight');
+            if (shouldPromote) {
+                syncReadingAnnotation('highlight');
+            }
             return;
         }
         if (interaction.currentHighlightNode) {
@@ -12336,6 +12459,14 @@
                 applyAnswersToDom,
                 applyReplayAnswersToDom,
                 captureDom,
+                updateSelectionToolbar,
+                applySelectionHighlight,
+                getSelectionHighlightTestState() {
+                    return {
+                        hasLastRange: Boolean(interaction.lastRange),
+                        hasCurrentHighlightNode: interaction.currentHighlightNode instanceof HTMLElement
+                    };
+                },
                 renderResults,
                 updateNavStatuses,
                 renderTimer,

--- a/js/runtime/readingHighlightShared.js
+++ b/js/runtime/readingHighlightShared.js
@@ -89,6 +89,40 @@
         });
     }
 
+    function expandRangeToFullySelectedBoundaries(range) {
+        if (!range || range.collapsed) {
+            return range;
+        }
+        const commonAncestor = range.commonAncestorContainer;
+        let startContainer = range.startContainer;
+        let startOffset = range.startOffset;
+        while (startContainer !== commonAncestor && startOffset === 0) {
+            const parent = startContainer.parentNode;
+            if (!parent) break;
+            startOffset = Array.prototype.indexOf.call(parent.childNodes, startContainer);
+            startContainer = parent;
+        }
+
+        let endContainer = range.endContainer;
+        let endOffset = range.endOffset;
+        let endLength = endContainer.nodeType === Node.TEXT_NODE
+            ? (endContainer.textContent || '').length
+            : endContainer.childNodes.length;
+        while (endContainer !== commonAncestor && endOffset === endLength) {
+            const parent = endContainer.parentNode;
+            if (!parent) break;
+            endOffset = Array.prototype.indexOf.call(parent.childNodes, endContainer) + 1;
+            endContainer = parent;
+            endLength = endContainer.nodeType === Node.TEXT_NODE
+                ? (endContainer.textContent || '').length
+                : endContainer.childNodes.length;
+        }
+
+        range.setStart(startContainer, startOffset);
+        range.setEnd(endContainer, endOffset);
+        return range;
+    }
+
     function resolveRangeFromOffsets(root, start, end) {
         const nodes = getTextNodes(root);
         let offset = 0;
@@ -100,11 +134,15 @@
             const node = nodes[index];
             const text = node.textContent || '';
             const nextOffset = offset + text.length;
-            if (!startNode && start >= offset && start <= nextOffset) {
+            if (
+                !startNode
+                && start >= offset
+                && (start < nextOffset || (index === nodes.length - 1 && start === nextOffset))
+            ) {
                 startNode = node;
                 startOffset = Math.max(0, start - offset);
             }
-            if (!endNode && end >= offset && end <= nextOffset) {
+            if (!endNode && end > offset && end <= nextOffset) {
                 endNode = node;
                 endOffset = Math.max(0, end - offset);
             }
@@ -119,7 +157,7 @@
         const range = document.createRange();
         range.setStart(startNode, startOffset);
         range.setEnd(endNode, endOffset);
-        return range;
+        return expandRangeToFullySelectedBoundaries(range);
     }
 
     function resolveHighlightKind(node) {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -611,6 +611,89 @@
         });
     }
 
+    function getNonEmptyTextNodes(root) {
+        const textNodes = [];
+        if (!(root instanceof Node)) {
+            return textNodes;
+        }
+        const ownerDocument = root.ownerDocument || document;
+        const nodeFilter = ownerDocument.defaultView?.NodeFilter || global.NodeFilter;
+        if (!nodeFilter) {
+            return textNodes;
+        }
+        const walker = ownerDocument.createTreeWalker(root, nodeFilter.SHOW_TEXT);
+        let textNode = walker.nextNode();
+        while (textNode) {
+            if ((textNode.data || '').length > 0) {
+                textNodes.push(textNode);
+            }
+            textNode = walker.nextNode();
+        }
+        return textNodes;
+    }
+
+    function rangeHasPositiveTextOverlap(range, node) {
+        if (!range || range.collapsed || !(node instanceof Node)) {
+            return false;
+        }
+        const textNodes = getNonEmptyTextNodes(node);
+        if (!textNodes.length) {
+            return false;
+        }
+        const ownerDocument = node.ownerDocument || document;
+        const rangeType = ownerDocument.defaultView?.Range || global.Range;
+        if (!rangeType || typeof range.compareBoundaryPoints !== 'function') {
+            return false;
+        }
+        try {
+            const nodeTextRange = ownerDocument.createRange();
+            nodeTextRange.setStart(textNodes[0], 0);
+            const lastTextNode = textNodes[textNodes.length - 1];
+            nodeTextRange.setEnd(lastTextNode, lastTextNode.data.length);
+            return range.compareBoundaryPoints(rangeType.START_TO_END, nodeTextRange) > 0
+                && range.compareBoundaryPoints(rangeType.END_TO_START, nodeTextRange) < 0;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function isAtomicPrimaryHighlightSelection(range, highlightNode) {
+        if (
+            !range
+            || range.collapsed
+            || !(highlightNode instanceof HTMLElement)
+            || !highlightNode.matches('.hl')
+            || !highlightNode.isConnected
+            || highlightNode.dataset.hlLevel === 'secondary'
+            || typeof range.comparePoint !== 'function'
+        ) {
+            return false;
+        }
+
+        const textNodes = getNonEmptyTextNodes(highlightNode);
+        if (!textNodes.length) {
+            return false;
+        }
+
+        try {
+            const ownerDocument = highlightNode.ownerDocument || document;
+            const scope = highlightNode.closest('#left, #right') || ownerDocument;
+            const intersectedHighlights = Array.from(scope.querySelectorAll('.hl'))
+                .filter((node) => rangeHasPositiveTextOverlap(range, node));
+            if (intersectedHighlights.length !== 1 || intersectedHighlights[0] !== highlightNode) {
+                return false;
+            }
+
+            const firstTextNode = textNodes[0];
+            const lastTextNode = textNodes[textNodes.length - 1];
+            return range.comparePoint(firstTextNode, 0) === 0
+                && range.comparePoint(lastTextNode, lastTextNode.data.length) === 0
+                && range.toString() === String(highlightNode.textContent || '');
+        } catch (_) {
+            return false;
+        }
+    }
+
     function updateSelectionToolbar() {
         const toolbar = document.getElementById('selbar');
         if (!toolbar) return;
@@ -647,13 +730,7 @@
                 const hls = containerElement.querySelectorAll('.hl');
                 for (let i = 0; i < hls.length; i++) {
                     const hl = hls[i];
-                    let intersects = false;
-                    if (typeof range.intersectsNode === 'function') {
-                        intersects = range.intersectsNode(hl);
-                    } else if (selection && typeof selection.containsNode === 'function') {
-                        intersects = selection.containsNode(hl, true);
-                    }
-                    if (intersects) {
+                    if (rangeHasPositiveTextOverlap(range, hl)) {
                         hasHighlight = true;
                         finalHighlightNode = hl;
                         break;
@@ -688,12 +765,20 @@
             return;
         }
         if (kind === 'highlight' && interaction.currentHighlightNode instanceof HTMLElement) {
-            interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            const shouldPromote = isAtomicPrimaryHighlightSelection(
+                interaction.lastRange,
+                interaction.currentHighlightNode
+            );
+            if (shouldPromote) {
+                interaction.currentHighlightNode.dataset.hlLevel = 'secondary';
+            }
             selection?.removeAllRanges();
             if (toolbar) toolbar.style.display = 'none';
             interaction.lastRange = null;
             interaction.currentHighlightNode = null;
-            syncReadingAnnotation('highlight');
+            if (shouldPromote) {
+                syncReadingAnnotation('highlight');
+            }
             return;
         }
         if (interaction.currentHighlightNode) {
@@ -6076,6 +6161,14 @@
                 applyAnswersToDom,
                 applyReplayAnswersToDom,
                 captureDom,
+                updateSelectionToolbar,
+                applySelectionHighlight,
+                getSelectionHighlightTestState() {
+                    return {
+                        hasLastRange: Boolean(interaction.lastRange),
+                        hasCurrentHighlightNode: interaction.currentHighlightNode instanceof HTMLElement
+                    };
+                },
                 renderResults,
                 updateNavStatuses,
                 renderTimer,


### PR DESCRIPTION
## Summary

- Require an exact selection of one primary highlight before promoting it to the secondary color
- Treat partial, mixed, multiple-highlight, and already-secondary selections as deterministic no-ops while clearing stale toolbar state
- Preserve adjacent and nested-inline primary/secondary ranges during snapshot restore
- Add Chromium regression coverage for selection boundaries and persistence

## Root cause

`updateSelectionToolbar()` treated any `Range.intersectsNode()` result as a full highlight match, so `applySelectionHighlight()` recolored the entire span and discarded the saved range. Boundary-only contact also counted as overlap. Highlight restore additionally assigned seam offsets to the preceding text node and did not expand fully selected inline boundaries, causing adjacent or inline ranges to be lost.

## Impact

Partial or cross-boundary selections no longer recolor unselected text or create nested highlights. Complete primary-highlight selections still promote to secondary, and resulting highlight levels survive snapshot/restore.

## Validation

- `node developer/tests/js/readingInteractionRegression.test.js`
- `npm test --prefix developer` (72 tests)
- `python -m unittest discover -s developer/tests/py -p "test_*.py"` (20 tests)
- `python developer/tests/ci/check_reading_data_integrity.py`
- `python developer/tests/e2e/e2e_runner.py`
- `node scripts/build-bundles.mjs --check`
- `git diff --check`

Fixes #115