### PR TITLE
Fix repeated Question Bank navigation reset

### DIFF
--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -183,6 +183,12 @@ const filterSecond = deferred();
 resolverQueue.push(filterFirst, filterSecond);
 const staleFilter = sandbox.filterByType('reading');
 const latestFilter = sandbox.filterByType('all');
+const latestFilterRequestId = sandbox.__getBrowseResultsRequestId();
+assert.strictEqual(
+    sandbox.__isBrowseUserResultsRequestInFlight(latestFilterRequestId),
+    true,
+    'a hot type filter must own its request while the active index is unresolved'
+);
 const allExams = [
     {
         id: 'reading',
@@ -203,6 +209,7 @@ const allExams = [
 ];
 filterSecond.resolve(allExams);
 await latestFilter;
+assert.strictEqual(sandbox.__isBrowseUserResultsRequestInFlight(latestFilterRequestId), false);
 filterFirst.resolve(allExams);
 await staleFilter;
 
@@ -223,14 +230,43 @@ const sharedPendingFilter = sandbox.applyBrowseFilter(
     sharedPendingFilterRequestId
 );
 assert.strictEqual(
+    sandbox.__isBrowseUserResultsRequestInFlight(sharedPendingFilterRequestId),
+    true,
+    'a caller-supplied user request must be retained during filter resolution'
+);
+assert.strictEqual(
     sandbox.__getBrowseResultsRequestId(),
     sharedPendingFilterRequestId,
     'a synchronized pending filter must reuse the initialization request token'
 );
 sharedPendingFilterIndex.resolve(allExams);
 await sharedPendingFilter;
+assert.strictEqual(sandbox.__isBrowseUserResultsRequestInFlight(sharedPendingFilterRequestId), false);
 assert.strictEqual(browseState.category, 'P1');
 assert.strictEqual(browseState.type, 'reading');
+
+rendered.length = 0;
+searchInput.value = 'zzzz-no-match';
+const queryAwareTypeIndex = deferred();
+resolverQueue.push(queryAwareTypeIndex);
+const queryAwareTypeFilter = sandbox.filterByType('reading');
+queryAwareTypeIndex.resolve(allExams);
+await queryAwareTypeFilter;
+assert.strictEqual(searchInput.value, 'zzzz-no-match');
+assert.strictEqual(browseState.category, 'all');
+assert.strictEqual(browseState.type, 'reading');
+assert.deepStrictEqual(rendered.at(-1), [], 'type filtering must preserve and apply the visible query');
+
+const queryAwareCategoryIndex = deferred();
+resolverQueue.push(queryAwareCategoryIndex);
+const queryAwareCategoryFilter = sandbox.applyBrowseFilter('P1', 'listening');
+queryAwareCategoryIndex.resolve(allExams);
+await queryAwareCategoryFilter;
+assert.strictEqual(searchInput.value, 'zzzz-no-match');
+assert.strictEqual(browseState.category, 'P1');
+assert.strictEqual(browseState.type, 'listening');
+assert.deepStrictEqual(rendered.at(-1), [], 'category filtering must preserve and apply the visible query');
+searchInput.value = '';
 
 rendered.length = 0;
 const sharedSearchIndex = deferred();
@@ -296,20 +332,27 @@ assert.deepStrictEqual(
 );
 assert.strictEqual(navigationIntentMarks, 2, 'each fallback view activation must mark a navigation intent');
 
+const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
+vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
+const productionLoadExamList = sandbox.ExamActions.loadExamList;
+sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
+    const result = productionLoadExamList.call(this, exams);
+    if (Array.isArray(result)) {
+        rendered.push(Array.from(result, (exam) => exam.id));
+    }
+    return result;
+};
+
 searchInput.value = 'stale-query';
 sandbox.__browseFilterMode = 'frequency-p1';
 sandbox.__browsePath = 'ReadingPractice/P1';
 sandbox.__browseFrequencyFilter = 'high';
 sandbox.browseController.currentMode = 'frequency-p1';
 sandbox.browseController.activeFilter = 'reading';
-sandbox.ExamActions.applyBrowsePostFilters = function applyBrowsePostFilters(exams, _sortMode, frequencyFilter) {
-    if (!frequencyFilter || frequencyFilter === 'all') return exams;
-    return exams.filter((exam) => exam.frequency === frequencyFilter);
-};
-const helperFreeLoadExamList = sandbox.ExamActions.loadExamList;
-sandbox.ExamActions.loadExamList = function loadExamListWithActiveFilters(exams) {
-    return helperFreeLoadExamList.call(this, sandbox.getBrowseFilteredExamBase(exams));
-};
+const mainResetBrowseFilterStateToAll = sandbox.resetBrowseFilterStateToAll;
+const mainUpdateBrowseFrequencyButtons = sandbox.updateBrowseFrequencyButtons;
+sandbox.resetBrowseFilterStateToAll = undefined;
+sandbox.updateBrowseFrequencyButtons = undefined;
 const helperFreeResetIndex = deferred();
 resolverQueue.push(helperFreeResetIndex);
 const helperFreeReset = sandbox.showView('browse', true);
@@ -322,6 +365,8 @@ assert.strictEqual(sandbox.__browseFrequencyFilter, 'all');
 assert.strictEqual(sandbox.browseController.currentMode, 'default');
 assert.strictEqual(sandbox.browseController.activeFilter, 'all');
 assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening']);
+sandbox.resetBrowseFilterStateToAll = mainResetBrowseFilterStateToAll;
+sandbox.updateBrowseFrequencyButtons = mainUpdateBrowseFrequencyButtons;
 searchInput.value = '';
 
 const failedReentryIndex = deferred();
@@ -333,17 +378,6 @@ assert.strictEqual(
     false,
     'fallback navigation must observe and contain an asynchronous Browse refresh failure'
 );
-
-const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
-vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
-const productionLoadExamList = sandbox.ExamActions.loadExamList;
-sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
-    const result = productionLoadExamList.call(this, exams);
-    if (Array.isArray(result)) {
-        rendered.push(Array.from(result, (exam) => exam.id));
-    }
-    return result;
-};
 
 rendered.length = 0;
 const latestFilterIndex = deferred();

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -151,6 +151,21 @@ const sandbox = {
         if (!next) throw new Error('unexpected index resolution');
         return next.promise;
     },
+    prepareBrowseCompletionIndex(records) {
+        return { records: Array.from(records || []) };
+    },
+    isPreparedBrowseCompletionIndex(prepared) {
+        return !!prepared;
+    },
+    commitBrowseCompletionIndex() {
+        return true;
+    },
+    prepareBrowseAnchorUpdates(records, index) {
+        return { records: Array.from(records || []), index: Array.from(index || []) };
+    },
+    commitBrowseAnchorUpdates() {
+        return true;
+    },
     browseController: {
         currentMode: 'default',
         buttonContainer: typeButtonContainer,
@@ -518,6 +533,29 @@ const integrationSandbox = {
             Array.isArray(records) ? Array.from(records, (record) => record && record.id) : null
         );
     },
+    prepareBrowseCompletionIndex(records) {
+        return {
+            records: Array.isArray(records)
+                ? Array.from(records, (record) => record && record.id)
+                : null
+        };
+    },
+    isPreparedBrowseCompletionIndex(prepared) {
+        return !!prepared;
+    },
+    commitBrowseCompletionIndex(prepared) {
+        integrationCompletionRefreshes.push(prepared.records);
+        return true;
+    },
+    prepareBrowseAnchorUpdates(records, index) {
+        return {
+            index: Array.from(index || [], (exam) => exam.id)
+        };
+    },
+    commitBrowseAnchorUpdates(prepared) {
+        integrationAnchorIndexes.push(prepared.index);
+        return true;
+    },
     browseController: {
         currentMode: 'default',
         buttonContainer: {},
@@ -793,71 +831,75 @@ assert.deepStrictEqual(
     'the successful queued Browse projection must render after the foreground request settles'
 );
 
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const acceptedPublicationRecords = deferred();
-const acceptedPublicationIndex = deferred();
-const rejectedPublicationRecords = deferred();
-const rejectedPublicationIndex = deferred();
-integrationPracticeRecordResolvers.push(
-    acceptedPublicationRecords,
-    rejectedPublicationRecords
-);
-integrationIndexResolvers.push(acceptedPublicationIndex, rejectedPublicationIndex);
-const publicationUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
-const acceptedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
-acceptedPublicationRecords.resolve([{ id: 'accepted-publication-record' }]);
-acceptedPublicationIndex.resolve([{ id: 'accepted-publication-index' }]);
-assert.deepStrictEqual(
-    Array.from(await acceptedPublication, (record) => record.id),
-    ['accepted-publication-record']
-);
-const productionCompletionRebuild = integrationSandbox.rebuildBrowseCompletionIndex;
-integrationSandbox.rebuildBrowseCompletionIndex = function rejectProjectionPublication() {
-    throw new Error('newer projection publication failed');
-};
-const rejectedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
-rejectedPublicationRecords.resolve([{ id: 'rejected-publication-record' }]);
-rejectedPublicationIndex.resolve([{ id: 'rejected-publication-index' }]);
-assert.deepStrictEqual(
-    Array.from(await rejectedPublication, (record) => record.id),
-    ['rejected-publication-record'],
-    'Browse publication failure must not change the baseline Practice sync result'
-);
-integrationSandbox.rebuildBrowseCompletionIndex = productionCompletionRebuild;
-integrationSandbox.__endBrowseUserResultsRequest(publicationUserRequest);
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.deepStrictEqual(
-    integrationCompletionRefreshes,
-    [['accepted-publication-record']],
-    'a rejected newer publication must preserve the accepted completion projection'
-);
-assert.deepStrictEqual(
-    integrationAnchorIndexes,
-    [['accepted-publication-index']],
-    'a rejected newer publication must preserve the accepted anchor projection'
-);
-assert.deepStrictEqual(
-    integrationPracticeUpdates,
-    [
-        {
-            records: ['accepted-publication-record'],
-            index: ['accepted-publication-index']
-        },
-        {
-            records: ['rejected-publication-record'],
-            index: ['rejected-publication-index']
-        }
-    ],
-    'Browse publication rejection must not suppress either Practice update'
-);
-assert.deepStrictEqual(
-    integrationRenders,
-    [['accepted-publication-index']],
-    'a rejected newer publication must not invalidate the accepted queued repaint'
-);
+for (const failurePoint of [
+    'prepareBrowseCompletionIndex',
+    'prepareBrowseAnchorUpdates',
+    'commitBrowseAnchorUpdates'
+]) {
+    integrationRenders.length = 0;
+    integrationAnchorIndexes.length = 0;
+    integrationCompletionRefreshes.length = 0;
+    integrationPracticeUpdates.length = 0;
+    const acceptedRecordId = `accepted-${failurePoint}-record`;
+    const acceptedIndexId = `accepted-${failurePoint}-index`;
+    const rejectedRecordId = `rejected-${failurePoint}-record`;
+    const rejectedIndexId = `rejected-${failurePoint}-index`;
+    const acceptedPublicationRecords = deferred();
+    const acceptedPublicationIndex = deferred();
+    const rejectedPublicationRecords = deferred();
+    const rejectedPublicationIndex = deferred();
+    integrationPracticeRecordResolvers.push(
+        acceptedPublicationRecords,
+        rejectedPublicationRecords
+    );
+    integrationIndexResolvers.push(acceptedPublicationIndex, rejectedPublicationIndex);
+    const publicationUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+    const acceptedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
+    acceptedPublicationRecords.resolve([{ id: acceptedRecordId }]);
+    acceptedPublicationIndex.resolve([{ id: acceptedIndexId }]);
+    assert.deepStrictEqual(
+        Array.from(await acceptedPublication, (record) => record.id),
+        [acceptedRecordId]
+    );
+    const productionPublicationStage = integrationSandbox[failurePoint];
+    integrationSandbox[failurePoint] = function rejectProjectionPublication() {
+        throw new Error(`newer projection ${failurePoint} failed`);
+    };
+    const rejectedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
+    rejectedPublicationRecords.resolve([{ id: rejectedRecordId }]);
+    rejectedPublicationIndex.resolve([{ id: rejectedIndexId }]);
+    assert.deepStrictEqual(
+        Array.from(await rejectedPublication, (record) => record.id),
+        [rejectedRecordId],
+        'Browse publication failure must not change the baseline Practice sync result'
+    );
+    integrationSandbox[failurePoint] = productionPublicationStage;
+    integrationSandbox.__endBrowseUserResultsRequest(publicationUserRequest);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepStrictEqual(
+        integrationCompletionRefreshes,
+        [[acceptedRecordId]],
+        `${failurePoint} failure must preserve the accepted completion projection`
+    );
+    assert.deepStrictEqual(
+        integrationAnchorIndexes,
+        [[acceptedIndexId]],
+        `${failurePoint} failure must preserve the accepted anchor projection`
+    );
+    assert.deepStrictEqual(
+        integrationPracticeUpdates,
+        [
+            { records: [acceptedRecordId], index: [acceptedIndexId] },
+            { records: [rejectedRecordId], index: [rejectedIndexId] }
+        ],
+        'Browse publication rejection must not suppress either Practice update'
+    );
+    assert.deepStrictEqual(
+        integrationRenders,
+        [[acceptedIndexId]],
+        `${failurePoint} failure must not invalidate the accepted queued repaint`
+    );
+}
 
 const identicalHeadIndex = deferred();
 const redundantTailPoison = {
@@ -2215,6 +2257,33 @@ assert.strictEqual(
     'failed',
     'only a terminal DOM commit receipt may clear failed-reset debt'
 );
+const getElementByIdBeforeMissingCommit = integrationDocument.getElementById;
+integrationDocument.getElementById = function getElementByIdWithUncommittedContainer(id) {
+    if (id === 'exam-list-container') {
+        return {};
+    }
+    return getElementByIdBeforeMissingCommit.call(this, id);
+};
+assert.strictEqual(
+    integrationSandbox.ExamListView.render([{ id: 'uncommitted-wrapper-result' }]),
+    false,
+    'the exported view wrapper must propagate a cached view commit failure'
+);
+integrationDocument.getElementById = getElementByIdBeforeMissingCommit;
+const missingCommitResetIndex = deferred();
+integrationIndexResolvers.push(missingCommitResetIndex);
+const missingCommitReset = integrationSandbox.ExamActions.resetBrowseViewToAll();
+missingCommitResetIndex.resolve([{ id: 'uncommitted-direct-reset-result' }]);
+assert.strictEqual(
+    await missingCommitReset,
+    false,
+    'the direct reset path must propagate a missing-container view failure'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'an uncommitted direct reset must leave failed-reset debt intact'
+);
 integrationSandbox.refreshBrowseProgressFromRecords(
     [],
     [{ id: 'progress-blocked-after-missing-commit-receipt' }]
@@ -2465,6 +2534,17 @@ sandbox.showView = productionShowView;
 const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
 vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
 const productionLoadExamList = sandbox.ExamActions.loadExamList;
+const successfulProductionExamListView = {
+    render() {
+        return true;
+    }
+};
+sandbox.browseController.getExamListView = function getExamListView() {
+    return successfulProductionExamListView;
+};
+sandbox.browseController.ensureExamListView = function ensureExamListView() {
+    return successfulProductionExamListView;
+};
 sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams, options = {}) {
     const result = productionLoadExamList.call(this, exams, options);
     if (Array.isArray(result)) {

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -166,6 +166,30 @@ sandbox.self = sandbox;
 const context = vm.createContext(sandbox);
 vm.runInContext(source, context, { filename: 'js/main.js' });
 
+const firstHydrationIndex = deferred();
+const latestHydrationIndex = deferred();
+const initialPersistedFilterReader = sandbox.getPersistedBrowseFilter;
+let initialPersistedFilterReads = 0;
+sandbox.getPersistedBrowseFilter = () => {
+    initialPersistedFilterReads += 1;
+    return { category: 'P2', type: 'reading' };
+};
+resolverQueue.push(firstHydrationIndex, latestHydrationIndex);
+const firstHydration = sandbox.initializeBrowseView({ skipLoad: true });
+const latestHydration = sandbox.initializeBrowseView({ skipLoad: true });
+latestHydrationIndex.resolve([
+    { id: 'hydrated-reading', title: 'Hydrated Reading', category: 'P2', type: 'reading' }
+]);
+await latestHydration;
+assert.deepStrictEqual(browseState, { category: 'P2', type: 'reading' });
+assert.strictEqual(initialPersistedFilterReads, 1, 'the latest successful initialization must hydrate once');
+firstHydrationIndex.resolve([
+    { id: 'stale-reading', title: 'Stale Reading', category: 'P1', type: 'reading' }
+]);
+assert.strictEqual(await firstHydration, null, 'the superseded initialization must stand down');
+assert.strictEqual(initialPersistedFilterReads, 1, 'a stale initialization must not hydrate a second time');
+sandbox.getPersistedBrowseFilter = initialPersistedFilterReader;
+
 const searchFirst = deferred();
 const searchSecond = deferred();
 resolverQueue.push(searchFirst, searchSecond);
@@ -313,6 +337,7 @@ sandbox.__markAppNavigationIntent = function markAppNavigationIntent() {
     navigationIntentMarks += 1;
     return navigationIntentMarks;
 };
+sandbox.__getAppNavigationIntentGeneration = () => navigationIntentMarks;
 const bootFallbackSource = fs.readFileSync(path.join(repoRoot, 'js/boot-fallbacks.js'), 'utf8');
 vm.runInContext(bootFallbackSource, context, { filename: 'js/boot-fallbacks.js' });
 rendered.length = 0;
@@ -332,12 +357,67 @@ reentryNoMatchIndex.resolve(allExams);
 await new Promise((resolve) => setTimeout(resolve, 0));
 
 assert.strictEqual(searchInput.value, 'zzzz-no-match', 'ordinary Browse re-entry must preserve the query');
+assert.strictEqual(browseState.category, 'P1', 'ordinary Browse re-entry must preserve the live category');
+assert.strictEqual(
+    browseState.type,
+    'listening',
+    'ordinary Browse re-entry must not restore an older persisted type over the live selection'
+);
 assert.deepStrictEqual(
     rendered,
     [[], []],
     'ordinary Browse re-entry must reapply the preserved query instead of flashing the full list'
 );
 assert.strictEqual(navigationIntentMarks, 2, 'each fallback view activation must mark a navigation intent');
+
+rendered.length = 0;
+const stateBeforeCancelledApply = { ...browseState };
+const delayedNavigationFilterIndex = deferred();
+resolverQueue.push(delayedNavigationFilterIndex);
+const delayedNavigationFilter = sandbox.applyBrowseFilter(
+    'P3',
+    'listening',
+    null,
+    null,
+    null,
+    sandbox.__getAppNavigationIntentGeneration()
+);
+sandbox.showView('overview', false);
+delayedNavigationFilterIndex.resolve(allExams);
+assert.strictEqual(
+    await delayedNavigationFilter,
+    false,
+    'a filter continuation must stop when a newer navigation intent wins'
+);
+assert.deepStrictEqual(browseState, stateBeforeCancelledApply);
+assert.deepStrictEqual(rendered, [], 'the cancelled filter must not render after leaving Browse');
+assert.strictEqual(overviewView.classList.contains('active'), true);
+assert.strictEqual(browseView.classList.contains('active'), false);
+
+rendered.length = 0;
+searchInput.value = '';
+const directOverviewFilterIndex = deferred();
+resolverQueue.push(directOverviewFilterIndex);
+const productionShowView = sandbox.showView;
+const directOverviewNavigations = [];
+sandbox.showView = (viewName, resetCategory) => {
+    directOverviewNavigations.push([viewName, resetCategory]);
+    sandbox.__markAppNavigationIntent();
+    browseView.classList.remove('active');
+    overviewView.classList.remove('active');
+    (viewName === 'browse' ? browseView : overviewView).classList.add('active');
+};
+const directOverviewFilter = sandbox.applyBrowseFilter('P1', 'reading');
+directOverviewFilterIndex.resolve(allExams);
+await directOverviewFilter;
+assert.deepStrictEqual(rendered, [['reading', 'listening']]);
+assert.deepStrictEqual(browseState, { category: 'P1', type: 'reading' });
+assert.deepStrictEqual(
+    directOverviewNavigations,
+    [['browse', false]],
+    'a direct stable Overview filter must retain its contract of entering Browse after rendering'
+);
+sandbox.showView = productionShowView;
 
 const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
 vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
@@ -360,13 +440,18 @@ const previousControllerInitialize = sandbox.browseController.initialize;
 const previousControllerContainer = sandbox.browseController.buttonContainer;
 const previousPersistedFilter = sandbox.getPersistedBrowseFilter;
 const previousListeningAvailabilityRefresh = sandbox.refreshListeningAvailabilityUI;
+let stalePersistedFilterReads = 0;
 sandbox.browseController.buttonContainer = null;
 sandbox.browseController.initialize = function initializeBrowseController(containerId) {
     firstActivationControllerSetups += 1;
     this.buttonContainer = containerId === 'type-filter-buttons' ? typeButtonContainer : null;
     return true;
 };
-sandbox.getPersistedBrowseFilter = () => ({ category: 'P2', type: 'reading' });
+sandbox.setBrowseFilterState('P2', 'reading');
+sandbox.getPersistedBrowseFilter = () => {
+    stalePersistedFilterReads += 1;
+    return { category: 'all', type: 'all' };
+};
 sandbox.refreshListeningAvailabilityUI = () => {
     firstActivationListeningSyncs += 1;
 };
@@ -381,7 +466,16 @@ assert.strictEqual(firstActivationControllerSetups, 1, 'first Browse activation 
 assert.strictEqual(firstActivationListeningSyncs, 1, 'first Browse activation must refresh listening availability');
 assert.strictEqual(browseState.category, 'P2');
 assert.strictEqual(browseState.type, 'reading');
-assert.deepStrictEqual(rendered, [['p2-reading']], 'first activation must render once after restoring persisted scope');
+assert.strictEqual(
+    stalePersistedFilterReads,
+    0,
+    'ordinary Browse re-entry must not read stale persisted scope after an explicit filter intent'
+);
+assert.deepStrictEqual(
+    rendered,
+    [['p2-reading']],
+    'ordinary Browse re-entry must keep the live scope while an older persisted filter is still visible'
+);
 sandbox.browseController.initialize = previousControllerInitialize;
 sandbox.browseController.buttonContainer = previousControllerContainer;
 sandbox.getPersistedBrowseFilter = previousPersistedFilter;
@@ -624,6 +718,43 @@ for (const scenario of [
     assert.deepStrictEqual(compositionRenders, [scenario.expected]);
 }
 
+const duplicateP4Numbered = {
+    id: 'p4-shared-numbered',
+    title: 'Shared P4 Duplicate',
+    searchText: 'shared p4 duplicate',
+    category: 'P4',
+    type: 'listening',
+    path: 'ListeningPractice/100 P4/1-10/shared.html'
+};
+const duplicateP4High = {
+    id: 'p4-shared-high',
+    title: 'Shared P4 Duplicate',
+    searchText: 'shared p4 duplicate',
+    category: 'P4',
+    type: 'listening',
+    path: 'ListeningPractice/100 P4/P4 高频(52)/shared.html'
+};
+sandbox.__browseFilterMode = 'frequency-p4';
+sandbox.__browsePath = 'ListeningPractice/100 P4';
+sandbox.__browseFrequencyFilter = 'all';
+productionBrowseController.currentMode = 'frequency-p4';
+productionBrowseController.activeFilter = 'high';
+sandbox.setBrowseFilterState('P4', 'listening');
+searchInput.value = 'shared p4';
+for (const duplicateOrder of [
+    [duplicateP4Numbered, duplicateP4High],
+    [duplicateP4High, duplicateP4Numbered]
+]) {
+    compositionRenders.length = 0;
+    const requestId = sandbox.__beginBrowseResultsRequest();
+    await sandbox.__renderBrowseResultsForState(duplicateOrder, requestId);
+    assert.deepStrictEqual(
+        compositionRenders,
+        [['p4-shared-high']],
+        'the active folder must be applied before deduplication regardless of index order'
+    );
+}
+
 compositionRenders.length = 0;
 compositionLoadCalls = 0;
 searchInput.value = 'shared';
@@ -678,12 +809,15 @@ sandbox.AppEntry = {
         coldResetOrder.push('ensure');
         sandbox.ExamActions = {
             browseFilterStateOwner: {
-                resetToAll() {
-                    coldResetOrder.push('owner');
+                resetForActivation() {
+                    coldResetOrder.push('owner-activation');
                     sandbox.__browseFilterMode = 'default';
                     sandbox.__browsePath = null;
                     sandbox.__browseFrequencyFilter = 'all';
                     return true;
+                },
+                resetToAll() {
+                    throw new Error('the cold fallback must prefer the hydration-aware activation reset');
                 }
             }
         };
@@ -703,7 +837,7 @@ sandbox.__browseFrequencyFilter = 'high';
 assert.notStrictEqual(await sandbox.showView('browse', true), false);
 assert.deepStrictEqual(
     coldResetOrder,
-    ['barrier', 'ensure', 'owner', 'activate', 'load'],
+    ['barrier', 'ensure', 'owner-activation', 'activate', 'load'],
     'a cold reset must run its owner before the synchronized activation can render'
 );
 assert.strictEqual(unsafeBrowseGroupCalls, 0, 'cold reset must not invoke the synchronizing Browse loader');

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -20,6 +20,14 @@ function deferred() {
     return { promise, resolve, reject };
 }
 
+async function waitForCondition(predicate, message, attempts = 100) {
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (predicate()) return;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error(message || 'timed out waiting for condition');
+}
+
 function createClassList() {
     const values = new Set();
     return {
@@ -486,6 +494,7 @@ const integrationSandbox = {
     },
     getCurrentCategory() { return integrationBrowseState.category; },
     getCurrentExamType() { return integrationBrowseState.type; },
+    getPersistedBrowseFilter() { return null; },
     setBrowseTitle() {},
     formatBrowseTitle(category, type) { return `${category}:${type}`; },
     normalizeExamType(type) { return type || 'all'; },
@@ -681,6 +690,35 @@ assert.deepStrictEqual(
     'a progress snapshot captured before a reset must not repaint after the reset epoch closes'
 );
 
+integrationRenders.length = 0;
+const preCommitProgressRecords = deferred();
+const preCommitProgressIndex = deferred();
+integrationPracticeRecordResolvers.push(preCommitProgressRecords);
+integrationIndexResolvers.push(preCommitProgressIndex);
+const dataEpochUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+const preCommitProgressSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+preCommitProgressRecords.resolve([{ id: 'pre-commit-progress-record' }]);
+preCommitProgressIndex.resolve([{ id: 'pre-commit-progress' }]);
+await preCommitProgressSync;
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'progress must remain queued while the user results request is retained'
+);
+emitIntegrationDataCommitted([{ store: 'practiceSummaries' }]);
+integrationSandbox.__endBrowseUserResultsRequest(dataEpochUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'a pre-commit pending progress snapshot must not replay after the practice-data epoch changes'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    dataEpochUserRequest,
+    'discarding data-stale pending progress must not consume a Browse results token'
+);
+
 const identicalHeadIndex = deferred();
 const redundantTailPoison = {
     get promise() {
@@ -745,9 +783,10 @@ integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
     detail: { index: [{ id: 'queued-epoch-two-publication' }] }
 }));
 queuedEpochHeadIndex.resolve([{ id: 'queued-epoch-stale-head' }]);
-while (integrationIndexResolutionCount < queuedEpochResolutionCountBefore + 2) {
-    await Promise.resolve();
-}
+await waitForCondition(
+    () => integrationIndexResolutionCount === queuedEpochResolutionCountBefore + 2,
+    'the queued current-epoch tail must start before the alias joins it'
+);
 const queuedEpochCurrentJoin = integrationSandbox.ensurePracticeRecordsSync(
     'queued-epoch-current-alias',
     { forceRender: true }
@@ -766,8 +805,15 @@ assert.strictEqual(
     'a current-epoch join must not enqueue a third physical read'
 );
 
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const dataEpochHeadRecords = deferred();
+const dataEpochCurrentRecords = deferred();
 const dataEpochHeadIndex = deferred();
 const dataEpochCurrentIndex = deferred();
+integrationPracticeRecordResolvers.push(dataEpochHeadRecords, dataEpochCurrentRecords);
 integrationIndexResolvers.push(dataEpochHeadIndex, dataEpochCurrentIndex);
 const dataEpochResolutionCountBefore = integrationIndexResolutionCount;
 const dataEpochHeadCycle = integrationSandbox.ensurePracticeRecordsSync(
@@ -775,24 +821,105 @@ const dataEpochHeadCycle = integrationSandbox.ensurePracticeRecordsSync(
     { forceRender: true }
 );
 emitIntegrationDataCommitted([{ store: 'practiceSummaries' }]);
-const dataEpochJoinedCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'practice-view',
-    { forceRender: true }
-);
-assert.strictEqual(dataEpochJoinedCycle, dataEpochHeadCycle);
-dataEpochCurrentIndex.resolve([{ id: 'data-epoch-current' }]);
+dataEpochHeadRecords.resolve([{ id: 'data-epoch-stale-record' }]);
 dataEpochHeadIndex.resolve([{ id: 'data-epoch-stale' }]);
-await dataEpochJoinedCycle;
+await waitForCondition(
+    () => integrationIndexResolutionCount === dataEpochResolutionCountBefore + 2,
+    'a relevant commit must start the managed current-data replacement'
+);
+dataEpochCurrentRecords.resolve([{ id: 'data-epoch-current-record' }]);
+dataEpochCurrentIndex.resolve([{ id: 'data-epoch-current' }]);
+await dataEpochHeadCycle;
 assert.strictEqual(
     integrationIndexResolutionCount,
     dataEpochResolutionCountBefore + 2,
-    'a proven practice-store commit must schedule exactly one current-data follow-up'
+    'a managed sync invalidated by a practice-store commit must schedule exactly one automatic follow-up'
 );
-assert.deepStrictEqual(
-    integrationAnchorIndexes.at(-1),
-    ['data-epoch-current'],
-    'only the current practice-data epoch may update Browse anchors'
+assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'data-epoch-current-record');
+assert.deepStrictEqual(integrationCompletionRefreshes, [['data-epoch-current-record']]);
+assert.deepStrictEqual(integrationAnchorIndexes, [['data-epoch-current']]);
+assert.deepStrictEqual(integrationRenders, [['data-epoch-current']]);
+assert.deepStrictEqual(integrationPracticeUpdates, [{
+    records: ['data-epoch-current-record'],
+    index: ['data-epoch-current']
+}]);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const directCommitHeadRecords = deferred();
+const directCommitCurrentRecords = deferred();
+const directCommitHeadIndex = deferred();
+const directCommitCurrentIndex = deferred();
+integrationPracticeRecordResolvers.push(directCommitHeadRecords, directCommitCurrentRecords);
+integrationIndexResolvers.push(directCommitHeadIndex, directCommitCurrentIndex);
+const directCommitResolutionCountBefore = integrationIndexResolutionCount;
+const directCommitHead = integrationSandbox.syncPracticeRecords({ forceRender: true });
+emitIntegrationDataCommitted([{ store: 'practiceDetails' }]);
+await waitForCondition(
+    () => integrationIndexResolutionCount === directCommitResolutionCountBefore + 2,
+    'a relevant commit must start a replacement for an active direct sync'
 );
+directCommitCurrentRecords.resolve([{ id: 'direct-commit-current-record' }]);
+directCommitCurrentIndex.resolve([{ id: 'direct-commit-current-index' }]);
+directCommitHeadRecords.resolve([{ id: 'direct-commit-stale-record' }]);
+directCommitHeadIndex.resolve([{ id: 'direct-commit-stale-index' }]);
+await directCommitHead;
+await waitForCondition(
+    () => integrationPracticeUpdates.length === 1,
+    'the automatic direct replacement must complete all current-data projections'
+);
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    directCommitResolutionCountBefore + 2,
+    'a direct sync invalidated by a commit must start exactly one automatic physical replacement'
+);
+assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'direct-commit-current-record');
+assert.deepStrictEqual(integrationCompletionRefreshes, [['direct-commit-current-record']]);
+assert.deepStrictEqual(integrationAnchorIndexes, [['direct-commit-current-index']]);
+assert.deepStrictEqual(integrationRenders, [['direct-commit-current-index']]);
+assert.deepStrictEqual(integrationPracticeUpdates, [{
+    records: ['direct-commit-current-record'],
+    index: ['direct-commit-current-index']
+}]);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const annotationHeadRecords = deferred();
+const annotationHeadIndex = deferred();
+const annotationTailPoison = {
+    get promise() {
+        return Promise.reject(new Error('annotation commits must not schedule a practice projection tail'));
+    }
+};
+integrationPracticeRecordResolvers.push(annotationHeadRecords);
+integrationIndexResolvers.push(annotationHeadIndex, annotationTailPoison);
+const annotationResolutionCountBefore = integrationIndexResolutionCount;
+const annotationCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'annotation-no-op',
+    { forceRender: true }
+);
+emitIntegrationDataCommitted([{ store: 'practiceAnnotations' }]);
+annotationHeadRecords.resolve([{ id: 'annotation-head-record' }]);
+annotationHeadIndex.resolve([{ id: 'annotation-head-index' }]);
+await annotationCycle;
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    annotationResolutionCountBefore + 1,
+    'annotation-only commits must not invalidate the summary/detail projection'
+);
+assert.strictEqual(integrationIndexResolvers.shift(), annotationTailPoison);
+assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'annotation-head-record');
+assert.deepStrictEqual(integrationCompletionRefreshes, [['annotation-head-record']]);
+assert.deepStrictEqual(integrationAnchorIndexes, [['annotation-head-index']]);
+assert.deepStrictEqual(integrationRenders, [['annotation-head-index']]);
+assert.deepStrictEqual(integrationPracticeUpdates, [{
+    records: ['annotation-head-record'],
+    index: ['annotation-head-index']
+}]);
 
 const preservedForceBaselineRecords = deferred();
 const preservedForceBaselineIndex = deferred();
@@ -1162,7 +1289,10 @@ assert.strictEqual(
 assert.deepStrictEqual(integrationRenders, []);
 failedFunctionalReset.resolve(false);
 assert.strictEqual(await failedFunctionalResetNavigation, false);
-await new Promise((resolve) => setTimeout(resolve, 80));
+await waitForCondition(
+    () => integrationSandbox.__getBrowseFunctionalResetState().status === 'failed',
+    'the failed functional reset must settle to the fail-closed state'
+);
 assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'failed');
 assert.deepStrictEqual(
     integrationRenders,
@@ -1180,8 +1310,36 @@ assert.deepStrictEqual(
     'a failed functional reset must remain fail-closed for later progress refreshes'
 );
 
-integrationBrowseView.classList.remove('active');
-integrationOverviewView.classList.add('active');
+integrationSandbox.showView('overview', false);
+const ordinaryRecoveryIndex = deferred();
+integrationIndexResolvers.push(ordinaryRecoveryIndex);
+const ordinaryRecoveryNavigation = integrationSandbox.showView('browse', false);
+ordinaryRecoveryIndex.resolve([{ id: 'functional-reset-ordinary-recovery' }]);
+assert.notStrictEqual(await ordinaryRecoveryNavigation, false);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['functional-reset-ordinary-recovery']],
+    'a successful ordinary Browse activation must provide the canonical recovery render'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'functional-reset-progress-after-ordinary-recovery' }]
+);
+await waitForCondition(
+    () => integrationRenders.length === 2,
+    'progress must resume after a successful ordinary Browse recovery'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [
+        ['functional-reset-ordinary-recovery'],
+        ['functional-reset-progress-after-ordinary-recovery']
+    ],
+    'a failed functional reset must not poison progress after ordinary activation recovers'
+);
+
+integrationRenders.length = 0;
+integrationSandbox.showView('overview', false);
 const successfulFunctionalReset = deferred();
 const successfulFunctionalResetIndex = deferred();
 integrationIndexResolvers.push(successfulFunctionalResetIndex);
@@ -1201,7 +1359,10 @@ assert.deepStrictEqual(integrationRenders, []);
 successfulFunctionalReset.resolve(true);
 successfulFunctionalResetIndex.resolve([{ id: 'functional-reset-canonical' }]);
 assert.notStrictEqual(await successfulFunctionalResetNavigation, false);
-await new Promise((resolve) => setTimeout(resolve, 80));
+await waitForCondition(
+    () => integrationSandbox.__getBrowseFunctionalResetState().status === 'succeeded',
+    'the successful functional reset must complete its canonical barrier'
+);
 assert.deepStrictEqual(
     integrationRenders,
     [['functional-reset-canonical']],
@@ -1220,6 +1381,99 @@ assert.deepStrictEqual(
 );
 
 integrationRenders.length = 0;
+integrationSandbox.showView('overview', false);
+const navigationAbaFunctionalReset = deferred();
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return navigationAbaFunctionalReset.promise;
+};
+const navigationAbaFunctionalNavigation = integrationSandbox.showView('browse', true);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'pending');
+integrationSandbox.showView('overview', false);
+const navigationAbaReentryIndex = deferred();
+integrationIndexResolvers.push(navigationAbaReentryIndex);
+const navigationAbaReentry = integrationSandbox.showView('browse', false);
+navigationAbaReentryIndex.resolve([{ id: 'navigation-aba-reentry', category: 'all', type: 'reading' }]);
+assert.notStrictEqual(await navigationAbaReentry, false);
+integrationRenders.length = 0;
+const navigationAbaFilterIndex = deferred();
+integrationIndexResolvers.push(navigationAbaFilterIndex);
+const navigationAbaFilter = integrationSandbox.applyBrowseFilter('P2', 'reading');
+const navigationAbaPoisonIndex = {
+    promise: Promise.resolve([{ id: 'navigation-aba-stale-reset' }])
+};
+integrationIndexResolvers.push(navigationAbaPoisonIndex);
+const navigationAbaResolutionCount = integrationIndexResolutionCount;
+const navigationAbaResultsToken = integrationSandbox.__getBrowseResultsRequestId();
+navigationAbaFunctionalReset.resolve(true);
+assert.strictEqual(
+    await navigationAbaFunctionalNavigation,
+    false,
+    'a functional reset superseded by a navigation ABA must stand down'
+);
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    navigationAbaResolutionCount,
+    'the superseded functional reset must not start another index read'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    navigationAbaResultsToken,
+    'the superseded functional reset must not claim the newer filter token'
+);
+assert.strictEqual(
+    integrationIndexResolvers.shift(),
+    navigationAbaPoisonIndex,
+    'the superseded functional reset must leave the poison index untouched'
+);
+navigationAbaFilterIndex.resolve([
+    { id: 'navigation-aba-p2-reading', category: 'P2', type: 'reading' }
+]);
+assert.notStrictEqual(await navigationAbaFilter, false);
+assert.deepStrictEqual(integrationBrowseState, { category: 'P2', type: 'reading' });
+assert.deepStrictEqual(
+    integrationRenders,
+    [['navigation-aba-p2-reading']],
+    'the newer filter must remain authoritative after the old reset settles'
+);
+assert.ok(
+    !['pending', 'failed'].includes(integrationSandbox.__getBrowseFunctionalResetState().status),
+    'a superseded functional reset must not leave a pending or failed global gate'
+);
+
+integrationRenders.length = 0;
+integrationSandbox.showView('overview', false);
+const midCanonicalFunctionalReset = deferred();
+const midCanonicalFunctionalIndex = deferred();
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return midCanonicalFunctionalReset.promise;
+};
+integrationIndexResolvers.push(midCanonicalFunctionalIndex);
+const midCanonicalResolutionCountBefore = integrationIndexResolutionCount;
+const midCanonicalFunctionalNavigation = integrationSandbox.showView('browse', true);
+midCanonicalFunctionalReset.resolve(true);
+await waitForCondition(
+    () => integrationIndexResolutionCount === midCanonicalResolutionCountBefore + 1,
+    'the functional reset canonical refresh must start before the navigation supersedes it'
+);
+integrationSandbox.showView('overview', false);
+midCanonicalFunctionalIndex.resolve([{ id: 'mid-canonical-stale-reset' }]);
+assert.strictEqual(
+    await midCanonicalFunctionalNavigation,
+    false,
+    'navigation must cancel an already-started functional-reset canonical refresh'
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'an in-flight functional canonical refresh must not render after leaving Browse'
+);
+assert.ok(
+    !['pending', 'failed'].includes(integrationSandbox.__getBrowseFunctionalResetState().status),
+    'mid-canonical navigation cancellation must release the global barrier gate'
+);
+
+integrationRenders.length = 0;
 integrationBrowseView.classList.remove('active');
 integrationOverviewView.classList.add('active');
 const supersededFunctionalReset = deferred();
@@ -1234,7 +1488,11 @@ integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = funct
 };
 const supersededFunctionalNavigation = integrationSandbox.showView('browse', true);
 supersededFunctionalReset.resolve(true);
-await new Promise((resolve) => setTimeout(resolve, 0));
+const overlappingResolutionCountBefore = integrationIndexResolutionCount;
+await waitForCondition(
+    () => integrationIndexResolutionCount === overlappingResolutionCountBefore + 1,
+    'the first overlapping functional reset must enter its canonical refresh'
+);
 const currentFunctionalNavigation = integrationSandbox.showView('browse', true);
 assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'pending');
 supersededFunctionalIndex.resolve([{ id: 'superseded-functional-canonical' }]);
@@ -1252,6 +1510,444 @@ assert.deepStrictEqual(
     [['current-functional-canonical']],
     'only the newest functional reset may complete a canonical render'
 );
+
+integrationRenders.length = 0;
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return false;
+};
+assert.strictEqual(await integrationSandbox.showView('browse', true), false);
+await waitForCondition(
+    () => integrationSandbox.__getBrowseFunctionalResetState().status === 'failed',
+    'the second failed functional reset must settle before reset recovery begins'
+);
+const integrationExamActionsSource = fs.readFileSync(
+    path.join(repoRoot, 'js/app/examActions.js'),
+    'utf8'
+);
+vm.runInContext(integrationExamActionsSource, integrationContext, {
+    filename: 'js/app/examActions.js'
+});
+const integrationProductionExamListLoader = integrationSandbox.ExamActions.loadExamList;
+integrationSandbox.ExamActions.loadExamList = function captureResetRecoveryRender(exams) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    return snapshot;
+};
+
+const productionActivationReset = integrationSandbox.ExamActions
+    .browseFilterStateOwner.resetForActivation;
+const productionBrowseStateManager = integrationSandbox.browseStateManager;
+const productionSetBrowseFilterState = integrationSandbox.setBrowseFilterState;
+const productionSaveBrowseViewPreferences = integrationSandbox.saveBrowseViewPreferences;
+const productionFlushBrowsePreferenceWrites = integrationSandbox.flushBrowsePreferenceWrites;
+const productionPatchBrowse = integrationSandbox.AppData.preferences.patchBrowse;
+const activationManagerReady = deferred();
+let activationManagerReadyObserved = false;
+let staleActivationManagerResetCount = 0;
+const staleActivationStateCalls = [];
+const staleActivationPreferenceWrites = [];
+integrationSandbox.browseStateManager = {
+    ready: {
+        then(resolve, reject) {
+            activationManagerReadyObserved = true;
+            return activationManagerReady.promise.then(resolve, reject);
+        }
+    },
+    currentFilter: 'high',
+    state: {
+        currentCategory: 'P1',
+        currentFrequency: 'high',
+        filters: { frequency: 'high' },
+        searchQuery: 'keep-current-search'
+    },
+    clearSearchState() {},
+    resetToAllExams() { staleActivationManagerResetCount += 1; },
+    async persistState() {
+        staleActivationPreferenceWrites.push({ stateManager: true });
+    }
+};
+integrationSandbox.setBrowseFilterState = function captureActivationState(category, type) {
+    staleActivationStateCalls.push({ category, type });
+    productionSetBrowseFilterState(category, type);
+};
+integrationSandbox.saveBrowseViewPreferences = function captureActivationSave(patch) {
+    staleActivationPreferenceWrites.push({ save: patch });
+};
+integrationSandbox.flushBrowsePreferenceWrites = async function flushActivationSave() {
+    return {
+        lastFilter: {
+            category: integrationBrowseState.category,
+            type: integrationBrowseState.type
+        }
+    };
+};
+integrationSandbox.AppData.preferences.patchBrowse = async function captureActivationPatch(patch) {
+    staleActivationPreferenceWrites.push({ patch });
+    return patch;
+};
+productionSetBrowseFilterState('P1', 'listening');
+integrationSandbox.__browseFilterMode = 'legacy-mode';
+integrationSandbox.__browsePath = 'legacy/path';
+integrationSandbox.__browseFrequencyFilter = 'high';
+const staleProductionActivation = integrationSandbox.showView('browse', true);
+await waitForCondition(
+    () => activationManagerReadyObserved,
+    'the production activation reset must enter its awaited manager preparation'
+);
+integrationSandbox.showView('overview', false);
+const activationReentryIndex = deferred();
+integrationIndexResolvers.push(activationReentryIndex);
+const activationReentry = integrationSandbox.showView('browse', false);
+activationReentryIndex.resolve([
+    { id: 'activation-reentry-reading', category: 'P1', type: 'reading' }
+]);
+assert.notStrictEqual(await activationReentry, false);
+integrationRenders.length = 0;
+const activationNewerFilterIndex = deferred();
+integrationIndexResolvers.push(activationNewerFilterIndex);
+const activationNewerFilter = integrationSandbox.applyBrowseFilter(
+    'P2',
+    'reading',
+    'frequency',
+    'newer/path'
+);
+activationNewerFilterIndex.resolve([
+    { id: 'activation-newer-reading', category: 'P2', type: 'reading' },
+    { id: 'activation-listening-capability', category: 'P2', type: 'listening' }
+]);
+assert.notStrictEqual(await activationNewerFilter, false);
+activationManagerReady.resolve();
+assert.strictEqual(
+    await staleProductionActivation,
+    false,
+    'a real activation reset canceled during manager preparation must stand down'
+);
+assert.deepStrictEqual(integrationBrowseState, { category: 'P2', type: 'reading' });
+assert.strictEqual(integrationSandbox.__browseFilterMode, 'frequency');
+assert.strictEqual(integrationSandbox.__browsePath, 'newer/path');
+assert.strictEqual(integrationSandbox.__browseFrequencyFilter, 'high');
+assert.strictEqual(staleActivationManagerResetCount, 0);
+assert.deepStrictEqual(
+    staleActivationStateCalls.filter((call) => call.category === 'all' && call.type === 'all'),
+    [],
+    'the canceled production reset must not apply all/all over the newer filter'
+);
+assert.deepStrictEqual(
+    staleActivationPreferenceWrites,
+    [],
+    'the canceled production reset must not persist any all/all state'
+);
+integrationSandbox.browseStateManager = productionBrowseStateManager;
+integrationSandbox.setBrowseFilterState = productionSetBrowseFilterState;
+integrationSandbox.saveBrowseViewPreferences = productionSaveBrowseViewPreferences;
+integrationSandbox.flushBrowsePreferenceWrites = productionFlushBrowsePreferenceWrites;
+integrationSandbox.AppData.preferences.patchBrowse = productionPatchBrowse;
+
+integrationRenders.length = 0;
+const warmFunctionalManagerReady = deferred();
+const warmFunctionalCanonicalIndex = deferred();
+const warmFunctionalLatestIndex = [
+    { id: 'warm-functional-latest-p2', category: 'P2', type: 'reading' },
+    { id: 'warm-functional-latest-listening', category: 'all', type: 'listening' }
+];
+const warmFunctionalPersistedBrowse = {
+    lastFilter: { category: 'P2', type: 'reading' },
+    filter: { category: 'P2', type: 'reading' },
+    frequencyFilter: 'high',
+    stateManager: null
+};
+const warmFunctionalOriginalGetBrowse = integrationSandbox.AppData.preferences.getBrowse;
+let warmFunctionalManagerReadyObserved = false;
+integrationSandbox.browseStateManager = {
+    ready: {
+        then(resolve, reject) {
+            warmFunctionalManagerReadyObserved = true;
+            return warmFunctionalManagerReady.promise.then(resolve, reject);
+        }
+    },
+    currentFilter: 'P2',
+    state: {
+        currentCategory: 'P2',
+        currentFrequency: 'high',
+        filters: { frequency: 'high' },
+        searchQuery: 'warm-reset-search'
+    },
+    clearSearchState() {
+        this.state.searchQuery = '';
+    },
+    resetToAllExams() {
+        this.currentFilter = 'all';
+        this.state.currentCategory = null;
+        this.state.currentFrequency = null;
+        this.state.filters.frequency = 'all';
+        this.state.searchQuery = '';
+    },
+    async persistState() {
+        warmFunctionalPersistedBrowse.stateManager = {
+            currentFilter: this.currentFilter,
+            state: JSON.parse(JSON.stringify(this.state))
+        };
+    }
+};
+integrationSandbox.saveBrowseViewPreferences = function saveWarmFunctionalPreferences(patch) {
+    if (patch && patch.lastFilter) {
+        warmFunctionalPersistedBrowse.lastFilter = Object.assign({}, patch.lastFilter);
+    }
+    return warmFunctionalPersistedBrowse;
+};
+integrationSandbox.flushBrowsePreferenceWrites = async function flushWarmFunctionalPreferences() {
+    return JSON.parse(JSON.stringify(warmFunctionalPersistedBrowse));
+};
+integrationSandbox.AppData.preferences.patchBrowse = async function patchWarmFunctionalPreferences(patch) {
+    Object.assign(warmFunctionalPersistedBrowse, JSON.parse(JSON.stringify(patch || {})));
+    return patch;
+};
+integrationSandbox.AppData.preferences.getBrowse = async function getWarmFunctionalPreferences() {
+    return JSON.parse(JSON.stringify(warmFunctionalPersistedBrowse));
+};
+productionSetBrowseFilterState('P2', 'reading');
+integrationSandbox.__browseFilterMode = 'frequency';
+integrationSandbox.__browsePath = 'warm/reset/path';
+integrationSandbox.__browseFrequencyFilter = 'high';
+integrationIndexResolvers.push(warmFunctionalCanonicalIndex);
+const warmFunctionalNavigation = integrationSandbox.showView('browse', true);
+await waitForCondition(
+    () => warmFunctionalManagerReadyObserved,
+    'the warm production reset must pause at manager readiness'
+);
+const warmFunctionalBarrierToken = integrationSandbox.__getBrowseResultsRequestId();
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: warmFunctionalLatestIndex }
+}));
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    warmFunctionalBarrierToken,
+    'a warm-runtime index publication must not steal a pending functional-reset token'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'a warm-runtime index publication must wait for the functional canonical barrier'
+);
+warmFunctionalCanonicalIndex.resolve(warmFunctionalLatestIndex);
+warmFunctionalManagerReady.resolve();
+assert.notStrictEqual(
+    await warmFunctionalNavigation,
+    false,
+    'the foreground functional reset must survive a warm-runtime index publication'
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(integrationBrowseState, { category: 'all', type: 'all' });
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'succeeded');
+assert.ok(integrationRenders.length > 0, 'the successful functional reset must render canonically');
+assert.deepStrictEqual(
+    integrationRenders.at(-1),
+    warmFunctionalLatestIndex.map((exam) => exam.id),
+    'the latest published index must remain authoritative after the functional canonical render'
+);
+integrationSandbox.browseStateManager = productionBrowseStateManager;
+integrationSandbox.saveBrowseViewPreferences = productionSaveBrowseViewPreferences;
+integrationSandbox.flushBrowsePreferenceWrites = productionFlushBrowsePreferenceWrites;
+integrationSandbox.AppData.preferences.patchBrowse = productionPatchBrowse;
+integrationSandbox.AppData.preferences.getBrowse = warmFunctionalOriginalGetBrowse;
+
+const productionBeginBrowseResultsRequest = integrationSandbox.__beginBrowseResultsRequest;
+const productionGetBrowseResultsRequestId = integrationSandbox.__getBrowseResultsRequestId;
+const productionIsBrowseResultsRequestCurrent = integrationSandbox.__isBrowseResultsRequestCurrent;
+integrationSandbox.__beginBrowseResultsRequest = undefined;
+integrationSandbox.__getBrowseResultsRequestId = undefined;
+integrationSandbox.__isBrowseResultsRequestCurrent = undefined;
+const coldFunctionalLeaseReset = deferred();
+const coldFunctionalLeaseBarrier = integrationSandbox.AppEntry.registerBrowseFunctionalResetBarrier(
+    coldFunctionalLeaseReset.promise
+);
+let coldFunctionalResultsRequestId = 0;
+integrationSandbox.__beginBrowseResultsRequest = function beginColdFunctionalResultsRequest() {
+    coldFunctionalResultsRequestId += 1;
+    return coldFunctionalResultsRequestId;
+};
+integrationSandbox.__getBrowseResultsRequestId = function getColdFunctionalResultsRequestId() {
+    return coldFunctionalResultsRequestId;
+};
+integrationSandbox.__isBrowseResultsRequestCurrent = function isColdFunctionalResultsRequestCurrent(
+    requestId
+) {
+    return requestId == null || requestId === coldFunctionalResultsRequestId;
+};
+await waitForCondition(
+    () => coldFunctionalResultsRequestId === 1,
+    'a cold functional barrier must bind the first token as soon as the runtime API appears'
+);
+assert.strictEqual(
+    integrationSandbox.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+        coldFunctionalLeaseBarrier
+    ),
+    true,
+    'the newly bound cold functional lease must initially own the results token'
+);
+const coldFunctionalPendingGeneration =
+    integrationSandbox.__getBrowseFunctionalResetState().generation;
+const newerColdFilterRequestId = integrationSandbox.__beginBrowseResultsRequest();
+assert.strictEqual(newerColdFilterRequestId, 2);
+assert.strictEqual(
+    integrationSandbox.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+        coldFunctionalLeaseBarrier
+    ),
+    false,
+    'a newer cold-runtime filter token must cancel the older functional lease'
+);
+const coldFunctionalCancelledState = integrationSandbox.__getBrowseFunctionalResetState();
+assert.strictEqual(coldFunctionalCancelledState.status, 'idle');
+assert.strictEqual(coldFunctionalCancelledState.outcome, null);
+assert.ok(
+    coldFunctionalCancelledState.generation > coldFunctionalPendingGeneration,
+    'cold token supersession must cancel neutrally and invalidate pending-era work'
+);
+coldFunctionalLeaseReset.resolve(true);
+assert.strictEqual(await coldFunctionalLeaseBarrier, true);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'idle',
+    'a late cold reset settlement must not reclaim ownership after cancellation'
+);
+integrationSandbox.__beginBrowseResultsRequest = productionBeginBrowseResultsRequest;
+integrationSandbox.__getBrowseResultsRequestId = productionGetBrowseResultsRequestId;
+integrationSandbox.__isBrowseResultsRequestCurrent = productionIsBrowseResultsRequestCurrent;
+
+async function establishFailedIntegrationFunctionalReset(message) {
+    integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+        return false;
+    };
+    try {
+        assert.strictEqual(await integrationSandbox.showView('browse', true), false);
+        await waitForCondition(
+            () => integrationSandbox.__getBrowseFunctionalResetState().status === 'failed',
+            message
+        );
+    } finally {
+        integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation
+            = productionActivationReset;
+    }
+}
+
+await establishFailedIntegrationFunctionalReset(
+    'the pending-filter recovery fixture must start from a failed functional barrier'
+);
+integrationRenders.length = 0;
+const pendingRecoveryInitializationIndex = deferred();
+const pendingRecoveryFilterIndex = deferred();
+integrationIndexResolvers.push(pendingRecoveryInitializationIndex, pendingRecoveryFilterIndex);
+const pendingRecoveryRequestId = integrationSandbox.__beginBrowseUserResultsRequest();
+const pendingRecoveryFilter = {
+    category: 'P2',
+    type: 'reading',
+    filterMode: null,
+    path: null
+};
+integrationSandbox.__pendingBrowseFilter = pendingRecoveryFilter;
+const pendingRecoveryInitialization = integrationSandbox.initializeBrowseView({
+    skipLoad: true,
+    renderRequestId: pendingRecoveryRequestId
+});
+pendingRecoveryInitializationIndex.resolve([
+    { id: 'pending-recovery-initialize', category: 'all', type: 'reading' }
+]);
+assert.ok(Array.isArray(await pendingRecoveryInitialization));
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'the pending-filter skipLoad initialization must not recover the failed barrier early'
+);
+const pendingRecoveryApply = integrationSandbox.applyBrowseFilter(
+    pendingRecoveryFilter.category,
+    pendingRecoveryFilter.type,
+    pendingRecoveryFilter.filterMode,
+    pendingRecoveryFilter.path,
+    pendingRecoveryRequestId
+);
+pendingRecoveryFilterIndex.resolve([
+    { id: 'pending-recovery-current', category: 'P2', type: 'reading' }
+]);
+assert.notStrictEqual(await pendingRecoveryApply, false);
+delete integrationSandbox.__pendingBrowseFilter;
+integrationSandbox.__endBrowseUserResultsRequest(pendingRecoveryRequestId);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'succeeded');
+assert.deepStrictEqual(
+    integrationRenders,
+    [['pending-recovery-current']],
+    'only the successful shared-token pending filter may provide the recovery render'
+);
+
+await establishFailedIntegrationFunctionalReset(
+    'the stale-filter recovery fixture must start from a failed functional barrier'
+);
+integrationRenders.length = 0;
+const staleRecoveryFilterIndex = deferred();
+integrationIndexResolvers.push(staleRecoveryFilterIndex);
+const staleRecoveryResolutionCount = integrationIndexResolutionCount;
+const staleRecoveryFilter = integrationSandbox.applyBrowseFilter('P1', 'reading');
+await waitForCondition(
+    () => integrationIndexResolutionCount === staleRecoveryResolutionCount + 1,
+    'the failed-barrier filter recovery must enter its canonical index read'
+);
+integrationSandbox.showView('overview', false);
+staleRecoveryFilterIndex.resolve([
+    { id: 'stale-filter-must-not-recover', category: 'P1', type: 'reading' }
+]);
+assert.strictEqual(await staleRecoveryFilter, false);
+assert.deepStrictEqual(integrationRenders, []);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'a filter made stale by navigation must not recover the failed barrier'
+);
+
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+const resetSupersededRecoveryIndex = deferred();
+integrationIndexResolvers.push(resetSupersededRecoveryIndex);
+const resetSupersededResolutionCount = integrationIndexResolutionCount;
+const resetSupersededRecovery = integrationSandbox.activateBrowseView();
+await waitForCondition(
+    () => integrationIndexResolutionCount === resetSupersededResolutionCount + 1,
+    'the failed-barrier activation recovery must enter its canonical index read'
+);
+const supersedingRecoveryResetIntent = integrationSandbox.__beginBrowseResetIntent();
+resetSupersededRecoveryIndex.resolve([{ id: 'reset-superseded-recovery' }]);
+assert.strictEqual(await resetSupersededRecovery, false);
+integrationSandbox.__endBrowseResetIntent(supersedingRecoveryResetIntent);
+assert.deepStrictEqual(integrationRenders, []);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'a reset intent superseding mid-canonical must not allow stale state recovery'
+);
+
+const explicitResetRecoveryIndex = deferred();
+integrationIndexResolvers.push(explicitResetRecoveryIndex);
+const explicitResetRecovery = integrationSandbox.ExamActions.resetBrowseViewToAll();
+explicitResetRecoveryIndex.resolve([{ id: 'functional-reset-explicit-recovery' }]);
+assert.notStrictEqual(await explicitResetRecovery, false);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'succeeded');
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'functional-reset-progress-after-explicit-recovery' }]
+);
+await waitForCondition(
+    () => integrationRenders.length === 2,
+    'progress must resume after resetBrowseViewToAll recovers a failed barrier'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [
+        ['functional-reset-explicit-recovery'],
+        ['functional-reset-progress-after-explicit-recovery']
+    ],
+    'a real resetBrowseViewToAll recovery must release the failed progress gate'
+);
+integrationSandbox.ExamActions.loadExamList = integrationProductionExamListLoader;
 integrationBrowseView.classList.add = originalIntegrationBrowseAdd;
 
 rendered.length = 0;
@@ -1759,6 +2455,15 @@ sandbox.AppEntry = {
     registerBrowseFunctionalResetBarrier(resetPromise) {
         coldResetOrder.push('barrier');
         return resetPromise;
+    },
+    isBrowseFunctionalResetBarrierCurrent() {
+        return true;
+    },
+    completeBrowseFunctionalResetBarrier(_barrier, succeeded) {
+        return succeeded === true;
+    },
+    updateBrowseFunctionalResetResultsRequest() {
+        return true;
     },
     async ensureBrowseRuntimeGroup() {
         coldResetOrder.push('ensure');

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -467,6 +467,7 @@ const integrationDocument = {
 };
 const integrationRenders = [];
 const integrationAnchorIndexes = [];
+const integrationAnchorPublicationGenerations = [];
 const integrationCompletionRefreshes = [];
 const integrationPracticeUpdates = [];
 const integrationBrowseState = { category: 'all', type: 'all' };
@@ -552,8 +553,11 @@ const integrationSandbox = {
             index: Array.from(index || [], (exam) => exam.id)
         };
     },
-    commitBrowseAnchorUpdates(prepared) {
+    commitBrowseAnchorUpdates(prepared, publication = null) {
         integrationAnchorIndexes.push(prepared.index);
+        integrationAnchorPublicationGenerations.push(
+            publication && publication.practiceProjectionGeneration
+        );
         return true;
     },
     browseController: {
@@ -838,6 +842,7 @@ for (const failurePoint of [
 ]) {
     integrationRenders.length = 0;
     integrationAnchorIndexes.length = 0;
+    integrationAnchorPublicationGenerations.length = 0;
     integrationCompletionRefreshes.length = 0;
     integrationPracticeUpdates.length = 0;
     const acceptedRecordId = `accepted-${failurePoint}-record`;
@@ -885,6 +890,15 @@ for (const failurePoint of [
         integrationAnchorIndexes,
         [[acceptedIndexId]],
         `${failurePoint} failure must preserve the accepted anchor projection`
+    );
+    assert.strictEqual(
+        integrationAnchorPublicationGenerations.length,
+        1,
+        `${failurePoint} failure must not publish a generation for rejected B anchors`
+    );
+    assert.ok(
+        Number.isFinite(integrationAnchorPublicationGenerations[0]),
+        'the accepted anchor projection must receive the Practice publication generation'
     );
     assert.deepStrictEqual(
         integrationPracticeUpdates,

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -44,7 +44,10 @@ const typeButtons = ['all', 'reading', 'listening'].map((type) => ({
 const typeButtonContainer = {
     querySelectorAll() { return typeButtons; }
 };
-const browseView = { classList: { contains(value) { return value === 'active'; } } };
+const browseView = { id: 'browse-view', classList: createClassList() };
+const overviewView = { id: 'overview-view', classList: createClassList() };
+browseView.classList.add('active');
+const searchInput = { value: '' };
 const searchClearButton = { hidden: true };
 const documentStub = {
     readyState: 'loading',
@@ -52,12 +55,25 @@ const documentStub = {
     documentElement: { classList: createClassList() },
     addEventListener() {},
     removeEventListener() {},
-    querySelector() { return null; },
-    querySelectorAll() { return []; },
+    querySelector(selector) {
+        if (selector === '.search-input') return searchInput;
+        if (selector === '.view.active') {
+            return [browseView, overviewView].find((view) => view.classList.contains('active')) || null;
+        }
+        return null;
+    },
+    querySelectorAll(selector) {
+        if (selector === '.view.active') {
+            return [browseView, overviewView].filter((view) => view.classList.contains('active'));
+        }
+        return [];
+    },
     createElement() { return { style: {}, classList: createClassList(), appendChild() {}, setAttribute() {} }; },
     getElementById(id) {
         if (id === 'type-filter-buttons') return typeButtonContainer;
         if (id === 'browse-view') return browseView;
+        if (id === 'overview-view') return overviewView;
+        if (id === 'exam-search-input') return searchInput;
         if (id === 'search-clear-btn') return searchClearButton;
         return null;
     }
@@ -168,8 +184,22 @@ resolverQueue.push(filterFirst, filterSecond);
 const staleFilter = sandbox.filterByType('reading');
 const latestFilter = sandbox.filterByType('all');
 const allExams = [
-    { id: 'reading', title: 'Reading', type: 'reading', category: 'P1' },
-    { id: 'listening', title: 'Listening', type: 'listening', category: 'P1' }
+    {
+        id: 'reading',
+        title: 'Reading',
+        type: 'reading',
+        category: 'P1',
+        path: 'ReadingPractice/P1/reading.html',
+        frequency: 'high'
+    },
+    {
+        id: 'listening',
+        title: 'Listening',
+        type: 'listening',
+        category: 'P1',
+        path: 'ListeningPractice/P1/listening.html',
+        frequency: 'low'
+    }
 ];
 filterSecond.resolve(allExams);
 await latestFilter;
@@ -234,6 +264,75 @@ assert.strictEqual(
 );
 assert.strictEqual(debouncedSearchCalls.length, 1, 'stale replay must not replace the pending latest search');
 delete sandbox.performanceOptimizer;
+
+let navigationIntentMarks = 0;
+sandbox.__markAppNavigationIntent = function markAppNavigationIntent() {
+    navigationIntentMarks += 1;
+    return navigationIntentMarks;
+};
+const bootFallbackSource = fs.readFileSync(path.join(repoRoot, 'js/boot-fallbacks.js'), 'utf8');
+vm.runInContext(bootFallbackSource, context, { filename: 'js/boot-fallbacks.js' });
+rendered.length = 0;
+searchInput.value = 'zzzz-no-match';
+const initialNoMatchIndex = deferred();
+resolverQueue.push(initialNoMatchIndex);
+sandbox.searchExams(searchInput.value);
+initialNoMatchIndex.resolve(allExams);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(rendered, [[]], 'the active no-match search should render an empty result');
+
+sandbox.showView('overview', false);
+const reentryNoMatchIndex = deferred();
+resolverQueue.push(reentryNoMatchIndex);
+sandbox.showView('browse', false);
+reentryNoMatchIndex.resolve(allExams);
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+assert.strictEqual(searchInput.value, 'zzzz-no-match', 'ordinary Browse re-entry must preserve the query');
+assert.deepStrictEqual(
+    rendered,
+    [[], []],
+    'ordinary Browse re-entry must reapply the preserved query instead of flashing the full list'
+);
+assert.strictEqual(navigationIntentMarks, 2, 'each fallback view activation must mark a navigation intent');
+
+searchInput.value = 'stale-query';
+sandbox.__browseFilterMode = 'frequency-p1';
+sandbox.__browsePath = 'ReadingPractice/P1';
+sandbox.__browseFrequencyFilter = 'high';
+sandbox.browseController.currentMode = 'frequency-p1';
+sandbox.browseController.activeFilter = 'reading';
+sandbox.ExamActions.applyBrowsePostFilters = function applyBrowsePostFilters(exams, _sortMode, frequencyFilter) {
+    if (!frequencyFilter || frequencyFilter === 'all') return exams;
+    return exams.filter((exam) => exam.frequency === frequencyFilter);
+};
+const helperFreeLoadExamList = sandbox.ExamActions.loadExamList;
+sandbox.ExamActions.loadExamList = function loadExamListWithActiveFilters(exams) {
+    return helperFreeLoadExamList.call(this, sandbox.getBrowseFilteredExamBase(exams));
+};
+const helperFreeResetIndex = deferred();
+resolverQueue.push(helperFreeResetIndex);
+const helperFreeReset = sandbox.showView('browse', true);
+helperFreeResetIndex.resolve(allExams);
+await helperFreeReset;
+assert.strictEqual(searchInput.value, '', 'the helper-free repeat reset must clear the preserved query');
+assert.strictEqual(sandbox.__browseFilterMode, 'default');
+assert.strictEqual(sandbox.__browsePath, null);
+assert.strictEqual(sandbox.__browseFrequencyFilter, 'all');
+assert.strictEqual(sandbox.browseController.currentMode, 'default');
+assert.strictEqual(sandbox.browseController.activeFilter, 'all');
+assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening']);
+searchInput.value = '';
+
+const failedReentryIndex = deferred();
+resolverQueue.push(failedReentryIndex);
+const failedReentry = sandbox.showView('browse', false);
+failedReentryIndex.reject(new Error('index unavailable'));
+assert.strictEqual(
+    await failedReentry,
+    false,
+    'fallback navigation must observe and contain an asynchronous Browse refresh failure'
+);
 
 const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
 vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -165,8 +165,16 @@ const sandbox = {
         updateBrowseTitle() {}
     },
     ExamActions: {
-        loadExamList(exams) { rendered.push(Array.from(exams, (exam) => exam.id)); },
-        displayExams(exams) { rendered.push(Array.from(exams, (exam) => exam.id)); }
+        loadExamList(exams, options = {}) {
+            rendered.push(Array.from(exams, (exam) => exam.id));
+            sandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+            return exams;
+        },
+        displayExams(exams, options = {}) {
+            rendered.push(Array.from(exams, (exam) => exam.id));
+            sandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+            return true;
+        }
     },
     AppData: {
         ready: Promise.resolve(),
@@ -524,11 +532,15 @@ const integrationSandbox = {
             integrationSandbox.__browseFrequencyFilter = value;
             return value;
         },
-        loadExamList(exams) {
+        loadExamList(exams, options = {}) {
             integrationRenders.push(Array.from(exams, (exam) => exam.id));
+            integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
             return exams;
         },
-        displayExams(exams) { return exams; }
+        displayExams(exams, options = {}) {
+            integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+            return true;
+        }
     },
     AppLazyLoader: {
         ensureGroup() { return Promise.resolve(true); }
@@ -589,22 +601,35 @@ assert.ok(
 const productionIntegrationGetBrowse = integrationSandbox.AppData.preferences.getBrowse;
 const staleBrowseControlSeed = deferred();
 let staleBrowseControlSeedReads = 0;
+let staleBrowseControlSeedCallerCurrent = true;
 integrationSandbox.AppData.preferences.getBrowse = function getStaleBrowseControlSeed() {
     staleBrowseControlSeedReads += 1;
     return staleBrowseControlSeed.promise;
 };
-const browseControlSeed = integrationSandbox.setupBrowseControls();
+const staleBrowseControlSeedWaiter = integrationSandbox.setupBrowseControls({
+    isCurrent() { return staleBrowseControlSeedCallerCurrent; }
+});
 await waitForCondition(
     () => staleBrowseControlSeedReads === 1,
-    'Browse controls must enter the persisted seed read before the live frequency intent'
+    'the first Browse-controls waiter must enter the shared persisted seed read'
 );
+const currentBrowseControlSeedWaiter = integrationSandbox.setupBrowseControls({
+    isCurrent() { return true; }
+});
 const liveFrequencyIndex = deferred();
 integrationIndexResolvers.push(liveFrequencyIndex);
 integrationSandbox.filterByFrequency('high');
 liveFrequencyIndex.resolve([{ id: 'live-frequency-high', frequency: 7 }]);
+staleBrowseControlSeedCallerCurrent = false;
 staleBrowseControlSeed.resolve({ sortMode: 'default', frequencyFilter: 'all' });
-assert.strictEqual(await browseControlSeed, true);
+assert.strictEqual(await staleBrowseControlSeedWaiter, false);
+assert.strictEqual(await currentBrowseControlSeedWaiter, true);
 await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    staleBrowseControlSeedReads,
+    1,
+    'a stale waiter must not discard and reread the shared controls seed for a current waiter'
+);
 assert.strictEqual(
     integrationSandbox.__browseFrequencyFilter,
     'high',
@@ -715,6 +740,57 @@ assert.deepStrictEqual(
     integrationRenders,
     [],
     'a progress snapshot captured before a reset must not repaint after the reset epoch closes'
+);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const successfulProjectionRecords = deferred();
+const successfulProjectionIndex = deferred();
+const failedNewerProjectionRecords = deferred();
+const failedNewerProjectionIndex = deferred();
+integrationPracticeRecordResolvers.push(
+    successfulProjectionRecords,
+    failedNewerProjectionRecords
+);
+integrationIndexResolvers.push(successfulProjectionIndex, failedNewerProjectionIndex);
+const projectionUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+const successfulProjection = integrationSandbox.syncPracticeRecords({ forceRender: true });
+successfulProjectionRecords.resolve([{ id: 'successful-projection-record' }]);
+successfulProjectionIndex.resolve([{ id: 'successful-projection-index' }]);
+assert.deepStrictEqual(
+    Array.from(await successfulProjection, (record) => record.id),
+    ['successful-projection-record']
+);
+const failedNewerProjection = integrationSandbox.syncPracticeRecords({ forceRender: true });
+failedNewerProjectionRecords.resolve([{ id: 'failed-newer-projection-record' }]);
+failedNewerProjectionIndex.reject(new Error('newer projection read failed'));
+await assert.rejects(failedNewerProjection, /newer projection read failed/);
+integrationSandbox.__endBrowseUserResultsRequest(projectionUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationCompletionRefreshes,
+    [['successful-projection-record']],
+    'a failed newer sync must not invalidate an already successful completion projection'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes,
+    [['successful-projection-index']],
+    'a failed newer sync must not invalidate the successful Browse anchor projection'
+);
+assert.deepStrictEqual(
+    integrationPracticeUpdates,
+    [{
+        records: ['successful-projection-record'],
+        index: ['successful-projection-index']
+    }],
+    'the successful direct sync must keep the baseline Practice commit contract'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['successful-projection-index']],
+    'the successful queued Browse projection must render after the foreground request settles'
 );
 
 const identicalHeadIndex = deferred();
@@ -1136,9 +1212,10 @@ vm.runInContext(integrationExamActionsSource, integrationContext, {
     filename: 'js/app/examActions.js'
 });
 const integrationProductionExamListLoader = integrationSandbox.ExamActions.loadExamList;
-integrationSandbox.ExamActions.loadExamList = function captureResetRecoveryRender(exams) {
+integrationSandbox.ExamActions.loadExamList = function captureResetRecoveryRender(exams, options = {}) {
     const snapshot = Array.isArray(exams) ? exams : [];
     integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
     return snapshot;
 };
 
@@ -1548,10 +1625,11 @@ await establishFailedIntegrationFunctionalReset(
 integrationRenders.length = 0;
 const displayBeforeLibraryEpochForeground = integrationSandbox.ExamActions.displayExams;
 const libraryEpochForegroundDisplays = [];
-integrationSandbox.ExamActions.displayExams = function captureLibraryEpochForeground(exams) {
+integrationSandbox.ExamActions.displayExams = function captureLibraryEpochForeground(exams, options = {}) {
     const snapshot = Array.isArray(exams) ? exams : [];
     libraryEpochForegroundDisplays.push(Array.from(snapshot, (exam) => exam && exam.id));
-    return snapshot;
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+    return true;
 };
 const oldLibraryForegroundIndex = deferred();
 integrationIndexResolvers.push(oldLibraryForegroundIndex);
@@ -1643,9 +1721,10 @@ integrationSandbox.browseController.resetToDefault = function captureApplyFailur
 integrationSandbox.showMessage = function captureApplyFailureToast(...args) {
     applyFailureToasts.push(args);
 };
-integrationSandbox.ExamActions.loadExamList = function captureApplyFailureFallback(exams) {
+integrationSandbox.ExamActions.loadExamList = function captureApplyFailureFallback(exams, options = {}) {
     const snapshot = Array.isArray(exams) ? exams : [];
     applyFailureFallbackRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
     return snapshot;
 };
 setBrowseFilterStateBeforeApplyFailure('P2', 'reading');
@@ -1732,10 +1811,11 @@ integrationRenders.length = 0;
 integrationSearchInput.value = 'raw-background-query';
 integrationSandbox.__browseFrequencyFilter = 'all';
 const displayBeforeExplicitTokenSearch = integrationSandbox.ExamActions.displayExams;
-integrationSandbox.ExamActions.displayExams = function captureExplicitTokenSearch(exams) {
+integrationSandbox.ExamActions.displayExams = function captureExplicitTokenSearch(exams, options = {}) {
     const snapshot = Array.isArray(exams) ? exams : [];
     integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
-    return snapshot;
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+    return true;
 };
 const explicitTokenSearchIndex = deferred();
 integrationIndexResolvers.push(explicitTokenSearchIndex);
@@ -1835,10 +1915,11 @@ assert.deepStrictEqual(integrationRenders, [
 ]);
 
 const displayBeforeForegroundRecoveryMatrix = integrationSandbox.ExamActions.displayExams;
-integrationSandbox.ExamActions.displayExams = function captureForegroundSearch(exams) {
+integrationSandbox.ExamActions.displayExams = function captureForegroundSearch(exams, options = {}) {
     const snapshot = Array.isArray(exams) ? exams : [];
     integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
-    return snapshot;
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+    return true;
 };
 const foregroundRecoveryScenarios = [
     {
@@ -1912,6 +1993,157 @@ for (const scenario of foregroundRecoveryScenarios) {
     assert.deepStrictEqual(integrationRenders.at(-1), [`progress-after-${scenario.name}`]);
 }
 integrationSandbox.ExamActions.displayExams = displayBeforeForegroundRecoveryMatrix;
+
+await establishFailedIntegrationFunctionalReset(
+    'the folder-filter recovery fixture must start from failed-reset debt'
+);
+integrationRenders.length = 0;
+integrationSearchInput.value = '';
+const browseControllerBeforeFolderRecovery = integrationSandbox.browseController;
+const displayBeforeFolderRecovery = integrationSandbox.displayExams;
+const refreshListeningBeforeFolderRecovery =
+    integrationSandbox.refreshListeningAvailabilityUI;
+const BrowseControllerBeforeFolderRecovery = integrationSandbox.BrowseController;
+const browseModesBeforeFolderRecovery = integrationSandbox.BROWSE_MODES;
+const folderRecoveryBrowseControllerSource = fs.readFileSync(
+    path.join(repoRoot, 'js/app/browseController.js'),
+    'utf8'
+);
+vm.runInContext(folderRecoveryBrowseControllerSource, integrationContext, {
+    filename: 'js/app/browseController.js'
+});
+const folderRecoveryController = integrationSandbox.browseController;
+folderRecoveryController.currentMode = 'frequency-p1';
+folderRecoveryController.activeFilter = 'high';
+integrationSandbox.__browseFilterMode = 'frequency-p1';
+integrationSandbox.__browsePath = 'ListeningPractice/100 P1';
+integrationSandbox.displayExams = function captureFolderRecoveryCommit(exams, options = {}) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    integrationSandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
+    return true;
+};
+const folderRecoveryRequestId = integrationSandbox.__beginBrowseUserResultsRequest();
+const folderRecoveryEpoch = integrationSandbox.__captureBrowseForegroundRenderEpoch();
+const folderRecoveryResult = folderRecoveryController.filterByFolder(
+    'high',
+    [
+        {
+            id: 'folder-recovery-high',
+            path: 'ListeningPractice/100 P1/P1 高频（35）/question.html',
+            type: 'listening'
+        },
+        {
+            id: 'folder-recovery-medium',
+            path: 'ListeningPractice/100 P1/P1 中频(48)/question.html',
+            type: 'listening'
+        }
+    ],
+    folderRecoveryRequestId,
+    { foregroundEpoch: folderRecoveryEpoch }
+);
+integrationSandbox.__endBrowseUserResultsRequest(folderRecoveryRequestId);
+assert.ok(Array.isArray(folderRecoveryResult));
+assert.deepStrictEqual(
+    Array.from(folderRecoveryResult, (exam) => exam.id),
+    ['folder-recovery-high']
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['folder-recovery-high']],
+    'the direct folder path must commit through the authoritative foreground boundary'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'succeeded',
+    'a receipted folder DOM commit must recover failed-reset debt'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'progress-after-folder-recovery' }]
+);
+await waitForCondition(
+    () => integrationRenders.length === 2,
+    'progress must resume after the folder path recovers failed-reset debt'
+);
+assert.deepStrictEqual(integrationRenders.at(-1), ['progress-after-folder-recovery']);
+integrationSandbox.displayExams = displayBeforeFolderRecovery;
+integrationSandbox.browseController = browseControllerBeforeFolderRecovery;
+if (refreshListeningBeforeFolderRecovery === undefined) {
+    integrationSandbox.refreshListeningAvailabilityUI = undefined;
+} else {
+    integrationSandbox.refreshListeningAvailabilityUI =
+        refreshListeningBeforeFolderRecovery;
+}
+if (BrowseControllerBeforeFolderRecovery === undefined) {
+    integrationSandbox.BrowseController = undefined;
+} else {
+    integrationSandbox.BrowseController = BrowseControllerBeforeFolderRecovery;
+}
+if (browseModesBeforeFolderRecovery === undefined) {
+    integrationSandbox.BROWSE_MODES = undefined;
+} else {
+    integrationSandbox.BROWSE_MODES = browseModesBeforeFolderRecovery;
+}
+integrationSandbox.__browseFilterMode = 'default';
+integrationSandbox.__browsePath = null;
+
+await establishFailedIntegrationFunctionalReset(
+    'the rejected type-index fixture must start from failed-reset debt'
+);
+integrationRenders.length = 0;
+const rejectedTypeIndex = deferred();
+integrationIndexResolvers.push(rejectedTypeIndex);
+const rejectedTypeFilter = integrationSandbox.filterByType('reading');
+rejectedTypeIndex.reject(new Error('type filter index read failed'));
+assert.strictEqual(await rejectedTypeFilter, false);
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'an index-read rejection must not manufacture an empty-list DOM commit'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'an index-read rejection must leave failed-reset debt intact'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'progress-blocked-after-type-index-rejection' }]
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(integrationRenders, []);
+
+await establishFailedIntegrationFunctionalReset(
+    'the missing-commit-receipt fixture must start from failed-reset debt'
+);
+integrationRenders.length = 0;
+const receiptedLoaderBeforeMissingCommit = integrationSandbox.ExamActions.loadExamList;
+integrationSandbox.ExamActions.loadExamList = function returnWithoutDomCommit(exams) {
+    return Array.isArray(exams) ? exams : [];
+};
+assert.strictEqual(
+    await integrationSandbox.__renderBrowseResultsForState(
+        [{ id: 'uncommitted-foreground-result' }],
+        null,
+        { foreground: true }
+    ),
+    false,
+    'a resolved loader value without a DOM commit receipt must fail closed'
+);
+assert.deepStrictEqual(integrationRenders, []);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'only a terminal DOM commit receipt may clear failed-reset debt'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'progress-blocked-after-missing-commit-receipt' }]
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(integrationRenders, []);
+integrationSandbox.ExamActions.loadExamList = receiptedLoaderBeforeMissingCommit;
 
 await establishFailedIntegrationFunctionalReset(
     'the pending-filter recovery fixture must start from a failed functional barrier'
@@ -2154,10 +2386,11 @@ sandbox.showView = productionShowView;
 const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
 vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
 const productionLoadExamList = sandbox.ExamActions.loadExamList;
-sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
-    const result = productionLoadExamList.call(this, exams);
+sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams, options = {}) {
+    const result = productionLoadExamList.call(this, exams, options);
     if (Array.isArray(result)) {
         rendered.push(Array.from(result, (exam) => exam.id));
+        sandbox.__markBrowseRenderCommitReceipt?.(options.commitReceipt);
     }
     return result;
 };
@@ -2257,13 +2490,13 @@ const terminalOwnerIndex = deferred();
 resolverQueue.push(terminalOwnerIndex);
 const terminalResetStates = [];
 const ownerAwareLoadExamList = sandbox.ExamActions.loadExamList;
-sandbox.ExamActions.loadExamList = function captureTerminalResetState(exams) {
+sandbox.ExamActions.loadExamList = function captureTerminalResetState(exams, options = {}) {
     terminalResetStates.push({
         mode: sandbox.__browseFilterMode,
         path: sandbox.__browsePath,
         frequency: sandbox.__browseFrequencyFilter
     });
-    return ownerAwareLoadExamList.call(this, exams);
+    return ownerAwareLoadExamList.call(this, exams, options);
 };
 const terminalOwnerReset = sandbox.showView('browse', true);
 terminalOwnerIndex.resolve(allExams);

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -793,6 +793,72 @@ assert.deepStrictEqual(
     'the successful queued Browse projection must render after the foreground request settles'
 );
 
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const acceptedPublicationRecords = deferred();
+const acceptedPublicationIndex = deferred();
+const rejectedPublicationRecords = deferred();
+const rejectedPublicationIndex = deferred();
+integrationPracticeRecordResolvers.push(
+    acceptedPublicationRecords,
+    rejectedPublicationRecords
+);
+integrationIndexResolvers.push(acceptedPublicationIndex, rejectedPublicationIndex);
+const publicationUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+const acceptedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
+acceptedPublicationRecords.resolve([{ id: 'accepted-publication-record' }]);
+acceptedPublicationIndex.resolve([{ id: 'accepted-publication-index' }]);
+assert.deepStrictEqual(
+    Array.from(await acceptedPublication, (record) => record.id),
+    ['accepted-publication-record']
+);
+const productionCompletionRebuild = integrationSandbox.rebuildBrowseCompletionIndex;
+integrationSandbox.rebuildBrowseCompletionIndex = function rejectProjectionPublication() {
+    throw new Error('newer projection publication failed');
+};
+const rejectedPublication = integrationSandbox.syncPracticeRecords({ forceRender: true });
+rejectedPublicationRecords.resolve([{ id: 'rejected-publication-record' }]);
+rejectedPublicationIndex.resolve([{ id: 'rejected-publication-index' }]);
+assert.deepStrictEqual(
+    Array.from(await rejectedPublication, (record) => record.id),
+    ['rejected-publication-record'],
+    'Browse publication failure must not change the baseline Practice sync result'
+);
+integrationSandbox.rebuildBrowseCompletionIndex = productionCompletionRebuild;
+integrationSandbox.__endBrowseUserResultsRequest(publicationUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationCompletionRefreshes,
+    [['accepted-publication-record']],
+    'a rejected newer publication must preserve the accepted completion projection'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes,
+    [['accepted-publication-index']],
+    'a rejected newer publication must preserve the accepted anchor projection'
+);
+assert.deepStrictEqual(
+    integrationPracticeUpdates,
+    [
+        {
+            records: ['accepted-publication-record'],
+            index: ['accepted-publication-index']
+        },
+        {
+            records: ['rejected-publication-record'],
+            index: ['rejected-publication-index']
+        }
+    ],
+    'Browse publication rejection must not suppress either Practice update'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['accepted-publication-index']],
+    'a rejected newer publication must not invalidate the accepted queued repaint'
+);
+
 const identicalHeadIndex = deferred();
 const redundantTailPoison = {
     get promise() {
@@ -2119,9 +2185,21 @@ await establishFailedIntegrationFunctionalReset(
 );
 integrationRenders.length = 0;
 const receiptedLoaderBeforeMissingCommit = integrationSandbox.ExamActions.loadExamList;
-integrationSandbox.ExamActions.loadExamList = function returnWithoutDomCommit(exams) {
-    return Array.isArray(exams) ? exams : [];
+const browseControllerBeforeMissingCommit = integrationSandbox.browseController;
+const missingContainerView = {
+    render() {
+        return false;
+    }
 };
+integrationSandbox.browseController = Object.assign({}, browseControllerBeforeMissingCommit, {
+    getExamListView() {
+        return missingContainerView;
+    },
+    ensureExamListView() {
+        return missingContainerView;
+    }
+});
+integrationSandbox.ExamActions.loadExamList = integrationProductionExamListLoader;
 assert.strictEqual(
     await integrationSandbox.__renderBrowseResultsForState(
         [{ id: 'uncommitted-foreground-result' }],
@@ -2144,6 +2222,7 @@ integrationSandbox.refreshBrowseProgressFromRecords(
 await new Promise((resolve) => setTimeout(resolve, 0));
 assert.deepStrictEqual(integrationRenders, []);
 integrationSandbox.ExamActions.loadExamList = receiptedLoaderBeforeMissingCommit;
+integrationSandbox.browseController = browseControllerBeforeMissingCommit;
 
 await establishFailedIntegrationFunctionalReset(
     'the pending-filter recovery fixture must start from a failed functional barrier'

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -396,6 +396,393 @@ sandbox.setBrowseFilterState(
     browseScopeBeforeColdProgress.type
 );
 
+const integrationListeners = new Map();
+const integrationBrowseView = { id: 'browse-view', classList: createClassList() };
+const integrationOverviewView = { id: 'overview-view', classList: createClassList() };
+integrationOverviewView.classList.add('active');
+const integrationSearchInput = { value: '' };
+const integrationDocument = {
+    readyState: 'loading',
+    body: { appendChild() {}, classList: createClassList() },
+    documentElement: { classList: createClassList() },
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector(selector) {
+        if (selector === '.search-input') return integrationSearchInput;
+        if (selector === '.view.active') {
+            return [integrationBrowseView, integrationOverviewView]
+                .find((view) => view.classList.contains('active')) || null;
+        }
+        return null;
+    },
+    querySelectorAll() { return []; },
+    createElement() {
+        return { style: {}, classList: createClassList(), appendChild() {}, setAttribute() {} };
+    },
+    getElementById(id) {
+        if (id === 'browse-view') return integrationBrowseView;
+        if (id === 'overview-view') return integrationOverviewView;
+        if (id === 'exam-search-input') return integrationSearchInput;
+        if (id === 'search-clear-btn') return { hidden: true };
+        if (id === 'type-filter-buttons') return { querySelectorAll() { return []; } };
+        return null;
+    }
+};
+const integrationRenders = [];
+const integrationAnchorIndexes = [];
+const integrationCompletionRefreshes = [];
+const integrationBrowseState = { category: 'all', type: 'all' };
+const integrationIndexResolvers = [];
+let integrationIndexResolutionCount = 0;
+const IntegrationCustomEvent = class CustomEvent {
+    constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
+};
+const integrationSandbox = {
+    console: quietConsole,
+    document: integrationDocument,
+    location: { href: 'https://example.test/index.html', search: '', origin: 'https://example.test', protocol: 'https:' },
+    history: { replaceState() {} },
+    navigator: {},
+    URL,
+    URLSearchParams,
+    Promise,
+    Set,
+    Map,
+    Date,
+    Math,
+    JSON,
+    CustomEvent: IntegrationCustomEvent,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+    cancelAnimationFrame: clearTimeout,
+    addEventListener(type, listener) {
+        const listeners = integrationListeners.get(type) || [];
+        listeners.push(listener);
+        integrationListeners.set(type, listeners);
+    },
+    removeEventListener() {},
+    dispatchEvent(event) {
+        (integrationListeners.get(event.type) || []).slice().forEach((listener) => listener(event));
+        return true;
+    },
+    confirm() { return false; },
+    alert() {},
+    showMessage() {},
+    setBrowseFilterState(category, type) {
+        integrationBrowseState.category = category;
+        integrationBrowseState.type = type;
+    },
+    getCurrentCategory() { return integrationBrowseState.category; },
+    getCurrentExamType() { return integrationBrowseState.type; },
+    setBrowseTitle() {},
+    formatBrowseTitle(category, type) { return `${category}:${type}`; },
+    normalizeExamType(type) { return type || 'all'; },
+    async resolveActiveLibraryIndex() {
+        integrationIndexResolutionCount += 1;
+        const next = integrationIndexResolvers.shift();
+        return next ? next.promise : [];
+    },
+    updateBrowseAnchorsFromRecords(records, index) {
+        integrationAnchorIndexes.push(Array.from(index || [], (exam) => exam.id));
+    },
+    rebuildBrowseCompletionIndex(records) {
+        integrationCompletionRefreshes.push(Array.isArray(records) ? records.length : -1);
+    },
+    browseController: {
+        currentMode: 'default',
+        buttonContainer: {},
+        currentCategory: 'all',
+        currentExamType: 'all',
+        getCurrentCategory() { return integrationBrowseState.category; },
+        getCurrentExamType() { return integrationBrowseState.type; },
+        updateBrowseTitle() {}
+    },
+    ExamActions: {
+        loadExamList(exams) {
+            integrationRenders.push(Array.from(exams, (exam) => exam.id));
+            return exams;
+        },
+        displayExams(exams) { return exams; }
+    },
+    AppLazyLoader: {
+        ensureGroup() { return Promise.resolve(true); }
+    },
+    AppData: {
+        ready: Promise.resolve(),
+        preferences: {
+            async getBrowse() { return { lastFilter: null, frequencyFilter: 'all' }; },
+            async patchBrowse(value) { return value; },
+            async setBrowse(value) { return value; }
+        },
+        practice: {
+            async list() { return []; },
+            async listInsights() { return []; },
+            async getStats() { return {}; }
+        },
+        library: {
+            async getActive() { return null; },
+            async listConfigurations() { return []; }
+        }
+    }
+};
+integrationSandbox.window = integrationSandbox;
+integrationSandbox.globalThis = integrationSandbox;
+integrationSandbox.self = integrationSandbox;
+const integrationContext = vm.createContext(integrationSandbox);
+const mainEntrySource = fs.readFileSync(path.join(repoRoot, 'js/app/main-entry.js'), 'utf8');
+vm.runInContext(mainEntrySource, integrationContext, { filename: 'js/app/main-entry.js' });
+vm.runInContext(source, integrationContext, { filename: 'js/main.js' });
+await integrationSandbox.AppEntry.ensureBrowseGroup();
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+
+const oldProgressIndex = deferred();
+integrationIndexResolvers.push(oldProgressIndex);
+const arbitrationUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+await integrationSandbox.__renderBrowseResultsForState(
+    [{ id: 'user-current' }],
+    arbitrationUserRequest
+);
+const oldProgressSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'index-fresh' }] }
+}));
+oldProgressIndex.resolve([{ id: 'progress-old' }]);
+await oldProgressSync;
+integrationSandbox.__endBrowseUserResultsRequest(arbitrationUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['user-current'], ['index-fresh']],
+    'a fresher authoritative index publication must beat an older progress resolver at settlement'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    arbitrationUserRequest + 1,
+    'discarding stale progress must not consume an extra results token'
+);
+
+integrationRenders.length = 0;
+const laterProgressUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'index-older-than-progress' }] }
+}));
+integrationSandbox.refreshBrowseProgressFromRecords([], [{ id: 'progress-newest' }]);
+integrationSandbox.__endBrowseUserResultsRequest(laterProgressUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['progress-newest']],
+    'a progress snapshot received after an index publication must remain the latest background render'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    laterProgressUserRequest + 1,
+    'the later progress render must claim exactly one results token'
+);
+
+integrationRenders.length = 0;
+const abaUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+integrationSandbox.refreshBrowseProgressFromRecords([], [{ id: 'aba-progress-old' }]);
+integrationSandbox.__markAppNavigationIntent();
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+integrationSandbox.__markAppNavigationIntent();
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+const abaCurrentRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+await integrationSandbox.__renderBrowseResultsForState(
+    [{ id: 'aba-current' }],
+    abaCurrentRequest
+);
+integrationSandbox.__endBrowseUserResultsRequest(abaCurrentRequest);
+integrationSandbox.__endBrowseUserResultsRequest(abaUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['aba-current']],
+    'a queued progress snapshot must not survive a Browse navigation ABA epoch'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    abaCurrentRequest,
+    'discarding an ABA progress snapshot must preserve the new activation token'
+);
+
+integrationRenders.length = 0;
+const libraryEpochUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+integrationSandbox.refreshBrowseProgressFromRecords([], [{ id: 'library-progress-old' }]);
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'library-publication' }] }
+}));
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+integrationSandbox.__endBrowseUserResultsRequest(libraryEpochUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'an authoritative index publication must invalidate queued progress even without a navigation epoch change'
+);
+
+integrationRenders.length = 0;
+const resetEpochUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+integrationSandbox.refreshBrowseProgressFromRecords([], [{ id: 'pre-reset-progress' }]);
+const resetEpochIntent = integrationSandbox.__beginBrowseResetIntent();
+integrationSandbox.__endBrowseResetIntent(resetEpochIntent);
+integrationSandbox.__endBrowseUserResultsRequest(resetEpochUserRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'a progress snapshot captured before a reset must not repaint after the reset epoch closes'
+);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+const coalescedOldLibraryIndex = deferred();
+const coalescedCurrentLibraryIndex = deferred();
+integrationIndexResolvers.push(coalescedOldLibraryIndex, coalescedCurrentLibraryIndex);
+const coalescedResolutionCountBefore = integrationIndexResolutionCount;
+const oldLibrarySyncCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'pre-library-publication',
+    { forceRender: true }
+);
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'coalesced-index-publication' }] }
+}));
+const currentLibrarySyncCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'library-loaded',
+    { forceRender: true }
+);
+assert.strictEqual(
+    currentLibrarySyncCycle,
+    oldLibrarySyncCycle,
+    'an overlapping library sync must join the active coalescing cycle'
+);
+coalescedCurrentLibraryIndex.resolve([{ id: 'coalesced-progress-current' }]);
+coalescedOldLibraryIndex.resolve([{ id: 'coalesced-progress-old' }]);
+await oldLibrarySyncCycle;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    coalescedResolutionCountBefore + 2,
+    'one overlapping request must schedule exactly one follow-up sync against the latest library epoch'
+);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['coalesced-index-publication'], ['coalesced-progress-current']],
+    'the coalesced latest-library sync must repaint progress after the stale source is discarded'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes,
+    [['coalesced-progress-current']],
+    'a stale library index must not update or persist Browse anchors'
+);
+assert.strictEqual(
+    integrationCompletionRefreshes.length,
+    2,
+    'record-only completion state may refresh for both the stale and latest library syncs'
+);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+const rejectedOldLibraryIndex = deferred();
+const currentLibraryIndexAfterFailure = deferred();
+integrationIndexResolvers.push(rejectedOldLibraryIndex, currentLibraryIndexAfterFailure);
+const failedOldCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'failing-pre-library-publication',
+    { forceRender: true }
+);
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'failure-index-publication' }] }
+}));
+const joinedRecoveryCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'library-loaded',
+    { forceRender: true }
+);
+assert.strictEqual(joinedRecoveryCycle, failedOldCycle);
+currentLibraryIndexAfterFailure.resolve([{ id: 'failure-followup-current' }]);
+rejectedOldLibraryIndex.reject(new Error('simulated stale library resolution failure'));
+await joinedRecoveryCycle;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['failure-index-publication'], ['failure-followup-current']],
+    'a stale sync failure must not suppress the queued latest-library follow-up'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes,
+    [['failure-followup-current']],
+    'only the successful latest-library follow-up may update anchors after an older failure'
+);
+
+const tailFailureIndex = deferred();
+integrationIndexResolvers.push(tailFailureIndex);
+const tailFailureCycle = integrationSandbox.ensurePracticeRecordsSync('tail-failure');
+tailFailureIndex.reject(new Error('simulated terminal sync failure'));
+await assert.rejects(tailFailureCycle, /simulated terminal sync failure/);
+const postFailureRecoveryIndex = deferred();
+integrationIndexResolvers.push(postFailureRecoveryIndex);
+const postFailureRecoveryCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'post-failure-recovery',
+    { forceRender: true }
+);
+postFailureRecoveryIndex.resolve([{ id: 'post-failure-recovery' }]);
+await postFailureRecoveryCycle;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders.at(-1),
+    ['post-failure-recovery'],
+    'a terminal failure must release the queue so a later sync can recover normally'
+);
+
+integrationRenders.length = 0;
+const postNavigationProgressIndex = deferred();
+integrationIndexResolvers.push(postNavigationProgressIndex);
+const postNavigationProgressSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+integrationSandbox.__markAppNavigationIntent();
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+integrationSandbox.__markAppNavigationIntent();
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+const postNavigationRequest = integrationSandbox.__beginBrowseUserResultsRequest();
+await integrationSandbox.__renderBrowseResultsForState(
+    [{ id: 'post-navigation-current' }],
+    postNavigationRequest
+);
+postNavigationProgressIndex.resolve([{ id: 'post-navigation-progress' }]);
+await postNavigationProgressSync;
+integrationSandbox.__endBrowseUserResultsRequest(postNavigationRequest);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['post-navigation-current'], ['post-navigation-progress']],
+    'a same-library sync resolving after navigation must bind to and repaint the current Browse epoch'
+);
+
+integrationRenders.length = 0;
+const postResetProgressIndex = deferred();
+integrationIndexResolvers.push(postResetProgressIndex);
+const postResetProgressSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+const postResetIntent = integrationSandbox.__beginBrowseResetIntent();
+integrationSandbox.__endBrowseResetIntent(postResetIntent);
+postResetProgressIndex.resolve([{ id: 'post-reset-progress' }]);
+await postResetProgressSync;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['post-reset-progress']],
+    'a same-library sync resolving after reset must bind to and repaint the post-reset epoch'
+);
+
 rendered.length = 0;
 const sharedSearchIndex = deferred();
 resolverQueue.push(sharedSearchIndex);
@@ -986,6 +1373,8 @@ const authoritativeDocument = {
     }
 };
 let authoritativePersistedReads = 0;
+let authoritativeDurableReads = 0;
+let authoritativeWritesDurably = false;
 const authoritativePatchGate = deferred();
 const authoritativePreferencePatches = [];
 const authoritativeDurableBrowse = {
@@ -1045,6 +1434,7 @@ const authoritativeSandbox = {
         ready: Promise.resolve(),
         preferences: {
             async getBrowse() {
+                authoritativeDurableReads += 1;
                 return JSON.parse(JSON.stringify(authoritativeDurableBrowse));
             },
             async setBrowse(value) {
@@ -1054,7 +1444,9 @@ const authoritativeSandbox = {
             async patchBrowse(value) {
                 authoritativePreferencePatches.push(JSON.parse(JSON.stringify(value || {})));
                 await authoritativePatchGate.promise;
-                Object.assign(authoritativeDurableBrowse, JSON.parse(JSON.stringify(value || {})));
+                if (authoritativeWritesDurably) {
+                    Object.assign(authoritativeDurableBrowse, JSON.parse(JSON.stringify(value || {})));
+                }
                 return value;
             }
         },
@@ -1085,29 +1477,75 @@ assert.strictEqual(
     0,
     'legacy-app startup preference hydration must not masquerade as a live mutation'
 );
-const browsePreferencesSource = fs.readFileSync(path.join(repoRoot, 'js/utils/BrowsePreferencesUtils.js'), 'utf8');
-vm.runInContext(browsePreferencesSource, authoritativeContext, { filename: 'js/utils/BrowsePreferencesUtils.js' });
-await authoritativeSandbox.whenBrowseViewPreferencesReady();
-const productionAuthoritativePersistedReader = authoritativeSandbox.getPersistedBrowseFilter;
-authoritativeSandbox.getPersistedBrowseFilter = () => {
-    authoritativePersistedReads += 1;
-    return productionAuthoritativePersistedReader();
-};
 authoritativeSandbox.setBrowseFilterState('all', 'all');
-await new Promise((resolve) => setTimeout(resolve, 0));
 assert.strictEqual(
     authoritativeSandbox.getBrowseFilterMutationRevision(),
     1,
     'a same-value authoritative reset before Browse loads must advance the mutation revision'
 );
-assert.strictEqual(authoritativePreferencePatches.length, 1);
+assert.strictEqual(
+    authoritativePreferencePatches.length,
+    0,
+    'a strict pre-activation library mutation cannot persist before BrowsePreferencesUtils loads'
+);
+const browsePreferencesSource = fs.readFileSync(path.join(repoRoot, 'js/utils/BrowsePreferencesUtils.js'), 'utf8');
+vm.runInContext(browsePreferencesSource, authoritativeContext, { filename: 'js/utils/BrowsePreferencesUtils.js' });
+await authoritativeSandbox.whenBrowseViewPreferencesReady();
+const authoritativeDurableReadsAfterPreferencesLoad = authoritativeDurableReads;
+const productionAuthoritativePersistedReader = authoritativeSandbox.getPersistedBrowseFilter;
+authoritativeSandbox.getPersistedBrowseFilter = () => {
+    authoritativePersistedReads += 1;
+    return productionAuthoritativePersistedReader();
+};
+vm.runInContext(source, authoritativeContext, { filename: 'js/main.js' });
+const authoritativeInitialization = authoritativeSandbox.initializeBrowseView({ skipLoad: true });
+for (let attempt = 0; attempt < 16 && authoritativePreferencePatches.length === 0; attempt += 1) {
+    await Promise.resolve();
+}
+assert.strictEqual(
+    authoritativePreferencePatches.length,
+    1,
+    'first Browse initialization must drain the live authoritative filter once preferences are ready'
+);
 assert.deepStrictEqual(
     authoritativeDurableBrowse.lastFilter,
     { category: 'P2', type: 'reading' },
-    'the authoritative all/all write must still be pending during first Browse initialization'
+    'the durable filter must remain old until the authoritative drain commits'
 );
-vm.runInContext(source, authoritativeContext, { filename: 'js/main.js' });
-await authoritativeSandbox.initializeBrowseView({ skipLoad: true });
+authoritativePatchGate.resolve();
+assert.strictEqual(
+    await authoritativeInitialization,
+    null,
+    'a resolved preference write without durable readback must fail closed'
+);
+assert.strictEqual(
+    authoritativeDurableReads,
+    authoritativeDurableReadsAfterPreferencesLoad + 1,
+    'the authoritative drain must verify the storage adapter after flushing its write queue'
+);
+assert.deepStrictEqual(
+    authoritativeDurableBrowse.lastFilter,
+    { category: 'P2', type: 'reading' },
+    'a no-op storage adapter must not be mistaken for a durable commit'
+);
+assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(authoritativeSandbox.getBrowseFilterState())),
+    { category: 'all', type: 'all' },
+    'failed durable verification must not hydrate the older persisted filter'
+);
+
+authoritativeWritesDurably = true;
+const authoritativeRetry = await authoritativeSandbox.initializeBrowseView({ skipLoad: true });
+assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(authoritativeRetry)),
+    authoritativeIndex,
+    'a later initialization must retry the unconsumed authoritative drain'
+);
+assert.strictEqual(
+    authoritativeDurableReads,
+    authoritativeDurableReadsAfterPreferencesLoad + 2,
+    'the successful retry must perform a fresh durable readback'
+);
 assert.strictEqual(
     authoritativePersistedReads,
     0,
@@ -1117,7 +1555,6 @@ assert.deepStrictEqual(
     JSON.parse(JSON.stringify(authoritativeSandbox.getBrowseFilterState())),
     { category: 'all', type: 'all' }
 );
-authoritativePatchGate.resolve();
 await authoritativeSandbox.flushBrowsePreferenceWrites();
 assert.deepStrictEqual(authoritativeDurableBrowse.lastFilter, { category: 'all', type: 'all' });
 assert.strictEqual(
@@ -1126,6 +1563,79 @@ assert.strictEqual(
     )),
     false,
     'initial hydration must not enqueue a trailing stale P2/reading write'
+);
+
+let reloadPersistedReads = 0;
+const reloadSandbox = {
+    console: quietConsole,
+    document: authoritativeDocument,
+    location: { href: 'https://example.test/index.html', search: '', origin: 'https://example.test', protocol: 'https:' },
+    history: { replaceState() {} },
+    navigator: {},
+    URL,
+    URLSearchParams,
+    Promise,
+    Set,
+    Map,
+    Date,
+    Math,
+    JSON,
+    CustomEvent: authoritativeSandbox.CustomEvent,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+    cancelAnimationFrame: clearTimeout,
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {},
+    confirm() { return false; },
+    alert() {},
+    setBrowseTitle() {},
+    formatBrowseTitle(category, type) { return `${category}:${type}`; },
+    normalizeExamType(type) { return type || 'all'; },
+    async resolveActiveLibraryIndex() { return authoritativeIndex; },
+    browseController: {
+        currentMode: 'default',
+        buttonContainer: {},
+        currentCategory: 'all',
+        currentExamType: 'all',
+        getCurrentCategory() { return 'all'; },
+        getCurrentExamType() { return 'all'; },
+        updateBrowseTitle() {}
+    },
+    ExamActions: {
+        loadExamList(exams) { return exams; },
+        displayExams(exams) { return exams; }
+    },
+    AppData: authoritativeSandbox.AppData
+};
+reloadSandbox.window = reloadSandbox;
+reloadSandbox.globalThis = reloadSandbox;
+reloadSandbox.self = reloadSandbox;
+const reloadContext = vm.createContext(reloadSandbox);
+vm.runInContext(stateServiceSource, reloadContext, { filename: 'js/app/state-service.js' });
+assert.strictEqual(
+    reloadSandbox.getBrowseFilterMutationRevision(),
+    0,
+    'a clean reload must begin with no live mutation revision'
+);
+vm.runInContext(browsePreferencesSource, reloadContext, { filename: 'js/utils/BrowsePreferencesUtils.js' });
+await reloadSandbox.whenBrowseViewPreferencesReady();
+const reloadPersistedFilterReader = reloadSandbox.getPersistedBrowseFilter;
+reloadSandbox.getPersistedBrowseFilter = () => {
+    reloadPersistedReads += 1;
+    return reloadPersistedFilterReader();
+};
+vm.runInContext(source, reloadContext, { filename: 'js/main.js' });
+await reloadSandbox.initializeBrowseView({ skipLoad: true });
+await reloadSandbox.flushBrowsePreferenceWrites();
+assert.strictEqual(reloadPersistedReads, 1, 'a clean reload must hydrate the committed filter once');
+assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(reloadSandbox.getBrowseFilterState())),
+    { category: 'all', type: 'all' },
+    'a clean reload must retain the drained all/all filter instead of reviving P2/reading'
 );
 
 console.log(JSON.stringify({

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -80,6 +80,7 @@ const documentStub = {
 };
 
 const rendered = [];
+const dispatchedWindowEvents = [];
 const browseState = { category: 'all', type: 'all' };
 const resolverQueue = [];
 const quietConsole = { log() {}, warn() {}, error() {} };
@@ -108,7 +109,7 @@ const sandbox = {
     cancelAnimationFrame: clearTimeout,
     addEventListener() {},
     removeEventListener() {},
-    dispatchEvent() {},
+    dispatchEvent(event) { dispatchedWindowEvents.push(event); },
     confirm() { return false; },
     alert() {},
     setBrowseFilterState(category, type) {
@@ -184,6 +185,7 @@ resolverQueue.push(filterFirst, filterSecond);
 const staleFilter = sandbox.filterByType('reading');
 const latestFilter = sandbox.filterByType('all');
 const latestFilterRequestId = sandbox.__getBrowseResultsRequestId();
+dispatchedWindowEvents.length = 0;
 assert.strictEqual(
     sandbox.__isBrowseUserResultsRequestInFlight(latestFilterRequestId),
     true,
@@ -210,6 +212,11 @@ const allExams = [
 filterSecond.resolve(allExams);
 await latestFilter;
 assert.strictEqual(sandbox.__isBrowseUserResultsRequestInFlight(latestFilterRequestId), false);
+assert.ok(
+    dispatchedWindowEvents.some((event) => event.type === 'browseUserResultsRequestSettled'
+        && event.detail.requestId === latestFilterRequestId),
+    'the final retain release must dispatch the production settlement notification'
+);
 filterFirst.resolve(allExams);
 await staleFilter;
 
@@ -343,6 +350,43 @@ sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
     return result;
 };
 
+rendered.length = 0;
+searchInput.value = '';
+const firstActivationIndex = deferred();
+resolverQueue.push(firstActivationIndex);
+let firstActivationControllerSetups = 0;
+let firstActivationListeningSyncs = 0;
+const previousControllerInitialize = sandbox.browseController.initialize;
+const previousControllerContainer = sandbox.browseController.buttonContainer;
+const previousPersistedFilter = sandbox.getPersistedBrowseFilter;
+const previousListeningAvailabilityRefresh = sandbox.refreshListeningAvailabilityUI;
+sandbox.browseController.buttonContainer = null;
+sandbox.browseController.initialize = function initializeBrowseController(containerId) {
+    firstActivationControllerSetups += 1;
+    this.buttonContainer = containerId === 'type-filter-buttons' ? typeButtonContainer : null;
+    return true;
+};
+sandbox.getPersistedBrowseFilter = () => ({ category: 'P2', type: 'reading' });
+sandbox.refreshListeningAvailabilityUI = () => {
+    firstActivationListeningSyncs += 1;
+};
+sandbox.showView('overview', false);
+const firstActivation = sandbox.showView('browse', false);
+firstActivationIndex.resolve([
+    { id: 'p2-reading', title: 'P2 Reading', category: 'P2', type: 'reading' },
+    { id: 'p2-listening', title: 'P2 Listening', category: 'P2', type: 'listening' }
+]);
+await firstActivation;
+assert.strictEqual(firstActivationControllerSetups, 1, 'first Browse activation must initialize its controller');
+assert.strictEqual(firstActivationListeningSyncs, 1, 'first Browse activation must refresh listening availability');
+assert.strictEqual(browseState.category, 'P2');
+assert.strictEqual(browseState.type, 'reading');
+assert.deepStrictEqual(rendered, [['p2-reading']], 'first activation must render once after restoring persisted scope');
+sandbox.browseController.initialize = previousControllerInitialize;
+sandbox.browseController.buttonContainer = previousControllerContainer;
+sandbox.getPersistedBrowseFilter = previousPersistedFilter;
+sandbox.refreshListeningAvailabilityUI = previousListeningAvailabilityRefresh;
+
 searchInput.value = 'stale-query';
 sandbox.__browseFilterMode = 'frequency-p1';
 sandbox.__browsePath = 'ReadingPractice/P1';
@@ -368,6 +412,45 @@ assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening']);
 sandbox.resetBrowseFilterStateToAll = mainResetBrowseFilterStateToAll;
 sandbox.updateBrowseFrequencyButtons = mainUpdateBrowseFrequencyButtons;
 searchInput.value = '';
+
+rendered.length = 0;
+sandbox.__browseFilterMode = 'frequency-p1';
+sandbox.__browsePath = 'ListeningPractice/100 P1';
+sandbox.__browseFrequencyFilter = 'high';
+sandbox.browseController.currentMode = 'frequency-p1';
+sandbox.browseController.activeFilter = 'high';
+const throwingMainReset = sandbox.resetBrowseFilterStateToAll;
+const throwingPublicOwnerReset = sandbox.ExamActions.resetBrowseFilterStateToAll;
+sandbox.resetBrowseFilterStateToAll = () => {
+    throw new Error('main reset unavailable');
+};
+sandbox.ExamActions.resetBrowseFilterStateToAll = () => {
+    throw new Error('public owner reset unavailable');
+};
+const terminalOwnerIndex = deferred();
+resolverQueue.push(terminalOwnerIndex);
+const terminalResetStates = [];
+const ownerAwareLoadExamList = sandbox.ExamActions.loadExamList;
+sandbox.ExamActions.loadExamList = function captureTerminalResetState(exams) {
+    terminalResetStates.push({
+        mode: sandbox.__browseFilterMode,
+        path: sandbox.__browsePath,
+        frequency: sandbox.__browseFrequencyFilter
+    });
+    return ownerAwareLoadExamList.call(this, exams);
+};
+const terminalOwnerReset = sandbox.showView('browse', true);
+terminalOwnerIndex.resolve(allExams);
+assert.notStrictEqual(await terminalOwnerReset, false);
+assert.deepStrictEqual(
+    terminalResetStates,
+    [{ mode: 'default', path: null, frequency: 'all' }],
+    'the loader must only run after the stable functional-state owner resets all globals'
+);
+assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening']);
+sandbox.ExamActions.loadExamList = ownerAwareLoadExamList;
+sandbox.resetBrowseFilterStateToAll = throwingMainReset;
+sandbox.ExamActions.resetBrowseFilterStateToAll = throwingPublicOwnerReset;
 
 const failedReentryIndex = deferred();
 resolverQueue.push(failedReentryIndex);
@@ -426,6 +509,230 @@ assert.deepStrictEqual(
     ['reading', 'listening'],
     'an empty reset prefetch must never render the module-local [] default'
 );
+
+const previousGetElementByIdForComposition = documentStub.getElementById.bind(documentStub);
+const previousCreateElementForComposition = documentStub.createElement.bind(documentStub);
+const compositionButtons = [];
+const compositionButtonContainer = {
+    classList: createClassList(),
+    appendChild(button) { compositionButtons.push(button); },
+    querySelectorAll(selector) {
+        if (selector.includes('listening')) {
+            return compositionButtons.filter((button) => button.dataset.filterType === 'listening');
+        }
+        return compositionButtons;
+    }
+};
+Object.defineProperty(compositionButtonContainer, 'innerHTML', {
+    set() { compositionButtons.length = 0; }
+});
+documentStub.getElementById = function getCompositionElementById(id) {
+    if (id === 'type-filter-buttons') return compositionButtonContainer;
+    return previousGetElementByIdForComposition(id);
+};
+documentStub.createElement = function createCompositionElement(tagName) {
+    if (tagName === 'button') {
+        return {
+            className: '',
+            textContent: '',
+            dataset: {},
+            classList: createClassList(),
+            addEventListener() {},
+            setAttribute() {},
+            appendChild() {}
+        };
+    }
+    return previousCreateElementForComposition(tagName);
+};
+sandbox.appStateService = {
+    setBrowseFilter(filter) {
+        browseState.category = filter.category;
+        browseState.type = filter.type;
+    },
+    getBrowseFilter() {
+        return { category: browseState.category, type: browseState.type };
+    },
+    setFilteredExams() {}
+};
+const browseControllerSource = fs.readFileSync(path.join(repoRoot, 'js/app/browseController.js'), 'utf8');
+vm.runInContext(browseControllerSource, context, { filename: 'js/app/browseController.js' });
+const productionBrowseController = sandbox.browseController;
+const frequencyIndex = [
+    {
+        id: 'p1-ultra', title: 'Shared Ultra', searchText: 'shared ultra', category: 'P1', type: 'listening',
+        path: 'ListeningPractice/100 P1/P1 超高频（43）/ultra.html'
+    },
+    {
+        id: 'p1-high', title: 'Shared High', searchText: 'shared high', category: 'P1', type: 'listening',
+        path: 'ListeningPractice/100 P1/P1 高频（35）/high.html'
+    },
+    {
+        id: 'p1-medium', title: 'Shared Medium', searchText: 'shared medium', category: 'P1', type: 'listening',
+        path: 'ListeningPractice/100 P1/P1 中频(48)/medium.html'
+    },
+    {
+        id: 'p4-numbered', title: 'Shared P4', searchText: 'shared p4', category: 'P4', type: 'listening',
+        path: 'ListeningPractice/100 P4/1-10/p4.html'
+    }
+];
+const compositionRenders = [];
+sandbox.displayExams = (exams) => {
+    compositionRenders.push(Array.from(exams, (exam) => exam.id));
+};
+sandbox.ExamActions.displayExams = sandbox.displayExams;
+sandbox.setFilteredExamsState = () => {};
+sandbox.handlePostExamListRender = () => {};
+let compositionLoadCalls = 0;
+sandbox.ExamActions.loadExamList = function guardedProductionLoad(exams) {
+    compositionLoadCalls += 1;
+    assert.ok(compositionLoadCalls <= 4, 'frequency-mode rendering must not recurse');
+    return productionLoadExamList.call(this, exams);
+};
+sandbox.__browseFilterMode = 'default';
+sandbox.__browsePath = null;
+sandbox.__browseFrequencyFilter = 'all';
+productionBrowseController.initialize('type-filter-buttons', frequencyIndex);
+
+for (const scenario of [
+    {
+        mode: 'frequency-p1',
+        path: 'ListeningPractice/100 P1',
+        filter: 'ultra-high',
+        expected: ['p1-ultra']
+    },
+    {
+        mode: 'frequency-p4',
+        path: 'ListeningPractice/100 P4',
+        filter: 'all',
+        expected: ['p4-numbered']
+    }
+]) {
+    compositionRenders.length = 0;
+    compositionLoadCalls = 0;
+    searchInput.value = '';
+    sandbox.__browseFilterMode = scenario.mode;
+    sandbox.__browsePath = scenario.path;
+    productionBrowseController.currentMode = scenario.mode;
+    productionBrowseController.activeFilter = scenario.filter;
+    const requestId = sandbox.__beginBrowseResultsRequest();
+
+    await sandbox.__renderBrowseResultsForState(frequencyIndex, requestId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.strictEqual(compositionLoadCalls, 1, `${scenario.mode} must enter ExamActions once`);
+    assert.strictEqual(sandbox.__getBrowseResultsRequestId(), requestId);
+    assert.deepStrictEqual(compositionRenders, [scenario.expected]);
+}
+
+compositionRenders.length = 0;
+compositionLoadCalls = 0;
+searchInput.value = 'shared';
+sandbox.resolveActiveLibraryIndex = async () => frequencyIndex;
+sandbox.getPersistedBrowseFilter = () => ({ category: 'P1', type: 'listening' });
+await sandbox.applyBrowseFilter(
+    'P1',
+    'listening',
+    'frequency-p1',
+    'ListeningPractice/100 P1'
+);
+assert.strictEqual(productionBrowseController.activeFilter, 'ultra-high');
+assert.deepStrictEqual(compositionRenders, [['p1-ultra']], 'mode entry search must honor the active folder');
+
+compositionRenders.length = 0;
+await productionBrowseController.handleFilterClick('high', frequencyIndex);
+assert.deepStrictEqual(compositionRenders, [['p1-high']]);
+compositionRenders.length = 0;
+sandbox.showView('overview', false);
+await sandbox.showView('browse', false);
+assert.strictEqual(searchInput.value, 'shared');
+assert.strictEqual(productionBrowseController.activeFilter, 'high');
+assert.deepStrictEqual(
+    compositionRenders,
+    [['p1-high']],
+    'ordinary Browse re-entry must preserve the live query and active folder subfilter'
+);
+
+const savedResetDelegate = sandbox.resetBrowseFilterStateToAll;
+const savedExamActions = sandbox.ExamActions;
+const savedEnsureBrowseGroup = sandbox.ensureBrowseGroup;
+const savedAppEntry = sandbox.AppEntry;
+const savedAppLazyLoader = sandbox.AppLazyLoader;
+const savedRefreshBrowseResults = sandbox.refreshBrowseResults;
+const savedLoadExamList = sandbox.loadExamList;
+const coldResetOrder = [];
+let unsafeBrowseGroupCalls = 0;
+sandbox.resetBrowseFilterStateToAll = undefined;
+sandbox.ExamActions = undefined;
+sandbox.refreshBrowseResults = undefined;
+sandbox.ensureBrowseGroup = () => {
+    unsafeBrowseGroupCalls += 1;
+    throw new Error('the synchronizing group loader must not run before reset');
+};
+sandbox.AppEntry = {
+    ...(savedAppEntry || {}),
+    registerBrowseFunctionalResetBarrier(resetPromise) {
+        coldResetOrder.push('barrier');
+        return resetPromise;
+    },
+    async ensureBrowseRuntimeGroup() {
+        coldResetOrder.push('ensure');
+        sandbox.ExamActions = {
+            browseFilterStateOwner: {
+                resetToAll() {
+                    coldResetOrder.push('owner');
+                    sandbox.__browseFilterMode = 'default';
+                    sandbox.__browsePath = null;
+                    sandbox.__browseFrequencyFilter = 'all';
+                    return true;
+                }
+            }
+        };
+    },
+    async ensureBrowseGroup() {
+        coldResetOrder.push('activate');
+        return sandbox.loadExamList();
+    }
+};
+sandbox.loadExamList = () => {
+    coldResetOrder.push('load');
+    return [];
+};
+sandbox.__browseFilterMode = 'frequency-p1';
+sandbox.__browsePath = 'ReadingPractice/P1';
+sandbox.__browseFrequencyFilter = 'high';
+assert.notStrictEqual(await sandbox.showView('browse', true), false);
+assert.deepStrictEqual(
+    coldResetOrder,
+    ['barrier', 'ensure', 'owner', 'activate', 'load'],
+    'a cold reset must run its owner before the synchronized activation can render'
+);
+assert.strictEqual(unsafeBrowseGroupCalls, 0, 'cold reset must not invoke the synchronizing Browse loader');
+
+let unsafeFallbackLoads = 0;
+sandbox.ExamActions = undefined;
+sandbox.ensureBrowseGroup = undefined;
+sandbox.AppEntry = undefined;
+sandbox.AppLazyLoader = undefined;
+sandbox.loadExamList = () => {
+    unsafeFallbackLoads += 1;
+    return [];
+};
+sandbox.__browseFilterMode = 'frequency-p1';
+sandbox.__browsePath = 'ReadingPractice/P1';
+sandbox.__browseFrequencyFilter = 'high';
+assert.strictEqual(await sandbox.showView('browse', true), false);
+assert.strictEqual(
+    unsafeFallbackLoads,
+    0,
+    'an irrecoverable reset must fail closed instead of loading with stale functional state'
+);
+sandbox.resetBrowseFilterStateToAll = savedResetDelegate;
+sandbox.ExamActions = savedExamActions;
+sandbox.ensureBrowseGroup = savedEnsureBrowseGroup;
+sandbox.AppEntry = savedAppEntry;
+sandbox.AppLazyLoader = savedAppLazyLoader;
+sandbox.refreshBrowseResults = savedRefreshBrowseResults;
+sandbox.loadExamList = savedLoadExamList;
 
 console.log(JSON.stringify({
     status: 'pass',

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -145,7 +145,8 @@ const sandbox = {
 sandbox.window = sandbox;
 sandbox.globalThis = sandbox;
 sandbox.self = sandbox;
-vm.runInContext(source, vm.createContext(sandbox), { filename: 'js/main.js' });
+const context = vm.createContext(sandbox);
+vm.runInContext(source, context, { filename: 'js/main.js' });
 
 const searchFirst = deferred();
 const searchSecond = deferred();
@@ -179,7 +180,69 @@ assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening'], '最终列表�
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'all').ariaPressed, 'true');
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'reading').ariaPressed, 'false');
 
+const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
+vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
+const productionLoadExamList = sandbox.ExamActions.loadExamList;
+sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
+    const result = productionLoadExamList.call(this, exams);
+    if (Array.isArray(result)) {
+        rendered.push(Array.from(result, (exam) => exam.id));
+    }
+    return result;
+};
+
+rendered.length = 0;
+const staleResetIndex = deferred();
+const latestFilterIndex = deferred();
+resolverQueue.push(staleResetIndex, latestFilterIndex);
+const staleReset = sandbox.ExamActions.resetBrowseViewToAll();
+await Promise.resolve();
+const latestFilterAfterReset = sandbox.filterByType('reading');
+latestFilterIndex.resolve(allExams);
+await latestFilterAfterReset;
+staleResetIndex.resolve([{ id: 'stale-reset', title: 'Stale reset', type: 'listening', category: 'P2' }]);
+assert.strictEqual(await staleReset, false, 'a newer explicit filter must supersede an older reset');
+assert.deepStrictEqual(rendered.at(-1), ['reading'], 'the newer explicit filter must remain the final render');
+assert.strictEqual(browseState.type, 'reading', 'a stale reset must not clear the newer filter state');
+assert.strictEqual(
+    typeButtons.find((button) => button.dataset.filterType === 'reading').ariaPressed,
+    'true',
+    'a stale reset must not clear the newer filter UI'
+);
+
+rendered.length = 0;
+const staleFilterIndex = deferred();
+const latestResetIndex = deferred();
+resolverQueue.push(staleFilterIndex, latestResetIndex);
+const staleFilterBeforeReset = sandbox.filterByType('reading');
+const latestReset = sandbox.ExamActions.resetBrowseViewToAll();
+latestResetIndex.resolve(allExams);
+await latestReset;
+staleFilterIndex.resolve(allExams);
+await staleFilterBeforeReset;
+assert.strictEqual(browseState.type, 'all', 'a newer reset must supersede an older explicit filter');
+assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening'], 'the reset must remain the final all-exams render');
+
+rendered.length = 0;
+const emptyResetPrefetch = deferred();
+const adapterResolvedIndex = deferred();
+resolverQueue.push(emptyResetPrefetch, adapterResolvedIndex);
+const resetThroughAdapter = sandbox.ExamActions.resetBrowseViewToAll();
+emptyResetPrefetch.resolve([]);
+adapterResolvedIndex.resolve(allExams);
+const adapterResult = await resetThroughAdapter;
+assert.deepStrictEqual(
+    Array.from(adapterResult, (exam) => exam.id),
+    ['reading', 'listening'],
+    'the real global adapter must re-resolve the active index when reset passes null'
+);
+assert.deepStrictEqual(
+    rendered.at(-1),
+    ['reading', 'listening'],
+    'an empty reset prefetch must never render the module-local [] default'
+);
+
 console.log(JSON.stringify({
     status: 'pass',
-    detail: 'browse search and type filters use latest-wins rendering'
+    detail: 'browse search, filters, and repeat reset use latest-wins rendering'
 }, null, 2));

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -415,7 +415,13 @@ const integrationDocument = {
         }
         return null;
     },
-    querySelectorAll() { return []; },
+    querySelectorAll(selector) {
+        if (selector === '.view.active') {
+            return [integrationBrowseView, integrationOverviewView]
+                .filter((view) => view.classList.contains('active'));
+        }
+        return [];
+    },
     createElement() {
         return { style: {}, classList: createClassList(), appendChild() {}, setAttribute() {} };
     },
@@ -431,8 +437,11 @@ const integrationDocument = {
 const integrationRenders = [];
 const integrationAnchorIndexes = [];
 const integrationCompletionRefreshes = [];
+const integrationPracticeUpdates = [];
 const integrationBrowseState = { category: 'all', type: 'all' };
 const integrationIndexResolvers = [];
+const integrationPracticeRecordResolvers = [];
+const integrationCommitListeners = new Set();
 let integrationIndexResolutionCount = 0;
 const IntegrationCustomEvent = class CustomEvent {
     constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
@@ -489,7 +498,9 @@ const integrationSandbox = {
         integrationAnchorIndexes.push(Array.from(index || [], (exam) => exam.id));
     },
     rebuildBrowseCompletionIndex(records) {
-        integrationCompletionRefreshes.push(Array.isArray(records) ? records.length : -1);
+        integrationCompletionRefreshes.push(
+            Array.isArray(records) ? Array.from(records, (record) => record && record.id) : null
+        );
     },
     browseController: {
         currentMode: 'default',
@@ -518,9 +529,18 @@ const integrationSandbox = {
             async setBrowse(value) { return value; }
         },
         practice: {
-            async list() { return []; },
+            async list() {
+                const next = integrationPracticeRecordResolvers.shift();
+                return next ? next.promise : [];
+            },
             async listInsights() { return []; },
             async getStats() { return {}; }
+        },
+        backups: {
+            onDataCommitted(listener) {
+                integrationCommitListeners.add(listener);
+                return () => integrationCommitListeners.delete(listener);
+            }
         },
         library: {
             async getActive() { return null; },
@@ -535,9 +555,27 @@ const integrationContext = vm.createContext(integrationSandbox);
 const mainEntrySource = fs.readFileSync(path.join(repoRoot, 'js/app/main-entry.js'), 'utf8');
 vm.runInContext(mainEntrySource, integrationContext, { filename: 'js/app/main-entry.js' });
 vm.runInContext(source, integrationContext, { filename: 'js/main.js' });
+integrationSandbox.PracticeHistoryRenderer = {
+    helpers: {
+        computeRecordsSignature(records) {
+            return Array.from(records || [], (record) => record && record.id).join('|');
+        }
+    }
+};
+integrationSandbox.updatePracticeView = function capturePracticeUpdate(records, index) {
+    integrationPracticeUpdates.push({
+        records: Array.from(records || [], (record) => record && record.id),
+        index: Array.from(index || [], (exam) => exam && exam.id)
+    });
+};
 await integrationSandbox.AppEntry.ensureBrowseGroup();
 integrationOverviewView.classList.remove('active');
 integrationBrowseView.classList.add('active');
+
+function emitIntegrationDataCommitted(targets) {
+    const event = { targets: Array.isArray(targets) ? targets : [] };
+    integrationCommitListeners.forEach((listener) => listener(event));
+}
 
 const oldProgressIndex = deferred();
 integrationIndexResolvers.push(oldProgressIndex);
@@ -643,6 +681,160 @@ assert.deepStrictEqual(
     'a progress snapshot captured before a reset must not repaint after the reset epoch closes'
 );
 
+const identicalHeadIndex = deferred();
+const redundantTailPoison = {
+    get promise() {
+        return Promise.reject(new Error('an identical join must not start a redundant tail'));
+    }
+};
+integrationIndexResolvers.push(identicalHeadIndex, redundantTailPoison);
+const identicalResolutionCountBefore = integrationIndexResolutionCount;
+const identicalHeadCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'practice-view',
+    { forceRender: true }
+);
+const identicalJoinCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'practice-view',
+    { forceRender: true }
+);
+const sameEpochAliasCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'exam-index-loaded',
+    { forceRender: true }
+);
+assert.strictEqual(identicalJoinCycle, identicalHeadCycle);
+assert.strictEqual(sameEpochAliasCycle, identicalHeadCycle);
+identicalHeadIndex.resolve([{ id: 'identical-head' }]);
+await identicalHeadCycle;
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    identicalResolutionCountBefore + 1,
+    'identical and trigger-alias joins in the same epoch must share one physical read'
+);
+assert.strictEqual(
+    integrationIndexResolvers.shift(),
+    redundantTailPoison,
+    'a head success must not be overturned by an invented failing tail'
+);
+
+const queuedEpochHeadIndex = deferred();
+const queuedEpochCurrentIndex = deferred();
+const queuedEpochRedundantPoison = {
+    get promise() {
+        return Promise.reject(new Error('the running current-epoch tail must cover its join'));
+    }
+};
+integrationIndexResolvers.push(
+    queuedEpochHeadIndex,
+    queuedEpochCurrentIndex,
+    queuedEpochRedundantPoison
+);
+const queuedEpochResolutionCountBefore = integrationIndexResolutionCount;
+const queuedEpochCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'queued-epoch-head',
+    { forceRender: true }
+);
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'queued-epoch-one-publication' }] }
+}));
+const queuedEpochTail = integrationSandbox.ensurePracticeRecordsSync(
+    'queued-epoch-tail',
+    { forceRender: true }
+);
+assert.strictEqual(queuedEpochTail, queuedEpochCycle);
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'queued-epoch-two-publication' }] }
+}));
+queuedEpochHeadIndex.resolve([{ id: 'queued-epoch-stale-head' }]);
+while (integrationIndexResolutionCount < queuedEpochResolutionCountBefore + 2) {
+    await Promise.resolve();
+}
+const queuedEpochCurrentJoin = integrationSandbox.ensurePracticeRecordsSync(
+    'queued-epoch-current-alias',
+    { forceRender: true }
+);
+assert.strictEqual(queuedEpochCurrentJoin, queuedEpochCycle);
+queuedEpochCurrentIndex.resolve([{ id: 'queued-epoch-current-tail' }]);
+await queuedEpochCurrentJoin;
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    queuedEpochResolutionCountBefore + 2,
+    'a queued tail must advertise the current epoch it reads when execution starts'
+);
+assert.strictEqual(
+    integrationIndexResolvers.shift(),
+    queuedEpochRedundantPoison,
+    'a current-epoch join must not enqueue a third physical read'
+);
+
+const dataEpochHeadIndex = deferred();
+const dataEpochCurrentIndex = deferred();
+integrationIndexResolvers.push(dataEpochHeadIndex, dataEpochCurrentIndex);
+const dataEpochResolutionCountBefore = integrationIndexResolutionCount;
+const dataEpochHeadCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'practice-view',
+    { forceRender: true }
+);
+emitIntegrationDataCommitted([{ store: 'practiceSummaries' }]);
+const dataEpochJoinedCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'practice-view',
+    { forceRender: true }
+);
+assert.strictEqual(dataEpochJoinedCycle, dataEpochHeadCycle);
+dataEpochCurrentIndex.resolve([{ id: 'data-epoch-current' }]);
+dataEpochHeadIndex.resolve([{ id: 'data-epoch-stale' }]);
+await dataEpochJoinedCycle;
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    dataEpochResolutionCountBefore + 2,
+    'a proven practice-store commit must schedule exactly one current-data follow-up'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes.at(-1),
+    ['data-epoch-current'],
+    'only the current practice-data epoch may update Browse anchors'
+);
+
+const preservedForceBaselineRecords = deferred();
+const preservedForceBaselineIndex = deferred();
+integrationPracticeRecordResolvers.push(preservedForceBaselineRecords);
+integrationIndexResolvers.push(preservedForceBaselineIndex);
+const preservedForceBaselineCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'force-baseline',
+    { forceRender: true }
+);
+preservedForceBaselineRecords.resolve([{ id: 'preserved-force-record' }]);
+preservedForceBaselineIndex.resolve([{ id: 'preserved-force-baseline' }]);
+await preservedForceBaselineCycle;
+integrationPracticeUpdates.length = 0;
+const preservedForceStaleRecords = deferred();
+const preservedForceCurrentRecords = deferred();
+const preservedForceStaleIndex = deferred();
+const preservedForceCurrentIndex = deferred();
+integrationPracticeRecordResolvers.push(
+    preservedForceStaleRecords,
+    preservedForceCurrentRecords
+);
+integrationIndexResolvers.push(preservedForceStaleIndex, preservedForceCurrentIndex);
+const preservedForceCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'force-before-data-epoch',
+    { forceRender: true }
+);
+emitIntegrationDataCommitted([{ store: 'practiceDetails' }]);
+const preservedForceJoinedCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'current-data-default-options'
+);
+assert.strictEqual(preservedForceJoinedCycle, preservedForceCycle);
+preservedForceCurrentRecords.resolve([{ id: 'preserved-force-record' }]);
+preservedForceCurrentIndex.resolve([{ id: 'preserved-force-current' }]);
+preservedForceStaleRecords.resolve([{ id: 'preserved-force-record' }]);
+preservedForceStaleIndex.resolve([{ id: 'preserved-force-stale' }]);
+await preservedForceJoinedCycle;
+assert.deepStrictEqual(
+    integrationPracticeUpdates,
+    [{ records: ['preserved-force-record'], index: ['preserved-force-current'] }],
+    'a replacement tail must preserve stronger options from a stale active head'
+);
+
 integrationRenders.length = 0;
 integrationAnchorIndexes.length = 0;
 integrationCompletionRefreshes.length = 0;
@@ -687,8 +879,8 @@ assert.deepStrictEqual(
 );
 assert.strictEqual(
     integrationCompletionRefreshes.length,
-    2,
-    'record-only completion state may refresh for both the stale and latest library syncs'
+    1,
+    'a stale-library sync must not mutate the completion projection before standing down'
 );
 
 integrationRenders.length = 0;
@@ -723,11 +915,24 @@ assert.deepStrictEqual(
     'only the successful latest-library follow-up may update anchors after an older failure'
 );
 
-const tailFailureIndex = deferred();
-integrationIndexResolvers.push(tailFailureIndex);
-const tailFailureCycle = integrationSandbox.ensurePracticeRecordsSync('tail-failure');
-tailFailureIndex.reject(new Error('simulated terminal sync failure'));
-await assert.rejects(tailFailureCycle, /simulated terminal sync failure/);
+const headBeforeTailFailureIndex = deferred();
+const genuineTailFailureIndex = deferred();
+integrationIndexResolvers.push(headBeforeTailFailureIndex, genuineTailFailureIndex);
+const tailFailureCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'pre-tail-failure',
+    { forceRender: true }
+);
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'tail-failure-publication' }] }
+}));
+const joinedTailFailureCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'library-loaded',
+    { forceRender: true }
+);
+assert.strictEqual(joinedTailFailureCycle, tailFailureCycle);
+headBeforeTailFailureIndex.resolve([{ id: 'successful-stale-head' }]);
+genuineTailFailureIndex.reject(new Error('simulated current tail failure'));
+await assert.rejects(joinedTailFailureCycle, /simulated current tail failure/);
 const postFailureRecoveryIndex = deferred();
 integrationIndexResolvers.push(postFailureRecoveryIndex);
 const postFailureRecoveryCycle = integrationSandbox.ensurePracticeRecordsSync(
@@ -782,6 +987,272 @@ assert.deepStrictEqual(
     [['post-reset-progress']],
     'a same-library sync resolving after reset must bind to and repaint the post-reset epoch'
 );
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const sameLibraryOldRecords = deferred();
+const sameLibraryCurrentRecords = deferred();
+const sameLibraryOldIndex = deferred();
+const sameLibraryCurrentIndex = deferred();
+integrationPracticeRecordResolvers.push(sameLibraryOldRecords, sameLibraryCurrentRecords);
+integrationIndexResolvers.push(sameLibraryOldIndex, sameLibraryCurrentIndex);
+const directResultsTokenBefore = integrationSandbox.__getBrowseResultsRequestId();
+const sameLibraryOldSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+const sameLibraryCurrentSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+sameLibraryCurrentRecords.resolve([{ id: 'direct-r2' }]);
+sameLibraryCurrentIndex.resolve([{ id: 'direct-index-r2' }]);
+await sameLibraryCurrentSync;
+sameLibraryOldRecords.resolve([{ id: 'direct-r1' }]);
+sameLibraryOldIndex.resolve([{ id: 'direct-index-r1' }]);
+await sameLibraryOldSync;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    vm.runInContext('lastPracticeRecordsSignature', integrationContext),
+    'direct-r2',
+    'a late same-library direct sync must not replace the current records signature'
+);
+assert.deepStrictEqual(integrationCompletionRefreshes, [['direct-r2']]);
+assert.deepStrictEqual(integrationAnchorIndexes, [['direct-index-r2']]);
+assert.deepStrictEqual(integrationRenders, [['direct-index-r2']]);
+assert.deepStrictEqual(integrationPracticeUpdates, [{
+    records: ['direct-r2'],
+    index: ['direct-index-r2']
+}]);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    directResultsTokenBefore + 1,
+    'discarding the late direct sync must not consume a Browse results token'
+);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const oldLibraryDirectRecords = deferred();
+const currentLibraryManagedRecords = deferred();
+const oldLibraryDirectIndex = deferred();
+const currentLibraryManagedIndex = deferred();
+integrationPracticeRecordResolvers.push(oldLibraryDirectRecords, currentLibraryManagedRecords);
+integrationIndexResolvers.push(oldLibraryDirectIndex, currentLibraryManagedIndex);
+const oldLibraryDirectSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'direct-library-publication' }] }
+}));
+const currentLibraryManagedSync = integrationSandbox.ensurePracticeRecordsSync(
+    'library-loaded',
+    { forceRender: true }
+);
+currentLibraryManagedRecords.resolve([{ id: 'managed-r2' }]);
+currentLibraryManagedIndex.resolve([{ id: 'managed-index-r2' }]);
+await currentLibraryManagedSync;
+await new Promise((resolve) => setTimeout(resolve, 0));
+const projectionsBeforeLateDirect = {
+    signature: vm.runInContext('lastPracticeRecordsSignature', integrationContext),
+    completion: JSON.parse(JSON.stringify(integrationCompletionRefreshes)),
+    anchors: JSON.parse(JSON.stringify(integrationAnchorIndexes)),
+    renders: JSON.parse(JSON.stringify(integrationRenders)),
+    practice: JSON.parse(JSON.stringify(integrationPracticeUpdates)),
+    token: integrationSandbox.__getBrowseResultsRequestId()
+};
+oldLibraryDirectRecords.resolve([{ id: 'direct-old-library-r1' }]);
+oldLibraryDirectIndex.resolve([{ id: 'direct-old-library-index-r1' }]);
+await oldLibraryDirectSync;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    {
+        signature: vm.runInContext('lastPracticeRecordsSignature', integrationContext),
+        completion: integrationCompletionRefreshes,
+        anchors: integrationAnchorIndexes,
+        renders: integrationRenders,
+        practice: integrationPracticeUpdates,
+        token: integrationSandbox.__getBrowseResultsRequestId()
+    },
+    projectionsBeforeLateDirect,
+    'a late pre-publication direct sync must not mutate any records projection'
+);
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const mixedManagedHeadRecords = deferred();
+const mixedDirectRecords = deferred();
+const mixedManagedTailRecords = deferred();
+const mixedManagedHeadIndex = deferred();
+const mixedDirectIndex = deferred();
+const mixedManagedTailIndex = deferred();
+integrationPracticeRecordResolvers.push(
+    mixedManagedHeadRecords,
+    mixedDirectRecords,
+    mixedManagedTailRecords
+);
+integrationIndexResolvers.push(
+    mixedManagedHeadIndex,
+    mixedDirectIndex,
+    mixedManagedTailIndex
+);
+const mixedManagedCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'mixed-managed',
+    { forceRender: true }
+);
+const mixedDirectSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
+const mixedManagedJoin = integrationSandbox.ensurePracticeRecordsSync(
+    'mixed-managed',
+    { forceRender: true }
+);
+assert.strictEqual(mixedManagedJoin, mixedManagedCycle);
+mixedManagedTailRecords.resolve([{ id: 'mixed-managed-tail-record' }]);
+mixedManagedTailIndex.resolve([{ id: 'mixed-managed-tail-index' }]);
+mixedManagedHeadRecords.resolve([{ id: 'mixed-managed-head-record' }]);
+mixedManagedHeadIndex.resolve([{ id: 'mixed-managed-head-index' }]);
+await mixedManagedCycle;
+mixedDirectRecords.resolve([{ id: 'mixed-direct-record' }]);
+mixedDirectIndex.resolve([{ id: 'mixed-direct-index' }]);
+await mixedDirectSync;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    vm.runInContext('lastPracticeRecordsSignature', integrationContext),
+    'mixed-managed-tail-record'
+);
+assert.deepStrictEqual(integrationCompletionRefreshes, [['mixed-managed-tail-record']]);
+assert.deepStrictEqual(integrationAnchorIndexes, [['mixed-managed-tail-index']]);
+assert.deepStrictEqual(integrationRenders, [['mixed-managed-tail-index']]);
+assert.deepStrictEqual(integrationPracticeUpdates, [{
+    records: ['mixed-managed-tail-record'],
+    index: ['mixed-managed-tail-index']
+}]);
+
+const bootFallbackIntegrationSource = fs.readFileSync(
+    path.join(repoRoot, 'js/boot-fallbacks.js'),
+    'utf8'
+);
+vm.runInContext(bootFallbackIntegrationSource, integrationContext, {
+    filename: 'js/boot-fallbacks.js'
+});
+integrationRenders.length = 0;
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+const failedFunctionalReset = deferred();
+integrationSandbox.ExamActions.browseFilterStateOwner = {
+    resetForActivation() { return failedFunctionalReset.promise; },
+    resetToAll() { return true; }
+};
+const originalIntegrationBrowseAdd = integrationBrowseView.classList.add;
+let activationProgressProbe = () => {
+    integrationSandbox.refreshBrowseProgressFromRecords(
+        [],
+        [{ id: 'functional-reset-progress-failed' }]
+    );
+};
+integrationBrowseView.classList.add = function addWithFunctionalResetProbe(value) {
+    originalIntegrationBrowseAdd.call(this, value);
+    if (value === 'active' && activationProgressProbe) {
+        activationProgressProbe();
+    }
+};
+const failedFunctionalResetNavigation = integrationSandbox.showView('browse', true);
+activationProgressProbe = null;
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'pending',
+    'the cold functional barrier must exist before Browse becomes active'
+);
+assert.deepStrictEqual(integrationRenders, []);
+failedFunctionalReset.resolve(false);
+assert.strictEqual(await failedFunctionalResetNavigation, false);
+await new Promise((resolve) => setTimeout(resolve, 80));
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'failed');
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'a progress snapshot captured during a failed functional reset must never render'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'functional-reset-progress-after-failure' }]
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [],
+    'a failed functional reset must remain fail-closed for later progress refreshes'
+);
+
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+const successfulFunctionalReset = deferred();
+const successfulFunctionalResetIndex = deferred();
+integrationIndexResolvers.push(successfulFunctionalResetIndex);
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return successfulFunctionalReset.promise;
+};
+activationProgressProbe = () => {
+    integrationSandbox.refreshBrowseProgressFromRecords(
+        [],
+        [{ id: 'functional-reset-progress-success' }]
+    );
+};
+const successfulFunctionalResetNavigation = integrationSandbox.showView('browse', true);
+activationProgressProbe = null;
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'pending');
+assert.deepStrictEqual(integrationRenders, []);
+successfulFunctionalReset.resolve(true);
+successfulFunctionalResetIndex.resolve([{ id: 'functional-reset-canonical' }]);
+assert.notStrictEqual(await successfulFunctionalResetNavigation, false);
+await new Promise((resolve) => setTimeout(resolve, 80));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['functional-reset-canonical']],
+    'a successful functional reset must render only its canonical post-reset snapshot'
+);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'succeeded');
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'functional-reset-next-progress' }]
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationRenders,
+    [['functional-reset-canonical'], ['functional-reset-next-progress']],
+    'a completed functional reset must not permanently block later progress refreshes'
+);
+
+integrationRenders.length = 0;
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+const supersededFunctionalReset = deferred();
+const currentFunctionalReset = deferred();
+const supersededFunctionalIndex = deferred();
+const currentFunctionalIndex = deferred();
+const overlappingFunctionalResets = [supersededFunctionalReset, currentFunctionalReset];
+integrationIndexResolvers.push(supersededFunctionalIndex, currentFunctionalIndex);
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    const next = overlappingFunctionalResets.shift();
+    return next ? next.promise : false;
+};
+const supersededFunctionalNavigation = integrationSandbox.showView('browse', true);
+supersededFunctionalReset.resolve(true);
+await new Promise((resolve) => setTimeout(resolve, 0));
+const currentFunctionalNavigation = integrationSandbox.showView('browse', true);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'pending');
+supersededFunctionalIndex.resolve([{ id: 'superseded-functional-canonical' }]);
+assert.strictEqual(
+    await supersededFunctionalNavigation,
+    false,
+    'a newer functional barrier must invalidate an older canonical continuation'
+);
+assert.deepStrictEqual(integrationRenders, []);
+currentFunctionalReset.resolve(true);
+currentFunctionalIndex.resolve([{ id: 'current-functional-canonical' }]);
+assert.notStrictEqual(await currentFunctionalNavigation, false);
+assert.deepStrictEqual(
+    integrationRenders,
+    [['current-functional-canonical']],
+    'only the newest functional reset may complete a canonical render'
+);
+integrationBrowseView.classList.add = originalIntegrationBrowseAdd;
 
 rendered.length = 0;
 const sharedSearchIndex = deferred();

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -103,6 +103,7 @@ const sandbox = {
     getCurrentExamType() { return browseState.type; },
     setBrowseTitle() {},
     formatBrowseTitle(category, type) { return `${category}:${type}`; },
+    normalizeExamType(type) { return type || 'all'; },
     getPersistedBrowseFilter() { return null; },
     async resolveActiveLibraryIndex() {
         const next = resolverQueue.shift();
@@ -180,6 +181,60 @@ assert.deepStrictEqual(rendered.at(-1), ['reading', 'listening'], '最终列表�
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'all').ariaPressed, 'true');
 assert.strictEqual(typeButtons.find((button) => button.dataset.filterType === 'reading').ariaPressed, 'false');
 
+rendered.length = 0;
+const sharedPendingFilterIndex = deferred();
+resolverQueue.push(sharedPendingFilterIndex);
+const sharedPendingFilterRequestId = sandbox.__beginBrowseResultsRequest();
+const sharedPendingFilter = sandbox.applyBrowseFilter(
+    'P1',
+    'reading',
+    null,
+    null,
+    sharedPendingFilterRequestId
+);
+assert.strictEqual(
+    sandbox.__getBrowseResultsRequestId(),
+    sharedPendingFilterRequestId,
+    'a synchronized pending filter must reuse the initialization request token'
+);
+sharedPendingFilterIndex.resolve(allExams);
+await sharedPendingFilter;
+assert.strictEqual(browseState.category, 'P1');
+assert.strictEqual(browseState.type, 'reading');
+
+rendered.length = 0;
+const sharedSearchIndex = deferred();
+resolverQueue.push(sharedSearchIndex);
+const sharedSearchRequestId = sandbox.__beginBrowseResultsRequest();
+sandbox.searchExams('reading', sharedSearchRequestId);
+assert.strictEqual(
+    sandbox.__getBrowseResultsRequestId(),
+    sharedSearchRequestId,
+    'a background search replay must reuse the index event request token'
+);
+sharedSearchIndex.resolve(allExams);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(sandbox.__getBrowseResultsRequestId(), sharedSearchRequestId);
+
+const debouncedSearchCalls = [];
+sandbox.performanceOptimizer = {
+    debounce() {
+        return function captureDebouncedSearch() {
+            debouncedSearchCalls.push(Array.from(arguments));
+        };
+    }
+};
+const latestDebouncedSearchRequestId = sandbox.__beginBrowseResultsRequest();
+sandbox.searchExams('latest-query', latestDebouncedSearchRequestId);
+assert.strictEqual(debouncedSearchCalls.length, 1);
+assert.strictEqual(
+    sandbox.searchExams('stale-replay', latestDebouncedSearchRequestId - 1),
+    false,
+    'a stale background replay must stand down before touching the shared debounce'
+);
+assert.strictEqual(debouncedSearchCalls.length, 1, 'stale replay must not replace the pending latest search');
+delete sandbox.performanceOptimizer;
+
 const examActionsSource = fs.readFileSync(path.join(repoRoot, 'js/app/examActions.js'), 'utf8');
 vm.runInContext(examActionsSource, context, { filename: 'js/app/examActions.js' });
 const productionLoadExamList = sandbox.ExamActions.loadExamList;
@@ -192,15 +247,12 @@ sandbox.ExamActions.loadExamList = function captureExamActionsRender(exams) {
 };
 
 rendered.length = 0;
-const staleResetIndex = deferred();
 const latestFilterIndex = deferred();
-resolverQueue.push(staleResetIndex, latestFilterIndex);
+resolverQueue.push(latestFilterIndex);
 const staleReset = sandbox.ExamActions.resetBrowseViewToAll();
-await Promise.resolve();
 const latestFilterAfterReset = sandbox.filterByType('reading');
 latestFilterIndex.resolve(allExams);
 await latestFilterAfterReset;
-staleResetIndex.resolve([{ id: 'stale-reset', title: 'Stale reset', type: 'listening', category: 'P2' }]);
 assert.strictEqual(await staleReset, false, 'a newer explicit filter must supersede an older reset');
 assert.deepStrictEqual(rendered.at(-1), ['reading'], 'the newer explicit filter must remain the final render');
 assert.strictEqual(browseState.type, 'reading', 'a stale reset must not clear the newer filter state');

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -83,6 +83,11 @@ const rendered = [];
 const dispatchedWindowEvents = [];
 const browseState = { category: 'all', type: 'all' };
 const resolverQueue = [];
+const persistedBrowseState = {
+    lastFilter: null,
+    filter: { category: 'all', type: 'all' },
+    frequencyFilter: 'all'
+};
 const quietConsole = { log() {}, warn() {}, error() {} };
 const sandbox = {
     console: quietConsole,
@@ -122,6 +127,17 @@ const sandbox = {
     formatBrowseTitle(category, type) { return `${category}:${type}`; },
     normalizeExamType(type) { return type || 'all'; },
     getPersistedBrowseFilter() { return null; },
+    saveBrowseViewPreferences(partial = {}) {
+        if (Object.prototype.hasOwnProperty.call(partial, 'lastFilter')) {
+            persistedBrowseState.lastFilter = partial.lastFilter
+                ? { ...partial.lastFilter }
+                : null;
+        }
+        return { lastFilter: persistedBrowseState.lastFilter };
+    },
+    async flushBrowsePreferenceWrites() {
+        return { lastFilter: persistedBrowseState.lastFilter };
+    },
     async resolveActiveLibraryIndex() {
         const next = resolverQueue.shift();
         if (!next) throw new Error('unexpected index resolution');
@@ -147,11 +163,19 @@ const sandbox = {
     AppData: {
         ready: Promise.resolve(),
         preferences: {
-            async getBrowse() { return {}; },
-            async setBrowse(value) { return value; }
+            async getBrowse() { return JSON.parse(JSON.stringify(persistedBrowseState)); },
+            async setBrowse(value) {
+                Object.assign(persistedBrowseState, JSON.parse(JSON.stringify(value || {})));
+                return value;
+            },
+            async patchBrowse(value) {
+                Object.assign(persistedBrowseState, JSON.parse(JSON.stringify(value || {})));
+                return value;
+            }
         },
         practice: {
             async list() { return []; },
+            async listInsights() { return []; },
             async getStats() { return {}; }
         },
         library: {
@@ -166,6 +190,29 @@ sandbox.self = sandbox;
 const context = vm.createContext(sandbox);
 vm.runInContext(source, context, { filename: 'js/main.js' });
 
+let hydrationNavigationGeneration = 0;
+sandbox.__getAppNavigationIntentGeneration = () => hydrationNavigationGeneration;
+const cancelledApplyIndex = deferred();
+resolverQueue.push(cancelledApplyIndex);
+const cancelledApply = sandbox.applyBrowseFilter(
+    'P3',
+    'listening',
+    null,
+    null,
+    null,
+    hydrationNavigationGeneration
+);
+hydrationNavigationGeneration += 1;
+browseView.classList.remove('active');
+overviewView.classList.add('active');
+cancelledApplyIndex.resolve([
+    { id: 'cancelled-listening', title: 'Cancelled Listening', category: 'P3', type: 'listening' }
+]);
+assert.strictEqual(await cancelledApply, false, 'a navigation-cancelled explicit filter must stand down');
+
+browseView.classList.add('active');
+overviewView.classList.remove('active');
+const cancelledTypeIndex = deferred();
 const firstHydrationIndex = deferred();
 const latestHydrationIndex = deferred();
 const initialPersistedFilterReader = sandbox.getPersistedBrowseFilter;
@@ -174,7 +221,8 @@ sandbox.getPersistedBrowseFilter = () => {
     initialPersistedFilterReads += 1;
     return { category: 'P2', type: 'reading' };
 };
-resolverQueue.push(firstHydrationIndex, latestHydrationIndex);
+resolverQueue.push(cancelledTypeIndex, firstHydrationIndex, latestHydrationIndex);
+const cancelledType = sandbox.filterByType('listening');
 const firstHydration = sandbox.initializeBrowseView({ skipLoad: true });
 const latestHydration = sandbox.initializeBrowseView({ skipLoad: true });
 latestHydrationIndex.resolve([
@@ -188,6 +236,16 @@ firstHydrationIndex.resolve([
 ]);
 assert.strictEqual(await firstHydration, null, 'the superseded initialization must stand down');
 assert.strictEqual(initialPersistedFilterReads, 1, 'a stale initialization must not hydrate a second time');
+cancelledTypeIndex.resolve([
+    { id: 'late-listening', title: 'Late Listening', category: 'P1', type: 'listening' }
+]);
+await cancelledType;
+assert.deepStrictEqual(
+    browseState,
+    { category: 'P2', type: 'reading' },
+    'a superseded first explicit type intent must not suppress or replace persisted hydration'
+);
+assert.strictEqual(initialPersistedFilterReads, 1);
 sandbox.getPersistedBrowseFilter = initialPersistedFilterReader;
 
 const searchFirst = deferred();
@@ -298,6 +356,45 @@ assert.strictEqual(browseState.category, 'P1');
 assert.strictEqual(browseState.type, 'listening');
 assert.deepStrictEqual(rendered.at(-1), [], 'category filtering must preserve and apply the visible query');
 searchInput.value = '';
+
+rendered.length = 0;
+searchInput.value = 'ocean';
+const browseScopeBeforeColdProgress = { ...browseState };
+sandbox.setBrowseFilterState('all', 'all');
+const coldBrowseIndex = [
+    { id: 'ocean', title: 'Ocean Passage', searchText: 'ocean passage', category: 'P1', type: 'reading' },
+    { id: 'desert', title: 'Desert Passage', searchText: 'desert passage', category: 'P2', type: 'reading' }
+];
+const coldActivationIndex = deferred();
+const coldProgressIndex = deferred();
+resolverQueue.push(coldActivationIndex);
+const coldActivation = sandbox.activateBrowseView();
+resolverQueue.push(coldProgressIndex);
+sandbox.updatePracticeView = () => {};
+const coldProgressSync = sandbox.syncPracticeRecords({ forceRender: true });
+coldProgressIndex.resolve(coldBrowseIndex);
+await coldProgressSync;
+const coldActivationRequestId = sandbox.__getBrowseResultsRequestId();
+assert.strictEqual(
+    sandbox.__isBrowseUserResultsRequestInFlight(coldActivationRequestId),
+    true,
+    'the first activation must retain its request while hydration is unresolved'
+);
+assert.deepStrictEqual(rendered, [], 'background progress must wait for the explicit activation');
+
+coldActivationIndex.resolve(coldBrowseIndex);
+await coldActivation;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    rendered,
+    [['ocean'], ['ocean']],
+    'practice progress refresh must stay query-aware instead of restoring the full library'
+);
+searchInput.value = '';
+sandbox.setBrowseFilterState(
+    browseScopeBeforeColdProgress.category,
+    browseScopeBeforeColdProgress.type
+);
 
 rendered.length = 0;
 const sharedSearchIndex = deferred();
@@ -495,7 +592,7 @@ const helperFreeResetIndex = deferred();
 resolverQueue.push(helperFreeResetIndex);
 const helperFreeReset = sandbox.showView('browse', true);
 helperFreeResetIndex.resolve(allExams);
-await helperFreeReset;
+assert.notStrictEqual(await helperFreeReset, false, 'the helper-free reset must complete');
 assert.strictEqual(searchInput.value, '', 'the helper-free repeat reset must clear the preserved query');
 assert.strictEqual(sandbox.__browseFilterMode, 'default');
 assert.strictEqual(sandbox.__browsePath, null);
@@ -867,6 +964,169 @@ sandbox.AppEntry = savedAppEntry;
 sandbox.AppLazyLoader = savedAppLazyLoader;
 sandbox.refreshBrowseResults = savedRefreshBrowseResults;
 sandbox.loadExamList = savedLoadExamList;
+
+const authoritativeBrowseView = { id: 'browse-view', classList: createClassList() };
+authoritativeBrowseView.classList.add('active');
+const authoritativeDocument = {
+    readyState: 'loading',
+    body: { appendChild() {}, classList: createClassList() },
+    documentElement: { classList: createClassList() },
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector(selector) {
+        if (selector === '.view.active') return authoritativeBrowseView;
+        return null;
+    },
+    querySelectorAll() { return []; },
+    createElement() {
+        return { style: {}, classList: createClassList(), appendChild() {}, setAttribute() {} };
+    },
+    getElementById(id) {
+        return id === 'browse-view' ? authoritativeBrowseView : null;
+    }
+};
+let authoritativePersistedReads = 0;
+const authoritativePatchGate = deferred();
+const authoritativePreferencePatches = [];
+const authoritativeDurableBrowse = {
+    lastFilter: { category: 'P2', type: 'reading' },
+    filter: { category: 'all', type: 'all' },
+    frequencyFilter: 'high'
+};
+const authoritativeIndex = [
+    { id: 'authoritative-reading', title: 'Authoritative Reading', category: 'P1', type: 'reading' }
+];
+const authoritativeSandbox = {
+    console: quietConsole,
+    document: authoritativeDocument,
+    location: { href: 'https://example.test/index.html', search: '', origin: 'https://example.test', protocol: 'https:' },
+    history: { replaceState() {} },
+    navigator: {},
+    URL,
+    URLSearchParams,
+    Promise,
+    Set,
+    Map,
+    Date,
+    Math,
+    JSON,
+    CustomEvent: class CustomEvent {
+        constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
+    },
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+    cancelAnimationFrame: clearTimeout,
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {},
+    confirm() { return false; },
+    alert() {},
+    setBrowseTitle() {},
+    formatBrowseTitle(category, type) { return `${category}:${type}`; },
+    normalizeExamType(type) { return type || 'all'; },
+    async resolveActiveLibraryIndex() { return authoritativeIndex; },
+    browseController: {
+        currentMode: 'default',
+        buttonContainer: {},
+        currentCategory: 'all',
+        currentExamType: 'all',
+        getCurrentCategory() { return 'all'; },
+        getCurrentExamType() { return 'all'; },
+        updateBrowseTitle() {}
+    },
+    ExamActions: {
+        loadExamList(exams) { return exams; },
+        displayExams(exams) { return exams; }
+    },
+    AppData: {
+        ready: Promise.resolve(),
+        preferences: {
+            async getBrowse() {
+                return JSON.parse(JSON.stringify(authoritativeDurableBrowse));
+            },
+            async setBrowse(value) {
+                Object.assign(authoritativeDurableBrowse, JSON.parse(JSON.stringify(value || {})));
+                return value;
+            },
+            async patchBrowse(value) {
+                authoritativePreferencePatches.push(JSON.parse(JSON.stringify(value || {})));
+                await authoritativePatchGate.promise;
+                Object.assign(authoritativeDurableBrowse, JSON.parse(JSON.stringify(value || {})));
+                return value;
+            }
+        },
+        practice: {
+            async list() { return []; },
+            async listInsights() { return []; },
+            async getStats() { return {}; }
+        },
+        library: {
+            async getActive() { return null; },
+            async listConfigurations() { return []; }
+        }
+    }
+};
+authoritativeSandbox.window = authoritativeSandbox;
+authoritativeSandbox.globalThis = authoritativeSandbox;
+authoritativeSandbox.self = authoritativeSandbox;
+const authoritativeContext = vm.createContext(authoritativeSandbox);
+const stateServiceSource = fs.readFileSync(path.join(repoRoot, 'js/app/state-service.js'), 'utf8');
+vm.runInContext(stateServiceSource, authoritativeContext, { filename: 'js/app/state-service.js' });
+assert.strictEqual(authoritativeSandbox.getBrowseFilterMutationRevision(), 0);
+authoritativeSandbox.appStateService.syncFromAppPath(
+    'ui.browseFilter',
+    { category: 'all', type: 'all' }
+);
+assert.strictEqual(
+    authoritativeSandbox.getBrowseFilterMutationRevision(),
+    0,
+    'legacy-app startup preference hydration must not masquerade as a live mutation'
+);
+const browsePreferencesSource = fs.readFileSync(path.join(repoRoot, 'js/utils/BrowsePreferencesUtils.js'), 'utf8');
+vm.runInContext(browsePreferencesSource, authoritativeContext, { filename: 'js/utils/BrowsePreferencesUtils.js' });
+await authoritativeSandbox.whenBrowseViewPreferencesReady();
+const productionAuthoritativePersistedReader = authoritativeSandbox.getPersistedBrowseFilter;
+authoritativeSandbox.getPersistedBrowseFilter = () => {
+    authoritativePersistedReads += 1;
+    return productionAuthoritativePersistedReader();
+};
+authoritativeSandbox.setBrowseFilterState('all', 'all');
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    authoritativeSandbox.getBrowseFilterMutationRevision(),
+    1,
+    'a same-value authoritative reset before Browse loads must advance the mutation revision'
+);
+assert.strictEqual(authoritativePreferencePatches.length, 1);
+assert.deepStrictEqual(
+    authoritativeDurableBrowse.lastFilter,
+    { category: 'P2', type: 'reading' },
+    'the authoritative all/all write must still be pending during first Browse initialization'
+);
+vm.runInContext(source, authoritativeContext, { filename: 'js/main.js' });
+await authoritativeSandbox.initializeBrowseView({ skipLoad: true });
+assert.strictEqual(
+    authoritativePersistedReads,
+    0,
+    'lazy Browse hydration must not revive committed preferences older than an authoritative mutation'
+);
+assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(authoritativeSandbox.getBrowseFilterState())),
+    { category: 'all', type: 'all' }
+);
+authoritativePatchGate.resolve();
+await authoritativeSandbox.flushBrowsePreferenceWrites();
+assert.deepStrictEqual(authoritativeDurableBrowse.lastFilter, { category: 'all', type: 'all' });
+assert.strictEqual(
+    authoritativePreferencePatches.some((patch) => (
+        patch.lastFilter?.category === 'P2' && patch.lastFilter?.type === 'reading'
+    )),
+    false,
+    'initial hydration must not enqueue a trailing stale P2/reading write'
+);
 
 console.log(JSON.stringify({
     status: 'pass',

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -449,7 +449,6 @@ const integrationPracticeUpdates = [];
 const integrationBrowseState = { category: 'all', type: 'all' };
 const integrationIndexResolvers = [];
 const integrationPracticeRecordResolvers = [];
-const integrationCommitListeners = new Set();
 let integrationIndexResolutionCount = 0;
 const IntegrationCustomEvent = class CustomEvent {
     constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
@@ -521,6 +520,10 @@ const integrationSandbox = {
         updateBrowseTitle() {}
     },
     ExamActions: {
+        setBrowseFrequencyFilter(value) {
+            integrationSandbox.__browseFrequencyFilter = value;
+            return value;
+        },
         loadExamList(exams) {
             integrationRenders.push(Array.from(exams, (exam) => exam.id));
             return exams;
@@ -544,12 +547,6 @@ const integrationSandbox = {
             },
             async listInsights() { return []; },
             async getStats() { return {}; }
-        },
-        backups: {
-            onDataCommitted(listener) {
-                integrationCommitListeners.add(listener);
-                return () => integrationCommitListeners.delete(listener);
-            }
         },
         library: {
             async getActive() { return null; },
@@ -581,10 +578,40 @@ await integrationSandbox.AppEntry.ensureBrowseGroup();
 integrationOverviewView.classList.remove('active');
 integrationBrowseView.classList.add('active');
 
-function emitIntegrationDataCommitted(targets) {
-    const event = { targets: Array.isArray(targets) ? targets : [] };
-    integrationCommitListeners.forEach((listener) => listener(event));
-}
+assert.ok(
+    !source.includes('practiceRecordsDataGeneration')
+        && !source.includes('ensurePracticeRecordsCommitSubscription')
+        && !source.includes('activePracticeRecordsSyncInvocations')
+        && !source.includes('pendingPracticeRecordsSyncRequest'),
+    'Browse reset scope must not add a generic practice-data commit scheduler contract'
+);
+
+const productionIntegrationGetBrowse = integrationSandbox.AppData.preferences.getBrowse;
+const staleBrowseControlSeed = deferred();
+let staleBrowseControlSeedReads = 0;
+integrationSandbox.AppData.preferences.getBrowse = function getStaleBrowseControlSeed() {
+    staleBrowseControlSeedReads += 1;
+    return staleBrowseControlSeed.promise;
+};
+const browseControlSeed = integrationSandbox.setupBrowseControls();
+await waitForCondition(
+    () => staleBrowseControlSeedReads === 1,
+    'Browse controls must enter the persisted seed read before the live frequency intent'
+);
+const liveFrequencyIndex = deferred();
+integrationIndexResolvers.push(liveFrequencyIndex);
+integrationSandbox.filterByFrequency('high');
+liveFrequencyIndex.resolve([{ id: 'live-frequency-high', frequency: 7 }]);
+staleBrowseControlSeed.resolve({ sortMode: 'default', frequencyFilter: 'all' });
+assert.strictEqual(await browseControlSeed, true);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    integrationSandbox.__browseFrequencyFilter,
+    'high',
+    'a live high-frequency intent during seed hydration must beat the older persisted all value'
+);
+integrationSandbox.AppData.preferences.getBrowse = productionIntegrationGetBrowse;
+integrationRenders.length = 0;
 
 const oldProgressIndex = deferred();
 integrationIndexResolvers.push(oldProgressIndex);
@@ -690,35 +717,6 @@ assert.deepStrictEqual(
     'a progress snapshot captured before a reset must not repaint after the reset epoch closes'
 );
 
-integrationRenders.length = 0;
-const preCommitProgressRecords = deferred();
-const preCommitProgressIndex = deferred();
-integrationPracticeRecordResolvers.push(preCommitProgressRecords);
-integrationIndexResolvers.push(preCommitProgressIndex);
-const dataEpochUserRequest = integrationSandbox.__beginBrowseUserResultsRequest();
-const preCommitProgressSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
-preCommitProgressRecords.resolve([{ id: 'pre-commit-progress-record' }]);
-preCommitProgressIndex.resolve([{ id: 'pre-commit-progress' }]);
-await preCommitProgressSync;
-assert.deepStrictEqual(
-    integrationRenders,
-    [],
-    'progress must remain queued while the user results request is retained'
-);
-emitIntegrationDataCommitted([{ store: 'practiceSummaries' }]);
-integrationSandbox.__endBrowseUserResultsRequest(dataEpochUserRequest);
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.deepStrictEqual(
-    integrationRenders,
-    [],
-    'a pre-commit pending progress snapshot must not replay after the practice-data epoch changes'
-);
-assert.strictEqual(
-    integrationSandbox.__getBrowseResultsRequestId(),
-    dataEpochUserRequest,
-    'discarding data-stale pending progress must not consume a Browse results token'
-);
-
 const identicalHeadIndex = deferred();
 const redundantTailPoison = {
     get promise() {
@@ -754,325 +752,71 @@ assert.strictEqual(
     'a head success must not be overturned by an invented failing tail'
 );
 
-const queuedEpochHeadIndex = deferred();
-const queuedEpochCurrentIndex = deferred();
-const queuedEpochRedundantPoison = {
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+const libraryARecords = deferred();
+const libraryBRecords = deferred();
+const libraryAIndex = deferred();
+const libraryBIndex = deferred();
+const redundantLibraryTailPoison = {
     get promise() {
-        return Promise.reject(new Error('the running current-epoch tail must cover its join'));
+        return Promise.reject(new Error('one library generation change must schedule only one tail'));
     }
 };
-integrationIndexResolvers.push(
-    queuedEpochHeadIndex,
-    queuedEpochCurrentIndex,
-    queuedEpochRedundantPoison
-);
-const queuedEpochResolutionCountBefore = integrationIndexResolutionCount;
-const queuedEpochCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'queued-epoch-head',
+integrationPracticeRecordResolvers.push(libraryARecords, libraryBRecords);
+integrationIndexResolvers.push(libraryAIndex, libraryBIndex, redundantLibraryTailPoison);
+const libraryTailResolutionCountBefore = integrationIndexResolutionCount;
+const libraryACycle = integrationSandbox.ensurePracticeRecordsSync(
+    'library-a',
     { forceRender: true }
 );
 integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'queued-epoch-one-publication' }] }
+    detail: { index: [{ id: 'library-b-publication' }] }
 }));
-const queuedEpochTail = integrationSandbox.ensurePracticeRecordsSync(
-    'queued-epoch-tail',
+const libraryBJoin = integrationSandbox.ensurePracticeRecordsSync(
+    'library-b',
     { forceRender: true }
 );
-assert.strictEqual(queuedEpochTail, queuedEpochCycle);
-integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'queued-epoch-two-publication' }] }
-}));
-queuedEpochHeadIndex.resolve([{ id: 'queued-epoch-stale-head' }]);
+assert.strictEqual(
+    libraryBJoin,
+    libraryACycle,
+    'the newer library request must join the active managed cycle'
+);
+libraryARecords.resolve([{ id: 'library-a-record' }]);
+libraryAIndex.resolve([{ id: 'library-a-index' }]);
 await waitForCondition(
-    () => integrationIndexResolutionCount === queuedEpochResolutionCountBefore + 2,
-    'the queued current-epoch tail must start before the alias joins it'
+    () => integrationIndexResolutionCount === libraryTailResolutionCountBefore + 2,
+    'settling library A must start exactly one coalesced library B tail'
 );
-const queuedEpochCurrentJoin = integrationSandbox.ensurePracticeRecordsSync(
-    'queued-epoch-current-alias',
-    { forceRender: true }
-);
-assert.strictEqual(queuedEpochCurrentJoin, queuedEpochCycle);
-queuedEpochCurrentIndex.resolve([{ id: 'queued-epoch-current-tail' }]);
-await queuedEpochCurrentJoin;
+libraryBRecords.resolve([{ id: 'library-b-record' }]);
+libraryBIndex.resolve([{ id: 'library-b-index' }]);
+await libraryBJoin;
+await new Promise((resolve) => setTimeout(resolve, 0));
 assert.strictEqual(
     integrationIndexResolutionCount,
-    queuedEpochResolutionCountBefore + 2,
-    'a queued tail must advertise the current epoch it reads when execution starts'
+    libraryTailResolutionCountBefore + 2,
+    'a single library change must perform one head read and one current-library tail read'
 );
 assert.strictEqual(
     integrationIndexResolvers.shift(),
-    queuedEpochRedundantPoison,
-    'a current-epoch join must not enqueue a third physical read'
-);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const dataEpochHeadRecords = deferred();
-const dataEpochCurrentRecords = deferred();
-const dataEpochHeadIndex = deferred();
-const dataEpochCurrentIndex = deferred();
-integrationPracticeRecordResolvers.push(dataEpochHeadRecords, dataEpochCurrentRecords);
-integrationIndexResolvers.push(dataEpochHeadIndex, dataEpochCurrentIndex);
-const dataEpochResolutionCountBefore = integrationIndexResolutionCount;
-const dataEpochHeadCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'practice-view',
-    { forceRender: true }
-);
-emitIntegrationDataCommitted([{ store: 'practiceSummaries' }]);
-dataEpochHeadRecords.resolve([{ id: 'data-epoch-stale-record' }]);
-dataEpochHeadIndex.resolve([{ id: 'data-epoch-stale' }]);
-await waitForCondition(
-    () => integrationIndexResolutionCount === dataEpochResolutionCountBefore + 2,
-    'a relevant commit must start the managed current-data replacement'
-);
-dataEpochCurrentRecords.resolve([{ id: 'data-epoch-current-record' }]);
-dataEpochCurrentIndex.resolve([{ id: 'data-epoch-current' }]);
-await dataEpochHeadCycle;
-assert.strictEqual(
-    integrationIndexResolutionCount,
-    dataEpochResolutionCountBefore + 2,
-    'a managed sync invalidated by a practice-store commit must schedule exactly one automatic follow-up'
-);
-assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'data-epoch-current-record');
-assert.deepStrictEqual(integrationCompletionRefreshes, [['data-epoch-current-record']]);
-assert.deepStrictEqual(integrationAnchorIndexes, [['data-epoch-current']]);
-assert.deepStrictEqual(integrationRenders, [['data-epoch-current']]);
-assert.deepStrictEqual(integrationPracticeUpdates, [{
-    records: ['data-epoch-current-record'],
-    index: ['data-epoch-current']
-}]);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const directCommitHeadRecords = deferred();
-const directCommitCurrentRecords = deferred();
-const directCommitHeadIndex = deferred();
-const directCommitCurrentIndex = deferred();
-integrationPracticeRecordResolvers.push(directCommitHeadRecords, directCommitCurrentRecords);
-integrationIndexResolvers.push(directCommitHeadIndex, directCommitCurrentIndex);
-const directCommitResolutionCountBefore = integrationIndexResolutionCount;
-const directCommitHead = integrationSandbox.syncPracticeRecords({ forceRender: true });
-emitIntegrationDataCommitted([{ store: 'practiceDetails' }]);
-await waitForCondition(
-    () => integrationIndexResolutionCount === directCommitResolutionCountBefore + 2,
-    'a relevant commit must start a replacement for an active direct sync'
-);
-directCommitCurrentRecords.resolve([{ id: 'direct-commit-current-record' }]);
-directCommitCurrentIndex.resolve([{ id: 'direct-commit-current-index' }]);
-directCommitHeadRecords.resolve([{ id: 'direct-commit-stale-record' }]);
-directCommitHeadIndex.resolve([{ id: 'direct-commit-stale-index' }]);
-await directCommitHead;
-await waitForCondition(
-    () => integrationPracticeUpdates.length === 1,
-    'the automatic direct replacement must complete all current-data projections'
-);
-assert.strictEqual(
-    integrationIndexResolutionCount,
-    directCommitResolutionCountBefore + 2,
-    'a direct sync invalidated by a commit must start exactly one automatic physical replacement'
-);
-assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'direct-commit-current-record');
-assert.deepStrictEqual(integrationCompletionRefreshes, [['direct-commit-current-record']]);
-assert.deepStrictEqual(integrationAnchorIndexes, [['direct-commit-current-index']]);
-assert.deepStrictEqual(integrationRenders, [['direct-commit-current-index']]);
-assert.deepStrictEqual(integrationPracticeUpdates, [{
-    records: ['direct-commit-current-record'],
-    index: ['direct-commit-current-index']
-}]);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const annotationHeadRecords = deferred();
-const annotationHeadIndex = deferred();
-const annotationTailPoison = {
-    get promise() {
-        return Promise.reject(new Error('annotation commits must not schedule a practice projection tail'));
-    }
-};
-integrationPracticeRecordResolvers.push(annotationHeadRecords);
-integrationIndexResolvers.push(annotationHeadIndex, annotationTailPoison);
-const annotationResolutionCountBefore = integrationIndexResolutionCount;
-const annotationCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'annotation-no-op',
-    { forceRender: true }
-);
-emitIntegrationDataCommitted([{ store: 'practiceAnnotations' }]);
-annotationHeadRecords.resolve([{ id: 'annotation-head-record' }]);
-annotationHeadIndex.resolve([{ id: 'annotation-head-index' }]);
-await annotationCycle;
-assert.strictEqual(
-    integrationIndexResolutionCount,
-    annotationResolutionCountBefore + 1,
-    'annotation-only commits must not invalidate the summary/detail projection'
-);
-assert.strictEqual(integrationIndexResolvers.shift(), annotationTailPoison);
-assert.strictEqual(vm.runInContext('lastPracticeRecordsSignature', integrationContext), 'annotation-head-record');
-assert.deepStrictEqual(integrationCompletionRefreshes, [['annotation-head-record']]);
-assert.deepStrictEqual(integrationAnchorIndexes, [['annotation-head-index']]);
-assert.deepStrictEqual(integrationRenders, [['annotation-head-index']]);
-assert.deepStrictEqual(integrationPracticeUpdates, [{
-    records: ['annotation-head-record'],
-    index: ['annotation-head-index']
-}]);
-
-const preservedForceBaselineRecords = deferred();
-const preservedForceBaselineIndex = deferred();
-integrationPracticeRecordResolvers.push(preservedForceBaselineRecords);
-integrationIndexResolvers.push(preservedForceBaselineIndex);
-const preservedForceBaselineCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'force-baseline',
-    { forceRender: true }
-);
-preservedForceBaselineRecords.resolve([{ id: 'preserved-force-record' }]);
-preservedForceBaselineIndex.resolve([{ id: 'preserved-force-baseline' }]);
-await preservedForceBaselineCycle;
-integrationPracticeUpdates.length = 0;
-const preservedForceStaleRecords = deferred();
-const preservedForceCurrentRecords = deferred();
-const preservedForceStaleIndex = deferred();
-const preservedForceCurrentIndex = deferred();
-integrationPracticeRecordResolvers.push(
-    preservedForceStaleRecords,
-    preservedForceCurrentRecords
-);
-integrationIndexResolvers.push(preservedForceStaleIndex, preservedForceCurrentIndex);
-const preservedForceCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'force-before-data-epoch',
-    { forceRender: true }
-);
-emitIntegrationDataCommitted([{ store: 'practiceDetails' }]);
-const preservedForceJoinedCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'current-data-default-options'
-);
-assert.strictEqual(preservedForceJoinedCycle, preservedForceCycle);
-preservedForceCurrentRecords.resolve([{ id: 'preserved-force-record' }]);
-preservedForceCurrentIndex.resolve([{ id: 'preserved-force-current' }]);
-preservedForceStaleRecords.resolve([{ id: 'preserved-force-record' }]);
-preservedForceStaleIndex.resolve([{ id: 'preserved-force-stale' }]);
-await preservedForceJoinedCycle;
-assert.deepStrictEqual(
-    integrationPracticeUpdates,
-    [{ records: ['preserved-force-record'], index: ['preserved-force-current'] }],
-    'a replacement tail must preserve stronger options from a stale active head'
-);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-const coalescedOldLibraryIndex = deferred();
-const coalescedCurrentLibraryIndex = deferred();
-integrationIndexResolvers.push(coalescedOldLibraryIndex, coalescedCurrentLibraryIndex);
-const coalescedResolutionCountBefore = integrationIndexResolutionCount;
-const oldLibrarySyncCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'pre-library-publication',
-    { forceRender: true }
-);
-integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'coalesced-index-publication' }] }
-}));
-const currentLibrarySyncCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'library-loaded',
-    { forceRender: true }
-);
-assert.strictEqual(
-    currentLibrarySyncCycle,
-    oldLibrarySyncCycle,
-    'an overlapping library sync must join the active coalescing cycle'
-);
-coalescedCurrentLibraryIndex.resolve([{ id: 'coalesced-progress-current' }]);
-coalescedOldLibraryIndex.resolve([{ id: 'coalesced-progress-old' }]);
-await oldLibrarySyncCycle;
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.strictEqual(
-    integrationIndexResolutionCount,
-    coalescedResolutionCountBefore + 2,
-    'one overlapping request must schedule exactly one follow-up sync against the latest library epoch'
+    redundantLibraryTailPoison,
+    'the current-library tail must cover the joined B request without a third read'
 );
 assert.deepStrictEqual(
-    integrationRenders,
-    [['coalesced-index-publication'], ['coalesced-progress-current']],
-    'the coalesced latest-library sync must repaint progress after the stale source is discarded'
+    integrationCompletionRefreshes,
+    [['library-b-record']],
+    'only the current library tail may rebuild Browse completion state'
 );
 assert.deepStrictEqual(
     integrationAnchorIndexes,
-    [['coalesced-progress-current']],
-    'a stale library index must not update or persist Browse anchors'
+    [['library-b-index']],
+    'only the current library tail may update Browse anchors'
 );
-assert.strictEqual(
-    integrationCompletionRefreshes.length,
-    1,
-    'a stale-library sync must not mutate the completion projection before standing down'
-);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-const rejectedOldLibraryIndex = deferred();
-const currentLibraryIndexAfterFailure = deferred();
-integrationIndexResolvers.push(rejectedOldLibraryIndex, currentLibraryIndexAfterFailure);
-const failedOldCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'failing-pre-library-publication',
-    { forceRender: true }
-);
-integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'failure-index-publication' }] }
-}));
-const joinedRecoveryCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'library-loaded',
-    { forceRender: true }
-);
-assert.strictEqual(joinedRecoveryCycle, failedOldCycle);
-currentLibraryIndexAfterFailure.resolve([{ id: 'failure-followup-current' }]);
-rejectedOldLibraryIndex.reject(new Error('simulated stale library resolution failure'));
-await joinedRecoveryCycle;
-await new Promise((resolve) => setTimeout(resolve, 0));
 assert.deepStrictEqual(
     integrationRenders,
-    [['failure-index-publication'], ['failure-followup-current']],
-    'a stale sync failure must not suppress the queued latest-library follow-up'
-);
-assert.deepStrictEqual(
-    integrationAnchorIndexes,
-    [['failure-followup-current']],
-    'only the successful latest-library follow-up may update anchors after an older failure'
-);
-
-const headBeforeTailFailureIndex = deferred();
-const genuineTailFailureIndex = deferred();
-integrationIndexResolvers.push(headBeforeTailFailureIndex, genuineTailFailureIndex);
-const tailFailureCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'pre-tail-failure',
-    { forceRender: true }
-);
-integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'tail-failure-publication' }] }
-}));
-const joinedTailFailureCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'library-loaded',
-    { forceRender: true }
-);
-assert.strictEqual(joinedTailFailureCycle, tailFailureCycle);
-headBeforeTailFailureIndex.resolve([{ id: 'successful-stale-head' }]);
-genuineTailFailureIndex.reject(new Error('simulated current tail failure'));
-await assert.rejects(joinedTailFailureCycle, /simulated current tail failure/);
-const postFailureRecoveryIndex = deferred();
-integrationIndexResolvers.push(postFailureRecoveryIndex);
-const postFailureRecoveryCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'post-failure-recovery',
-    { forceRender: true }
-);
-postFailureRecoveryIndex.resolve([{ id: 'post-failure-recovery' }]);
-await postFailureRecoveryCycle;
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.deepStrictEqual(
-    integrationRenders.at(-1),
-    ['post-failure-recovery'],
-    'a terminal failure must release the queue so a later sync can recover normally'
+    [['library-b-publication'], ['library-b-index']],
+    'the authoritative publication and current tail must never be followed by library A'
 );
 
 integrationRenders.length = 0;
@@ -1114,142 +858,6 @@ assert.deepStrictEqual(
     [['post-reset-progress']],
     'a same-library sync resolving after reset must bind to and repaint the post-reset epoch'
 );
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const sameLibraryOldRecords = deferred();
-const sameLibraryCurrentRecords = deferred();
-const sameLibraryOldIndex = deferred();
-const sameLibraryCurrentIndex = deferred();
-integrationPracticeRecordResolvers.push(sameLibraryOldRecords, sameLibraryCurrentRecords);
-integrationIndexResolvers.push(sameLibraryOldIndex, sameLibraryCurrentIndex);
-const directResultsTokenBefore = integrationSandbox.__getBrowseResultsRequestId();
-const sameLibraryOldSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
-const sameLibraryCurrentSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
-sameLibraryCurrentRecords.resolve([{ id: 'direct-r2' }]);
-sameLibraryCurrentIndex.resolve([{ id: 'direct-index-r2' }]);
-await sameLibraryCurrentSync;
-sameLibraryOldRecords.resolve([{ id: 'direct-r1' }]);
-sameLibraryOldIndex.resolve([{ id: 'direct-index-r1' }]);
-await sameLibraryOldSync;
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.strictEqual(
-    vm.runInContext('lastPracticeRecordsSignature', integrationContext),
-    'direct-r2',
-    'a late same-library direct sync must not replace the current records signature'
-);
-assert.deepStrictEqual(integrationCompletionRefreshes, [['direct-r2']]);
-assert.deepStrictEqual(integrationAnchorIndexes, [['direct-index-r2']]);
-assert.deepStrictEqual(integrationRenders, [['direct-index-r2']]);
-assert.deepStrictEqual(integrationPracticeUpdates, [{
-    records: ['direct-r2'],
-    index: ['direct-index-r2']
-}]);
-assert.strictEqual(
-    integrationSandbox.__getBrowseResultsRequestId(),
-    directResultsTokenBefore + 1,
-    'discarding the late direct sync must not consume a Browse results token'
-);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const oldLibraryDirectRecords = deferred();
-const currentLibraryManagedRecords = deferred();
-const oldLibraryDirectIndex = deferred();
-const currentLibraryManagedIndex = deferred();
-integrationPracticeRecordResolvers.push(oldLibraryDirectRecords, currentLibraryManagedRecords);
-integrationIndexResolvers.push(oldLibraryDirectIndex, currentLibraryManagedIndex);
-const oldLibraryDirectSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
-integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
-    detail: { index: [{ id: 'direct-library-publication' }] }
-}));
-const currentLibraryManagedSync = integrationSandbox.ensurePracticeRecordsSync(
-    'library-loaded',
-    { forceRender: true }
-);
-currentLibraryManagedRecords.resolve([{ id: 'managed-r2' }]);
-currentLibraryManagedIndex.resolve([{ id: 'managed-index-r2' }]);
-await currentLibraryManagedSync;
-await new Promise((resolve) => setTimeout(resolve, 0));
-const projectionsBeforeLateDirect = {
-    signature: vm.runInContext('lastPracticeRecordsSignature', integrationContext),
-    completion: JSON.parse(JSON.stringify(integrationCompletionRefreshes)),
-    anchors: JSON.parse(JSON.stringify(integrationAnchorIndexes)),
-    renders: JSON.parse(JSON.stringify(integrationRenders)),
-    practice: JSON.parse(JSON.stringify(integrationPracticeUpdates)),
-    token: integrationSandbox.__getBrowseResultsRequestId()
-};
-oldLibraryDirectRecords.resolve([{ id: 'direct-old-library-r1' }]);
-oldLibraryDirectIndex.resolve([{ id: 'direct-old-library-index-r1' }]);
-await oldLibraryDirectSync;
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.deepStrictEqual(
-    {
-        signature: vm.runInContext('lastPracticeRecordsSignature', integrationContext),
-        completion: integrationCompletionRefreshes,
-        anchors: integrationAnchorIndexes,
-        renders: integrationRenders,
-        practice: integrationPracticeUpdates,
-        token: integrationSandbox.__getBrowseResultsRequestId()
-    },
-    projectionsBeforeLateDirect,
-    'a late pre-publication direct sync must not mutate any records projection'
-);
-
-integrationRenders.length = 0;
-integrationAnchorIndexes.length = 0;
-integrationCompletionRefreshes.length = 0;
-integrationPracticeUpdates.length = 0;
-const mixedManagedHeadRecords = deferred();
-const mixedDirectRecords = deferred();
-const mixedManagedTailRecords = deferred();
-const mixedManagedHeadIndex = deferred();
-const mixedDirectIndex = deferred();
-const mixedManagedTailIndex = deferred();
-integrationPracticeRecordResolvers.push(
-    mixedManagedHeadRecords,
-    mixedDirectRecords,
-    mixedManagedTailRecords
-);
-integrationIndexResolvers.push(
-    mixedManagedHeadIndex,
-    mixedDirectIndex,
-    mixedManagedTailIndex
-);
-const mixedManagedCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'mixed-managed',
-    { forceRender: true }
-);
-const mixedDirectSync = integrationSandbox.syncPracticeRecords({ forceRender: true });
-const mixedManagedJoin = integrationSandbox.ensurePracticeRecordsSync(
-    'mixed-managed',
-    { forceRender: true }
-);
-assert.strictEqual(mixedManagedJoin, mixedManagedCycle);
-mixedManagedTailRecords.resolve([{ id: 'mixed-managed-tail-record' }]);
-mixedManagedTailIndex.resolve([{ id: 'mixed-managed-tail-index' }]);
-mixedManagedHeadRecords.resolve([{ id: 'mixed-managed-head-record' }]);
-mixedManagedHeadIndex.resolve([{ id: 'mixed-managed-head-index' }]);
-await mixedManagedCycle;
-mixedDirectRecords.resolve([{ id: 'mixed-direct-record' }]);
-mixedDirectIndex.resolve([{ id: 'mixed-direct-index' }]);
-await mixedDirectSync;
-await new Promise((resolve) => setTimeout(resolve, 0));
-assert.strictEqual(
-    vm.runInContext('lastPracticeRecordsSignature', integrationContext),
-    'mixed-managed-tail-record'
-);
-assert.deepStrictEqual(integrationCompletionRefreshes, [['mixed-managed-tail-record']]);
-assert.deepStrictEqual(integrationAnchorIndexes, [['mixed-managed-tail-index']]);
-assert.deepStrictEqual(integrationRenders, [['mixed-managed-tail-index']]);
-assert.deepStrictEqual(integrationPracticeUpdates, [{
-    records: ['mixed-managed-tail-record'],
-    index: ['mixed-managed-tail-index']
-}]);
 
 const bootFallbackIntegrationSource = fs.readFileSync(
     path.join(repoRoot, 'js/boot-fallbacks.js'),
@@ -1831,6 +1439,479 @@ async function establishFailedIntegrationFunctionalReset(message) {
             = productionActivationReset;
     }
 }
+
+await establishFailedIntegrationFunctionalReset(
+    'the retry-cancellation fixture must start with durable failed-reset debt'
+);
+integrationRenders.length = 0;
+const retryingFunctionalReset = deferred();
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return retryingFunctionalReset.promise;
+};
+const retryingFunctionalNavigation = integrationSandbox.showView('browse', true);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'pending',
+    'a retry may temporarily own the active functional-reset lease'
+);
+const failedOrdinaryReentryIndex = deferred();
+integrationIndexResolvers.push(failedOrdinaryReentryIndex);
+const loaderBeforeFailedOrdinaryReentry = integrationSandbox.ExamActions.loadExamList;
+integrationSandbox.ExamActions.loadExamList = function failOrdinaryReentry() {
+    return false;
+};
+const failedOrdinaryReentry = integrationSandbox.showView('browse', false);
+failedOrdinaryReentryIndex.resolve([{ id: 'failed-ordinary-reentry' }]);
+assert.strictEqual(await failedOrdinaryReentry, false);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'superseding a retry with a failed ordinary re-entry must preserve the predecessor debt'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'progress-must-remain-blocked-after-failed-reentry' }]
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(integrationRenders, []);
+retryingFunctionalReset.resolve(true);
+assert.strictEqual(
+    await retryingFunctionalNavigation,
+    false,
+    'the canceled retry must not settle over the newer failed re-entry'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'a late canceled retry settlement must not erase durable failed-reset debt'
+);
+integrationSandbox.ExamActions.loadExamList = loaderBeforeFailedOrdinaryReentry;
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation
+    = productionActivationReset;
+
+await establishFailedIntegrationFunctionalReset(
+    'the successful supersession fixture must start with durable failed-reset debt'
+);
+integrationRenders.length = 0;
+const staleSuccessfulRetry = deferred();
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation = function () {
+    return staleSuccessfulRetry.promise;
+};
+const staleSuccessfulRetryNavigation = integrationSandbox.showView('browse', true);
+const staleSuccessfulRetryRequestId = integrationSandbox.__getBrowseResultsRequestId();
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'pending',
+    'the retry barrier must own its request before a newer foreground intent starts'
+);
+assert.notStrictEqual(
+    await integrationSandbox.__renderBrowseResultsForState(
+        [{ id: 'newer-foreground-clears-failed-debt' }],
+        null,
+        { foreground: true }
+    ),
+    false
+);
+const newerSuccessfulForegroundRequestId = integrationSandbox.__getBrowseResultsRequestId();
+assert.ok(
+    newerSuccessfulForegroundRequestId > staleSuccessfulRetryRequestId,
+    'the successful foreground commit must own a request newer than the retry barrier'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'succeeded',
+    'the atomic foreground preparation and commit must clear the predecessor debt'
+);
+assert.deepStrictEqual(integrationRenders, [['newer-foreground-clears-failed-debt']]);
+assert.strictEqual(
+    integrationSandbox.AppEntry.captureBrowseFunctionalResetRecovery(),
+    null,
+    'a successful foreground commit must leave no failed-reset debt to recapture'
+);
+staleSuccessfulRetry.resolve(true);
+assert.strictEqual(
+    await staleSuccessfulRetryNavigation,
+    false,
+    'the retry that lost its request must remain stale when it settles'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'succeeded',
+    'a late stale retry settlement must not recreate cleared failed-reset debt'
+);
+integrationSandbox.ExamActions.browseFilterStateOwner.resetForActivation
+    = productionActivationReset;
+
+await establishFailedIntegrationFunctionalReset(
+    'the old-library foreground fixture must start with durable failed-reset debt'
+);
+integrationRenders.length = 0;
+const displayBeforeLibraryEpochForeground = integrationSandbox.ExamActions.displayExams;
+const libraryEpochForegroundDisplays = [];
+integrationSandbox.ExamActions.displayExams = function captureLibraryEpochForeground(exams) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    libraryEpochForegroundDisplays.push(Array.from(snapshot, (exam) => exam && exam.id));
+    return snapshot;
+};
+const oldLibraryForegroundIndex = deferred();
+integrationIndexResolvers.push(oldLibraryForegroundIndex);
+assert.strictEqual(integrationSandbox.searchExams('old-library-query'), true);
+const oldLibraryForegroundRequestId = integrationSandbox.__getBrowseResultsRequestId();
+assert.strictEqual(
+    integrationSandbox.__isBrowseUserResultsRequestInFlight(oldLibraryForegroundRequestId),
+    true,
+    'the foreground search must retain its request across the asynchronous library read'
+);
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'new-library-publication-without-token-steal' }] }
+}));
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    oldLibraryForegroundRequestId,
+    'advancing only the active library generation must not steal the foreground token'
+);
+oldLibraryForegroundIndex.resolve([{
+    id: 'old-library-result-must-not-display',
+    title: 'Old Library Query',
+    searchText: 'old-library-query',
+    category: 'P1',
+    type: 'reading'
+}]);
+await waitForCondition(
+    () => !integrationSandbox.__isBrowseUserResultsRequestInFlight(
+        oldLibraryForegroundRequestId
+    ),
+    'the old-library foreground request must settle without displaying its stale result'
+);
+assert.deepStrictEqual(
+    libraryEpochForegroundDisplays,
+    [],
+    'a retained foreground result from the previous active library must not display'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'discarding the old-library result must not clear failed-reset debt'
+);
+const currentLibraryForegroundIndex = deferred();
+integrationIndexResolvers.push(currentLibraryForegroundIndex);
+assert.strictEqual(integrationSandbox.searchExams('current-library-query'), true);
+const currentLibraryForegroundRequestId = integrationSandbox.__getBrowseResultsRequestId();
+currentLibraryForegroundIndex.resolve([{
+    id: 'current-library-result',
+    title: 'Current Library Query',
+    searchText: 'current-library-query',
+    category: 'P2',
+    type: 'reading'
+}]);
+await waitForCondition(
+    () => libraryEpochForegroundDisplays.length === 1
+        && !integrationSandbox.__isBrowseUserResultsRequestInFlight(
+            currentLibraryForegroundRequestId
+        ),
+    'a later current-library foreground search must render and settle normally'
+);
+assert.deepStrictEqual(libraryEpochForegroundDisplays, [['current-library-result']]);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'succeeded',
+    'the later current-library foreground commit must be allowed to recover the debt'
+);
+integrationSandbox.ExamActions.displayExams = displayBeforeLibraryEpochForeground;
+
+integrationRenders.length = 0;
+integrationSearchInput.value = '';
+const setBrowseFilterStateBeforeApplyFailure = integrationSandbox.setBrowseFilterState;
+const resetToDefaultBeforeApplyFailure = integrationSandbox.browseController.resetToDefault;
+const showMessageBeforeApplyFailure = integrationSandbox.showMessage;
+const loadExamListBeforeApplyFailure = integrationSandbox.ExamActions.loadExamList;
+const applyFailureStateWrites = [];
+const applyFailureControllerResets = [];
+const applyFailureToasts = [];
+const applyFailureFallbackRenders = [];
+integrationSandbox.setBrowseFilterState = function captureApplyFailureState(category, type) {
+    applyFailureStateWrites.push({ category, type });
+    setBrowseFilterStateBeforeApplyFailure(category, type);
+};
+integrationSandbox.browseController.resetToDefault = function captureApplyFailureReset(...args) {
+    applyFailureControllerResets.push(args);
+};
+integrationSandbox.showMessage = function captureApplyFailureToast(...args) {
+    applyFailureToasts.push(args);
+};
+integrationSandbox.ExamActions.loadExamList = function captureApplyFailureFallback(exams) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    applyFailureFallbackRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    return snapshot;
+};
+setBrowseFilterStateBeforeApplyFailure('P2', 'reading');
+const staleApplyFailureIndex = deferred();
+integrationIndexResolvers.push(staleApplyFailureIndex);
+const staleApplyFailureResolutionCount = integrationIndexResolutionCount;
+const staleApplyFailure = integrationSandbox.applyBrowseFilter('P1', 'reading');
+const staleApplyFailureRequestId = integrationSandbox.__getBrowseResultsRequestId();
+assert.strictEqual(
+    integrationSandbox.__isBrowseUserResultsRequestInFlight(staleApplyFailureRequestId),
+    true,
+    'the failing filter must retain its foreground request while resolving the index'
+);
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    staleApplyFailureResolutionCount + 1,
+    'the stale failure fixture must enter its asynchronous index read'
+);
+integrationBrowseView.classList.remove('active');
+integrationOverviewView.classList.add('active');
+integrationSandbox.dispatchEvent(new IntegrationCustomEvent('examIndexLoaded', {
+    detail: { index: [{ id: 'apply-failure-new-library' }] }
+}));
+integrationOverviewView.classList.remove('active');
+integrationBrowseView.classList.add('active');
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    staleApplyFailureRequestId,
+    'a library-only generation change must not hide the stale catch behind token supersession'
+);
+staleApplyFailureIndex.reject(new Error('stale apply index failure'));
+assert.strictEqual(await staleApplyFailure, false);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationBrowseState,
+    { category: 'P2', type: 'reading' },
+    'a stale catch must not replace the live filter with all/all'
+);
+assert.deepStrictEqual(applyFailureStateWrites, []);
+assert.deepStrictEqual(applyFailureControllerResets, []);
+assert.deepStrictEqual(applyFailureToasts, []);
+assert.deepStrictEqual(applyFailureFallbackRenders, []);
+assert.strictEqual(
+    integrationIndexResolutionCount,
+    staleApplyFailureResolutionCount + 1,
+    'a stale catch must not start the deferred fallback index read'
+);
+
+const currentApplyFailureIndex = deferred();
+const currentApplyFallbackIndex = deferred();
+integrationIndexResolvers.push(currentApplyFailureIndex, currentApplyFallbackIndex);
+const currentApplyFailureResolutionCount = integrationIndexResolutionCount;
+const currentApplyFailure = integrationSandbox.applyBrowseFilter('P3', 'listening');
+const currentApplyFailureRequestId = integrationSandbox.__getBrowseResultsRequestId();
+currentApplyFailureIndex.reject(new Error('current apply index failure'));
+await waitForCondition(
+    () => integrationIndexResolutionCount === currentApplyFailureResolutionCount + 2,
+    'a current-epoch catch must retain ownership through its deferred fallback read'
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseResultsRequestId(),
+    currentApplyFailureRequestId,
+    'the current fallback must reuse the retained foreground request'
+);
+currentApplyFallbackIndex.resolve([{ id: 'current-apply-fallback' }]);
+assert.strictEqual(await currentApplyFailure, false);
+assert.deepStrictEqual(
+    integrationBrowseState,
+    { category: 'all', type: 'all' },
+    'a current-epoch failure may still reset the filter to its safe fallback'
+);
+assert.deepStrictEqual(applyFailureStateWrites, [{ category: 'all', type: 'all' }]);
+assert.strictEqual(applyFailureControllerResets.length, 1);
+assert.deepStrictEqual(applyFailureFallbackRenders, [['current-apply-fallback']]);
+integrationSandbox.setBrowseFilterState = setBrowseFilterStateBeforeApplyFailure;
+integrationSandbox.browseController.resetToDefault = resetToDefaultBeforeApplyFailure;
+integrationSandbox.showMessage = showMessageBeforeApplyFailure;
+integrationSandbox.ExamActions.loadExamList = loadExamListBeforeApplyFailure;
+
+await establishFailedIntegrationFunctionalReset(
+    'the explicit-token search fixture must start from failed-reset debt'
+);
+integrationRenders.length = 0;
+integrationSearchInput.value = 'raw-background-query';
+integrationSandbox.__browseFrequencyFilter = 'all';
+const displayBeforeExplicitTokenSearch = integrationSandbox.ExamActions.displayExams;
+integrationSandbox.ExamActions.displayExams = function captureExplicitTokenSearch(exams) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    return snapshot;
+};
+const explicitTokenSearchIndex = deferred();
+integrationIndexResolvers.push(explicitTokenSearchIndex);
+const explicitTokenSearchRequestId = integrationSandbox.__beginBrowseResultsRequest();
+assert.strictEqual(
+    integrationSandbox.__isBrowseUserResultsRequestInFlight(explicitTokenSearchRequestId),
+    false,
+    'a raw results token must not acquire foreground ownership before search replay'
+);
+assert.strictEqual(
+    integrationSandbox.searchExams('raw-background-query', explicitTokenSearchRequestId),
+    true
+);
+assert.strictEqual(
+    integrationSandbox.__isBrowseUserResultsRequestInFlight(explicitTokenSearchRequestId),
+    false,
+    'search replay must not silently promote an unretained explicit token to foreground'
+);
+explicitTokenSearchIndex.resolve([{
+    id: 'explicit-token-background-search',
+    title: 'Raw Background Query',
+    searchText: 'raw-background-query',
+    category: 'P1',
+    type: 'reading',
+    frequency: 7
+}]);
+await waitForCondition(
+    () => integrationRenders.length === 1,
+    'a current explicit-token search replay may still render as background work'
+);
+assert.deepStrictEqual(integrationRenders, [['explicit-token-background-search']]);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'a background search replay must not clear failed-reset debt'
+);
+const explicitTokenSearchDebt =
+    integrationSandbox.AppEntry.captureBrowseFunctionalResetRecovery();
+assert.ok(
+    explicitTokenSearchDebt,
+    'failed-reset debt must remain capturable after the background search render'
+);
+assert.strictEqual(
+    integrationSandbox.AppEntry.completeBrowseFunctionalResetRecovery(
+        explicitTokenSearchDebt,
+        false
+    ),
+    false,
+    'discarding the audit capture must leave the failed debt unresolved'
+);
+assert.strictEqual(integrationSandbox.__getBrowseFunctionalResetState().status, 'failed');
+integrationSandbox.ExamActions.displayExams = displayBeforeExplicitTokenSearch;
+
+await establishFailedIntegrationFunctionalReset(
+    'the central foreground-boundary fixture must start from failed-reset debt'
+);
+integrationRenders.length = 0;
+const backgroundRecoveryRequestId = integrationSandbox.__beginBrowseResultsRequest();
+assert.notStrictEqual(
+    await integrationSandbox.__renderBrowseResultsForState(
+        [{ id: 'background-must-not-recover' }],
+        backgroundRecoveryRequestId
+    ),
+    false
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'failed',
+    'a current background render must not clear failed-reset debt'
+);
+assert.deepStrictEqual(integrationRenders, [['background-must-not-recover']]);
+assert.notStrictEqual(
+    await integrationSandbox.__renderBrowseResultsForState(
+        [{ id: 'foreground-recovers-centrally' }],
+        null,
+        { foreground: true }
+    ),
+    false
+);
+assert.strictEqual(
+    integrationSandbox.__getBrowseFunctionalResetState().status,
+    'succeeded',
+    'the same canonical commit boundary must recover only an owned foreground render'
+);
+integrationSandbox.refreshBrowseProgressFromRecords(
+    [],
+    [{ id: 'progress-after-central-foreground-recovery' }]
+);
+await waitForCondition(
+    () => integrationRenders.length === 3,
+    'background progress must resume after the central foreground recovery commit'
+);
+assert.deepStrictEqual(integrationRenders, [
+    ['background-must-not-recover'],
+    ['foreground-recovers-centrally'],
+    ['progress-after-central-foreground-recovery']
+]);
+
+const displayBeforeForegroundRecoveryMatrix = integrationSandbox.ExamActions.displayExams;
+integrationSandbox.ExamActions.displayExams = function captureForegroundSearch(exams) {
+    const snapshot = Array.isArray(exams) ? exams : [];
+    integrationRenders.push(Array.from(snapshot, (exam) => exam && exam.id));
+    return snapshot;
+};
+const foregroundRecoveryScenarios = [
+    {
+        name: 'type',
+        start() {
+            integrationSearchInput.value = '';
+            return integrationSandbox.filterByType('reading');
+        }
+    },
+    {
+        name: 'search',
+        start() {
+            integrationSearchInput.value = 'needle';
+            return integrationSandbox.searchExams('needle');
+        }
+    },
+    {
+        name: 'sort',
+        start() {
+            integrationSearchInput.value = '';
+            integrationSandbox.__browseSortMode = 'difficulty-desc';
+            return integrationSandbox.refreshBrowseResults({ foreground: true });
+        }
+    },
+    {
+        name: 'frequency',
+        start() {
+            integrationSearchInput.value = '';
+            integrationSandbox.__browseFrequencyFilter = 'all';
+            return integrationSandbox.filterByFrequency('high');
+        }
+    }
+];
+for (const scenario of foregroundRecoveryScenarios) {
+    await establishFailedIntegrationFunctionalReset(
+        `the ${scenario.name} recovery fixture must start from failed-reset debt`
+    );
+    integrationRenders.length = 0;
+    const foregroundIndex = deferred();
+    integrationIndexResolvers.push(foregroundIndex);
+    const foregroundResult = scenario.start();
+    foregroundIndex.resolve([{
+        id: `foreground-${scenario.name}`,
+        title: `Needle ${scenario.name}`,
+        searchText: `needle ${scenario.name}`,
+        category: 'P1',
+        type: 'reading',
+        frequency: 7
+    }]);
+    if (foregroundResult && typeof foregroundResult.then === 'function') {
+        assert.notStrictEqual(await foregroundResult, false);
+    }
+    await waitForCondition(
+        () => integrationSandbox.__getBrowseFunctionalResetState().status === 'succeeded',
+        `a current ${scenario.name} render must recover the failed-reset gate`
+    );
+    assert.deepStrictEqual(
+        integrationRenders,
+        [[`foreground-${scenario.name}`]],
+        `the ${scenario.name} path must commit one current foreground render`
+    );
+    integrationSearchInput.value = '';
+    integrationSandbox.refreshBrowseProgressFromRecords(
+        [],
+        [{ id: `progress-after-${scenario.name}` }]
+    );
+    await waitForCondition(
+        () => integrationRenders.length === 2,
+        `progress must resume after the ${scenario.name} foreground recovery`
+    );
+    assert.deepStrictEqual(integrationRenders.at(-1), [`progress-after-${scenario.name}`]);
+}
+integrationSandbox.ExamActions.displayExams = displayBeforeForegroundRecoveryMatrix;
 
 await establishFailedIntegrationFunctionalReset(
     'the pending-filter recovery fixture must start from a failed functional barrier'

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -796,6 +796,75 @@ test('retryable Browse initialization failure retains the pending filter for the
     );
 });
 
+test('an older pending-filter consumer cannot consume the current retry intent', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'browse';
+    const pendingFilter = {
+        category: 'P3',
+        type: 'reading',
+        filterMode: 'default',
+        path: 'ReadingPractice/P3'
+    };
+    const firstInitialization = deferred();
+    const currentInitialization = deferred();
+    const initializationQueue = [firstInitialization, currentInitialization];
+    const appliedFilters = [];
+    let consumerGeneration = 0;
+    let currentConsumer = null;
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.AppEntry = {
+        beginBrowsePendingFilterConsumer(filter) {
+            currentConsumer = {
+                generation: ++consumerGeneration,
+                pendingFilter: filter
+            };
+            return currentConsumer;
+        },
+        isBrowsePendingFilterConsumerCurrent(consumer) {
+            return currentConsumer === consumer
+                && harness.window.__pendingBrowseFilter === consumer.pendingFilter;
+        },
+        isBrowsePendingFilterIntentCurrent(consumer) {
+            return this.isBrowsePendingFilterConsumerCurrent(consumer);
+        }
+    };
+    harness.window.initializeBrowseView = () => initializationQueue.shift().promise;
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve(true);
+    };
+
+    app.onViewActivated('browse');
+    app.onViewActivated('browse');
+    firstInitialization.resolve(null);
+    await flushMicrotasks();
+
+    assert.strictEqual(
+        harness.window.__pendingBrowseFilter,
+        pendingFilter,
+        'the older activation must not delete the pending object owned by the current retry'
+    );
+    assert.deepEqual(appliedFilters, []);
+
+    currentInitialization.resolve([{ id: 'current-p3-reading' }]);
+    await flushMicrotasks();
+
+    assert.deepEqual(appliedFilters, [[
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path
+    ]]);
+    assert.equal(
+        harness.window.__pendingBrowseFilter,
+        undefined,
+        'only the current successful consumer may consume the shared pending intent'
+    );
+});
+
 test('later type, search, and frequency intents supersede a pending Browse activation', async (t) => {
     const cases = [
         { name: 'type', initializationResult: null, finalIntent: { type: 'listening' } },

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function loadScript(relativePath, context) {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    vm.runInContext(source, context, { filename: relativePath });
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(value) { values.add(value); },
+        remove(value) { values.delete(value); },
+        toggle(value, enabled) {
+            if (enabled) values.add(value);
+            else values.delete(value);
+        },
+        contains(value) { return values.has(value); }
+    };
+}
+
+function createButton(dataset, active = false) {
+    return {
+        dataset: Object.assign({}, dataset),
+        classList: createClassList(active ? ['active'] : []),
+        ariaPressed: active ? 'true' : 'false',
+        setAttribute(name, value) {
+            if (name === 'aria-pressed') this.ariaPressed = value;
+        }
+    };
+}
+
+function createHarness(options = {}) {
+    const documentListeners = new Map();
+    const windowListeners = new Map();
+    const loaderCalls = [];
+    const renderedFilterIndexes = [];
+    const filterStateCalls = [];
+    const titleCalls = [];
+    const preferencePatches = [];
+    const resolverQueue = Array.isArray(options.resolverQueue) ? options.resolverQueue.slice() : [];
+    const defaultIndex = Array.isArray(options.activeIndex)
+        ? options.activeIndex
+        : [{ id: 'p2-active', title: 'Active P2', category: 'P2', type: 'reading' }];
+
+    const searchInput = { value: 'ocean' };
+    const searchClearButton = { hidden: false };
+    const typeButtons = [
+        createButton({ filterId: 'all', filterType: 'all' }),
+        createButton({ filterId: 'reading', filterType: 'reading' }, true),
+        createButton({ filterId: 'listening', filterType: 'listening' })
+    ];
+    const frequencyButtons = [
+        createButton({ frequencyFilter: 'high' }, true),
+        createButton({ frequencyFilter: 'medium' })
+    ];
+    const typeContainer = {
+        querySelectorAll() { return typeButtons; }
+    };
+    const frequencyContainer = {
+        querySelectorAll() { return frequencyButtons; }
+    };
+
+    const documentStub = {
+        readyState: 'complete',
+        body: {},
+        addEventListener(type, handler) {
+            if (!documentListeners.has(type)) documentListeners.set(type, []);
+            documentListeners.get(type).push(handler);
+        },
+        dispatchEvent() {},
+        getElementById(id) {
+            if (id === 'exam-search-input') return searchInput;
+            if (id === 'search-clear-btn') return searchClearButton;
+            if (id === 'type-filter-buttons') return typeContainer;
+            if (id === 'browse-frequency-filter-buttons') return frequencyContainer;
+            return null;
+        },
+        querySelector(selector) {
+            if (selector === '.search-input') return searchInput;
+            return null;
+        },
+        querySelectorAll() { return []; },
+        createElement() {
+            return {
+                classList: createClassList(),
+                dataset: {},
+                style: {},
+                appendChild() {},
+                removeChild() {},
+                addEventListener() {},
+                setAttribute() {},
+                querySelector() { return null; },
+                querySelectorAll() { return []; }
+            };
+        },
+        createTextNode(value) {
+            return { textContent: String(value || '') };
+        }
+    };
+
+    let browseRequestId = 0;
+    let clearedAutoScroll = 0;
+    let resetToDefaultCalls = 0;
+    const browseController = {
+        currentMode: 'frequency-p1',
+        activeFilter: 'high',
+        filterInteractionId: 3,
+        clearPendingBrowseAutoScroll() {
+            clearedAutoScroll += 1;
+        },
+        resetToDefault() {
+            resetToDefaultCalls += 1;
+            throw new Error('resetToDefault must not run during atomic reset');
+        },
+        renderFilterButtons(index) {
+            renderedFilterIndexes.push(Array.from(index, (exam) => exam.id));
+        }
+    };
+
+    const quietConsole = { log() {}, warn() {}, error() {}, info() {} };
+    const windowStub = {
+        console: quietConsole,
+        document: documentStub,
+        AppData: {
+            ready: Promise.resolve(),
+            preferences: {
+                async getBrowse() {
+                    return typeof options.getBrowse === 'function'
+                        ? options.getBrowse()
+                        : null;
+                },
+                async patchBrowse(value) {
+                    preferencePatches.push(JSON.parse(JSON.stringify(value)));
+                    return value;
+                }
+            }
+        },
+        browseController,
+        __browseFilterMode: 'frequency-p1',
+        __browsePath: 'ListeningPractice/100 P1',
+        __browseFrequencyFilter: 'high',
+        __readingMemorizeBrowseMode: true,
+        __browseMemorizeFilterMode: 'reading-memorize',
+        addEventListener(type, handler) {
+            if (!windowListeners.has(type)) windowListeners.set(type, []);
+            windowListeners.get(type).push(handler);
+        },
+        removeEventListener() {},
+        setBrowseFilterState(category, type) {
+            filterStateCalls.push({ category, type });
+        },
+        setBrowseTitle(value) {
+            titleCalls.push(value);
+        },
+        updateBrowseFrequencyButtons(value) {
+            this.__browseFrequencyFilter = value;
+            frequencyButtons.forEach((button) => {
+                const active = button.dataset.frequencyFilter === value;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-pressed', active ? 'true' : 'false');
+            });
+        },
+        setReadingMemorizeBrowseMode(value) {
+            this.__readingMemorizeBrowseMode = value;
+        },
+        syncReadingMemorizeBrowseModeUI() {},
+        flushBrowsePreferenceWrites() {
+            return Promise.resolve();
+        },
+        async setupBrowseControls() {
+            if (typeof options.setupBrowseControls === 'function') {
+                return options.setupBrowseControls(this);
+            }
+        },
+        __beginBrowseResultsRequest() {
+            browseRequestId += 1;
+            return browseRequestId;
+        },
+        __isBrowseResultsRequestCurrent(requestId) {
+            return requestId === browseRequestId;
+        },
+        resolveActiveLibraryIndex() {
+            const queued = resolverQueue.shift();
+            return queued ? queued.promise : Promise.resolve(defaultIndex);
+        },
+        loadExamList(indexOverride, renderRequestId) {
+            loaderCalls.push({
+                indexOverride,
+                ids: Array.isArray(indexOverride) ? Array.from(indexOverride, (exam) => exam.id) : null,
+                renderRequestId
+            });
+            if (options.loaderError) {
+                return Promise.reject(options.loaderError);
+            }
+            if (Object.prototype.hasOwnProperty.call(options, 'loaderResult')) {
+                return Promise.resolve(options.loaderResult);
+            }
+            return Promise.resolve(indexOverride);
+        }
+    };
+
+    const sandbox = {
+        window: windowStub,
+        document: documentStub,
+        console: quietConsole,
+        CustomEvent: class CustomEvent {
+            constructor(type, init = {}) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        },
+        Node: function Node() {},
+        Event: class Event {},
+        Promise,
+        Set,
+        Map,
+        Date,
+        Math,
+        JSON,
+        setTimeout,
+        clearTimeout
+    };
+    sandbox.globalThis = windowStub;
+    sandbox.self = windowStub;
+    const context = vm.createContext(sandbox);
+
+    loadScript('js/components/BrowseStateManager.js', context);
+    const stateManager = new windowStub.BrowseStateManager();
+    stateManager.currentFilter = 'P2';
+    stateManager.state.currentCategory = 'P2';
+    stateManager.state.currentFrequency = 'high';
+    stateManager.state.filters = { frequency: 'high', status: 'started', difficulty: 'hard' };
+    stateManager.state.searchQuery = 'ocean';
+    loadScript('js/app/examActions.js', context);
+
+    return {
+        window: windowStub,
+        stateManager,
+        searchInput,
+        searchClearButton,
+        typeButtons,
+        frequencyButtons,
+        loaderCalls,
+        renderedFilterIndexes,
+        filterStateCalls,
+        titleCalls,
+        preferencePatches,
+        context,
+        getClearedAutoScroll: () => clearedAutoScroll,
+        getResetToDefaultCalls: () => resetToDefaultCalls
+    };
+}
+
+test('ordinary Browse navigation preserves the selected scope and search state', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    let resetCalls = 0;
+    harness.stateManager.resetToAllExams = () => {
+        resetCalls += 1;
+    };
+
+    harness.stateManager.handleBrowseNavigation();
+
+    assert.equal(resetCalls, 0);
+    assert.equal(harness.stateManager.currentFilter, 'P2');
+    assert.equal(harness.stateManager.state.currentCategory, 'P2');
+    assert.equal(harness.stateManager.state.searchQuery, 'ocean');
+    assert.equal(harness.stateManager.getBrowseHistory().at(-1).action, 'navigate_to_browse');
+    assert.equal(harness.stateManager.getBrowseHistory().at(-1).filter, 'P2');
+});
+
+test('repeat Browse reset clears all browse state and renders the active index through the global adapter', async () => {
+    const activeIndex = [{ id: 'p3-active', title: 'Active P3', category: 'P3', type: 'reading' }];
+    const harness = createHarness({ activeIndex });
+    await harness.stateManager.ready;
+
+    await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(harness.loaderCalls.length, 1, 'reset must use the global loading adapter exactly once');
+    assert.deepEqual(harness.loaderCalls[0].ids, ['p3-active']);
+    assert.notDeepEqual(
+        harness.loaderCalls[0].indexOverride,
+        [],
+        'reset must never render the module-local loader default empty array'
+    );
+    assert.equal(harness.getResetToDefaultCalls(), 0, 'reset must not start the controller filtering pipeline');
+    assert.equal(harness.getClearedAutoScroll(), 1);
+    assert.equal(harness.window.browseController.currentMode, 'default');
+    assert.equal(harness.window.browseController.activeFilter, 'all');
+    assert.equal(harness.window.browseController.filterInteractionId, 4);
+    assert.deepEqual(harness.renderedFilterIndexes, [['p3-active']]);
+    assert.deepEqual(harness.filterStateCalls.at(-1), { category: 'all', type: 'all' });
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browsePath, null);
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.searchInput.value, '');
+    assert.equal(harness.searchClearButton.hidden, true);
+    assert.equal(harness.stateManager.currentFilter, 'all');
+    assert.equal(harness.stateManager.state.currentCategory, null);
+    assert.equal(harness.stateManager.state.currentFrequency, null);
+    assert.equal(harness.stateManager.state.searchQuery, '');
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.stateManager.state.filters)),
+        { frequency: 'all', status: 'all', difficulty: 'all' }
+    );
+    assert.equal(harness.typeButtons[0].classList.contains('active'), true);
+    assert.equal(harness.typeButtons[0].ariaPressed, 'true');
+    assert(harness.frequencyButtons.every((button) => button.ariaPressed === 'false'));
+    assert.equal(harness.titleCalls.at(-1), '题库列表');
+    assert.equal(
+        harness.preferencePatches.some((patch) => patch.frequencyFilter === 'all'),
+        true,
+        'cleared frequency state must be durable'
+    );
+});
+
+test('only the latest asynchronous repeat reset may update state or render', async () => {
+    const first = deferred();
+    const second = deferred();
+    const harness = createHarness({ resolverQueue: [first, second] });
+    await harness.stateManager.ready;
+
+    const staleReset = harness.window.ExamActions.resetBrowseViewToAll();
+    const latestReset = harness.window.ExamActions.resetBrowseViewToAll();
+    second.resolve([{ id: 'latest-index', category: 'P1', type: 'reading' }]);
+    await latestReset;
+    first.resolve([{ id: 'stale-index', category: 'P2', type: 'reading' }]);
+    const staleResult = await staleReset;
+
+    assert.equal(staleResult, false);
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.deepEqual(harness.loaderCalls[0].ids, ['latest-index']);
+    assert.deepEqual(harness.renderedFilterIndexes, [['latest-index']]);
+});
+
+test('an empty prefetch is passed as null so the global adapter can resolve the active index', async () => {
+    const adapterIndex = [{ id: 'adapter-index', category: 'P4', type: 'listening' }];
+    const harness = createHarness({
+        activeIndex: [],
+        loaderResult: adapterIndex
+    });
+    await harness.stateManager.ready;
+
+    const result = await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.deepEqual(result, adapterIndex);
+    assert.equal(harness.loaderCalls.length, 1);
+    assert.equal(harness.loaderCalls[0].indexOverride, null);
+    assert.equal(harness.loaderCalls[0].ids, null);
+    assert.deepEqual(harness.renderedFilterIndexes.at(-1), ['adapter-index']);
+});
+
+test('repeat reset waits for BrowseStateManager restoration before clearing saved filters', async () => {
+    const restoredBrowse = deferred();
+    const harness = createHarness({
+        getBrowse() {
+            return restoredBrowse.promise;
+        }
+    });
+
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks();
+    assert.equal(harness.loaderCalls.length, 0, 'reset must wait for persisted state restoration');
+
+    restoredBrowse.resolve({
+        stateManager: {
+            previousFilter: 'P1',
+            browseHistory: [],
+            state: {
+                currentCategory: 'P1',
+                currentFrequency: 'high',
+                filters: { frequency: 'high', status: 'started', difficulty: 'hard' },
+                searchQuery: 'restored query'
+            }
+        }
+    });
+    await reset;
+
+    assert.equal(harness.stateManager.state.currentCategory, null);
+    assert.equal(harness.stateManager.state.currentFrequency, null);
+    assert.equal(harness.stateManager.state.searchQuery, '');
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.stateManager.state.filters)),
+        { frequency: 'all', status: 'all', difficulty: 'all' }
+    );
+    assert.equal(harness.loaderCalls.length, 1);
+});
+
+test('repeat reset waits for browse-control hydration before clearing frequency state', async () => {
+    const controlsReady = deferred();
+    const harness = createHarness({
+        async setupBrowseControls(windowStub) {
+            await controlsReady.promise;
+            windowStub.__browseFrequencyFilter = 'high';
+        }
+    });
+    await harness.stateManager.ready;
+
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks();
+    assert.equal(harness.loaderCalls.length, 0, 'reset must wait for in-flight browse-control hydration');
+
+    controlsReady.resolve();
+    await reset;
+
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.loaderCalls.length, 1);
+});
+
+test('repeat reset clears the global frequency filter without the UI helper', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    delete harness.window.updateBrowseFrequencyButtons;
+
+    await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert(harness.frequencyButtons.every((button) => button.ariaPressed === 'false'));
+});
+
+test('repeat reset invalidates a captured pending Browse activation filter', async () => {
+    const activation = deferred();
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    const appliedFilters = [];
+    const pendingFilter = {
+        category: 'P3',
+        type: 'reading',
+        filterMode: null,
+        path: null
+    };
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.initializeBrowseView = () => activation.promise;
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+
+    app.onViewActivated('browse');
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    assert.equal(harness.window.__pendingBrowseFilter, undefined);
+    const replacementPendingFilter = {
+        category: 'P4',
+        type: 'listening',
+        filterMode: null,
+        path: null
+    };
+    harness.window.__pendingBrowseFilter = replacementPendingFilter;
+    await reset;
+
+    activation.resolve();
+    await flushMicrotasks();
+
+    assert.deepEqual(appliedFilters, [], 'captured activation must not restore the pre-reset category');
+    assert.strictEqual(
+        harness.window.__pendingBrowseFilter,
+        replacementPendingFilter,
+        'stale activation cleanup must retain a newer pending intent'
+    );
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+});
+
+test('explicit category activation applies its pending filter when no reset supersedes it', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    const initializationCalls = [];
+    const appliedFilters = [];
+    const pendingFilter = {
+        category: 'P3',
+        type: 'reading',
+        filterMode: 'default',
+        path: 'ReadingPractice/P3'
+    };
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.initializeBrowseView = (options) => {
+        initializationCalls.push(options);
+        return Promise.resolve();
+    };
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+
+    app.onViewActivated('browse');
+    await flushMicrotasks();
+
+    assert.equal(initializationCalls.length, 1);
+    assert.equal(initializationCalls[0].skipLoad, true);
+    assert.deepEqual(appliedFilters, [[
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path
+    ]]);
+    assert.equal(
+        harness.window.__pendingBrowseFilter,
+        undefined,
+        'the applied explicit category intent should be cleared'
+    );
+});
+
+test('a global adapter failure is contained by the public reset boundary', async () => {
+    const harness = createHarness({ loaderError: new Error('adapter failed') });
+    await harness.stateManager.ready;
+
+    const result = await harness.window.ExamActions.resetBrowseViewToAll();
+
+    assert.equal(result, false);
+    assert.equal(harness.loaderCalls.length, 1);
+});

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -462,7 +462,7 @@ test('owner reset without an index preserves controller buttons and clears contr
 
 test('one bubbling Browse click refreshes through the controller only once', () => {
     const harness = createHarness();
-    const browseView = { classList: createClassList(['active']) };
+    const browseView = { classList: createClassList() };
     const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
     harness.window.document.getElementById = (id) => {
         if (id === 'browse-view') return browseView;
@@ -471,11 +471,18 @@ test('one bubbling Browse click refreshes through the controller only once', () 
     loadScript('js/views/legacyViewBundle.js', harness.context);
     loadScript('js/app.js', harness.context);
     const app = vm.runInContext('new ExamSystemApp()', harness.context);
-    let appBrowseActivations = 0;
-    let controllerRefreshes = 0;
-    harness.window.initializeBrowseView = () => {
-        appBrowseActivations += 1;
+    let activationSetups = 0;
+    let terminalRenders = 0;
+    let unexpectedAppActivations = 0;
+    harness.window.activateBrowseView = () => {
+        activationSetups += 1;
+        terminalRenders += 1;
+        return Promise.resolve();
     };
+    harness.window.initializeBrowseView = () => {
+        unexpectedAppActivations += 1;
+    };
+    loadScript('js/boot-fallbacks.js', harness.context);
     app.currentView = 'overview';
     app.setupEventListeners();
 
@@ -494,9 +501,8 @@ test('one bubbling Browse click refreshes through the controller only once', () 
     };
     const controller = new harness.window.LegacyNavigationController({
         container: navRoot,
-        onNavigate() {
-            controllerRefreshes += 1;
-            browseView.classList.add('active');
+        onNavigate(viewName) {
+            harness.window.showView(viewName, false);
         }
     });
     controller.mount(navRoot);
@@ -521,8 +527,9 @@ test('one bubbling Browse click refreshes through the controller only once', () 
 
     assert.equal(event.__browseNavigationHandled, true);
     assert.equal(app.currentView, 'browse');
-    assert.equal(controllerRefreshes, 1);
-    assert.equal(appBrowseActivations, 0, 'the bubbled document handler must not start a second Browse render');
+    assert.equal(activationSetups, 1, 'the controller path must run first-activation setup exactly once');
+    assert.equal(terminalRenders, 1, 'first activation must produce one terminal render');
+    assert.equal(unexpectedAppActivations, 0, 'the bubbled document handler must not start a second activation');
     assert.equal(harness.searchInput.value, 'ocean', 'ordinary Browse navigation must preserve the active query');
 });
 

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -275,6 +275,7 @@ function createHarness(options = {}) {
         preferencePatches,
         documentListeners,
         context,
+        getBrowseRequestId: () => browseRequestId,
         getClearedAutoScroll: () => clearedAutoScroll,
         getResetToDefaultCalls: () => resetToDefaultCalls
     };
@@ -623,6 +624,112 @@ test('explicit category activation applies its pending filter when no reset supe
     );
 });
 
+test('a stable pending Browse activation reuses its initialization results request', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'browse';
+    const appliedFilters = [];
+    const pendingFilter = {
+        category: 'P1',
+        type: 'reading',
+        filterMode: null,
+        path: null
+    };
+    let initializationRequestId = null;
+    const retainedRequests = [];
+    const releasedRequests = [];
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.__getBrowseResultsRequestId = harness.getBrowseRequestId;
+    harness.window.__retainBrowseUserResultsRequest = (requestId) => {
+        retainedRequests.push(requestId);
+        return requestId;
+    };
+    harness.window.__endBrowseUserResultsRequest = (requestId) => {
+        releasedRequests.push(requestId);
+    };
+    harness.window.initializeBrowseView = () => {
+        initializationRequestId = harness.window.__beginBrowseResultsRequest();
+        return Promise.resolve([{ id: 'p1-reading' }]);
+    };
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+
+    app.onViewActivated('browse');
+    await flushMicrotasks();
+
+    assert.equal(appliedFilters.length, 1);
+    assert.deepEqual(appliedFilters[0], [
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path,
+        initializationRequestId
+    ]);
+    assert.equal(harness.getBrowseRequestId(), initializationRequestId);
+    assert.deepEqual(retainedRequests, [initializationRequestId]);
+    assert.deepEqual(releasedRequests, [initializationRequestId]);
+});
+
+test('later type, search, and frequency intents supersede a pending Browse activation', async (t) => {
+    const cases = [
+        { name: 'type', initializationResult: null, finalIntent: { type: 'listening' } },
+        { name: 'search', initializationResult: [], finalIntent: { query: 'latest' } },
+        { name: 'frequency', initializationResult: undefined, finalIntent: { frequency: 'high' } }
+    ];
+
+    for (const scenario of cases) {
+        await t.test(scenario.name, async () => {
+            const harness = createHarness();
+            await harness.stateManager.ready;
+            loadScript('js/app.js', harness.context);
+            const app = vm.runInContext('new ExamSystemApp()', harness.context);
+            app.currentView = 'browse';
+            const initialization = deferred();
+            const appliedFilters = [];
+            const pendingFilter = {
+                category: 'P1',
+                type: 'reading',
+                filterMode: null,
+                path: null
+            };
+            let initializationRequestId = null;
+            const finalIntent = { ...scenario.finalIntent };
+            harness.window.__pendingBrowseFilter = pendingFilter;
+            harness.window.__getBrowseResultsRequestId = harness.getBrowseRequestId;
+            harness.window.initializeBrowseView = () => {
+                initializationRequestId = harness.window.__beginBrowseResultsRequest();
+                return initialization.promise;
+            };
+            harness.window.applyBrowseFilter = (...args) => {
+                appliedFilters.push(args);
+                finalIntent.category = args[0];
+                finalIntent.type = args[1];
+                harness.window.__beginBrowseResultsRequest();
+                return Promise.resolve();
+            };
+
+            app.onViewActivated('browse');
+            const laterIntentRequestId = harness.window.__beginBrowseResultsRequest();
+            initialization.resolve(scenario.initializationResult);
+            await flushMicrotasks();
+
+            assert.equal(initializationRequestId + 1, laterIntentRequestId);
+            assert.deepEqual(appliedFilters, [], `the later ${scenario.name} intent must not be replayed over`);
+            assert.equal(
+                harness.getBrowseRequestId(),
+                laterIntentRequestId,
+                'the stale activation must not create a third results request'
+            );
+            assert.deepEqual(finalIntent, scenario.finalIntent);
+            assert.equal(harness.window.__pendingBrowseFilter, undefined);
+        });
+    }
+});
+
 test('a newer navigation cancels a delayed hot pending Browse filter', async () => {
     const harness = createHarness();
     await harness.stateManager.ready;
@@ -750,9 +857,25 @@ test('activation reset waits for hydration and durably clears restored Browse st
         }
     });
     await harness.stateManager.ready;
+    const durableBrowse = {
+        lastFilter: { category: 'P2', type: 'reading' },
+        filter: { category: 'P2', type: 'reading' },
+        frequencyFilter: 'high'
+    };
+    harness.window.AppData.preferences.getBrowse = async () => (
+        JSON.parse(JSON.stringify(durableBrowse))
+    );
+    harness.window.AppData.preferences.patchBrowse = async (partial) => {
+        harness.preferencePatches.push(JSON.parse(JSON.stringify(partial)));
+        Object.assign(durableBrowse, JSON.parse(JSON.stringify(partial)));
+        return partial;
+    };
     let cachedLastFilter = { category: 'P2', type: 'reading' };
     harness.window.saveBrowseViewPreferences = (partial) => {
-        if (partial && partial.lastFilter) cachedLastFilter = partial.lastFilter;
+        if (partial && partial.lastFilter) {
+            cachedLastFilter = partial.lastFilter;
+            durableBrowse.lastFilter = JSON.parse(JSON.stringify(partial.lastFilter));
+        }
         return { lastFilter: cachedLastFilter };
     };
     harness.window.flushBrowsePreferenceWrites = async () => ({ lastFilter: cachedLastFilter });
@@ -785,6 +908,48 @@ test('activation reset waits for hydration and durably clears restored Browse st
         true,
         'the activation reset must persist both current and legacy cleared filters after hydration'
     );
+});
+
+test('activation reset fails closed when the production preference write is rejected', async () => {
+    const durableBrowse = {
+        lastFilter: { category: 'P2', type: 'reading' },
+        filter: { category: 'P2', type: 'reading' },
+        frequencyFilter: 'high',
+        stateManager: {
+            currentFilter: 'P2',
+            previousFilter: null,
+            state: {
+                currentCategory: 'P2',
+                currentFrequency: 'high',
+                filters: { frequency: 'high', status: 'all', difficulty: 'all' },
+                searchQuery: 'ocean'
+            },
+            browseHistory: []
+        }
+    };
+    const harness = createHarness({
+        getBrowse() {
+            return JSON.parse(JSON.stringify(durableBrowse));
+        }
+    });
+    await harness.stateManager.ready;
+    harness.window.AppData.preferences.patchBrowse = async () => {
+        throw new Error('injected Browse preference write failure');
+    };
+    loadScript('js/utils/BrowsePreferencesUtils.js', harness.context);
+    await harness.window.whenBrowseViewPreferencesReady();
+
+    const result = await harness.window.ExamActions.browseFilterStateOwner.resetForActivation();
+
+    assert.equal(result, false, 'the first-render barrier must remain closed after a rejected write');
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.window.getPersistedBrowseFilter())),
+        { category: 'P2', type: 'reading' },
+        'the production preference cache must retain its last committed value'
+    );
+    assert.deepEqual(durableBrowse.lastFilter, { category: 'P2', type: 'reading' });
+    assert.deepEqual(durableBrowse.filter, { category: 'P2', type: 'reading' });
+    assert.equal(durableBrowse.frequencyFilter, 'high');
 });
 
 test('a global adapter failure is contained by the public reset boundary', async () => {

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -271,6 +271,7 @@ function createHarness(options = {}) {
         filterStateCalls,
         titleCalls,
         preferencePatches,
+        documentListeners,
         context,
         getClearedAutoScroll: () => clearedAutoScroll,
         getResetToDefaultCalls: () => resetToDefaultCalls
@@ -431,20 +432,98 @@ test('repeat reset waits for browse-control hydration before clearing frequency 
     assert.equal(harness.loaderCalls.length, 1);
 });
 
-test('repeat reset delegates frequency state to the main-owned UI helper', async () => {
+test('repeat reset owns frequency state when the main UI helper is unavailable', async () => {
     const harness = createHarness();
     await harness.stateManager.ready;
-    const ownerCalls = [];
-    const updateBrowseFrequencyButtons = harness.window.updateBrowseFrequencyButtons.bind(harness.window);
-    harness.window.updateBrowseFrequencyButtons = (value) => {
-        ownerCalls.push(value);
-        updateBrowseFrequencyButtons(value);
-    };
+    harness.window.updateBrowseFrequencyButtons = undefined;
 
     await harness.window.ExamActions.resetBrowseViewToAll();
 
-    assert.deepEqual(ownerCalls, ['all']);
     assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert(harness.frequencyButtons.every((button) => button.ariaPressed === 'false'));
+});
+
+test('owner reset without an index preserves controller buttons and clears controller state', () => {
+    const harness = createHarness();
+    const controllerStateCalls = [];
+    harness.window.setBrowseFilterState = undefined;
+    harness.window.browseController.setBrowseFilterState = (category, type) => {
+        controllerStateCalls.push({ category, type });
+    };
+
+    harness.window.ExamActions.resetBrowseFilterStateToAll();
+
+    assert.deepEqual(harness.renderedFilterIndexes, [], 'an absent index must not be treated as an empty listening library');
+    assert.deepEqual(controllerStateCalls, [{ category: 'all', type: 'all' }]);
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browsePath, null);
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+});
+
+test('one bubbling Browse click refreshes through the controller only once', () => {
+    const harness = createHarness();
+    const browseView = { classList: createClassList(['active']) };
+    const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
+    harness.window.document.getElementById = (id) => {
+        if (id === 'browse-view') return browseView;
+        return originalGetElementById(id);
+    };
+    loadScript('js/views/legacyViewBundle.js', harness.context);
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    let appBrowseActivations = 0;
+    let controllerRefreshes = 0;
+    harness.window.initializeBrowseView = () => {
+        appBrowseActivations += 1;
+    };
+    app.currentView = 'overview';
+    app.setupEventListeners();
+
+    const button = {
+        dataset: { view: 'browse' },
+        classList: createClassList()
+    };
+    let rootClickListener = null;
+    const navRoot = {
+        addEventListener(type, listener) {
+            if (type === 'click') rootClickListener = listener;
+        },
+        removeEventListener() {},
+        contains(value) { return value === button; },
+        querySelectorAll() { return [button]; }
+    };
+    const controller = new harness.window.LegacyNavigationController({
+        container: navRoot,
+        onNavigate() {
+            controllerRefreshes += 1;
+            browseView.classList.add('active');
+        }
+    });
+    controller.mount(navRoot);
+
+    const clickListeners = harness.documentListeners.get('click') || [];
+    const appClickListener = clickListeners.at(-1);
+    assert.equal(typeof rootClickListener, 'function');
+    assert.equal(typeof appClickListener, 'function');
+    const event = {
+        preventDefault() {},
+        target: {
+            closest(selector) {
+                if (selector === '.nav-btn' || selector === '.nav-btn[data-view]') {
+                    return button;
+                }
+                return null;
+            }
+        }
+    };
+    rootClickListener(event);
+    appClickListener(event);
+
+    assert.equal(event.__browseNavigationHandled, true);
+    assert.equal(app.currentView, 'browse');
+    assert.equal(controllerRefreshes, 1);
+    assert.equal(appBrowseActivations, 0, 'the bubbled document handler must not start a second Browse render');
+    assert.equal(harness.searchInput.value, 'ocean', 'ordinary Browse navigation must preserve the active query');
 });
 
 test('repeat reset invalidates a captured pending Browse activation filter', async () => {

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -431,15 +431,20 @@ test('repeat reset waits for browse-control hydration before clearing frequency 
     assert.equal(harness.loaderCalls.length, 1);
 });
 
-test('repeat reset clears the global frequency filter without the UI helper', async () => {
+test('repeat reset delegates frequency state to the main-owned UI helper', async () => {
     const harness = createHarness();
     await harness.stateManager.ready;
-    delete harness.window.updateBrowseFrequencyButtons;
+    const ownerCalls = [];
+    const updateBrowseFrequencyButtons = harness.window.updateBrowseFrequencyButtons.bind(harness.window);
+    harness.window.updateBrowseFrequencyButtons = (value) => {
+        ownerCalls.push(value);
+        updateBrowseFrequencyButtons(value);
+    };
 
     await harness.window.ExamActions.resetBrowseViewToAll();
 
+    assert.deepEqual(ownerCalls, ['all']);
     assert.equal(harness.window.__browseFrequencyFilter, 'all');
-    assert(harness.frequencyButtons.every((button) => button.ariaPressed === 'false'));
 });
 
 test('repeat reset invalidates a captured pending Browse activation filter', async () => {

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -341,16 +341,14 @@ test('repeat Browse reset clears all browse state and renders the active index t
 });
 
 test('only the latest asynchronous repeat reset may update state or render', async () => {
-    const first = deferred();
-    const second = deferred();
-    const harness = createHarness({ resolverQueue: [first, second] });
+    const latest = deferred();
+    const harness = createHarness({ resolverQueue: [latest] });
     await harness.stateManager.ready;
 
     const staleReset = harness.window.ExamActions.resetBrowseViewToAll();
     const latestReset = harness.window.ExamActions.resetBrowseViewToAll();
-    second.resolve([{ id: 'latest-index', category: 'P1', type: 'reading' }]);
+    latest.resolve([{ id: 'latest-index', category: 'P1', type: 'reading' }]);
     await latestReset;
-    first.resolve([{ id: 'stale-index', category: 'P2', type: 'reading' }]);
     const staleResult = await staleReset;
 
     assert.equal(staleResult, false);

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -435,6 +435,75 @@ test('repeat reset waits for browse-control hydration before clearing frequency 
     assert.equal(harness.loaderCalls.length, 1);
 });
 
+test('navigation ABA during control hydration cancels reset before state, persistence, or render', async () => {
+    const controlsReady = deferred();
+    let controlsHydrationStarted = false;
+    const harness = createHarness({
+        async setupBrowseControls() {
+            controlsHydrationStarted = true;
+            await controlsReady.promise;
+            return true;
+        }
+    });
+    await harness.stateManager.ready;
+
+    let navigationGeneration = 7;
+    const browseView = { id: 'browse-view', classList: createClassList(['active']) };
+    const overviewView = { id: 'overview-view', classList: createClassList() };
+    const views = [browseView, overviewView];
+    const originalQuerySelector = harness.window.document.querySelector.bind(
+        harness.window.document
+    );
+    harness.window.document.querySelector = (selector) => {
+        if (selector === '.view.active') {
+            return views.find((view) => view.classList.contains('active')) || null;
+        }
+        return originalQuerySelector(selector);
+    };
+    harness.window.__getAppNavigationIntentGeneration = () => navigationGeneration;
+
+    const reset = harness.window.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks();
+    assert.equal(
+        controlsHydrationStarted,
+        true,
+        'the reset must capture its navigation epoch before awaiting control hydration'
+    );
+
+    navigationGeneration += 1;
+    browseView.classList.remove('active');
+    overviewView.classList.add('active');
+    navigationGeneration += 1;
+    overviewView.classList.remove('active');
+    browseView.classList.add('active');
+    controlsReady.resolve();
+
+    assert.equal(
+        await reset,
+        false,
+        'returning to Browse must not make the pre-navigation reset current again'
+    );
+    assert.equal(browseView.classList.contains('active'), true);
+    assert.equal(harness.loaderCalls.length, 0, 'the stale reset must not load or render');
+    assert.deepEqual(harness.renderedFilterIndexes, []);
+    assert.deepEqual(harness.filterStateCalls, [], 'the stale reset must not apply all/all');
+    assert.deepEqual(harness.titleCalls, []);
+    assert.deepEqual(harness.preferencePatches, [], 'the stale reset must not persist defaults');
+    assert.equal(harness.stateManager.currentFilter, 'P2');
+    assert.equal(harness.stateManager.state.currentCategory, 'P2');
+    assert.equal(harness.stateManager.state.currentFrequency, 'high');
+    assert.equal(harness.stateManager.state.searchQuery, 'ocean');
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(harness.stateManager.state.filters)),
+        { frequency: 'high', status: 'started', difficulty: 'hard' }
+    );
+    assert.equal(harness.window.__browseFilterMode, 'frequency-p1');
+    assert.equal(harness.window.__browsePath, 'ListeningPractice/100 P1');
+    assert.equal(harness.window.__browseFrequencyFilter, 'high');
+    assert.equal(harness.window.__readingMemorizeBrowseMode, true);
+    assert.equal(harness.searchInput.value, 'ocean');
+});
+
 test('repeat reset owns frequency state when the main UI helper is unavailable', async () => {
     const harness = createHarness();
     await harness.stateManager.ready;
@@ -554,7 +623,7 @@ test('repeat reset invalidates a captured pending Browse activation filter', asy
     harness.window.initializeBrowseView = () => activation.promise;
     harness.window.applyBrowseFilter = (...args) => {
         appliedFilters.push(args);
-        return Promise.resolve();
+        return Promise.resolve(true);
     };
 
     app.onViewActivated('browse');
@@ -603,7 +672,7 @@ test('explicit category activation applies its pending filter when no reset supe
     };
     harness.window.applyBrowseFilter = (...args) => {
         appliedFilters.push(args);
-        return Promise.resolve();
+        return Promise.resolve(true);
     };
 
     app.onViewActivated('browse');
@@ -655,7 +724,7 @@ test('a stable pending Browse activation reuses its initialization results reque
     };
     harness.window.applyBrowseFilter = (...args) => {
         appliedFilters.push(args);
-        return Promise.resolve();
+        return Promise.resolve(true);
     };
 
     app.onViewActivated('browse');
@@ -672,6 +741,59 @@ test('a stable pending Browse activation reuses its initialization results reque
     assert.equal(harness.getBrowseRequestId(), initializationRequestId);
     assert.deepEqual(retainedRequests, [initializationRequestId]);
     assert.deepEqual(releasedRequests, [initializationRequestId]);
+});
+
+test('retryable Browse initialization failure retains the pending filter for the next activation', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'browse';
+    const pendingFilter = {
+        category: 'P4',
+        type: 'listening',
+        filterMode: 'default',
+        path: 'ListeningPractice/P4'
+    };
+    const appliedFilters = [];
+    let initializationAttempt = 0;
+    harness.window.__pendingBrowseFilter = pendingFilter;
+    harness.window.initializeBrowseView = () => {
+        initializationAttempt += 1;
+        return Promise.resolve(initializationAttempt === 1
+            ? null
+            : [{ id: 'p4-listening', category: 'P4', type: 'listening' }]);
+    };
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve(true);
+    };
+
+    app.onViewActivated('browse');
+    await flushMicrotasks();
+
+    assert.strictEqual(
+        harness.window.__pendingBrowseFilter,
+        pendingFilter,
+        'a retryable initialization failure must not consume the explicit category intent'
+    );
+    assert.deepEqual(appliedFilters, []);
+
+    app.onViewActivated('browse');
+    await flushMicrotasks();
+
+    assert.equal(initializationAttempt, 2);
+    assert.deepEqual(appliedFilters, [[
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path
+    ]]);
+    assert.equal(
+        harness.window.__pendingBrowseFilter,
+        undefined,
+        'the pending category intent must be consumed after its successful retry'
+    );
 });
 
 test('later type, search, and frequency intents supersede a pending Browse activation', async (t) => {

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -243,6 +243,8 @@ function createHarness(options = {}) {
         Date,
         Math,
         JSON,
+        URL,
+        URLSearchParams,
         setTimeout,
         clearTimeout
     };
@@ -539,6 +541,7 @@ test('repeat reset invalidates a captured pending Browse activation filter', asy
     await harness.stateManager.ready;
     loadScript('js/app.js', harness.context);
     const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'browse';
     const appliedFilters = [];
     const pendingFilter = {
         category: 'P3',
@@ -583,6 +586,7 @@ test('explicit category activation applies its pending filter when no reset supe
     await harness.stateManager.ready;
     loadScript('js/app.js', harness.context);
     const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'browse';
     const initializationCalls = [];
     const appliedFilters = [];
     const pendingFilter = {
@@ -616,6 +620,170 @@ test('explicit category activation applies its pending filter when no reset supe
         harness.window.__pendingBrowseFilter,
         undefined,
         'the applied explicit category intent should be cleared'
+    );
+});
+
+test('a newer navigation cancels a delayed hot pending Browse filter', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    const initialization = deferred();
+    const appliedFilters = [];
+    const browseView = { id: 'browse-view', classList: createClassList() };
+    const overviewView = { id: 'overview-view', classList: createClassList(['active']) };
+    const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
+    const originalQuerySelector = harness.window.document.querySelector.bind(harness.window.document);
+    const originalQuerySelectorAll = harness.window.document.querySelectorAll.bind(harness.window.document);
+    harness.window.document.getElementById = (id) => {
+        if (id === 'browse-view') return browseView;
+        if (id === 'overview-view') return overviewView;
+        return originalGetElementById(id);
+    };
+    harness.window.document.querySelector = (selector) => {
+        if (selector === '.view.active') {
+            return [browseView, overviewView].find((view) => view.classList.contains('active')) || null;
+        }
+        if (selector.startsWith('[data-view=')) return null;
+        return originalQuerySelector(selector);
+    };
+    harness.window.document.querySelectorAll = (selector) => {
+        if (selector === '.view') return [browseView, overviewView];
+        if (selector === '.nav-btn') return [];
+        return originalQuerySelectorAll(selector);
+    };
+    harness.window.location = 'https://example.test/?view=overview';
+    harness.window.history = { replaceState() {} };
+    harness.window.initializeBrowseView = () => initialization.promise;
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+    app.refreshOverviewData = () => {};
+
+    app.browseCategory('P3', 'reading');
+    app.navigateToView('overview');
+    initialization.resolve();
+    await flushMicrotasks();
+
+    assert.deepEqual(appliedFilters, [], 'the stale pending filter must not reactivate Browse');
+    assert.equal(app.currentView, 'overview');
+    assert.equal(overviewView.classList.contains('active'), true);
+    assert.equal(browseView.classList.contains('active'), false);
+    assert.equal(harness.window.__pendingBrowseFilter, undefined);
+});
+
+test('a fallback navigation round trip invalidates a delayed hot Browse filter', async () => {
+    const harness = createHarness();
+    await harness.stateManager.ready;
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    const initialization = deferred();
+    const appliedFilters = [];
+    let sharedNavigationGeneration = 0;
+    const browseView = { id: 'browse-view', classList: createClassList() };
+    const overviewView = { id: 'overview-view', classList: createClassList(['active']) };
+    const views = [browseView, overviewView];
+    const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
+    const originalQuerySelector = harness.window.document.querySelector.bind(harness.window.document);
+    const originalQuerySelectorAll = harness.window.document.querySelectorAll.bind(harness.window.document);
+    harness.window.document.getElementById = (id) => {
+        if (id === 'browse-view') return browseView;
+        if (id === 'overview-view') return overviewView;
+        return originalGetElementById(id);
+    };
+    harness.window.document.querySelector = (selector) => {
+        if (selector === '.view.active') {
+            return views.find((view) => view.classList.contains('active')) || null;
+        }
+        if (selector.startsWith('[data-view=')) return null;
+        return originalQuerySelector(selector);
+    };
+    harness.window.document.querySelectorAll = (selector) => {
+        if (selector === '.view') return views;
+        if (selector === '.nav-btn') return [];
+        return originalQuerySelectorAll(selector);
+    };
+    harness.window.location = 'https://example.test/?view=overview';
+    harness.window.history = { replaceState() {} };
+    harness.window.__markAppNavigationIntent = () => {
+        sharedNavigationGeneration += 1;
+        return sharedNavigationGeneration;
+    };
+    harness.window.__getAppNavigationIntentGeneration = () => sharedNavigationGeneration;
+    harness.window.showView = (viewName) => {
+        harness.window.__markAppNavigationIntent();
+        views.forEach((view) => view.classList.remove('active'));
+        (viewName === 'browse' ? browseView : overviewView).classList.add('active');
+    };
+    harness.window.initializeBrowseView = () => initialization.promise;
+    harness.window.applyBrowseFilter = (...args) => {
+        appliedFilters.push(args);
+        return Promise.resolve();
+    };
+
+    app.browseCategory('P3', 'reading');
+    const capturedPendingFilter = harness.window.__pendingBrowseFilter;
+    harness.window.showView('overview', false);
+    harness.window.showView('browse', false);
+    initialization.resolve();
+    await flushMicrotasks();
+
+    assert.deepEqual(
+        appliedFilters,
+        [],
+        'returning to Browse must not make an older activation intent current again'
+    );
+    assert.equal(app.currentView, 'browse', 'the fallback does not update app-local view state');
+    assert.equal(browseView.classList.contains('active'), true);
+    assert.equal(overviewView.classList.contains('active'), false);
+    assert.notEqual(capturedPendingFilter, undefined);
+    assert.equal(harness.window.__pendingBrowseFilter, undefined);
+});
+
+test('activation reset waits for hydration and durably clears restored Browse state', async () => {
+    const controlsReady = deferred();
+    const harness = createHarness({
+        async setupBrowseControls(windowStub) {
+            await controlsReady.promise;
+            windowStub.__browseFrequencyFilter = 'high';
+        }
+    });
+    await harness.stateManager.ready;
+    let cachedLastFilter = { category: 'P2', type: 'reading' };
+    harness.window.saveBrowseViewPreferences = (partial) => {
+        if (partial && partial.lastFilter) cachedLastFilter = partial.lastFilter;
+        return { lastFilter: cachedLastFilter };
+    };
+    harness.window.flushBrowsePreferenceWrites = async () => ({ lastFilter: cachedLastFilter });
+    harness.window.getPersistedBrowseFilter = () => cachedLastFilter;
+
+    const reset = harness.window.ExamActions.browseFilterStateOwner.resetForActivation();
+    await flushMicrotasks();
+    assert.equal(harness.window.__browseFrequencyFilter, 'high');
+    controlsReady.resolve();
+    assert.equal(await reset, true);
+
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(cachedLastFilter)),
+        { category: 'all', type: 'all' }
+    );
+    assert.equal(harness.window.__browseFilterMode, 'default');
+    assert.equal(harness.window.__browsePath, null);
+    assert.equal(harness.window.__browseFrequencyFilter, 'all');
+    assert.equal(harness.searchInput.value, '');
+    assert.equal(harness.stateManager.currentFilter, 'all');
+    assert.equal(harness.stateManager.state.currentCategory, null);
+    assert.equal(harness.stateManager.state.currentFrequency, null);
+    assert.equal(harness.stateManager.state.searchQuery, '');
+    assert.equal(
+        harness.preferencePatches.some((patch) => (
+            patch.frequencyFilter === 'all'
+            && patch.filter?.category === 'all'
+            && patch.filter?.type === 'all'
+        )),
+        true,
+        'the activation reset must persist both current and legacy cleared filters after hydration'
     );
 });
 

--- a/developer/tests/js/browsePreferencesRecords.test.js
+++ b/developer/tests/js/browsePreferencesRecords.test.js
@@ -14,7 +14,23 @@ function loadScript(relativePath, context) {
     vm.runInContext(source, context, { filename: relativePath });
 }
 
-function createHarness({ examIndex = [], records = [], initialBrowse = null, browseReadGate = null } = {}) {
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+function createHarness({
+    examIndex = [],
+    records = [],
+    initialBrowse = null,
+    browseReadGate = null,
+    browseWriteHook = null
+} = {}) {
     let persistedBrowse = initialBrowse ? structuredClone(initialBrowse) : null;
     let failNextWrite = false;
     const documentStub = {
@@ -34,6 +50,9 @@ function createHarness({ examIndex = [], records = [], initialBrowse = null, bro
                     if (failNextWrite) {
                         failNextWrite = false;
                         throw new Error('injected preference commit failure');
+                    }
+                    if (typeof browseWriteHook === 'function') {
+                        await browseWriteHook(structuredClone(value));
                     }
                     persistedBrowse = structuredClone(value);
                     return { committed: true };
@@ -65,7 +84,14 @@ function createHarness({ examIndex = [], records = [], initialBrowse = null, bro
     };
     const context = vm.createContext(sandbox);
     loadScript('js/utils/BrowsePreferencesUtils.js', context);
-    return { window: windowStub, examIndex, records };
+    return {
+        window: windowStub,
+        examIndex,
+        records,
+        readPersistedBrowse() {
+            return persistedBrowse ? structuredClone(persistedBrowse) : null;
+        }
+    };
 }
 
 const results = [];
@@ -168,8 +194,11 @@ async function testLatestTimestampWinsPerFilter() {
     recordResult('浏览锚点按时间保留最新记录', prefs.listAnchors['P3|reading']);
 }
 
-async function testPreparedAnchorUpdatesRemainInvisibleUntilCommit() {
-    const { window } = createHarness();
+async function testDelayedAnchorProjectionPublishesBeforePersistence() {
+    const writeGate = deferred();
+    const { window, readPersistedBrowse } = createHarness({
+        browseWriteHook: async () => writeGate.promise
+    });
     await window.whenBrowseViewPreferencesReady();
     const updates = window.prepareBrowseAnchorUpdates([{
         id: 'staged-anchor-record',
@@ -184,13 +213,148 @@ async function testPreparedAnchorUpdatesRemainInvisibleUntilCommit() {
         undefined,
         'anchor preparation must not mutate the accepted preference cache'
     );
-    assert.strictEqual(window.commitBrowseAnchorUpdates(updates), true);
-    await window.flushBrowsePreferenceWrites();
+    assert.strictEqual(window.commitBrowseAnchorUpdates(updates, {
+        practiceProjectionGeneration: 7
+    }), true);
     assert.strictEqual(
         window.getBrowseViewPreferences().listAnchors['P2|reading'].examId,
+        'staged-anchor-exam',
+        'the accepted anchor projection must be visible before persistence settles'
+    );
+    assert.strictEqual(readPersistedBrowse(), null, 'the delayed write must still be pending');
+    assert.deepStrictEqual(
+        structuredClone(window.getBrowseAnchorProjectionState()),
+        { revision: 1, generation: 7, persistence: 'pending' }
+    );
+    writeGate.resolve();
+    await window.flushBrowsePreferenceWrites();
+    assert.strictEqual(
+        readPersistedBrowse().listAnchors['P2|reading'].examId,
         'staged-anchor-exam'
     );
-    recordResult('浏览锚点仅在显式 commit 后发布', updates['P2|reading']);
+    assert.strictEqual(window.getBrowseAnchorProjectionState().persistence, 'persisted');
+    recordResult('浏览锚点投影先于延迟持久化同步发布', updates['P2|reading']);
+}
+
+async function testRejectedAnchorPersistenceRetainsCurrentProjection() {
+    const { window, readPersistedBrowse } = createHarness();
+    await window.whenBrowseViewPreferencesReady();
+    const baseline = window.prepareBrowseAnchorUpdates([{
+        id: 'baseline-anchor-record',
+        examId: 'baseline-anchor-exam',
+        title: 'P2 Reading Baseline',
+        metadata: { category: 'P2', examType: 'reading' },
+        timestamp: 1799999999999
+    }], []);
+    assert.strictEqual(window.commitBrowseAnchorUpdates(baseline, {
+        practiceProjectionGeneration: 8
+    }), true);
+    await window.flushBrowsePreferenceWrites();
+    assert.deepStrictEqual(Object.keys(readPersistedBrowse().listAnchors), ['P2|reading']);
+
+    window.failNextBrowsePreferenceWrite();
+    const rejected = window.prepareBrowseAnchorUpdates([{
+        id: 'rejected-anchor-record',
+        examId: 'rejected-anchor-exam',
+        title: 'P3 Reading Rejected Persistence',
+        metadata: { category: 'P3', examType: 'reading' },
+        timestamp: 1800000000000
+    }], []);
+
+    assert.strictEqual(window.commitBrowseAnchorUpdates(rejected, {
+        practiceProjectionGeneration: 9
+    }), true);
+    await window.flushBrowsePreferenceWrites();
+    assert.strictEqual(
+        window.getBrowseViewPreferences().listAnchors['P3|reading'].examId,
+        'rejected-anchor-exam',
+        'a durable rejection must not tear down the accepted live projection'
+    );
+    assert.deepStrictEqual(
+        Object.keys(window.getBrowseViewPreferences().listAnchors),
+        ['P3|reading']
+    );
+    assert.deepStrictEqual(
+        Object.keys(readPersistedBrowse().listAnchors),
+        ['P2|reading'],
+        'the injected rejection must leave the older durable snapshot unchanged'
+    );
+    assert.strictEqual(window.getBrowseAnchorProjectionState().persistence, 'failed');
+
+    const stale = window.prepareBrowseAnchorUpdates([{
+        id: 'stale-anchor-record',
+        examId: 'stale-anchor-exam',
+        title: 'P4 Reading Stale',
+        metadata: { category: 'P4', examType: 'reading' },
+        timestamp: 1800000000001
+    }], []);
+    assert.strictEqual(window.commitBrowseAnchorUpdates(stale, {
+        practiceProjectionGeneration: 8
+    }), false, 'an older generation must not replace the accepted projection');
+    assert.deepStrictEqual(
+        Object.keys(window.getBrowseViewPreferences().listAnchors),
+        ['P3|reading']
+    );
+
+    assert.strictEqual(window.commitBrowseAnchorUpdates(rejected, {
+        practiceProjectionGeneration: 10
+    }), true);
+    await window.flushBrowsePreferenceWrites();
+    assert.deepStrictEqual(Object.keys(readPersistedBrowse().listAnchors), ['P3|reading']);
+    assert.strictEqual(window.getBrowseAnchorProjectionState().persistence, 'persisted');
+    recordResult('锚点持久化失败保留当前代投影并由更新代收敛', rejected['P3|reading']);
+}
+
+async function testConsecutiveAnchorSnapshotsReplacePendingPredecessor() {
+    const firstWriteGate = deferred();
+    const firstWriteStarted = deferred();
+    let writeCount = 0;
+    const { window, readPersistedBrowse } = createHarness({
+        browseWriteHook: async () => {
+            writeCount += 1;
+            if (writeCount === 1) {
+                firstWriteStarted.resolve();
+                await firstWriteGate.promise;
+            }
+        }
+    });
+    await window.whenBrowseViewPreferencesReady();
+
+    const first = window.prepareBrowseAnchorUpdates([{
+        id: 'first-anchor-record',
+        examId: 'first-anchor-exam',
+        title: 'P2 Reading First',
+        metadata: { category: 'P2', examType: 'reading' },
+        timestamp: 1800000000000
+    }], []);
+    assert.strictEqual(window.commitBrowseAnchorUpdates(first, {
+        practiceProjectionGeneration: 10
+    }), true);
+    await firstWriteStarted.promise;
+    const second = window.prepareBrowseAnchorUpdates([{
+        id: 'second-anchor-record',
+        examId: 'second-anchor-exam',
+        title: 'P3 Reading Second',
+        metadata: { category: 'P3', examType: 'reading' },
+        timestamp: 1800000000001
+    }], []);
+    assert.strictEqual(window.commitBrowseAnchorUpdates(second, {
+        practiceProjectionGeneration: 11
+    }), true);
+    assert.deepStrictEqual(
+        Object.keys(window.getBrowseViewPreferences().listAnchors),
+        ['P3|reading'],
+        'the newer full projection must synchronously replace pending A'
+    );
+    firstWriteGate.resolve();
+    await window.flushBrowsePreferenceWrites();
+    assert.deepStrictEqual(
+        Object.keys(readPersistedBrowse().listAnchors),
+        ['P3|reading'],
+        'the later durable snapshot must remove every A-only anchor'
+    );
+    assert.strictEqual(readPersistedBrowse().listAnchors['P3|reading'].examId, 'second-anchor-exam');
+    recordResult('连续 A/B 锚点写入仅保留最新完整快照', readPersistedBrowse().listAnchors);
 }
 
 async function testFailedPreferenceWriteDoesNotReplaceCommittedCache() {
@@ -249,7 +413,9 @@ async function main() {
         await testRecordMetadataBuildsAnchorWithoutCurrentExamIndex();
         await testExplicitMetadataOutranksCurrentExamIndex();
         await testLatestTimestampWinsPerFilter();
-        await testPreparedAnchorUpdatesRemainInvisibleUntilCommit();
+        await testDelayedAnchorProjectionPublishesBeforePersistence();
+        await testRejectedAnchorPersistenceRetainsCurrentProjection();
+        await testConsecutiveAnchorSnapshotsReplacePendingPredecessor();
         await testFailedPreferenceWriteDoesNotReplaceCommittedCache();
         await testFirstReadCanAwaitPersistedPreferences();
         console.log(JSON.stringify({

--- a/developer/tests/js/browsePreferencesRecords.test.js
+++ b/developer/tests/js/browsePreferencesRecords.test.js
@@ -168,6 +168,31 @@ async function testLatestTimestampWinsPerFilter() {
     recordResult('浏览锚点按时间保留最新记录', prefs.listAnchors['P3|reading']);
 }
 
+async function testPreparedAnchorUpdatesRemainInvisibleUntilCommit() {
+    const { window } = createHarness();
+    await window.whenBrowseViewPreferencesReady();
+    const updates = window.prepareBrowseAnchorUpdates([{
+        id: 'staged-anchor-record',
+        examId: 'staged-anchor-exam',
+        title: 'P2 Reading Staged',
+        metadata: { category: 'P2', examType: 'reading' },
+        timestamp: 1800000000000
+    }], []);
+
+    assert.strictEqual(
+        window.getBrowseViewPreferences().listAnchors['P2|reading'],
+        undefined,
+        'anchor preparation must not mutate the accepted preference cache'
+    );
+    assert.strictEqual(window.commitBrowseAnchorUpdates(updates), true);
+    await window.flushBrowsePreferenceWrites();
+    assert.strictEqual(
+        window.getBrowseViewPreferences().listAnchors['P2|reading'].examId,
+        'staged-anchor-exam'
+    );
+    recordResult('浏览锚点仅在显式 commit 后发布', updates['P2|reading']);
+}
+
 async function testFailedPreferenceWriteDoesNotReplaceCommittedCache() {
     const { window } = createHarness();
     await window.flushBrowsePreferenceWrites();
@@ -224,6 +249,7 @@ async function main() {
         await testRecordMetadataBuildsAnchorWithoutCurrentExamIndex();
         await testExplicitMetadataOutranksCurrentExamIndex();
         await testLatestTimestampWinsPerFilter();
+        await testPreparedAnchorUpdatesRemainInvisibleUntilCommit();
         await testFailedPreferenceWriteDoesNotReplaceCommittedCache();
         await testFirstReadCanAwaitPersistedPreferences();
         console.log(JSON.stringify({

--- a/developer/tests/js/legacyNavigationRepeat.test.js
+++ b/developer/tests/js/legacyNavigationRepeat.test.js
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(value) { values.add(value); },
+        remove(value) { values.delete(value); },
+        toggle(value, enabled) {
+            if (enabled) values.add(value);
+            else values.delete(value);
+        },
+        contains(value) { return values.has(value); }
+    };
+}
+
+function createLegacyControllerHarness() {
+    const listeners = new Map();
+    const warnings = [];
+    const button = {
+        dataset: { view: 'browse' },
+        classList: createClassList(['active'])
+    };
+    const container = {
+        addEventListener(type, listener) { listeners.set(type, listener); },
+        removeEventListener() {},
+        contains(value) { return value === button; },
+        querySelectorAll() { return [button]; }
+    };
+    const documentStub = {
+        contains(value) { return value === container; },
+        querySelector(selector) { return selector === '.main-nav' ? container : null; },
+        querySelectorAll() { return []; },
+        getElementById() { return null; },
+        createElement() {
+            return {
+                classList: createClassList(),
+                dataset: {},
+                style: {},
+                appendChild() {},
+                setAttribute() {},
+                addEventListener() {},
+                removeEventListener() {}
+            };
+        },
+        createTextNode(value) { return { textContent: String(value) }; }
+    };
+    const windowStub = {};
+    const sandbox = {
+        window: windowStub,
+        document: documentStub,
+        console: {
+            log() {},
+            error() {},
+            info() {},
+            warn(...args) { warnings.push(args); }
+        },
+        Node: function Node() {},
+        Promise,
+        Set,
+        Map,
+        Date,
+        Math,
+        JSON,
+        Object,
+        Array,
+        String,
+        Number,
+        Boolean,
+        RegExp,
+        setTimeout,
+        clearTimeout
+    };
+    sandbox.globalThis = windowStub;
+    sandbox.self = windowStub;
+    const context = vm.createContext(sandbox);
+    const source = fs.readFileSync(path.join(repoRoot, 'js/views/legacyViewBundle.js'), 'utf8');
+    vm.runInContext(source, context, { filename: 'js/views/legacyViewBundle.js' });
+    return { windowStub, listeners, warnings, button, container };
+}
+
+function createBootFallbackHarness({ controllerPresent, resetPresent }) {
+    const showViewCalls = [];
+    const warnings = [];
+    let navigationOptions = null;
+    let fallbackHandler = null;
+    let resetCalls = 0;
+    const button = {
+        classList: createClassList(['active']),
+        getAttribute(name) { return name === 'data-view' ? 'browse' : null; }
+    };
+    const navRoot = {
+        contains(value) { return value === button; },
+        addEventListener(type, listener) {
+            if (type === 'click') fallbackHandler = listener;
+        },
+        querySelectorAll() { return []; },
+        querySelector() { return null; }
+    };
+    const documentStub = {
+        readyState: 'loading',
+        body: {},
+        addEventListener() {},
+        querySelector(selector) { return selector === '.main-nav' ? navRoot : null; },
+        querySelectorAll() { return []; },
+        getElementById() { return null; },
+        createElement() { return {}; }
+    };
+    const windowStub = {
+        document: documentStub,
+        location: { search: '', hash: '' },
+        showView(viewName, resetCategory) {
+            showViewCalls.push({ viewName, resetCategory });
+            return true;
+        }
+    };
+    if (controllerPresent) {
+        windowStub.ensureLegacyNavigationController = function ensureLegacyNavigationController(options) {
+            navigationOptions = options;
+            return { syncActive() {} };
+        };
+    }
+    if (resetPresent) {
+        windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+            resetCalls += 1;
+            return Promise.resolve(true);
+        };
+    }
+    const sandbox = {
+        window: windowStub,
+        document: documentStub,
+        console: {
+            log() {},
+            error() {},
+            info() {},
+            warn(...args) { warnings.push(args); }
+        },
+        Promise,
+        Set,
+        Map,
+        Date,
+        Math,
+        JSON,
+        Object,
+        Array,
+        String,
+        Number,
+        Boolean,
+        RegExp,
+        URL,
+        URLSearchParams,
+        Blob,
+        setTimeout,
+        clearTimeout
+    };
+    sandbox.globalThis = windowStub;
+    sandbox.self = windowStub;
+    const context = vm.createContext(sandbox);
+    const source = fs.readFileSync(path.join(repoRoot, 'js/boot-fallbacks.js'), 'utf8');
+    vm.runInContext(source, context, { filename: 'js/boot-fallbacks.js' });
+    return {
+        navigationOptions,
+        fallbackHandler,
+        showViewCalls,
+        warnings,
+        button,
+        getResetCalls: () => resetCalls
+    };
+}
+
+test('legacy controller handles an active repeat before ordinary navigation and contains rejection', async () => {
+    const harness = createLegacyControllerHarness();
+    const calls = [];
+    const controller = new harness.windowStub.LegacyNavigationController({
+        container: harness.container,
+        syncOnNavigate: false,
+        onNavigate() { calls.push('navigate'); },
+        onRepeatNavigate() {
+            calls.push('repeat');
+            return Promise.reject(new Error('reset failed'));
+        }
+    });
+    controller.mount(harness.container);
+
+    harness.listeners.get('click')({
+        preventDefault() {},
+        target: {
+            closest() { return harness.button; }
+        }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.deepEqual(calls, ['repeat']);
+    assert.equal(harness.warnings.length, 1);
+    assert.match(String(harness.warnings[0][0]), /onRepeatNavigate/);
+});
+
+test('legacy controller falls through when a repeat callback explicitly declines handling', () => {
+    const harness = createLegacyControllerHarness();
+    const calls = [];
+    const controller = new harness.windowStub.LegacyNavigationController({
+        container: harness.container,
+        syncOnNavigate: false,
+        onNavigate() { calls.push('navigate'); },
+        onRepeatNavigate() {
+            calls.push('repeat');
+            return false;
+        }
+    });
+    controller.mount(harness.container);
+
+    harness.listeners.get('click')({
+        preventDefault() {},
+        target: {
+            closest() { return harness.button; }
+        }
+    });
+
+    assert.deepEqual(calls, ['repeat', 'navigate']);
+});
+
+test('boot fallback wires controller repeats and resets without a helper', async () => {
+    const controllerHarness = createBootFallbackHarness({ controllerPresent: true, resetPresent: true });
+    assert.equal(typeof controllerHarness.navigationOptions.onRepeatNavigate, 'function');
+    await controllerHarness.navigationOptions.onRepeatNavigate('browse');
+    assert.equal(controllerHarness.getResetCalls(), 1);
+    assert.equal(controllerHarness.navigationOptions.onRepeatNavigate('settings'), false);
+    assert.deepEqual(controllerHarness.showViewCalls, []);
+
+    const manualHarness = createBootFallbackHarness({ controllerPresent: false, resetPresent: false });
+    assert.equal(typeof manualHarness.fallbackHandler, 'function');
+    manualHarness.fallbackHandler({
+        preventDefault() {},
+        target: {
+            closest(selector) {
+                return selector === '.nav-btn[data-view]' ? manualHarness.button : null;
+            }
+        }
+    });
+    await Promise.resolve();
+
+    assert.deepEqual(
+        manualHarness.showViewCalls,
+        [{ viewName: 'browse', resetCategory: true }]
+    );
+});

--- a/developer/tests/js/legacyNavigationRepeat.test.js
+++ b/developer/tests/js/legacyNavigationRepeat.test.js
@@ -191,16 +191,18 @@ test('legacy controller handles an active repeat before ordinary navigation and 
     });
     controller.mount(harness.container);
 
-    harness.listeners.get('click')({
+    const event = {
         preventDefault() {},
         target: {
             closest() { return harness.button; }
         }
-    });
+    };
+    harness.listeners.get('click')(event);
     await Promise.resolve();
     await Promise.resolve();
 
     assert.deepEqual(calls, ['repeat']);
+    assert.equal(event.__browseNavigationHandled, true);
     assert.equal(harness.warnings.length, 1);
     assert.match(String(harness.warnings[0][0]), /onRepeatNavigate/);
 });

--- a/developer/tests/js/legacyViewReadStatus.test.js
+++ b/developer/tests/js/legacyViewReadStatus.test.js
@@ -80,6 +80,32 @@ function it(name, fn) {
     }
 }
 
+describe('LegacyExamListView.render commit contract', () => {
+    it('fails closed when its container is unavailable', () => {
+        const { LegacyExamListView } = loadLegacyExamListView();
+        const view = new LegacyExamListView();
+
+        assert.strictEqual(view.render([]), false);
+    });
+
+    it('reports success only after committing the empty state', () => {
+        const { LegacyExamListView } = loadLegacyExamListView();
+        const view = new LegacyExamListView();
+        const container = {};
+        let emptyStateCommits = 0;
+        view._getContainer = () => container;
+        view._getLoadingIndicator = () => null;
+        view._renderEmptyState = (target) => {
+            assert.strictEqual(target, container);
+            emptyStateCommits += 1;
+        };
+        view._hideLoading = () => {};
+
+        assert.strictEqual(view.render([]), true);
+        assert.strictEqual(emptyStateCommits, 1);
+    });
+});
+
 describe('LegacyExamListView._getCompletionStatus', () => {
     it('reads score and timestamp from matching suite child entries', () => {
         const { windowStub, LegacyExamListView } = loadLegacyExamListView();

--- a/developer/tests/js/legacyViewReadStatus.test.js
+++ b/developer/tests/js/legacyViewReadStatus.test.js
@@ -107,6 +107,26 @@ describe('LegacyExamListView.render commit contract', () => {
 });
 
 describe('LegacyExamListView._getCompletionStatus', () => {
+    it('keeps a prepared completion map invisible until commit', () => {
+        const { windowStub, LegacyExamListView } = loadLegacyExamListView();
+        const view = new LegacyExamListView();
+        const exam = { id: 'staged-reading', title: 'Staged Reading' };
+        const prepared = windowStub.prepareBrowseCompletionIndex([{
+            examId: 'staged-reading',
+            title: 'Staged Reading',
+            percentage: 77,
+            date: '2026-08-23T00:00:00.000Z'
+        }]);
+
+        assert.strictEqual(
+            view._getCompletionStatus(exam),
+            null,
+            'preparation alone must not replace the accepted completion map'
+        );
+        assert.strictEqual(windowStub.commitBrowseCompletionIndex(prepared), true);
+        assert.strictEqual(view._getCompletionStatus(exam).percentage, 77);
+    });
+
     it('reads score and timestamp from matching suite child entries', () => {
         const { windowStub, LegacyExamListView } = loadLegacyExamListView();
         const view = new LegacyExamListView();

--- a/developer/tests/js/libraryManagerImportConfig.test.js
+++ b/developer/tests/js/libraryManagerImportConfig.test.js
@@ -138,6 +138,9 @@ function createHarness(seed = {}) {
 
     const context = vm.createContext(sandbox);
     loadScript('js/core/resourceCore.js', context);
+    if (seed.useAppStateService) {
+        loadScript('js/app/state-service.js', context);
+    }
     loadScript('js/services/libraryDiscovery.js', context);
     loadScript('js/services/libraryManager.js', context);
     return { window: windowStub, indexes, getActiveId: () => activeId, getConfigurations: () => clone(configurations) };
@@ -304,6 +307,7 @@ async function testIncrementalCreatesSnapshotAndDedupes() {
 
 async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
     const seed = baseSeed();
+    seed.useAppStateService = true;
     seed.library.importedIndexes.alt_config = [{
         id: 'listening-alt',
         examId: 'listening-alt',
@@ -318,11 +322,22 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
     const { window } = createHarness(seed);
     const manager = window.LibraryManager.getInstance();
     const before = await window.AppData.practice.list();
+    const revisionBeforeSwitch = window.getBrowseFilterMutationRevision();
     const applied = await manager.applyLibraryConfiguration('alt_config');
 
     assert.strictEqual(applied, true, '配置切换应该成功');
     assert.strictEqual(await window.AppData.library.getActive(), 'alt_config', '活动配置应切换到目标配置');
     assert.deepStrictEqual(await window.AppData.practice.list(), before, '配置切换不能触碰练习记录');
+    assert.strictEqual(
+        window.getBrowseFilterMutationRevision(),
+        revisionBeforeSwitch + 1,
+        '配置切换的权威 all/all 写入必须使首次 Browse hydration 失效'
+    );
+    assert.deepStrictEqual(
+        clone(window.getBrowseFilterState()),
+        { category: 'all', type: 'all' },
+        '配置切换后实时筛选状态必须保持 all/all'
+    );
 
     recordResult('切换题库配置不触碰练习记录', { activeKey: 'alt_config' });
 }

--- a/developer/tests/js/libraryManagerImportConfig.test.js
+++ b/developer/tests/js/libraryManagerImportConfig.test.js
@@ -323,6 +323,19 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
     const manager = window.LibraryManager.getInstance();
     const before = await window.AppData.practice.list();
     const revisionBeforeSwitch = window.getBrowseFilterMutationRevision();
+    const publicationOrder = [];
+    window.dispatchEvent = function dispatchEvent(event) {
+        if (event && event.type === 'examIndexLoaded') {
+            publicationOrder.push('index-publication');
+        }
+        return true;
+    };
+    window.startPracticeRecordsSyncInBackground = function startPracticeRecordsSyncInBackground(
+        trigger,
+        options
+    ) {
+        publicationOrder.push(`progress-sync:${trigger}:${options?.forceRender === true}`);
+    };
     const applied = await manager.applyLibraryConfiguration('alt_config');
 
     assert.strictEqual(applied, true, '配置切换应该成功');
@@ -337,6 +350,11 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
         clone(window.getBrowseFilterState()),
         { category: 'all', type: 'all' },
         '配置切换后实时筛选状态必须保持 all/all'
+    );
+    assert.deepStrictEqual(
+        publicationOrder,
+        ['index-publication', 'progress-sync:library-loaded:true'],
+        'direct configuration switches must publish the new index epoch before requesting progress sync'
     );
 
     recordResult('切换题库配置不触碰练习记录', { activeKey: 'alt_config' });
@@ -627,6 +645,31 @@ async function testRecordResolverFallsBackForLegacyRecordsWhenNoCustomLibraries(
     recordResult('无自定义题库时旧记录回退当前题库解析', { title: resolved.title });
 }
 
+async function testLibraryPublishesIndexBeforeProgressSync() {
+    const { window } = createHarness(baseSeed());
+    const order = [];
+    window.dispatchEvent = function dispatchEvent(event) {
+        if (event && event.type === 'examIndexLoaded') {
+            order.push('index-publication');
+        }
+        return true;
+    };
+    window.startPracticeRecordsSyncInBackground = function startPracticeRecordsSyncInBackground() {
+        order.push('progress-sync');
+    };
+
+    window.LibraryManager.getInstance().finishLibraryLoading(Date.now(), [
+        { id: 'published-index', type: 'reading', category: 'P1' }
+    ]);
+
+    assert.deepStrictEqual(
+        order,
+        ['index-publication', 'progress-sync'],
+        'a new library index epoch must be published before its progress sync captures ownership'
+    );
+    recordResult('题库索引先于同轮进度同步发布', { order });
+}
+
 async function main() {
     try {
         await testFullListeningCreatesSnapshotAndKeepsReading();
@@ -642,6 +685,7 @@ async function main() {
         await testFullReadingDoesNotReAddDefaultListeningWhenManifestMissing();
         await testRecordResolverUsesStoredLibraryProvenance();
         await testRecordResolverFallsBackForLegacyRecordsWhenNoCustomLibraries();
+        await testLibraryPublishesIndexBeforeProgressSync();
         console.log(JSON.stringify({
             status: 'pass',
             detail: `${results.length}/${results.length} 测试通过`,

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -15,6 +15,22 @@ function loadScript(relativePath, context) {
     vm.runInContext(source, context, { filename: relativePath });
 }
 
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index += 1) {
+        await Promise.resolve();
+    }
+}
+
 const results = [];
 
 function recordResult(name, passed, detail) {
@@ -249,6 +265,793 @@ async function testFallbackQueuesRepeatBrowseResetDuringLazyLoad() {
         'the repeat click must not run ordinary Browse navigation again'
     );
     recordResult('Browse 冷加载窗口保留重复导航重置意图', true, { resetCalls });
+}
+
+async function testColdRepeatResetPreemptsBrowseSynchronization() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const browseSynchronization = deferred();
+    const resetCompletion = deferred();
+    let synchronizationCalls = 0;
+    let resetCalls = 0;
+    let loadCalls = 0;
+    let resultsRequestId = 0;
+    let synchronizationRequestId = null;
+    let resetRequestId = null;
+    const callOrder = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const initialBrowseLoad = harness.windowStub.loadExamList();
+    const repeatReset = harness.windowStub.resetBrowseViewToAll();
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        callOrder.push('initialize-start');
+        synchronizationCalls += 1;
+        synchronizationRequestId = ++resultsRequestId;
+        return browseSynchronization.promise;
+    };
+    harness.windowStub.loadExamList = function loadExamList() {
+        loadCalls += 1;
+        resultsRequestId += 1;
+    };
+    harness.windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+        callOrder.push('reset-start');
+        resetCalls += 1;
+        resetRequestId = ++resultsRequestId;
+        return resetCompletion.promise;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks();
+
+    assert.strictEqual(synchronizationCalls, 1, 'the existing Browse synchronization should still start');
+    assert.strictEqual(resetCalls, 1, 'repeat reset should run as soon as the raw runtime is available');
+    assert.strictEqual(loadCalls, 0, 'the older Browse load should remain blocked on synchronization');
+    assert.deepStrictEqual(callOrder, ['initialize-start', 'reset-start']);
+    assert(resetRequestId > synchronizationRequestId, 'repeat reset must own the latest request token');
+    assert.strictEqual(resetRequestId, resultsRequestId);
+
+    browseSynchronization.resolve();
+    await flushMicrotasks();
+    assert.strictEqual(loadCalls, 0, 'an older lazy load must not reclaim the token while reset is pending');
+    assert.strictEqual(resetRequestId, resultsRequestId);
+
+    resetCompletion.resolve(true);
+    await Promise.all([initialBrowseLoad, repeatReset]);
+    assert.strictEqual(loadCalls, 0);
+    recordResult('Browse 冷启动重复重置可抢占旧同步', true, {
+        synchronizationCalls,
+        resetCalls,
+        loadCalls
+    });
+}
+
+async function testDirectResetInvalidatesPendingColdBrowseLoad() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const browseSynchronization = deferred();
+    const resetPreparation = deferred();
+    const loadArguments = [];
+    let resultsRequestId = 0;
+    let initializationRequestId = null;
+    let resetRequestId = null;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.browseStateManager = {
+        ready: resetPreparation.promise,
+        resetToAllExams() {}
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const initialBrowseLoad = harness.windowStub.loadExamList();
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        initializationRequestId = harness.windowStub.__beginBrowseResultsRequest();
+        return browseSynchronization.promise;
+    };
+    harness.windowStub.loadExamList = function loadExamList() {
+        const args = Array.prototype.slice.call(arguments);
+        loadArguments.push(args);
+        return Promise.resolve(args[0]);
+    };
+
+    // The Browse bundle installs the real reset before its raw loader promise resolves.
+    const contextConsole = harness.context.console;
+    harness.context.console = Object.assign({}, contextConsole, { log() {} });
+    loadScript('js/app/examActions.js', harness.context);
+    harness.context.console = contextConsole;
+    runtimeReady.resolve(true);
+    await flushMicrotasks();
+    assert.strictEqual(initializationRequestId, 1, 'Browse synchronization should own the first results token');
+
+    const directReset = harness.windowStub.ExamActions.resetBrowseViewToAll();
+    resetRequestId = resultsRequestId;
+    assert(resetRequestId > initializationRequestId, 'direct reset should invalidate initialization immediately');
+
+    browseSynchronization.resolve();
+    await flushMicrotasks();
+    assert.strictEqual(
+        loadArguments.length,
+        0,
+        'the pre-runtime load must stay invalidated while the direct reset awaits preparation'
+    );
+    assert.strictEqual(resultsRequestId, resetRequestId);
+
+    resetPreparation.resolve();
+    await Promise.all([initialBrowseLoad, directReset]);
+    assert.strictEqual(loadArguments.length, 1, 'only the reset-owned adapter load should run');
+    assert(Array.isArray(loadArguments[0][0]));
+    assert.strictEqual(loadArguments[0][1], resetRequestId);
+    recordResult('Browse handoff 期间的直接重置会淘汰旧加载', true, {
+        initializationRequestId,
+        resetRequestId,
+        loadCalls: loadArguments.length
+    });
+}
+
+async function testHotBrowseCategorySupersedesQueuedColdCategory() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const browseSynchronization = deferred();
+    let resultsRequestId = 0;
+    const appliedCategories = [];
+    const snapshotReads = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    loadScript('js/app/main-entry.js', harness.context);
+    const repeatReset = harness.windowStub.resetBrowseViewToAll();
+    const staleCategory = harness.windowStub.browseCategory('P1', 'reading');
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return browseSynchronization.promise;
+    };
+    harness.windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve(true);
+    };
+    harness.windowStub.browseCategory = function browseCategory(category) {
+        harness.windowStub.__beginBrowseResultsRequest();
+        appliedCategories.push(category);
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        snapshotReads.push(resultsRequestId);
+        return resultsRequestId;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks();
+    assert.strictEqual(snapshotReads[snapshotReads.length - 1], 2, 'cold category should snapshot after reset starts');
+    harness.windowStub.browseCategory('P4', 'reading');
+    assert.deepStrictEqual(appliedCategories, ['P4']);
+
+    browseSynchronization.resolve();
+    await Promise.all([repeatReset, staleCategory]);
+    assert.deepStrictEqual(
+        appliedCategories,
+        ['P4'],
+        'a queued cold category must not overwrite a newer hot category after handoff'
+    );
+    recordResult('热分类交互淘汰 handoff 中的旧冷分类', true, {
+        appliedCategories,
+        resultsRequestId
+    });
+}
+
+async function testQueuedFilterBeatsLaterExamIndexRefresh() {
+    const harness = createHarness();
+    harness.inputState.value = 'ocean';
+    const runtimeReady = deferred();
+    const browseSynchronization = deferred();
+    const filterCompletion = deferred();
+    const listeners = new Map();
+    const callOrder = [];
+    let skippedBackgroundLoads = 0;
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const queuedFilter = harness.windowStub.filterByType('reading');
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return browseSynchronization.promise;
+    };
+    harness.windowStub.filterByType = function filterByType(type) {
+        harness.windowStub.__beginBrowseResultsRequest();
+        callOrder.push(`filter:${type}`);
+        return filterCompletion.promise;
+    };
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        if (!harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+            skippedBackgroundLoads += 1;
+            return false;
+        }
+        callOrder.push('background-load');
+        return index;
+    };
+    harness.windowStub.searchExams = function searchExams(query, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        if (!harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+            skippedBackgroundLoads += 1;
+            return false;
+        }
+        callOrder.push(`background-search:${query}`);
+        return query;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks();
+    browseSynchronization.resolve();
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(callOrder, ['filter:reading'], 'the earlier user filter should start before background refresh');
+    assert.strictEqual(skippedBackgroundLoads, 0, 'a stale background search must stand down before calling the adapter');
+    assert.strictEqual(resultsRequestId, 2, 'background refresh must not claim a new results token');
+
+    filterCompletion.resolve(true);
+    await queuedFilter;
+    recordResult('冷筛选优先于稍后登记的题库索引刷新', true, {
+        callOrder,
+        skippedBackgroundLoads,
+        resultsRequestId
+    });
+}
+
+async function testExamIndexRefreshPreservesActiveSearch() {
+    const harness = createHarness();
+    const listeners = new Map();
+    const calls = [];
+    let resultsRequestId = 0;
+    let finalRender = null;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        const requestId = harness.windowStub.__beginBrowseResultsRequest();
+        calls.push(`init:${requestId}`);
+        return Promise.resolve();
+    };
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    harness.windowStub.searchExams = function searchExams(query, renderRequestId) {
+        const requestId = renderRequestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : renderRequestId;
+        if (!harness.windowStub.__isBrowseResultsRequestCurrent(requestId)) {
+            return false;
+        }
+        calls.push(`search:${query}:${requestId}`);
+        finalRender = `search:${query}`;
+    };
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        calls.push(`background:${activeRequestId}`);
+        finalRender = 'background';
+        return index;
+    };
+    harness.inputState.value = 'ocean';
+    harness.windowStub.searchExams('ocean');
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(calls, ['init:1', 'search:ocean:2', 'search:ocean:2']);
+    assert.strictEqual(finalRender, 'search:ocean', 'background index refresh must preserve active search results');
+    recordResult('题库索引刷新保留活动搜索', true, { calls, finalRender });
+}
+
+async function testExamIndexRefreshStandsDownDuringReset() {
+    const harness = createHarness();
+    const resetIndex = deferred();
+    const listeners = new Map();
+    let resultsRequestId = 0;
+    let searchCalls = 0;
+    let resolverCalls = 0;
+    const loadedIndexes = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.resolveActiveLibraryIndex = function resolveActiveLibraryIndex() {
+        resolverCalls += 1;
+        return resetIndex.promise;
+    };
+    harness.windowStub.browseStateManager = {
+        ready: Promise.resolve(),
+        resetToAllExams() {
+            harness.inputState.value = '';
+        }
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    const contextConsole = harness.context.console;
+    harness.context.console = Object.assign({}, contextConsole, { log() {} });
+    loadScript('js/app/examActions.js', harness.context);
+    harness.context.console = contextConsole;
+    harness.windowStub.searchExams = function searchExams() {
+        searchCalls += 1;
+    };
+    harness.windowStub.loadExamList = function loadExamList(index) {
+        loadedIndexes.push(Array.isArray(index) ? index.map((exam) => exam.id) : null);
+        return Promise.resolve(index);
+    };
+    harness.inputState.value = 'ocean';
+
+    const reset = harness.windowStub.ExamActions.resetBrowseViewToAll();
+    assert.strictEqual(harness.windowStub.__isBrowseResetIntentInFlight(), true);
+    await flushMicrotasks();
+    assert.strictEqual(resolverCalls, 1, 'reset must resolve the active index after restoration finishes');
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    await flushMicrotasks();
+    assert.strictEqual(searchCalls, 0, 'index refresh must not replay an old query during reset preparation');
+    assert.strictEqual(loadedIndexes.length, 0, 'index refresh must not share an in-flight reset token');
+
+    resetIndex.resolve([{ id: 'stale-index' }]);
+    await reset;
+    assert.strictEqual(searchCalls, 0);
+    assert.deepStrictEqual(loadedIndexes, [['fresh-index']], 'reset must render the latest active index');
+    assert.strictEqual(harness.windowStub.__isBrowseResetIntentInFlight(), false);
+    recordResult('题库索引刷新在重置期间让行', true, {
+        searchCalls,
+        loadedIndexes,
+        resolverCalls,
+        resultsRequestId
+    });
+}
+
+async function testExamIndexRefreshDuringResetRenderUsesLatestSnapshot() {
+    const harness = createHarness();
+    const firstRender = deferred();
+    const secondRender = deferred();
+    const listeners = new Map();
+    let resultsRequestId = 0;
+    const loadedIndexes = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.resolveActiveLibraryIndex = function resolveActiveLibraryIndex() {
+        return Promise.resolve([{ id: 'initial-index' }]);
+    };
+    harness.windowStub.browseStateManager = {
+        ready: Promise.resolve(),
+        resetToAllExams() {
+            harness.inputState.value = '';
+        }
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    const contextConsole = harness.context.console;
+    harness.context.console = Object.assign({}, contextConsole, { log() {} });
+    loadScript('js/app/examActions.js', harness.context);
+    harness.context.console = contextConsole;
+    harness.windowStub.loadExamList = function loadExamList(index) {
+        loadedIndexes.push(Array.isArray(index) ? index.map((exam) => exam.id) : null);
+        if (loadedIndexes.length === 1) return firstRender.promise;
+        if (loadedIndexes.length === 2) return secondRender.promise;
+        return Promise.resolve(index);
+    };
+
+    const reset = harness.windowStub.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks(32);
+    assert.deepStrictEqual(loadedIndexes, [['initial-index']]);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    await flushMicrotasks();
+    assert.deepStrictEqual(loadedIndexes, [['initial-index']], 'the event must not start a competing load');
+
+    firstRender.resolve([{ id: 'initial-index' }]);
+    await flushMicrotasks();
+    assert.deepStrictEqual(loadedIndexes, [['initial-index'], ['fresh-index']]);
+    secondRender.resolve([{ id: 'fresh-index' }]);
+    queueMicrotask(() => {
+        listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'final-index' }] } });
+    });
+    await reset;
+    await flushMicrotasks();
+    assert.deepStrictEqual(
+        loadedIndexes,
+        [['initial-index'], ['fresh-index'], ['final-index']],
+        'a final microtask event must run through reset replay or the normal background refresh'
+    );
+    assert.strictEqual(harness.windowStub.__isBrowseResetIntentInFlight(), false);
+    recordResult('重置渲染期间采用最新题库快照', true, { loadedIndexes, resultsRequestId });
+}
+
+async function testBrowseResetIntentClearsAfterRuntimeFailure() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const reset = harness.windowStub.resetBrowseViewToAll();
+    assert.strictEqual(harness.windowStub.__isBrowseResetIntentInFlight(), true);
+    runtimeReady.reject(new Error('browse runtime failed'));
+    await assert.rejects(reset, /browse runtime failed/);
+    assert.strictEqual(
+        harness.windowStub.__isBrowseResetIntentInFlight(),
+        false,
+        'a rejected lazy runtime must release its reset intent'
+    );
+    recordResult('Browse runtime 失败后释放重置意图', true);
+}
+
+async function testBrowseResetIntentClearsAfterResetFailure() {
+    const harness = createHarness();
+    const resetIndex = deferred();
+    const listeners = new Map();
+    const loadedIndexes = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.resolveActiveLibraryIndex = function resolveActiveLibraryIndex() {
+        return resetIndex.promise;
+    };
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    const contextConsole = harness.context.console;
+    harness.context.console = Object.assign({}, contextConsole, { log() {}, warn() {} });
+    loadScript('js/app/examActions.js', harness.context);
+    harness.windowStub.browseStateManager = {
+        ready: Promise.resolve(),
+        resetToAllExams() {
+            throw new Error('reset state failed');
+        }
+    };
+    harness.windowStub.loadExamList = function loadExamList(index) {
+        loadedIndexes.push(Array.isArray(index) ? index.map((exam) => exam.id) : null);
+        return Promise.resolve(index);
+    };
+    harness.inputState.value = '';
+
+    const reset = harness.windowStub.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks();
+    resetIndex.resolve([{ id: 'initial-index' }]);
+    queueMicrotask(() => {
+        listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    });
+    const result = await reset;
+    await flushMicrotasks();
+    harness.context.console = contextConsole;
+    assert.strictEqual(result, false);
+    assert.deepStrictEqual(
+        loadedIndexes,
+        [['fresh-index']],
+        'an event queued behind a failing reset continuation must use the normal refresh path'
+    );
+    assert.strictEqual(
+        harness.windowStub.__isBrowseResetIntentInFlight(),
+        false,
+        'a failed real reset must release its reset intent'
+    );
+    recordResult('真实重置失败后释放重置意图', true, { loadedIndexes, resultsRequestId });
+}
+
+async function testBrowseResetAdapterFailureReplaysCapturedIndex() {
+    const harness = createHarness();
+    const failingRender = deferred();
+    const listeners = new Map();
+    const loadedIndexes = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.resolveActiveLibraryIndex = function resolveActiveLibraryIndex() {
+        return Promise.resolve([{ id: 'initial-index' }]);
+    };
+    harness.windowStub.browseStateManager = {
+        ready: Promise.resolve(),
+        resetToAllExams() {
+            harness.inputState.value = '';
+        }
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    const contextConsole = harness.context.console;
+    harness.context.console = Object.assign({}, contextConsole, { log() {}, warn() {} });
+    loadScript('js/app/examActions.js', harness.context);
+    harness.windowStub.loadExamList = function loadExamList(index) {
+        loadedIndexes.push(Array.isArray(index) ? index.map((exam) => exam.id) : null);
+        return loadedIndexes.length === 1 ? failingRender.promise : Promise.resolve(index);
+    };
+
+    const reset = harness.windowStub.ExamActions.resetBrowseViewToAll();
+    await flushMicrotasks(32);
+    assert.deepStrictEqual(loadedIndexes, [['initial-index']]);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    await flushMicrotasks();
+    assert.deepStrictEqual(loadedIndexes, [['initial-index']]);
+
+    failingRender.reject(new Error('adapter failed'));
+    assert.strictEqual(await reset, false);
+    await flushMicrotasks(32);
+    harness.context.console = contextConsole;
+    assert.deepStrictEqual(
+        loadedIndexes,
+        [['initial-index'], ['fresh-index']],
+        'an index captured before adapter rejection must be replayed after the reset releases ownership'
+    );
+    assert.strictEqual(harness.windowStub.__isBrowseResetIntentInFlight(), false);
+    recordResult('重置适配器失败后重放最新题库索引', true, { loadedIndexes, resultsRequestId });
+}
+
+async function testFailedResetReplayCannotBorrowNewResetToken() {
+    const harness = createHarness();
+    let resultsRequestId = 0;
+    const searches = [];
+    const loads = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    harness.windowStub.searchExams = function searchExams(query, requestId) {
+        searches.push([query, requestId]);
+    };
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        loads.push([Array.isArray(index) ? index.map((exam) => exam.id) : null, requestId]);
+    };
+    harness.inputState.value = 'old-query';
+
+    const oldIntent = harness.windowStub.__beginBrowseResetIntent();
+    const oldRequestId = harness.windowStub.__beginBrowseResultsRequest();
+    harness.windowStub.__setBrowseResetResultsRequest(oldIntent, oldRequestId);
+    harness.windowStub.__captureBrowseResetIndexSnapshot([{ id: 'old-index' }]);
+    harness.windowStub.__endBrowseResetIntent(oldIntent);
+
+    const newIntent = harness.windowStub.__beginBrowseResetIntent();
+    const newRequestId = harness.windowStub.__beginBrowseResultsRequest();
+    harness.windowStub.__setBrowseResetResultsRequest(newIntent, newRequestId);
+    await flushMicrotasks(32);
+
+    assert.strictEqual(newRequestId > oldRequestId, true);
+    assert.deepStrictEqual(searches, [], 'an old replay must not use the newer reset request token');
+    assert.deepStrictEqual(loads, [], 'an old replay must stand down after a newer reset starts');
+    harness.windowStub.__endBrowseResetIntent(newIntent);
+    recordResult('失败重置重放不得借用后续重置 token', true, {
+        oldRequestId,
+        newRequestId,
+        searches,
+        loads
+    });
+}
+
+async function testQueuedFilterSupersedesOlderPendingCategory() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const browseSynchronization = deferred();
+    const calls = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__pendingBrowseFilter = {
+        category: 'P1',
+        type: 'reading',
+        filterMode: null,
+        path: null
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const queuedFilter = harness.windowStub.filterByType('all');
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return browseSynchronization.promise;
+    };
+    harness.windowStub.applyBrowseFilter = function applyBrowseFilter(category, type, filterMode, path, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        if (harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+            calls.push(`pending:${category}:${activeRequestId}`);
+        }
+        return Promise.resolve();
+    };
+    harness.windowStub.filterByType = function filterByType(type) {
+        const requestId = harness.windowStub.__beginBrowseResultsRequest();
+        calls.push(`filter:${type}:${requestId}`);
+        return Promise.resolve();
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks();
+    browseSynchronization.resolve();
+    await queuedFilter;
+
+    assert.deepStrictEqual(calls, ['pending:P1:1', 'filter:all:2']);
+    assert.strictEqual(resultsRequestId, 2);
+    assert.strictEqual(harness.windowStub.__pendingBrowseFilter, undefined);
+    recordResult('较新的冷筛选可覆盖旧 pending 分类', true, { calls, resultsRequestId });
 }
 
 async function testClearSearchProxyLoadsBrowseRuntime(harness) {
@@ -585,6 +1388,18 @@ async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testFallbackQueuesRepeatBrowseResetDuringLazyLoad();
+        await testColdRepeatResetPreemptsBrowseSynchronization();
+        await testDirectResetInvalidatesPendingColdBrowseLoad();
+        await testHotBrowseCategorySupersedesQueuedColdCategory();
+        await testQueuedFilterBeatsLaterExamIndexRefresh();
+        await testExamIndexRefreshPreservesActiveSearch();
+        await testExamIndexRefreshStandsDownDuringReset();
+        await testExamIndexRefreshDuringResetRenderUsesLatestSnapshot();
+        await testBrowseResetIntentClearsAfterRuntimeFailure();
+        await testBrowseResetIntentClearsAfterResetFailure();
+        await testBrowseResetAdapterFailureReplaysCapturedIndex();
+        await testFailedResetReplayCannotBorrowNewResetToken();
+        await testQueuedFilterSupersedesOlderPendingCategory();
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
         await testColdBrowseProxyRestoresPreferences(createHarness());
         await testColdBrowseAppliesExplicitPendingFilter(createHarness());

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -287,7 +287,7 @@ async function testFailedBrowseResetBarrierStopsQueuedLoaderProxy() {
 
     runtimeReady.resolve(true);
     resetBarrier.resolve(false);
-    assert.strictEqual(await queuedLoad, false);
+    assert.strictEqual(await queuedLoad, false, 'the queued loader must observe the failed reset barrier');
     assert.strictEqual(initializationCalls, 0, 'a failed reset barrier must skip active-view synchronization');
     assert.strictEqual(realLoadCalls, 0, 'a failed reset barrier must stop the already queued loader proxy');
 
@@ -328,7 +328,7 @@ async function testAtomicForegroundRecoveryCancelsOnlyStaleRetryBarrier() {
         failedReset.promise
     );
     failedReset.resolve(false);
-    assert.strictEqual(await failedBarrier, false);
+    assert.strictEqual(await failedBarrier, false, 'the functional reset fixture must enter failed state');
     await flushMicrotasks();
     assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'failed');
 
@@ -1887,6 +1887,81 @@ async function testColdBrowseProxyRestoresPreferences(harness) {
     });
 }
 
+async function testColdBrowseSynchronizationRejectsNavigationAba() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const pendingFilter = {
+        category: 'P3',
+        type: 'reading',
+        filterMode: 'default',
+        path: 'ReadingPractice/P3'
+    };
+    const initializationCalls = [];
+    const appliedFilters = [];
+    let activeView = 'browse';
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(
+        harness.windowStub.document
+    );
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') {
+            return { id: `${activeView}-view` };
+        }
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.__pendingBrowseFilter = pendingFilter;
+    harness.windowStub.initializeBrowseView = function initializeBrowseView(options) {
+        initializationCalls.push(options || {});
+        return Promise.resolve(true);
+    };
+    harness.windowStub.applyBrowseFilter = function applyBrowseFilter(...args) {
+        appliedFilters.push(args);
+        return Promise.resolve(true);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const staleBrowseSynchronization = harness.windowStub.AppEntry.ensureBrowseGroup();
+    await flushMicrotasks();
+    harness.windowStub.__markAppNavigationIntent();
+    activeView = 'overview';
+    harness.windowStub.__markAppNavigationIntent();
+    activeView = 'browse';
+    runtimeReady.resolve(true);
+
+    assert.strictEqual(
+        await staleBrowseSynchronization,
+        false,
+        'a cold synchronization lease must fail closed after a Browse navigation ABA'
+    );
+    assert.deepStrictEqual(
+        initializationCalls,
+        [],
+        'the stale cold lease must not initialize the newer Browse activation'
+    );
+    assert.deepStrictEqual(appliedFilters, []);
+    assert.strictEqual(
+        harness.windowStub.__pendingBrowseFilter,
+        undefined,
+        'the stale lease may discard only the pending identity it originally captured'
+    );
+
+    assert.strictEqual(await harness.windowStub.AppEntry.ensureBrowseGroup(), true);
+    assert.strictEqual(initializationCalls.length, 1);
+    assert.strictEqual(initializationCalls[0].skipLoad, false);
+    assert.deepStrictEqual(
+        appliedFilters,
+        [],
+        'the current activation must not adopt the stale pending category'
+    );
+    recordResult('冷 Browse 同步绑定导航 epoch', true, {
+        initializationCalls: initializationCalls.length,
+        appliedFilters: appliedFilters.length
+    });
+}
+
 async function testColdBrowseRetryRetainsPendingFilterAfterRetryableInitializationFailure() {
     const harness = createHarness();
     const pendingFilter = {
@@ -2290,6 +2365,7 @@ async function main() {
         await testQueuedFilterSupersedesOlderPendingCategory();
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
         await testColdBrowseProxyRestoresPreferences(createHarness());
+        await testColdBrowseSynchronizationRejectsNavigationAba();
         await testColdBrowseRetryRetainsPendingFilterAfterRetryableInitializationFailure();
         await testColdBrowseAppliesExplicitPendingFilter(createHarness());
         await testColdBrowseRuntimeInitializesNavigationAndStateManager();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -187,6 +187,7 @@ async function testRandomPracticeEnsuresBrowseRuntime(harness) {
     loadScript('js/presentation/app-actions.js', harness.context);
 
     await harness.windowStub.AppActions.startRandomPractice('all', 'reading');
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
 
     assert(harness.ensureCalls.includes('browse-runtime'), '随机练习应主动确保 browse-runtime 已加载');
     assert.strictEqual(harness.windowStub.__openedExamId, 'reading-1', '随机练习应在严格按需模式下仍能打开题目');
@@ -194,6 +195,60 @@ async function testRandomPracticeEnsuresBrowseRuntime(harness) {
         ensureCalls: harness.ensureCalls,
         openedExamId: harness.windowStub.__openedExamId
     });
+}
+
+async function testFallbackQueuesRepeatBrowseResetDuringLazyLoad() {
+    const harness = createHarness();
+    let fallbackHandler = null;
+    let resetCalls = 0;
+    const showViewCalls = [];
+    const button = {
+        classList: {
+            contains(value) { return value === 'active'; }
+        },
+        getAttribute(name) { return name === 'data-view' ? 'browse' : null; }
+    };
+    const navRoot = {
+        contains(value) { return value === button; },
+        addEventListener(type, handler) {
+            if (type === 'click') fallbackHandler = handler;
+        },
+        querySelectorAll() { return []; },
+        querySelector() { return null; }
+    };
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.main-nav') return navRoot;
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.showView = function showView(viewName, resetCategory) {
+        showViewCalls.push({ viewName, resetCategory });
+    };
+    harness.windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+        resetCalls += 1;
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/boot-fallbacks.js', harness.context);
+    assert(fallbackHandler, 'strict on-demand startup should install the temporary navigation handler');
+    const showCallsBeforeRepeat = showViewCalls.length;
+    fallbackHandler({
+        preventDefault() {},
+        target: {
+            closest(selector) {
+                return selector === '.nav-btn[data-view]' ? button : null;
+            }
+        }
+    });
+    await Promise.resolve();
+
+    assert.strictEqual(resetCalls, 1, 'a repeat Browse click during lazy load must queue the reset intent');
+    assert.strictEqual(
+        showViewCalls.length,
+        showCallsBeforeRepeat,
+        'the repeat click must not run ordinary Browse navigation again'
+    );
+    recordResult('Browse 冷加载窗口保留重复导航重置意图', true, { resetCalls });
 }
 
 async function testClearSearchProxyLoadsBrowseRuntime(harness) {
@@ -246,6 +301,153 @@ async function testColdBrowseProxyRestoresPreferences(harness) {
     recordResult('browse 冷加载后恢复持久化偏好', true, {
         initializationCalls: initializationCalls.length,
         realLoadCalls
+    });
+}
+
+async function testColdBrowseAppliesExplicitPendingFilter(harness) {
+    const initializationCalls = [];
+    const appliedFilters = [];
+    const pendingFilter = {
+        category: 'P4',
+        type: 'listening',
+        filterMode: 'default',
+        path: 'ListeningPractice/P4'
+    };
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') {
+            return { id: 'browse-view' };
+        }
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.__pendingBrowseFilter = pendingFilter;
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.initializeBrowseView = async function initializeBrowseView(options) {
+                initializationCalls.push(options || {});
+            };
+            harness.windowStub.applyBrowseFilter = async function applyBrowseFilter(...args) {
+                appliedFilters.push(args);
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+
+    assert.strictEqual(
+        initializationCalls.length,
+        1,
+        'cold Browse activation should initialize exactly once when a category is pending'
+    );
+    assert.strictEqual(
+        initializationCalls[0].skipLoad,
+        true,
+        'cold Browse activation should initialize without an unfiltered render when a category is pending'
+    );
+    assert.deepStrictEqual(appliedFilters, [[
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path
+    ]], 'cold Browse activation should preserve and apply the explicit category intent');
+    assert.strictEqual(
+        harness.windowStub.__pendingBrowseFilter,
+        undefined,
+        'the applied cold-start category intent should be cleared'
+    );
+    recordResult('browse 冷加载保留显式分类意图', true, {
+        initializationCalls: initializationCalls.length,
+        appliedFilters: appliedFilters.length
+    });
+}
+
+async function testColdBrowseRuntimeInitializesNavigationAndStateManager() {
+    const harness = createHarness();
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    const fallbackHandler = function fallbackNavigation() {};
+    let fallbackRemovals = 0;
+    const navRoot = {
+        _legacyNavHandler: fallbackHandler,
+        removeEventListener(type, handler) {
+            if (type === 'click' && handler === fallbackHandler) {
+                fallbackRemovals += 1;
+            }
+        }
+    };
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.main-nav') {
+            return navRoot;
+        }
+        if (selector === '.view.active') {
+            return { id: 'browse-view' };
+        }
+        return originalQuerySelector(selector);
+    };
+
+    let navigationEnsureCalls = 0;
+    let navigationOptions = null;
+    let stateManagerCreations = 0;
+    let repeatResets = 0;
+    const showViewCalls = [];
+    harness.windowStub.showView = function showView(viewName, resetCategory) {
+        showViewCalls.push({ viewName, resetCategory });
+    };
+    harness.windowStub.NavigationController = {
+        ensure(options) {
+            navigationEnsureCalls += 1;
+            if (typeof harness.windowStub.ensureLegacyNavigationController !== 'function') {
+                return null;
+            }
+            navigationOptions = options;
+            return harness.windowStub.ensureLegacyNavigationController(options);
+        }
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.ensureLegacyNavigationController = function ensureLegacyNavigationController() {
+                return { mounted: true };
+            };
+            harness.windowStub.BrowseStateManager = function BrowseStateManager() {
+                stateManagerCreations += 1;
+                this.ready = Promise.resolve();
+                harness.windowStub.browseStateManager = this;
+            };
+            harness.windowStub.resetBrowseViewToAll = function resetBrowseViewToAll() {
+                repeatResets += 1;
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    loadScript('js/presentation/app-actions.js', harness.context);
+    await harness.windowStub.AppActions.preloadBrowseView();
+
+    assert.strictEqual(navigationEnsureCalls, 2, 'Browse 预取应在冷启动和懒加载完成后各尝试初始化导航');
+    assert.strictEqual(stateManagerCreations, 1, 'BrowseStateManager 应在懒加载完成后仅实例化一次');
+    assert(harness.windowStub.browseStateManager, '冷启动 Browse 应暴露全局状态管理器实例');
+    assert.strictEqual(fallbackRemovals, 1, '真实导航控制器挂载后应移除临时 fallback click handler');
+    assert.strictEqual(navRoot._legacyNavHandler, undefined, 'fallback handler 标记应在升级后清理');
+    assert(navigationOptions && typeof navigationOptions.onRepeatNavigate === 'function');
+    assert.strictEqual(navigationOptions.initialView, 'browse', '导航升级必须保留 fallback 已激活的 Browse 高亮');
+
+    navigationOptions.onNavigate('browse');
+    assert.deepStrictEqual(
+        showViewCalls.at(-1),
+        { viewName: 'browse', resetCategory: false },
+        '普通 Browse 导航必须保留当前分类和筛选状态'
+    );
+    navigationOptions.onRepeatNavigate('browse');
+    assert.strictEqual(repeatResets, 1, '懒加载后的重复 Browse 点击应进入 reset handler');
+    recordResult('browse 冷加载后补齐导航与状态管理器', true, {
+        navigationEnsureCalls,
+        stateManagerCreations,
+        fallbackRemovals,
+        repeatResets
     });
 }
 
@@ -382,8 +584,11 @@ async function testSuiteRecoveryCancelDoesNotMutateSession() {
 async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
+        await testFallbackQueuesRepeatBrowseResetDuringLazyLoad();
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
         await testColdBrowseProxyRestoresPreferences(createHarness());
+        await testColdBrowseAppliesExplicitPendingFilter(createHarness());
+        await testColdBrowseRuntimeInitializesNavigationAndStateManager();
         await testMoreViewActivationLoadsTools(createHarness());
         await testSuiteRecoveryRequiresExplicitContinueChoice();
         await testSuiteRecoveryAbandonThenStartsFreshSuite();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -257,6 +257,66 @@ async function testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView() {
     recordResult('原始 Browse runtime 加载等待功能重置后再同步视图', true);
 }
 
+async function testCompletedBrowseResetBarrierRetiresCachedLease() {
+    const harness = createHarness();
+    harness.windowStub.document.readyState = 'loading';
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(
+        harness.windowStub.document
+    );
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    let resultsRequestId = 0;
+    let initializationCalls = 0;
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(
+        requestId
+    ) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        initializationCalls += 1;
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const resetBarrier = harness.windowStub.AppEntry.registerBrowseFunctionalResetBarrier(
+        Promise.resolve(true)
+    );
+    assert.strictEqual(await resetBarrier, true);
+    assert.strictEqual(await harness.windowStub.AppEntry.ensureBrowseGroup(), true);
+    assert.strictEqual(initializationCalls, 1);
+    assert.strictEqual(
+        harness.windowStub.__getBrowseFunctionalResetState().status,
+        'succeeded'
+    );
+
+    const userFilterRequestId = harness.windowStub.__beginBrowseResultsRequest();
+    assert.strictEqual(await harness.windowStub.AppEntry.ensureBrowseGroup(), true);
+    assert.strictEqual(
+        initializationCalls,
+        1,
+        'an already completed barrier must not force a second active-view synchronization'
+    );
+    assert.strictEqual(
+        resultsRequestId,
+        userFilterRequestId,
+        'cached synchronization must not steal the newer user filter token'
+    );
+    recordResult('已完成的 Browse 重置屏障会从缓存 lease 精确退休', true, {
+        initializationCalls,
+        userFilterRequestId
+    });
+}
+
 async function testFailedBrowseResetBarrierStopsQueuedLoaderProxy() {
     const harness = createHarness();
     const runtimeReady = deferred();
@@ -2336,6 +2396,7 @@ async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView();
+        await testCompletedBrowseResetBarrierRetiresCachedLease();
         await testFailedBrowseResetBarrierStopsQueuedLoaderProxy();
         await testAtomicForegroundRecoveryCancelsOnlyStaleRetryBarrier();
         await testColdFallbackLetsBrowseSynchronizationOwnRender();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -298,6 +298,89 @@ async function testFailedBrowseResetBarrierStopsQueuedLoaderProxy() {
     recordResult('失败的 Browse 重置屏障会阻止已排队 loader', true, { initializationCalls, realLoadCalls });
 }
 
+async function testAtomicForegroundRecoveryCancelsOnlyStaleRetryBarrier() {
+    const harness = createHarness();
+    harness.windowStub.document.readyState = 'loading';
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(
+        harness.windowStub.document
+    );
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    let resultsRequestId = 0;
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(
+        requestId
+    ) {
+        return requestId === resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const failedReset = deferred();
+    const failedBarrier = harness.windowStub.AppEntry.registerBrowseFunctionalResetBarrier(
+        failedReset.promise
+    );
+    failedReset.resolve(false);
+    assert.strictEqual(await failedBarrier, false);
+    await flushMicrotasks();
+    assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'failed');
+
+    const retryReset = deferred();
+    const retryBarrier = harness.windowStub.AppEntry.registerBrowseFunctionalResetBarrier(
+        retryReset.promise
+    );
+    const retryRequestId = resultsRequestId;
+    assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'pending');
+    assert.strictEqual(
+        harness.windowStub.AppEntry.prepareBrowseFunctionalResetRecoveryForForeground(
+            retryRequestId
+        ),
+        null,
+        'the retry canonical request must retain its own current barrier'
+    );
+    assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'pending');
+
+    const foregroundRequestId = harness.windowStub.__beginBrowseResultsRequest();
+    const prepared = harness.windowStub.AppEntry
+        .prepareBrowseFunctionalResetRecoveryForForeground(foregroundRequestId);
+    assert.ok(prepared && prepared.recovery, 'the newer foreground request must receive a recovery lease');
+    assert.strictEqual(prepared.recovery.resultsRequestId, foregroundRequestId);
+    assert.strictEqual(
+        prepared.functionalResetGeneration,
+        harness.windowStub.__getBrowseFunctionalResetState().generation
+    );
+    assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'failed');
+    assert.strictEqual(Object.hasOwn(prepared, 'barrier'), false, 'the API must not expose the raw barrier');
+    assert.strictEqual(
+        harness.windowStub.AppEntry.completeBrowseFunctionalResetRecovery(
+            prepared.recovery,
+            true
+        ),
+        true
+    );
+    assert.strictEqual(harness.windowStub.__getBrowseFunctionalResetState().status, 'succeeded');
+
+    retryReset.resolve(true);
+    assert.strictEqual(await retryBarrier, true);
+    await flushMicrotasks();
+    assert.strictEqual(
+        harness.windowStub.__getBrowseFunctionalResetState().status,
+        'succeeded',
+        'the canceled retry must not reclaim the recovery committed by the newer foreground request'
+    );
+    recordResult('前台恢复原子边界仅取消 stale retry barrier', true, {
+        retryRequestId,
+        foregroundRequestId
+    });
+}
+
 async function testColdFallbackLetsBrowseSynchronizationOwnRender() {
     const harness = createHarness();
     let initializationCalls = 0;
@@ -1804,6 +1887,98 @@ async function testColdBrowseProxyRestoresPreferences(harness) {
     });
 }
 
+async function testColdBrowseRetryRetainsPendingFilterAfterRetryableInitializationFailure() {
+    const harness = createHarness();
+    const pendingFilter = {
+        category: 'P2',
+        type: 'reading',
+        filterMode: 'default',
+        path: 'ReadingPractice/P2'
+    };
+    const appliedFilters = [];
+    const releasedRequests = [];
+    let initializationAttempt = 0;
+    let resultsRequestId = 0;
+    let successfulInitializationRequestId = null;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(
+        harness.windowStub.document
+    );
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') {
+            return { id: 'browse-view' };
+        }
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.__pendingBrowseFilter = pendingFilter;
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__retainBrowseUserResultsRequest = function retainBrowseUserResultsRequest(requestId) {
+        return requestId;
+    };
+    harness.windowStub.__endBrowseUserResultsRequest = function endBrowseUserResultsRequest(requestId) {
+        releasedRequests.push(requestId);
+        resultsRequestId += 1;
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+                initializationAttempt += 1;
+                const requestId = harness.windowStub.__beginBrowseResultsRequest();
+                if (initializationAttempt === 2) {
+                    successfulInitializationRequestId = requestId;
+                }
+                return Promise.resolve(initializationAttempt === 1
+                    ? null
+                    : [{ id: 'p2-reading', category: 'P2', type: 'reading' }]);
+            };
+            harness.windowStub.applyBrowseFilter = function applyBrowseFilter(...args) {
+                appliedFilters.push(args);
+                return Promise.resolve(true);
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+
+    assert.strictEqual(await harness.windowStub.AppEntry.ensureBrowseGroup(), false);
+    assert.strictEqual(
+        harness.windowStub.__pendingBrowseFilter,
+        pendingFilter,
+        'a retryable cold initialization failure must retain the pending category intent'
+    );
+    assert.deepStrictEqual(appliedFilters, []);
+
+    assert.strictEqual(await harness.windowStub.AppEntry.ensureBrowseGroup(), true);
+    assert.strictEqual(initializationAttempt, 2);
+    assert.deepStrictEqual(appliedFilters, [[
+        pendingFilter.category,
+        pendingFilter.type,
+        pendingFilter.filterMode,
+        pendingFilter.path,
+        successfulInitializationRequestId
+    ]]);
+    assert.deepStrictEqual(releasedRequests, [1, successfulInitializationRequestId]);
+    assert.strictEqual(
+        harness.windowStub.__pendingBrowseFilter,
+        undefined,
+        'the successful cold retry must consume the pending category intent exactly once'
+    );
+    recordResult('冷入口可重试失败保留 pending 分类', true, {
+        initializationAttempt,
+        appliedFilters: appliedFilters.length
+    });
+}
+
 async function testColdBrowseAppliesExplicitPendingFilter(harness) {
     const initializationCalls = [];
     const appliedFilters = [];
@@ -1829,6 +2004,7 @@ async function testColdBrowseAppliesExplicitPendingFilter(harness) {
             };
             harness.windowStub.applyBrowseFilter = async function applyBrowseFilter(...args) {
                 appliedFilters.push(args);
+                return true;
             };
         }
         return Promise.resolve(true);
@@ -2086,6 +2262,7 @@ async function main() {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView();
         await testFailedBrowseResetBarrierStopsQueuedLoaderProxy();
+        await testAtomicForegroundRecoveryCancelsOnlyStaleRetryBarrier();
         await testColdFallbackLetsBrowseSynchronizationOwnRender();
         await testFallbackQueuesRepeatBrowseResetDuringLazyLoad();
         await testColdRepeatResetPreemptsBrowseSynchronization();
@@ -2113,6 +2290,7 @@ async function main() {
         await testQueuedFilterSupersedesOlderPendingCategory();
         await testClearSearchProxyLoadsBrowseRuntime(createHarness());
         await testColdBrowseProxyRestoresPreferences(createHarness());
+        await testColdBrowseRetryRetainsPendingFilterAfterRetryableInitializationFailure();
         await testColdBrowseAppliesExplicitPendingFilter(createHarness());
         await testColdBrowseRuntimeInitializesNavigationAndStateManager();
         await testMoreViewActivationLoadsTools(createHarness());

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -264,7 +264,26 @@ async function testFallbackQueuesRepeatBrowseResetDuringLazyLoad() {
         showCallsBeforeRepeat,
         'the repeat click must not run ordinary Browse navigation again'
     );
-    recordResult('Browse 冷加载窗口保留重复导航重置意图', true, { resetCalls });
+
+    delete harness.windowStub.resetBrowseViewToAll;
+    fallbackHandler({
+        preventDefault() {},
+        target: {
+            closest(selector) {
+                return selector === '.nav-btn[data-view]' ? button : null;
+            }
+        }
+    });
+
+    assert.deepStrictEqual(
+        showViewCalls.at(-1),
+        { viewName: 'browse', resetCategory: true },
+        'the helper-free fallback must use the reset-capable Browse activation path'
+    );
+    recordResult('Browse 冷加载窗口保留重复导航重置意图', true, {
+        resetCalls,
+        helperFreeFallback: showViewCalls.at(-1)
+    });
 }
 
 async function testColdRepeatResetPreemptsBrowseSynchronization() {
@@ -472,6 +491,111 @@ async function testHotBrowseCategorySupersedesQueuedColdCategory() {
     });
 }
 
+async function testQueuedBrowseCategoryStandsDownAfterNewNavigation() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    let activeView = 'overview';
+    const appliedCategories = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: `${activeView}-view` };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const queuedCategory = harness.windowStub.browseCategory('P1', 'reading');
+    activeView = 'settings';
+    harness.windowStub.browseCategory = function browseCategory(category) {
+        appliedCategories.push(category);
+        activeView = 'browse';
+    };
+
+    runtimeReady.resolve(true);
+    assert.strictEqual(await queuedCategory, false);
+    assert.deepStrictEqual(
+        appliedCategories,
+        [],
+        'a category queued from an older view must not navigate back after a newer view wins'
+    );
+    assert.strictEqual(activeView, 'settings');
+    recordResult('较新的非 Browse 导航淘汰冷分类代理', true, { activeView, appliedCategories });
+}
+
+async function testQueuedBrowseCategoryStandsDownAfterNavigationRoundTrip() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    let activeView = 'overview';
+    const appliedCategories = [];
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: `${activeView}-view` };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    assert.strictEqual(typeof harness.windowStub.__markAppNavigationIntent, 'function');
+    const queuedCategory = harness.windowStub.browseCategory('P1', 'reading');
+
+    function navigate(viewName) {
+        harness.windowStub.__markAppNavigationIntent();
+        activeView = viewName;
+    }
+
+    navigate('settings');
+    navigate('overview');
+    harness.windowStub.browseCategory = function browseCategory(category) {
+        appliedCategories.push(category);
+        activeView = 'browse';
+    };
+
+    runtimeReady.resolve(true);
+    assert.strictEqual(await queuedCategory, false);
+    assert.deepStrictEqual(
+        appliedCategories,
+        [],
+        'a navigation round trip must still invalidate the older queued category'
+    );
+    assert.strictEqual(activeView, 'overview');
+    recordResult('导航往返仍淘汰旧冷分类代理', true, { activeView, appliedCategories });
+}
+
+async function testAppNavigationMarksIntentBeforeSameViewShortCircuit() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const appliedCategories = [];
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const queuedCategory = harness.windowStub.browseCategory('P1', 'reading');
+    loadScript('js/app.js', harness.context);
+    const app = vm.runInContext('new ExamSystemApp()', harness.context);
+    app.currentView = 'overview';
+    app.navigateToView('overview');
+    harness.windowStub.browseCategory = function browseCategory(category) {
+        appliedCategories.push(category);
+    };
+
+    runtimeReady.resolve(true);
+    assert.strictEqual(await queuedCategory, false);
+    assert.deepStrictEqual(
+        appliedCategories,
+        [],
+        'even a same-view app navigation intent must cancel an older queued category'
+    );
+    recordResult('App 同视图导航也标记较新的导航意图', true, { appliedCategories });
+}
+
 async function testQueuedFilterBeatsLaterExamIndexRefresh() {
     const harness = createHarness();
     harness.inputState.value = 'ocean';
@@ -558,6 +682,128 @@ async function testQueuedFilterBeatsLaterExamIndexRefresh() {
     });
 }
 
+async function testLaterQueuedFilterBeatsEarlierExamIndexRefresh() {
+    const harness = createHarness();
+    harness.inputState.value = '';
+    const runtimeReady = deferred();
+    const listeners = new Map();
+    const callOrder = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'background-index' }] } });
+    const queuedFilter = harness.windowStub.filterByType('reading');
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.filterByType = function filterByType(type) {
+        harness.windowStub.__beginBrowseResultsRequest();
+        callOrder.push(`filter:${type}`);
+        return true;
+    };
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        if (!harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        callOrder.push(`background:${index[0].id}`);
+        return index;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+
+    runtimeReady.resolve(true);
+    assert.strictEqual(await queuedFilter, true);
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(
+        callOrder,
+        ['filter:reading'],
+        'a later cold user filter must invalidate an earlier queued background refresh'
+    );
+    assert.strictEqual(resultsRequestId, 2);
+    recordResult('较新的冷筛选淘汰更早的题库索引刷新', true, { callOrder, resultsRequestId });
+}
+
+async function testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization() {
+    const harness = createHarness();
+    harness.inputState.value = '';
+    const runtimeReady = deferred();
+    const listeners = new Map();
+    const renders = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'older-index' }] } });
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'latest-index' }] } });
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        if (harness.windowStub.__isBrowseResultsRequestCurrent(requestId)) {
+            renders.push(index.map((exam) => exam.id));
+        }
+        return index;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks(32);
+
+    assert.deepStrictEqual(
+        renders,
+        [['latest-index']],
+        'multiple queued index events must coalesce to the latest snapshot'
+    );
+    assert.strictEqual(resultsRequestId, 2);
+    recordResult('Browse 初始化期间仅重放最新题库索引', true, { renders, resultsRequestId });
+}
+
 async function testExamIndexRefreshPreservesActiveSearch() {
     const harness = createHarness();
     const listeners = new Map();
@@ -612,9 +858,81 @@ async function testExamIndexRefreshPreservesActiveSearch() {
     listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
     await flushMicrotasks();
 
-    assert.deepStrictEqual(calls, ['init:1', 'search:ocean:2', 'search:ocean:2']);
+    assert.deepStrictEqual(calls, ['init:1', 'search:ocean:2', 'search:ocean:3']);
     assert.strictEqual(finalRender, 'search:ocean', 'background index refresh must preserve active search results');
     recordResult('题库索引刷新保留活动搜索', true, { calls, finalRender });
+}
+
+async function testExamIndexRefreshPreemptsSameTokenLoad() {
+    const harness = createHarness();
+    const staleResolution = deferred();
+    const listeners = new Map();
+    const renders = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    harness.inputState.value = '';
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        const activeRequestId = requestId == null
+            ? harness.windowStub.__beginBrowseResultsRequest()
+            : requestId;
+        if (Array.isArray(index)) {
+            if (harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+                renders.push(index.map((exam) => exam.id));
+            }
+            return Promise.resolve(index);
+        }
+        return staleResolution.promise.then((resolvedIndex) => {
+            if (!harness.windowStub.__isBrowseResultsRequestCurrent(activeRequestId)) {
+                return false;
+            }
+            renders.push(resolvedIndex.map((exam) => exam.id));
+            return resolvedIndex;
+        });
+    };
+
+    const staleLoad = harness.windowStub.loadExamList(null);
+    assert.strictEqual(resultsRequestId, 2, 'the pending load should own the captured token');
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-index' }] } });
+    await flushMicrotasks(32);
+
+    assert.strictEqual(resultsRequestId, 3, 'the accepted index refresh must claim a newer token');
+    assert.deepStrictEqual(renders, [['fresh-index']]);
+
+    staleResolution.resolve([{ id: 'stale-index' }]);
+    assert.strictEqual(await staleLoad, false);
+    assert.deepStrictEqual(
+        renders,
+        [['fresh-index']],
+        'the older same-token continuation must not overwrite the fresh index render'
+    );
+    recordResult('题库索引刷新领取新 token 并淘汰旧 continuation', true, {
+        resultsRequestId,
+        renders
+    });
 }
 
 async function testExamIndexRefreshStandsDownDuringReset() {
@@ -1391,8 +1709,14 @@ async function main() {
         await testColdRepeatResetPreemptsBrowseSynchronization();
         await testDirectResetInvalidatesPendingColdBrowseLoad();
         await testHotBrowseCategorySupersedesQueuedColdCategory();
+        await testQueuedBrowseCategoryStandsDownAfterNewNavigation();
+        await testQueuedBrowseCategoryStandsDownAfterNavigationRoundTrip();
+        await testAppNavigationMarksIntentBeforeSameViewShortCircuit();
         await testQueuedFilterBeatsLaterExamIndexRefresh();
+        await testLaterQueuedFilterBeatsEarlierExamIndexRefresh();
+        await testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization();
         await testExamIndexRefreshPreservesActiveSearch();
+        await testExamIndexRefreshPreemptsSameTokenLoad();
         await testExamIndexRefreshStandsDownDuringReset();
         await testExamIndexRefreshDuringResetRenderUsesLatestSnapshot();
         await testBrowseResetIntentClearsAfterRuntimeFailure();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -25,6 +25,19 @@ function deferred() {
     return { promise, resolve, reject };
 }
 
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(value) { values.add(value); },
+        remove(value) { values.delete(value); },
+        contains(value) { return values.has(value); },
+        toggle(value, enabled) {
+            if (enabled) values.add(value);
+            else values.delete(value);
+        }
+    };
+}
+
 async function flushMicrotasks(rounds = 8) {
     for (let index = 0; index < rounds; index += 1) {
         await Promise.resolve();
@@ -242,6 +255,103 @@ async function testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView() {
     assert.strictEqual(initializationCalls, 1, 'the safe reset barrier must preserve first-activation setup');
     assert.ok(harness.ensureCalls.includes('browse-runtime'));
     recordResult('原始 Browse runtime 加载等待功能重置后再同步视图', true);
+}
+
+async function testFailedBrowseResetBarrierStopsQueuedLoaderProxy() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    let initializationCalls = 0;
+    let realLoadCalls = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    const queuedLoad = harness.windowStub.loadExamList();
+    const resetBarrier = deferred();
+    harness.windowStub.AppEntry.registerBrowseFunctionalResetBarrier(resetBarrier.promise);
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        initializationCalls += 1;
+        return Promise.resolve();
+    };
+    harness.windowStub.__legacyLoadExamList = function loadExamList() {
+        realLoadCalls += 1;
+        return true;
+    };
+
+    runtimeReady.resolve(true);
+    resetBarrier.resolve(false);
+    assert.strictEqual(await queuedLoad, false);
+    assert.strictEqual(initializationCalls, 0, 'a failed reset barrier must skip active-view synchronization');
+    assert.strictEqual(realLoadCalls, 0, 'a failed reset barrier must stop the already queued loader proxy');
+
+    await flushMicrotasks();
+    assert.strictEqual(await harness.windowStub.loadExamList(), true);
+    assert.strictEqual(initializationCalls, 1, 'a later request must retry after the failed barrier clears');
+    assert.strictEqual(realLoadCalls, 1, 'the retry must reach the real loader exactly once');
+    recordResult('失败的 Browse 重置屏障会阻止已排队 loader', true, { initializationCalls, realLoadCalls });
+}
+
+async function testColdFallbackLetsBrowseSynchronizationOwnRender() {
+    const harness = createHarness();
+    let initializationCalls = 0;
+    let realLoadCalls = 0;
+    const terminalRenders = [];
+    const views = {
+        overview: { id: 'overview-view', classList: createClassList(['active']) },
+        browse: { id: 'browse-view', classList: createClassList() }
+    };
+    const originalGetElementById = harness.windowStub.document.getElementById.bind(harness.windowStub.document);
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    const originalQuerySelectorAll = harness.windowStub.document.querySelectorAll.bind(harness.windowStub.document);
+    harness.windowStub.document.getElementById = function getElementById(id) {
+        if (id === 'overview-view') return views.overview;
+        if (id === 'browse-view') return views.browse;
+        return originalGetElementById(id);
+    };
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') {
+            return Object.values(views).find((view) => view.classList.contains('active')) || null;
+        }
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.document.querySelectorAll = function querySelectorAll(selector) {
+        if (selector === '.view.active') {
+            return Object.values(views).filter((view) => view.classList.contains('active'));
+        }
+        return originalQuerySelectorAll(selector);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        if (name === 'browse-runtime') {
+            harness.windowStub.initializeBrowseView = async function initializeBrowseView(options) {
+                initializationCalls += 1;
+                terminalRenders.push(`query:${harness.inputState.value}`);
+                assert.strictEqual(options.skipLoad, false);
+            };
+            harness.windowStub.loadExamList = function loadExamList() {
+                realLoadCalls += 1;
+                terminalRenders.push('all');
+            };
+        }
+        return Promise.resolve(true);
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    loadScript('js/boot-fallbacks.js', harness.context);
+    await harness.windowStub.showView('browse', false);
+
+    assert.strictEqual(harness.inputState.value, 'ocean');
+    assert.strictEqual(initializationCalls, 1);
+    assert.strictEqual(realLoadCalls, 0, 'the cold fallback must not invoke a second loader after synchronization');
+    assert.deepStrictEqual(terminalRenders, ['query:ocean']);
+    recordResult('冷 Browse 同步独占首次查询渲染', true, { terminalRenders });
 }
 
 async function testFallbackQueuesRepeatBrowseResetDuringLazyLoad() {
@@ -698,7 +808,7 @@ async function testQueuedFilterBeatsLaterExamIndexRefresh() {
     runtimeReady.resolve(true);
     await flushMicrotasks();
     browseSynchronization.resolve();
-    await flushMicrotasks();
+    await flushMicrotasks(32);
 
     assert.deepStrictEqual(callOrder, ['filter:reading'], 'the earlier user filter should start before background refresh');
     assert.strictEqual(skippedBackgroundLoads, 0, 'a stale background search must stand down before calling the adapter');
@@ -1437,7 +1547,7 @@ async function testBrowseResetIntentClearsAfterResetFailure() {
     const result = await reset;
     await flushMicrotasks();
     harness.context.console = contextConsole;
-    assert.strictEqual(result, false);
+    assert.strictEqual(result, false, 'a state-manager reset failure must return false');
     assert.deepStrictEqual(
         loadedIndexes,
         [['fresh-index']],
@@ -1507,7 +1617,7 @@ async function testBrowseResetAdapterFailureReplaysCapturedIndex() {
     assert.deepStrictEqual(loadedIndexes, [['initial-index']]);
 
     failingRender.reject(new Error('adapter failed'));
-    assert.strictEqual(await reset, false);
+    assert.strictEqual(await reset, false, 'an adapter failure must return false');
     await flushMicrotasks(32);
     harness.context.console = contextConsole;
     assert.deepStrictEqual(
@@ -1975,6 +2085,8 @@ async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
         await testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView();
+        await testFailedBrowseResetBarrierStopsQueuedLoaderProxy();
+        await testColdFallbackLetsBrowseSynchronizationOwnRender();
         await testFallbackQueuesRepeatBrowseResetDuringLazyLoad();
         await testColdRepeatResetPreemptsBrowseSynchronization();
         await testDirectResetInvalidatesPendingColdBrowseLoad();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -213,6 +213,37 @@ async function testRandomPracticeEnsuresBrowseRuntime(harness) {
     });
 }
 
+async function testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView() {
+    const harness = createHarness();
+    let initializationCalls = 0;
+    harness.windowStub.document.readyState = 'loading';
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        initializationCalls += 1;
+        return Promise.resolve();
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    assert.strictEqual(typeof harness.windowStub.AppEntry.ensureBrowseRuntimeGroup, 'function');
+    await harness.windowStub.AppEntry.ensureBrowseRuntimeGroup();
+
+    assert.strictEqual(initializationCalls, 0, 'raw owner loading must not synchronize or render the active view');
+    const resetBarrier = deferred();
+    harness.windowStub.AppEntry.registerBrowseFunctionalResetBarrier(resetBarrier.promise);
+    const synchronizedGroup = harness.windowStub.AppEntry.ensureBrowseGroup();
+    await flushMicrotasks();
+    assert.strictEqual(initializationCalls, 0, 'active-view synchronization must wait for functional reset');
+    resetBarrier.resolve(true);
+    await synchronizedGroup;
+    assert.strictEqual(initializationCalls, 1, 'the safe reset barrier must preserve first-activation setup');
+    assert.ok(harness.ensureCalls.includes('browse-runtime'));
+    recordResult('原始 Browse runtime 加载等待功能重置后再同步视图', true);
+}
+
 async function testFallbackQueuesRepeatBrowseResetDuringLazyLoad() {
     const harness = createHarness();
     let fallbackHandler = null;
@@ -782,9 +813,12 @@ async function createHotExamIndexRefreshHarness() {
 
     loadScript('js/app/main-entry.js', harness.context);
     await harness.windowStub.AppEntry.ensureBrowseGroup();
-    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+    harness.windowStub.__renderBrowseResultsForState = function renderBrowseResultsForState(index, requestId) {
         backgroundLoads.push([index.map((exam) => exam.id), requestId]);
         return index;
+    };
+    harness.windowStub.loadExamList = function unexpectedLegacyRefresh() {
+        throw new Error('the deferred refresh must use the shared state renderer');
     };
     harness.inputState.value = '';
 
@@ -799,6 +833,10 @@ async function createHotExamIndexRefreshHarness() {
         },
         endUserRequest(requestId) {
             inFlightUserRequests.delete(requestId);
+            const settled = listeners.get('browseUserResultsRequestSettled');
+            if (typeof settled === 'function') {
+                settled({ detail: { requestId } });
+            }
         },
         getResultsRequestId() {
             return resultsRequestId;
@@ -816,7 +854,13 @@ async function testHotFilterBeatsLaterExamIndexRefresh() {
     assert.strictEqual(state.getResultsRequestId(), userRequestId, 'background refresh must not revoke an active hot filter');
     assert.deepStrictEqual(state.backgroundLoads, []);
     state.endUserRequest(userRequestId);
-    recordResult('热筛选先发生时题库索引刷新让行', true, { userRequestId });
+    await flushMicrotasks(32);
+    assert.deepStrictEqual(
+        state.backgroundLoads,
+        [[['background-index'], userRequestId + 1]],
+        'the fresh index must replay after the retained user filter settles'
+    );
+    recordResult('热筛选完成后重放最新题库索引', true, { userRequestId });
 }
 
 async function testHotFilterAfterEventReceiptStillWins() {
@@ -833,7 +877,34 @@ async function testHotFilterAfterEventReceiptStillWins() {
     );
     assert.deepStrictEqual(state.backgroundLoads, []);
     state.endUserRequest(userRequestId);
-    recordResult('题库索引事件先登记时后续热筛选仍优先', true, { userRequestId });
+    await flushMicrotasks(32);
+    assert.deepStrictEqual(
+        state.backgroundLoads,
+        [[['background-index'], userRequestId + 1]],
+        'an event captured before the hot filter must replay its fresh snapshot after settlement'
+    );
+    recordResult('先登记的题库索引在热筛选完成后重放', true, { userRequestId });
+}
+
+async function testRetainedUserRequestCoalescesLatestExamIndexRefresh() {
+    const state = await createHotExamIndexRefreshHarness();
+    const userRequestId = state.beginUserRequest();
+
+    state.listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'index-b' }] } });
+    await flushMicrotasks(16);
+    state.listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'index-c' }] } });
+    await flushMicrotasks(32);
+
+    assert.deepStrictEqual(state.backgroundLoads, [], 'retained user work must not be preempted');
+    state.endUserRequest(userRequestId);
+    await flushMicrotasks(32);
+
+    assert.deepStrictEqual(
+        state.backgroundLoads,
+        [[['index-c'], userRequestId + 1]],
+        'only the latest deferred index snapshot may replay'
+    );
+    recordResult('热筛选期间题库索引刷新合并到最新快照', true, { userRequestId });
 }
 
 async function testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization() {
@@ -890,6 +961,116 @@ async function testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization() 
     );
     assert.strictEqual(resultsRequestId, 2);
     recordResult('Browse 初始化期间仅重放最新题库索引', true, { renders, resultsRequestId });
+}
+
+async function testExamIndexRefreshStopsAfterNavigationAwayDuringRuntimeLoad() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const listeners = new Map();
+    const renders = [];
+    let activeView = 'browse';
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: `${activeView}-view` };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'browse-index' }] } });
+    activeView = 'overview';
+    harness.windowStub.__markAppNavigationIntent();
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        throw new Error('inactive Browse must not initialize');
+    };
+    harness.windowStub.__renderBrowseResultsForState = function renderBrowseResultsForState(index) {
+        renders.push(index.map((exam) => exam.id));
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks(32);
+
+    assert.deepStrictEqual(renders, []);
+    assert.strictEqual(resultsRequestId, 0, 'navigation away must prevent a hidden refresh token');
+    recordResult('Browse 离开后丢弃等待 runtime 的题库索引刷新', true);
+}
+
+async function testSettledHotRequestReplaysIndexAfterRuntimeBecomesReady() {
+    const harness = createHarness();
+    const runtimeReady = deferred();
+    const listeners = new Map();
+    const renders = [];
+    const inFlightUserRequests = new Set();
+    let lastUserRequestId = null;
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.AppLazyLoader.ensureGroup = function ensureGroup(name) {
+        harness.ensureCalls.push(name);
+        return name === 'browse-runtime' ? runtimeReady.promise : Promise.resolve(true);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseUserResultsRequestInFlight = function isUserRequestInFlight(requestId) {
+        return inFlightUserRequests.has(requestId);
+    };
+    harness.windowStub.__isBrowseUserResultsRequest = function isUserRequest(requestId) {
+        return requestId === lastUserRequestId;
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        return Promise.resolve();
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'fresh-after-ready' }] } });
+    const userRequestId = harness.windowStub.__beginBrowseResultsRequest();
+    lastUserRequestId = userRequestId;
+    inFlightUserRequests.add(userRequestId);
+    inFlightUserRequests.delete(userRequestId);
+    const settled = listeners.get('browseUserResultsRequestSettled');
+    settled({ detail: { requestId: userRequestId } });
+    harness.windowStub.__renderBrowseResultsForState = function renderBrowseResultsForState(index, requestId) {
+        renders.push([index.map((exam) => exam.id), requestId]);
+        return index;
+    };
+
+    runtimeReady.resolve(true);
+    await flushMicrotasks(48);
+
+    assert.deepStrictEqual(renders, [[['fresh-after-ready'], userRequestId + 1]]);
+    assert.strictEqual(resultsRequestId, userRequestId + 1);
+    recordResult('runtime 就绪后重放已完成热请求期间的新索引', true, { userRequestId });
 }
 
 async function testExamIndexRefreshPreservesActiveSearch() {
@@ -1793,6 +1974,7 @@ async function testSuiteRecoveryCancelDoesNotMutateSession() {
 async function main() {
     try {
         await testRandomPracticeEnsuresBrowseRuntime(createHarness());
+        await testRawBrowseRuntimeLoadDoesNotSynchronizeActiveView();
         await testFallbackQueuesRepeatBrowseResetDuringLazyLoad();
         await testColdRepeatResetPreemptsBrowseSynchronization();
         await testDirectResetInvalidatesPendingColdBrowseLoad();
@@ -1804,7 +1986,10 @@ async function main() {
         await testLaterQueuedFilterBeatsEarlierExamIndexRefresh();
         await testHotFilterBeatsLaterExamIndexRefresh();
         await testHotFilterAfterEventReceiptStillWins();
+        await testRetainedUserRequestCoalescesLatestExamIndexRefresh();
         await testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization();
+        await testExamIndexRefreshStopsAfterNavigationAwayDuringRuntimeLoad();
+        await testSettledHotRequestReplaysIndexAfterRuntimeBecomesReady();
         await testExamIndexRefreshPreservesActiveSearch();
         await testExamIndexRefreshPreemptsSameTokenLoad();
         await testExamIndexRefreshStandsDownDuringReset();

--- a/developer/tests/js/onDemandEntrypoints.test.js
+++ b/developer/tests/js/onDemandEntrypoints.test.js
@@ -748,6 +748,94 @@ async function testLaterQueuedFilterBeatsEarlierExamIndexRefresh() {
     recordResult('较新的冷筛选淘汰更早的题库索引刷新', true, { callOrder, resultsRequestId });
 }
 
+async function createHotExamIndexRefreshHarness() {
+    const harness = createHarness();
+    const listeners = new Map();
+    const inFlightUserRequests = new Set();
+    const backgroundLoads = [];
+    let resultsRequestId = 0;
+    const originalQuerySelector = harness.windowStub.document.querySelector.bind(harness.windowStub.document);
+    harness.windowStub.document.querySelector = function querySelector(selector) {
+        if (selector === '.view.active') return { id: 'browse-view' };
+        return originalQuerySelector(selector);
+    };
+    harness.windowStub.addEventListener = function addEventListener(name, listener) {
+        listeners.set(name, listener);
+    };
+    harness.windowStub.__beginBrowseResultsRequest = function beginBrowseResultsRequest() {
+        resultsRequestId += 1;
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseResultsRequestCurrent = function isBrowseResultsRequestCurrent(requestId) {
+        return requestId === resultsRequestId;
+    };
+    harness.windowStub.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+        return resultsRequestId;
+    };
+    harness.windowStub.__isBrowseUserResultsRequestInFlight = function isUserRequestInFlight(requestId) {
+        return inFlightUserRequests.has(requestId);
+    };
+    harness.windowStub.initializeBrowseView = function initializeBrowseView() {
+        harness.windowStub.__beginBrowseResultsRequest();
+        return Promise.resolve();
+    };
+
+    loadScript('js/app/main-entry.js', harness.context);
+    await harness.windowStub.AppEntry.ensureBrowseGroup();
+    harness.windowStub.loadExamList = function loadExamList(index, requestId) {
+        backgroundLoads.push([index.map((exam) => exam.id), requestId]);
+        return index;
+    };
+    harness.inputState.value = '';
+
+    return {
+        harness,
+        listeners,
+        backgroundLoads,
+        beginUserRequest() {
+            const requestId = harness.windowStub.__beginBrowseResultsRequest();
+            inFlightUserRequests.add(requestId);
+            return requestId;
+        },
+        endUserRequest(requestId) {
+            inFlightUserRequests.delete(requestId);
+        },
+        getResultsRequestId() {
+            return resultsRequestId;
+        }
+    };
+}
+
+async function testHotFilterBeatsLaterExamIndexRefresh() {
+    const state = await createHotExamIndexRefreshHarness();
+    const userRequestId = state.beginUserRequest();
+
+    state.listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'background-index' }] } });
+    await flushMicrotasks(32);
+
+    assert.strictEqual(state.getResultsRequestId(), userRequestId, 'background refresh must not revoke an active hot filter');
+    assert.deepStrictEqual(state.backgroundLoads, []);
+    state.endUserRequest(userRequestId);
+    recordResult('热筛选先发生时题库索引刷新让行', true, { userRequestId });
+}
+
+async function testHotFilterAfterEventReceiptStillWins() {
+    const state = await createHotExamIndexRefreshHarness();
+
+    state.listeners.get('examIndexLoaded')({ detail: { index: [{ id: 'background-index' }] } });
+    const userRequestId = state.beginUserRequest();
+    await flushMicrotasks(32);
+
+    assert.strictEqual(
+        state.getResultsRequestId(),
+        userRequestId,
+        'an index event must validate the token captured at receipt instead of borrowing the later hot token'
+    );
+    assert.deepStrictEqual(state.backgroundLoads, []);
+    state.endUserRequest(userRequestId);
+    recordResult('题库索引事件先登记时后续热筛选仍优先', true, { userRequestId });
+}
+
 async function testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization() {
     const harness = createHarness();
     harness.inputState.value = '';
@@ -1714,6 +1802,8 @@ async function main() {
         await testAppNavigationMarksIntentBeforeSameViewShortCircuit();
         await testQueuedFilterBeatsLaterExamIndexRefresh();
         await testLaterQueuedFilterBeatsEarlierExamIndexRefresh();
+        await testHotFilterBeatsLaterExamIndexRefresh();
+        await testHotFilterAfterEventReceiptStillWins();
         await testLatestQueuedExamIndexRefreshWinsDuringBrowseInitialization();
         await testExamIndexRefreshPreservesActiveSearch();
         await testExamIndexRefreshPreemptsSameTokenLoad();

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@
 class ExamSystemApp {
     constructor() {
         this.currentView = 'overview';
+        this._navigationIntentGeneration = 0;
         this.components = {};
         this.isInitialized = false;
 
@@ -620,11 +621,20 @@ class ExamSystemApp {
             this.navigateToView(initialView);
         },
         navigateToView(viewName) {
+            const navigationIntentGeneration = ++this._navigationIntentGeneration;
+            let sharedNavigationIntentGeneration = null;
             if (typeof window.__markAppNavigationIntent === 'function') {
-                window.__markAppNavigationIntent();
+                sharedNavigationIntentGeneration = window.__markAppNavigationIntent();
+            }
+            if (sharedNavigationIntentGeneration == null
+                && typeof window.__getAppNavigationIntentGeneration === 'function') {
+                sharedNavigationIntentGeneration = window.__getAppNavigationIntentGeneration();
+            }
+            if (viewName !== 'browse' && window.__pendingBrowseFilter) {
+                delete window.__pendingBrowseFilter;
             }
             if (this.currentView === viewName) {
-                return;
+                return { navigationIntentGeneration, sharedNavigationIntentGeneration };
             }
             document.querySelectorAll('.view').forEach((view) => {
                 view.classList.remove('active');
@@ -643,10 +653,21 @@ class ExamSystemApp {
                 const url = new URL(window.location);
                 url.searchParams.set('view', viewName);
                 window.history.replaceState({}, '', url);
-                this.onViewActivated(viewName);
+                this.onViewActivated(
+                    viewName,
+                    navigationIntentGeneration,
+                    sharedNavigationIntentGeneration
+                );
             }
+            return { navigationIntentGeneration, sharedNavigationIntentGeneration };
         },
-        onViewActivated(viewName) {
+        onViewActivated(
+            viewName,
+            navigationIntentGeneration = this._navigationIntentGeneration,
+            sharedNavigationIntentGeneration = (typeof window.__getAppNavigationIntentGeneration === 'function'
+                ? window.__getAppNavigationIntentGeneration()
+                : null)
+        ) {
             switch (viewName) {
                 case 'overview':
                     this.refreshOverviewData();
@@ -660,10 +681,23 @@ class ExamSystemApp {
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
                         ).then(() => {
-                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                            const activeView = typeof document.querySelector === 'function'
+                                ? document.querySelector('.view.active')
+                                : null;
+                            if (window.__pendingBrowseFilter !== pendingFilter
+                                || navigationIntentGeneration !== this._navigationIntentGeneration
+                                || this.currentView !== 'browse'
+                                || (activeView && activeView.id !== 'browse-view')
+                                || (sharedNavigationIntentGeneration != null
+                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
+                                    && window.__getAppNavigationIntentGeneration() !== sharedNavigationIntentGeneration)) {
                                 return undefined;
                             }
-                            return window.applyBrowseFilter(category, type, filterMode, path);
+                            const filterArgs = [category, type, filterMode, path];
+                            if (sharedNavigationIntentGeneration != null) {
+                                filterArgs.push(null, sharedNavigationIntentGeneration);
+                            }
+                            return window.applyBrowseFilter(...filterArgs);
                         })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);

--- a/js/app.js
+++ b/js/app.js
@@ -620,6 +620,9 @@ class ExamSystemApp {
             this.navigateToView(initialView);
         },
         navigateToView(viewName) {
+            if (typeof window.__markAppNavigationIntent === 'function') {
+                window.__markAppNavigationIntent();
+            }
             if (this.currentView === viewName) {
                 return;
             }

--- a/js/app.js
+++ b/js/app.js
@@ -932,7 +932,21 @@ class ExamSystemApp {
                 if (navBtn) {
                     const view = navBtn.dataset.view;
                     if (view) {
-                        this.navigateToView(view);
+                        const browseViewAlreadyActive = view === 'browse'
+                            && e.__browseNavigationHandled === true
+                            && document.getElementById('browse-view')?.classList.contains('active');
+                        if (browseViewAlreadyActive) {
+                            // The main-nav controller already activated and refreshed Browse.
+                            // Keep app state/URL in sync without starting a second render.
+                            this.currentView = view;
+                            try {
+                                const url = new URL(window.location);
+                                url.searchParams.set('view', view);
+                                window.history.replaceState({}, '', url);
+                            } catch (_) { }
+                        } else {
+                            this.navigateToView(view);
+                        }
                     }
                 }
                 const backBtn = e.target.closest('.btn-back');

--- a/js/app.js
+++ b/js/app.js
@@ -688,26 +688,34 @@ class ExamSystemApp {
                             && typeof window.__retainBrowseUserResultsRequest === 'function'
                             ? window.__retainBrowseUserResultsRequest(initializationRequestId)
                             : null;
-                        Promise.resolve(initialization).then((initializationResult) => {
-                            if (hasInitializer && initializationResult === null) {
-                                return undefined;
-                            }
-                            if (initializationRequestId != null
-                                && typeof window.__isBrowseResultsRequestCurrent === 'function'
-                                && !window.__isBrowseResultsRequestCurrent(initializationRequestId)) {
-                                return undefined;
-                            }
+                        let pendingFilterOutcome = 'retryable-failure';
+                        const pendingFilterWasSuperseded = () => {
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
-                            if (window.__pendingBrowseFilter !== pendingFilter
+                            return window.__pendingBrowseFilter !== pendingFilter
                                 || navigationIntentGeneration !== this._navigationIntentGeneration
                                 || this.currentView !== 'browse'
                                 || (activeView && activeView.id !== 'browse-view')
                                 || (sharedNavigationIntentGeneration != null
                                     && typeof window.__getAppNavigationIntentGeneration === 'function'
-                                    && window.__getAppNavigationIntentGeneration() !== sharedNavigationIntentGeneration)) {
-                                return undefined;
+                                    && window.__getAppNavigationIntentGeneration()
+                                        !== sharedNavigationIntentGeneration)
+                                || (initializationRequestId != null
+                                    && typeof window.__isBrowseResultsRequestCurrent === 'function'
+                                    && !window.__isBrowseResultsRequestCurrent(
+                                        initializationRequestId
+                                    ));
+                        };
+                        Promise.resolve(initialization).then((initializationResult) => {
+                            if (hasInitializer
+                                && (initializationResult === null
+                                    || initializationResult === false)) {
+                                return false;
+                            }
+                            if (pendingFilterWasSuperseded()) {
+                                pendingFilterOutcome = 'superseded';
+                                return false;
                             }
                             const filterArgs = [category, type, filterMode, path];
                             if (initializationRequestId != null || sharedNavigationIntentGeneration != null) {
@@ -718,16 +726,35 @@ class ExamSystemApp {
                             }
                             return window.applyBrowseFilter(...filterArgs);
                         })
+                            .then((result) => {
+                                // Legacy filter implementations resolve without a
+                                // value after applying; null/false mean it did not
+                                // reach an authoritative commit.
+                                if (result !== false && result !== null) {
+                                    pendingFilterOutcome = 'applied';
+                                    return true;
+                                }
+                                if (pendingFilterWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
+                                return false;
+                            })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
+                                if (pendingFilterOutcome !== 'applied'
+                                    && pendingFilterWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
+                                if (window.__pendingBrowseFilter === pendingFilter
+                                    && (pendingFilterOutcome === 'applied'
+                                        || pendingFilterOutcome === 'superseded')) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                                 if (retainedInitializationRequestId != null
                                     && typeof window.__endBrowseUserResultsRequest === 'function') {
                                     window.__endBrowseUserResultsRequest(retainedInitializationRequestId);
-                                }
-                                if (window.__pendingBrowseFilter === pendingFilter) {
-                                    delete window.__pendingBrowseFilter;
                                 }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {

--- a/js/app.js
+++ b/js/app.js
@@ -677,6 +677,19 @@ class ExamSystemApp {
                         const pendingFilter = window.__pendingBrowseFilter;
                         const { category, type, filterMode, path } = pendingFilter;
                         const hasInitializer = typeof window.initializeBrowseView === 'function';
+                        const appEntry = window.AppEntry || null;
+                        const consumerNavigationGeneration = sharedNavigationIntentGeneration != null
+                            ? sharedNavigationIntentGeneration
+                            : (typeof window.__getAppNavigationIntentGeneration === 'function'
+                                ? window.__getAppNavigationIntentGeneration()
+                                : null);
+                        const pendingFilterConsumer = appEntry
+                            && typeof appEntry.beginBrowsePendingFilterConsumer === 'function'
+                            ? appEntry.beginBrowsePendingFilterConsumer(
+                                pendingFilter,
+                                consumerNavigationGeneration
+                            )
+                            : null;
                         const initialization = hasInitializer
                             ? window.initializeBrowseView({ skipLoad: true })
                             : null;
@@ -689,32 +702,50 @@ class ExamSystemApp {
                             ? window.__retainBrowseUserResultsRequest(initializationRequestId)
                             : null;
                         let pendingFilterOutcome = 'retryable-failure';
-                        const pendingFilterWasSuperseded = () => {
+                        const ownsPendingFilterConsumer = () => !pendingFilterConsumer
+                            || !appEntry
+                            || typeof appEntry.isBrowsePendingFilterConsumerCurrent !== 'function'
+                            || appEntry.isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer);
+                        const pendingFilterIntentIsCurrent = () => {
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
-                            return window.__pendingBrowseFilter !== pendingFilter
-                                || navigationIntentGeneration !== this._navigationIntentGeneration
-                                || this.currentView !== 'browse'
-                                || (activeView && activeView.id !== 'browse-view')
-                                || (sharedNavigationIntentGeneration != null
-                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
-                                    && window.__getAppNavigationIntentGeneration()
-                                        !== sharedNavigationIntentGeneration)
+                            const sharedIntentIsCurrent = !pendingFilterConsumer
+                                || !appEntry
+                                || typeof appEntry.isBrowsePendingFilterIntentCurrent !== 'function'
+                                || appEntry.isBrowsePendingFilterIntentCurrent(pendingFilterConsumer);
+                            return sharedIntentIsCurrent
+                                && window.__pendingBrowseFilter === pendingFilter
+                                && navigationIntentGeneration === this._navigationIntentGeneration
+                                && this.currentView === 'browse'
+                                && (!activeView || activeView.id === 'browse-view')
+                                && (sharedNavigationIntentGeneration == null
+                                    || typeof window.__getAppNavigationIntentGeneration !== 'function'
+                                    || window.__getAppNavigationIntentGeneration()
+                                        === sharedNavigationIntentGeneration);
+                        };
+                        const pendingFilterAttemptIsCurrent = () => ownsPendingFilterConsumer()
+                            && pendingFilterIntentIsCurrent()
+                            && (initializationRequestId == null
+                                || typeof window.__isBrowseResultsRequestCurrent !== 'function'
+                                || window.__isBrowseResultsRequestCurrent(initializationRequestId));
+                        const currentConsumerWasSuperseded = () => ownsPendingFilterConsumer()
+                            && (!pendingFilterIntentIsCurrent()
                                 || (initializationRequestId != null
                                     && typeof window.__isBrowseResultsRequestCurrent === 'function'
                                     && !window.__isBrowseResultsRequestCurrent(
                                         initializationRequestId
-                                    ));
-                        };
+                                    )));
                         Promise.resolve(initialization).then((initializationResult) => {
                             if (hasInitializer
                                 && (initializationResult === null
                                     || initializationResult === false)) {
                                 return false;
                             }
-                            if (pendingFilterWasSuperseded()) {
-                                pendingFilterOutcome = 'superseded';
+                            if (!pendingFilterAttemptIsCurrent()) {
+                                if (currentConsumerWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
                                 return false;
                             }
                             const filterArgs = [category, type, filterMode, path];
@@ -734,7 +765,7 @@ class ExamSystemApp {
                                     pendingFilterOutcome = 'applied';
                                     return true;
                                 }
-                                if (pendingFilterWasSuperseded()) {
+                                if (currentConsumerWasSuperseded()) {
                                     pendingFilterOutcome = 'superseded';
                                 }
                                 return false;
@@ -743,11 +774,14 @@ class ExamSystemApp {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                if (pendingFilterOutcome !== 'applied'
-                                    && pendingFilterWasSuperseded()) {
+                                const ownsCurrentConsumer = ownsPendingFilterConsumer();
+                                if (ownsCurrentConsumer
+                                    && pendingFilterOutcome !== 'applied'
+                                    && currentConsumerWasSuperseded()) {
                                     pendingFilterOutcome = 'superseded';
                                 }
-                                if (window.__pendingBrowseFilter === pendingFilter
+                                if (ownsCurrentConsumer
+                                    && window.__pendingBrowseFilter === pendingFilter
                                     && (pendingFilterOutcome === 'applied'
                                         || pendingFilterOutcome === 'superseded')) {
                                     delete window.__pendingBrowseFilter;

--- a/js/app.js
+++ b/js/app.js
@@ -650,17 +650,25 @@ class ExamSystemApp {
                     break;
                 case 'browse':
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
-                        const { category, type, filterMode, path } = window.__pendingBrowseFilter;
+                        const pendingFilter = window.__pendingBrowseFilter;
+                        const { category, type, filterMode, path } = pendingFilter;
                         Promise.resolve(
                             typeof window.initializeBrowseView === 'function'
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
-                        ).then(() => window.applyBrowseFilter(category, type, filterMode, path))
+                        ).then(() => {
+                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                                return undefined;
+                            }
+                            return window.applyBrowseFilter(category, type, filterMode, path);
+                        })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                delete window.__pendingBrowseFilter;
+                                if (window.__pendingBrowseFilter === pendingFilter) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {
                         window.initializeBrowseView();

--- a/js/app.js
+++ b/js/app.js
@@ -676,11 +676,27 @@ class ExamSystemApp {
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
                         const pendingFilter = window.__pendingBrowseFilter;
                         const { category, type, filterMode, path } = pendingFilter;
-                        Promise.resolve(
-                            typeof window.initializeBrowseView === 'function'
-                                ? window.initializeBrowseView({ skipLoad: true })
-                                : null
-                        ).then(() => {
+                        const hasInitializer = typeof window.initializeBrowseView === 'function';
+                        const initialization = hasInitializer
+                            ? window.initializeBrowseView({ skipLoad: true })
+                            : null;
+                        const initializationRequestId = hasInitializer
+                            && typeof window.__getBrowseResultsRequestId === 'function'
+                            ? window.__getBrowseResultsRequestId()
+                            : null;
+                        const retainedInitializationRequestId = initializationRequestId != null
+                            && typeof window.__retainBrowseUserResultsRequest === 'function'
+                            ? window.__retainBrowseUserResultsRequest(initializationRequestId)
+                            : null;
+                        Promise.resolve(initialization).then((initializationResult) => {
+                            if (hasInitializer && initializationResult === null) {
+                                return undefined;
+                            }
+                            if (initializationRequestId != null
+                                && typeof window.__isBrowseResultsRequestCurrent === 'function'
+                                && !window.__isBrowseResultsRequestCurrent(initializationRequestId)) {
+                                return undefined;
+                            }
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
@@ -694,8 +710,11 @@ class ExamSystemApp {
                                 return undefined;
                             }
                             const filterArgs = [category, type, filterMode, path];
+                            if (initializationRequestId != null || sharedNavigationIntentGeneration != null) {
+                                filterArgs.push(initializationRequestId);
+                            }
                             if (sharedNavigationIntentGeneration != null) {
-                                filterArgs.push(null, sharedNavigationIntentGeneration);
+                                filterArgs.push(sharedNavigationIntentGeneration);
                             }
                             return window.applyBrowseFilter(...filterArgs);
                         })
@@ -703,6 +722,10 @@ class ExamSystemApp {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
+                                if (retainedInitializationRequestId != null
+                                    && typeof window.__endBrowseUserResultsRequest === 'function') {
+                                    window.__endBrowseUserResultsRequest(retainedInitializationRequestId);
+                                }
                                 if (window.__pendingBrowseFilter === pendingFilter) {
                                     delete window.__pendingBrowseFilter;
                                 }

--- a/js/app/browseController.js
+++ b/js/app/browseController.js
@@ -154,7 +154,7 @@
 
             // 应用筛选
             if (!options.skipApply) {
-                return this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+                return this.applyFilter(this.activeFilter, examIndex, renderRequestId, options);
             }
             return undefined;
         }
@@ -215,6 +215,9 @@
                         : (typeof global.__beginBrowseResultsRequest === 'function'
                             ? global.__beginBrowseResultsRequest()
                             : null);
+                    const foregroundEpoch = typeof global.__captureBrowseForegroundRenderEpoch === 'function'
+                        ? global.__captureBrowseForegroundRenderEpoch()
+                        : null;
                     try {
                         const index = await global.resolveActiveLibraryIndex();
                         if (interactionId !== this.filterInteractionId) {
@@ -225,7 +228,12 @@
                             && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
                             return;
                         }
-                        await Promise.resolve(this.handleFilterClick(filter.id, index, renderRequestId));
+                        await Promise.resolve(this.handleFilterClick(
+                            filter.id,
+                            index,
+                            renderRequestId,
+                            { foregroundEpoch }
+                        ));
                     } catch (error) {
                         console.error('[BrowseController] 读取活动题库失败:', error);
                     } finally {
@@ -263,14 +271,14 @@
          * 处理筛选按钮点击
          * @param {string} filterId - 筛选器ID
          */
-        handleFilterClick(filterId, examIndex = [], renderRequestId = null) {
+        handleFilterClick(filterId, examIndex = [], renderRequestId = null, options = {}) {
             this.activeFilter = filterId;
 
             // 更新按钮激活状态
             this.updateButtonStates();
 
             // 应用筛选
-            return this.applyFilter(filterId, examIndex, renderRequestId);
+            return this.applyFilter(filterId, examIndex, renderRequestId, options);
         }
 
         /**
@@ -298,15 +306,15 @@
          * 应用筛选
          * @param {string} filterId - 筛选器ID
          */
-        applyFilter(filterId, examIndex = [], renderRequestId = null) {
+        applyFilter(filterId, examIndex = [], renderRequestId = null, options = {}) {
             const config = this.getCurrentModeConfig();
 
             if (config.filterLogic === 'type-based') {
                 // 默认模式：按类型筛选
-                return this.filterByType(filterId, examIndex, renderRequestId);
+                return this.filterByType(filterId, examIndex, renderRequestId, options);
             } else if (config.filterLogic === 'folder-based') {
                 // 频率模式：按文件夹筛选
-                return this.filterByFolder(filterId, examIndex, renderRequestId);
+                return this.filterByFolder(filterId, examIndex, renderRequestId, options);
             }
             return undefined;
         }
@@ -315,10 +323,10 @@
          * 按类型筛选（默认模式）
          * @param {string} type - 类型 (all | reading | listening)
          */
-        filterByType(type, examIndex = [], renderRequestId = null) {
+        filterByType(type, examIndex = [], renderRequestId = null, options = {}) {
             // 调用全局的 filterByType 函数
             if (typeof global.filterByType === 'function') {
-                return global.filterByType(type, examIndex, renderRequestId);
+                return global.filterByType(type, examIndex, renderRequestId, options);
             } else {
                 console.warn('[BrowseController] filterByType 函数未定义');
             }
@@ -361,7 +369,7 @@
             });
         }
 
-        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
+        filterByFolder(filterId, examIndex = [], renderRequestId = null, options = {}) {
             if (renderRequestId != null
                 && typeof global.__isBrowseResultsRequestCurrent === 'function'
                 && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
@@ -383,24 +391,46 @@
                 && typeof searchInput.value === 'string'
                 && searchInput.value.trim());
             if (hasActiveQuery && typeof global.__renderBrowseResultsForState === 'function') {
-                return global.__renderBrowseResultsForState(filtered, renderRequestId);
+                return global.__renderBrowseResultsForState(filtered, renderRequestId, {
+                    foregroundEpoch: options.foregroundEpoch
+                });
             }
-            this.displayFilteredExams(filtered);
+            if (!options.recoveryManaged
+                && renderRequestId != null
+                && typeof global.__commitForegroundBrowseResults === 'function') {
+                return global.__commitForegroundBrowseResults(
+                    renderRequestId,
+                    options.foregroundEpoch,
+                    (commitReceipt) => {
+                        const committed = this.displayFilteredExams(filtered, { commitReceipt });
+                        return committed === false ? false : filtered;
+                    }
+                );
+            }
+            const committed = this.displayFilteredExams(filtered, {
+                commitReceipt: options.commitReceipt
+            });
+            if (committed === false) {
+                return false;
+            }
             return filtered;
         }
         /**
          * 显示筛选后的题目
          * @param {Array} exams - 题目数组
          */
-        displayFilteredExams(exams) {
-            // 更新筛选状态
-            if (typeof global.setFilteredExamsState === 'function') {
-                global.setFilteredExamsState(exams);
+        displayFilteredExams(exams, options = {}) {
+            // DOM commit is the authority. Do not publish filtered state or
+            // post-render effects when no renderer/container accepted it.
+            const displayed = typeof global.displayExams === 'function'
+                ? global.displayExams(exams, { commitReceipt: options.commitReceipt })
+                : false;
+            if (displayed !== true) {
+                return false;
             }
 
-            // 显示题目
-            if (typeof global.displayExams === 'function') {
-                global.displayExams(exams);
+            if (typeof global.setFilteredExamsState === 'function') {
+                global.setFilteredExamsState(exams);
             }
 
             // 处理渲染后逻辑
@@ -409,6 +439,7 @@
                 const type = global.getCurrentExamType ? global.getCurrentExamType() : 'all';
                 global.handlePostExamListRender(exams, { category, type });
             }
+            return true;
         }
 
         /**

--- a/js/app/browseController.js
+++ b/js/app/browseController.js
@@ -329,12 +329,7 @@
          * 按文件夹筛选（频率模式）
          * @param {string} filterId - 筛选器ID
          */
-        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
-            if (renderRequestId != null
-                && typeof global.__isBrowseResultsRequestCurrent === 'function'
-                && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
-                return;
-            }
+        filterExamsByFolder(examIndex = [], filterId = this.activeFilter) {
             const config = this.getCurrentModeConfig();
             const basePath = global.__browsePath || config.basePath || null;
             const folders = config.folderMap[filterId];
@@ -342,12 +337,10 @@
             // 允许“全部”入口只按 basePath 过滤（frequency-p1 无全量按钮）
             const isAllFilter = filterId === 'all';
             if (!folders && !isAllFilter) {
-                console.warn('[BrowseController] 未找到文件夹映射:', filterId);
-                return;
+                return null;
             }
 
-            // 筛选题目
-            const filtered = (Array.isArray(examIndex) ? examIndex : []).filter(exam => {
+            return (Array.isArray(examIndex) ? examIndex : []).filter(exam => {
                 if (!exam || !exam.path) {
                     return false;
                 }
@@ -366,9 +359,30 @@
                     return exam.path.includes(folder);
                 });
             });
+        }
 
-            // 活动搜索必须继续约束当前文件夹结果。
-            if (typeof global.__renderBrowseResultsForState === 'function') {
+        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
+            if (renderRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
+                return;
+            }
+            const filtered = this.filterExamsByFolder(examIndex, filterId);
+            if (!Array.isArray(filtered)) {
+                console.warn('[BrowseController] 未找到文件夹映射:', filterId);
+                return;
+            }
+
+            // 活动搜索必须继续约束当前文件夹结果；无查询时在控制器层终止
+            // 渲染，避免 main -> ExamActions -> controller -> main 的递归刷新。
+            const searchInput = document.getElementById('exam-search-input')
+                || (typeof document.querySelector === 'function'
+                    ? document.querySelector('.search-input')
+                    : null);
+            const hasActiveQuery = !!(searchInput
+                && typeof searchInput.value === 'string'
+                && searchInput.value.trim());
+            if (hasActiveQuery && typeof global.__renderBrowseResultsForState === 'function') {
                 return global.__renderBrowseResultsForState(filtered, renderRequestId);
             }
             this.displayFilteredExams(filtered);

--- a/js/app/browseController.js
+++ b/js/app/browseController.js
@@ -131,7 +131,7 @@
          * 设置浏览模式
          * @param {string} mode - 模式ID (default | frequency-p1 | frequency-p4)
          */
-        setMode(mode, examIndex = [], renderRequestId = null) {
+        setMode(mode, examIndex = [], renderRequestId = null, options = {}) {
             if (isReadingMemorizeBrowseMode()) {
                 mode = 'default';
             }
@@ -153,7 +153,10 @@
             this.renderFilterButtons(examIndex);
 
             // 应用筛选
-            this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+            if (!options.skipApply) {
+                return this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+            }
+            return undefined;
         }
 
         /**
@@ -207,9 +210,11 @@
                 // 绑定点击事件
                 button.addEventListener('click', async () => {
                     const interactionId = ++this.filterInteractionId;
-                    const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
-                        ? global.__beginBrowseResultsRequest()
-                        : null;
+                    const renderRequestId = typeof global.__beginBrowseUserResultsRequest === 'function'
+                        ? global.__beginBrowseUserResultsRequest()
+                        : (typeof global.__beginBrowseResultsRequest === 'function'
+                            ? global.__beginBrowseResultsRequest()
+                            : null);
                     try {
                         const index = await global.resolveActiveLibraryIndex();
                         if (interactionId !== this.filterInteractionId) {
@@ -220,9 +225,13 @@
                             && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
                             return;
                         }
-                        this.handleFilterClick(filter.id, index, renderRequestId);
+                        await Promise.resolve(this.handleFilterClick(filter.id, index, renderRequestId));
                     } catch (error) {
                         console.error('[BrowseController] 读取活动题库失败:', error);
+                    } finally {
+                        if (typeof global.__endBrowseUserResultsRequest === 'function') {
+                            global.__endBrowseUserResultsRequest(renderRequestId);
+                        }
                     }
                 });
 
@@ -261,7 +270,7 @@
             this.updateButtonStates();
 
             // 应用筛选
-            this.applyFilter(filterId, examIndex, renderRequestId);
+            return this.applyFilter(filterId, examIndex, renderRequestId);
         }
 
         /**
@@ -294,11 +303,12 @@
 
             if (config.filterLogic === 'type-based') {
                 // 默认模式：按类型筛选
-                this.filterByType(filterId, examIndex, renderRequestId);
+                return this.filterByType(filterId, examIndex, renderRequestId);
             } else if (config.filterLogic === 'folder-based') {
                 // 频率模式：按文件夹筛选
-                this.filterByFolder(filterId, examIndex, renderRequestId);
+                return this.filterByFolder(filterId, examIndex, renderRequestId);
             }
+            return undefined;
         }
 
         /**
@@ -308,10 +318,11 @@
         filterByType(type, examIndex = [], renderRequestId = null) {
             // 调用全局的 filterByType 函数
             if (typeof global.filterByType === 'function') {
-                global.filterByType(type, examIndex, renderRequestId);
+                return global.filterByType(type, examIndex, renderRequestId);
             } else {
                 console.warn('[BrowseController] filterByType 函数未定义');
             }
+            return undefined;
         }
 
         /**
@@ -356,8 +367,12 @@
                 });
             });
 
-            // 显示筛选结果
+            // 活动搜索必须继续约束当前文件夹结果。
+            if (typeof global.__renderBrowseResultsForState === 'function') {
+                return global.__renderBrowseResultsForState(filtered, renderRequestId);
+            }
             this.displayFilteredExams(filtered);
+            return filtered;
         }
         /**
          * 显示筛选后的题目
@@ -412,8 +427,8 @@
         /**
          * 重置为默认模式
          */
-        resetToDefault(examIndex = [], renderRequestId = null) {
-            this.setMode('default', examIndex, renderRequestId);
+        resetToDefault(examIndex = [], renderRequestId = null, options = {}) {
+            return this.setMode('default', examIndex, renderRequestId, options);
         }
 
         // ============================================================================

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -808,7 +808,7 @@
     /**
      * 加载并渲染题库列表
      */
-    function loadExamList(examIndex = []) {
+    function loadExamList(examIndex = [], options = {}) {
         console.log('[ExamActions] loadExamList called');
 
         if (typeof global.setupBrowseControls === 'function') {
@@ -831,12 +831,21 @@
                     global.browseController.initialize('type-filter-buttons', examIndex);
                 }
                 if (global.browseController.currentMode !== global.__browseFilterMode) {
-                    global.browseController.setMode(global.__browseFilterMode, examIndex);
+                    return global.browseController.setMode(
+                        global.__browseFilterMode,
+                        examIndex,
+                        options.renderRequestId,
+                        options
+                    );
                 } else {
                     const activeFilter = global.browseController.activeFilter || 'all';
-                    global.browseController.applyFilter(activeFilter, examIndex);
+                    return global.browseController.applyFilter(
+                        activeFilter,
+                        examIndex,
+                        options.renderRequestId,
+                        options
+                    );
                 }
-                return;
             } catch (error) {
                 console.warn('[Browse] 频率模式刷新失败，回退到默认逻辑:', error);
             }
@@ -911,7 +920,8 @@
 
         displayExams(examsToShow, {
             selectionMode,
-            customSuiteDraft
+            customSuiteDraft,
+            commitReceipt: options.commitReceipt
         });
         refreshCustomSuiteSelectionPortal();
 
@@ -1548,13 +1558,16 @@
                 customSuiteDraft: effectiveOptions.customSuiteDraft || null
             });
             setupExamActionHandlers();
-            return;
+            if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+                global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+            }
+            return true;
         }
 
         // 2. 降级：直接 DOM 操作 (从 main.js 迁移)
         const container = document.getElementById('exam-list-container');
         if (!container) {
-            return;
+            return false;
         }
 
         while (container.firstChild) {
@@ -1570,7 +1583,10 @@
         const normalizedExams = Array.isArray(renderExams) ? renderExams : [];
         if (normalizedExams.length === 0) {
             renderEmptyState(container);
-            return;
+            if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+                global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+            }
+            return true;
         }
 
         const list = document.createElement('div');
@@ -1584,6 +1600,10 @@
 
         container.appendChild(list);
         setupExamActionHandlers();
+        if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+            global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+        }
+        return true;
     }
 
     /**

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1552,11 +1552,14 @@
         }
 
         if (view) {
-            view.render(renderExams, {
+            const committed = view.render(renderExams, {
                 loadingSelector: '#browse-view .loading',
                 selectionMode: effectiveOptions.selectionMode || '',
                 customSuiteDraft: effectiveOptions.customSuiteDraft || null
             });
+            if (committed !== true) {
+                return false;
+            }
             setupExamActionHandlers();
             if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
                 global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -923,50 +923,232 @@
         return examsToShow;
     }
 
-    /**
-     * 重置浏览视图
-     */
-    function resetBrowseViewToAll() {
-        clearReadingMemorizeBrowseMode();
-        // 1. 清除频率模式标记（关键修复）
-        if (typeof global.__browseFilterMode !== 'undefined') {
-            global.__browseFilterMode = 'default';
+    let browseResetInteractionId = 0;
+
+    function isBrowseResetCurrent(interactionId, renderRequestId) {
+        if (interactionId !== browseResetInteractionId) {
+            return false;
         }
-        if (typeof global.__browsePath !== 'undefined') {
-            global.__browsePath = null;
+        return renderRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(renderRequestId);
+    }
+
+    function clearBrowseSearchUI() {
+        if (global.browseStateManager && typeof global.browseStateManager.clearSearchState === 'function') {
+            global.browseStateManager.clearSearchState();
+            return;
+        }
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    }
+
+    function syncBrowseFilterUI(examIndex) {
+        const controller = global.browseController;
+        if (controller) {
+            controller.currentMode = 'default';
+            controller.activeFilter = 'all';
+            if (typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            }
         }
 
-        // 2. 重置 browseController 到默认模式
-        if (global.browseController) {
-            global.browseController.clearPendingBrowseAutoScroll();
+        const typeContainer = document.getElementById('type-filter-buttons');
+        if (typeContainer && typeof typeContainer.querySelectorAll === 'function') {
+            typeContainer.querySelectorAll('.shui-segmented-btn').forEach((button) => {
+                const filterId = button.dataset && (button.dataset.filterId || button.dataset.filterType);
+                const active = filterId === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
 
-            // 恢复默认模式（消除频率模式）
-            if (typeof global.browseController.resetToDefault === 'function') {
-                global.browseController.resetToDefault();
-            } else {
-                // 降级：手动重置
-                global.browseController.currentMode = 'default';
-                global.browseController.activeFilter = 'all';
-            }
-
-            const currentCategory = global.browseController.getCurrentCategory();
-            const currentType = global.browseController.getCurrentExamType();
-
-            if (currentCategory === 'all' && currentType === 'all') {
-                if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-                loadExamList();
-                return;
-            }
-
-            global.browseController.setBrowseFilterState('all', 'all');
+        global.__browseFrequencyFilter = 'all';
+        if (typeof global.updateBrowseFrequencyButtons === 'function') {
+            global.updateBrowseFrequencyButtons('all');
         } else {
-            // 降级
-            if (typeof global.clearPendingBrowseAutoScroll === 'function') global.clearPendingBrowseAutoScroll();
-            if (typeof global.setBrowseFilterState === 'function') global.setBrowseFilterState('all', 'all');
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    if (button.classList && typeof button.classList.remove === 'function') {
+                        button.classList.remove('active');
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', 'false');
+                    }
+                });
+            }
+        }
+    }
+
+    async function prepareBrowseReset() {
+        const pending = [];
+        const manager = global.browseStateManager;
+        if (manager && manager.ready && typeof manager.ready.then === 'function') {
+            pending.push(Promise.resolve(manager.ready).catch((error) => {
+                console.warn('[ExamActions] 等待浏览状态恢复失败:', error);
+            }));
+        }
+        if (typeof global.setupBrowseControls === 'function') {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+                console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
+            }));
+        }
+        if (pending.length > 0) {
+            await Promise.all(pending);
+        }
+    }
+
+    async function persistBrowseFrequencyReset() {
+        const preferences = global.AppData && global.AppData.preferences;
+        if (!preferences || typeof preferences.patchBrowse !== 'function') {
+            return;
+        }
+        try {
+            await preferences.patchBrowse({ frequencyFilter: 'all' });
+        } catch (error) {
+            console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+        }
+    }
+
+    function beginBrowseResetPersistence() {
+        const pending = [persistBrowseFrequencyReset()];
+        if (typeof global.flushBrowsePreferenceWrites === 'function') {
+            pending.push(Promise.resolve().then(() => global.flushBrowsePreferenceWrites()).catch((error) => {
+                console.warn('[ExamActions] 等待浏览筛选偏好写入失败:', error);
+            }));
+        }
+        return Promise.all(pending);
+    }
+
+    function applyBrowseResetState(examIndex) {
+        clearReadingMemorizeBrowseMode();
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+
+        if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
+            global.browseStateManager.resetToAllExams();
+        } else {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            }
+            clearBrowseSearchUI();
         }
 
-        if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-        loadExamList();
+        syncBrowseFilterUI(examIndex);
+        if (typeof global.setBrowseTitle === 'function') {
+            global.setBrowseTitle('题库列表');
+        }
+    }
+
+    /**
+     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
+     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     */
+    async function performBrowseViewResetToAll() {
+        const interactionId = ++browseResetInteractionId;
+        if (global.__pendingBrowseFilter) {
+            delete global.__pendingBrowseFilter;
+        }
+        const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+            ? global.__beginBrowseResultsRequest()
+            : null;
+
+        if (global.browseController) {
+            if (typeof global.browseController.filterInteractionId === 'number') {
+                global.browseController.filterInteractionId += 1;
+            }
+            if (typeof global.browseController.clearPendingBrowseAutoScroll === 'function') {
+                global.browseController.clearPendingBrowseAutoScroll();
+            }
+        } else if (typeof global.clearPendingBrowseAutoScroll === 'function') {
+            global.clearPendingBrowseAutoScroll();
+        }
+
+        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+            ? global.resolveActiveLibraryIndex
+            : global.resolveActiveExamIndex;
+        const indexPromise = typeof resolver === 'function'
+            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                Array.isArray(resolved) ? resolved : null
+            )).catch((error) => {
+                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                return null;
+            })
+            : Promise.resolve(null);
+        const [examIndex] = await Promise.all([
+            indexPromise,
+            prepareBrowseReset()
+        ]);
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        applyBrowseResetState(examIndex);
+
+        const globalLoader = global.loadExamList;
+        if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
+            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
+            let renderPromise;
+            try {
+                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+            } catch (error) {
+                renderPromise = Promise.reject(error);
+            }
+            const persistencePromise = beginBrowseResetPersistence();
+            try {
+                const result = await renderPromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    await persistencePromise;
+                    return false;
+                }
+                if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                    && Array.isArray(result)) {
+                    syncBrowseFilterUI(result);
+                }
+                await persistencePromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    return false;
+                }
+                return result;
+            } catch (error) {
+                console.warn('[ExamActions] 重置浏览视图加载失败:', error);
+                await persistencePromise;
+                return false;
+            }
+        }
+
+        if (Array.isArray(examIndex) && examIndex.length > 0) {
+            const result = loadExamList(examIndex);
+            await beginBrowseResetPersistence();
+            return result;
+        }
+
+        await beginBrowseResetPersistence();
+        console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
+        return false;
+    }
+
+    async function resetBrowseViewToAll() {
+        try {
+            return await performBrowseViewResetToAll();
+        } catch (error) {
+            console.warn('[ExamActions] 重置浏览视图失败:', error);
+            return false;
+        }
     }
 
     /**

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -950,14 +950,42 @@
         }
     }
 
-    function syncBrowseFilterUI(examIndex) {
+    function setBrowseFrequencyFilter(value) {
+        const activeFilter = normalizeBrowseFrequencyFilter(value);
+        global.__browseFrequencyFilter = activeFilter;
+        const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+        if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+            frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
+        return activeFilter;
+    }
+
+    function resetBrowseFilterStateToAll(examIndex) {
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+        setBrowseFrequencyFilter('all');
+
         const controller = global.browseController;
         if (controller) {
             controller.currentMode = 'default';
             controller.activeFilter = 'all';
-            if (typeof controller.renderFilterButtons === 'function') {
-                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            if (Array.isArray(examIndex) && typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(examIndex);
             }
+        }
+
+        if (typeof global.setBrowseFilterState === 'function') {
+            global.setBrowseFilterState('all', 'all');
+        } else if (controller && typeof controller.setBrowseFilterState === 'function') {
+            controller.setBrowseFilterState('all', 'all');
         }
 
         const typeContainer = document.getElementById('type-filter-buttons');
@@ -973,22 +1001,10 @@
                 }
             });
         }
+    }
 
-        if (typeof global.updateBrowseFrequencyButtons === 'function') {
-            global.updateBrowseFrequencyButtons('all');
-        } else {
-            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
-                    if (button.classList && typeof button.classList.remove === 'function') {
-                        button.classList.remove('active');
-                    }
-                    if (typeof button.setAttribute === 'function') {
-                        button.setAttribute('aria-pressed', 'false');
-                    }
-                });
-            }
-        }
+    function syncBrowseFilterUI(examIndex) {
+        resetBrowseFilterStateToAll(examIndex);
     }
 
     async function prepareBrowseReset() {
@@ -1033,19 +1049,14 @@
 
     function applyBrowseResetState(examIndex) {
         clearReadingMemorizeBrowseMode();
-        global.__browseFilterMode = 'default';
-        global.__browsePath = null;
+        resetBrowseFilterStateToAll(examIndex);
 
         if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
             global.browseStateManager.resetToAllExams();
         } else {
-            if (typeof global.setBrowseFilterState === 'function') {
-                global.setBrowseFilterState('all', 'all');
-            }
             clearBrowseSearchUI();
         }
 
-        syncBrowseFilterUI(examIndex);
         if (typeof global.setBrowseTitle === 'function') {
             global.setBrowseTitle('题库列表');
         }
@@ -1727,6 +1738,8 @@
         applyBrowsePostFilters,
         applyBrowseFrequencyFilter,
         normalizeBrowseFrequencyFilter,
+        setBrowseFrequencyFilter,
+        resetBrowseFilterStateToAll,
         launchReadingMemorizeExam,
         isReadingMemorizeBrowseMode,
         isReadingMemorizeExam

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1052,11 +1052,52 @@
         }
     }
 
+    function getBrowseResetIndexSnapshot(resetIntent) {
+        if (typeof global.__getBrowseResetIndexSnapshot !== 'function') {
+            return null;
+        }
+        try {
+            const snapshot = global.__getBrowseResetIndexSnapshot(resetIntent);
+            if (!snapshot || !Array.isArray(snapshot.index)) {
+                return null;
+            }
+            return {
+                index: snapshot.index,
+                version: Number(snapshot.version) || 0
+            };
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function closeBrowseResetIntent(resetIntent, consumedSnapshotVersion) {
+        if (typeof global.__closeBrowseResetIntent !== 'function') {
+            return null;
+        }
+        try {
+            const finalization = global.__closeBrowseResetIntent(
+                resetIntent,
+                consumedSnapshotVersion
+            );
+            if (!finalization || !finalization.snapshot
+                || !Array.isArray(finalization.snapshot.index)) {
+                return null;
+            }
+            return {
+                index: finalization.snapshot.index,
+                version: Number(finalization.snapshot.version) || 0
+            };
+        } catch (_) {
+            return null;
+        }
+    }
+
     /**
-     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
-     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     * 重置浏览视图。先等待浏览状态恢复，再解析活动题库快照并一次性更新
+     * UI/状态，避免恢复期间的题库切换被较早快照覆盖。
      */
-    async function performBrowseViewResetToAll() {
+    async function performBrowseViewResetToAll(resetIntent) {
+        try {
         const interactionId = ++browseResetInteractionId;
         if (global.__pendingBrowseFilter) {
             delete global.__pendingBrowseFilter;
@@ -1064,6 +1105,9 @@
         const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
             ? global.__beginBrowseResultsRequest()
             : null;
+        if (typeof global.__setBrowseResetResultsRequest === 'function') {
+            global.__setBrowseResetResultsRequest(resetIntent, renderRequestId);
+        }
 
         if (global.browseController) {
             if (typeof global.browseController.filterInteractionId === 'number') {
@@ -1076,21 +1120,33 @@
             global.clearPendingBrowseAutoScroll();
         }
 
-        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
-            ? global.resolveActiveLibraryIndex
-            : global.resolveActiveExamIndex;
-        const indexPromise = typeof resolver === 'function'
-            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
-                Array.isArray(resolved) ? resolved : null
-            )).catch((error) => {
-                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
-                return null;
-            })
-            : Promise.resolve(null);
-        const [examIndex] = await Promise.all([
-            indexPromise,
-            prepareBrowseReset()
-        ]);
+        await prepareBrowseReset();
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        let resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+        let examIndex = resetIndexSnapshot ? resetIndexSnapshot.index : null;
+        let resetIndexSnapshotVersion = resetIndexSnapshot ? resetIndexSnapshot.version : 0;
+        if (!resetIndexSnapshot) {
+            const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+                ? global.resolveActiveLibraryIndex
+                : global.resolveActiveExamIndex;
+            examIndex = typeof resolver === 'function'
+                ? await Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                    Array.isArray(resolved) ? resolved : null
+                )).catch((error) => {
+                    console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                    return null;
+                })
+                : null;
+            resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+            if (resetIndexSnapshot) {
+                examIndex = resetIndexSnapshot.index;
+                resetIndexSnapshotVersion = resetIndexSnapshot.version;
+            }
+        }
 
         if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
             return false;
@@ -1100,30 +1156,60 @@
 
         const globalLoader = global.loadExamList;
         if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
-            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
-            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
-            let renderPromise;
-            try {
-                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
-            } catch (error) {
-                renderPromise = Promise.reject(error);
-            }
             const persistencePromise = beginBrowseResetPersistence();
             try {
-                const result = await renderPromise;
-                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
-                    await persistencePromise;
-                    return false;
+                let result;
+                let persistenceComplete = false;
+                while (true) {
+                    // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+                    const indexOverride = Array.isArray(examIndex) && examIndex.length > 0
+                        ? examIndex
+                        : null;
+                    result = await Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+                    if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                        await persistencePromise;
+                        return false;
+                    }
+                    if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                        && Array.isArray(result)) {
+                        syncBrowseFilterUI(result);
+                    }
+                    resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+                    if (resetIndexSnapshot
+                        && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                        examIndex = resetIndexSnapshot.index;
+                        resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                        syncBrowseFilterUI(examIndex);
+                        continue;
+                    }
+                    if (!persistenceComplete) {
+                        await persistencePromise;
+                        persistenceComplete = true;
+                        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                            return false;
+                        }
+                        resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+                        if (resetIndexSnapshot
+                            && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                            examIndex = resetIndexSnapshot.index;
+                            resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                            syncBrowseFilterUI(examIndex);
+                            continue;
+                        }
+                    }
+                    resetIndexSnapshot = closeBrowseResetIntent(
+                        resetIntent,
+                        resetIndexSnapshotVersion
+                    );
+                    if (resetIndexSnapshot
+                        && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                        examIndex = resetIndexSnapshot.index;
+                        resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                        syncBrowseFilterUI(examIndex);
+                        continue;
+                    }
+                    return result;
                 }
-                if ((!Array.isArray(examIndex) || examIndex.length === 0)
-                    && Array.isArray(result)) {
-                    syncBrowseFilterUI(result);
-                }
-                await persistencePromise;
-                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
-                    return false;
-                }
-                return result;
             } catch (error) {
                 console.warn('[ExamActions] 重置浏览视图加载失败:', error);
                 await persistencePromise;
@@ -1132,22 +1218,53 @@
         }
 
         if (Array.isArray(examIndex) && examIndex.length > 0) {
-            const result = loadExamList(examIndex);
+            let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
+            resetIndexSnapshot = closeBrowseResetIntent(
+                resetIntent,
+                resetIndexSnapshotVersion
+            );
+            if (resetIndexSnapshot && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                examIndex = resetIndexSnapshot.index;
+                resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                if (examIndex.length > 0) {
+                    syncBrowseFilterUI(examIndex);
+                    result = loadExamList(examIndex);
+                } else {
+                    result = false;
+                }
+                closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
+            }
             return result;
         }
 
         await beginBrowseResetPersistence();
+        closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
         console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
         return false;
+        } finally {
+            if (typeof global.__endBrowseResetIntent === 'function') {
+                global.__endBrowseResetIntent(resetIntent);
+            }
+        }
     }
 
     async function resetBrowseViewToAll() {
+        var resetIntent = arguments.length > 0 ? arguments[arguments.length - 1] : null;
+        if (typeof global.__isBrowseResetIntentCurrent === 'function'
+            && !global.__isBrowseResetIntentCurrent(resetIntent)
+            && typeof global.__beginBrowseResetIntent === 'function') {
+            resetIntent = global.__beginBrowseResetIntent();
+        }
         try {
-            return await performBrowseViewResetToAll();
+            return await performBrowseViewResetToAll(resetIntent);
         } catch (error) {
             console.warn('[ExamActions] 重置浏览视图失败:', error);
             return false;
+        } finally {
+            if (typeof global.__endBrowseResetIntent === 'function') {
+                global.__endBrowseResetIntent(resetIntent);
+            }
         }
     }
 

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1157,35 +1157,58 @@
         }
     }
 
-    async function resetBrowseFunctionalStateForActivation() {
+    async function resetBrowseFunctionalStateForActivation(options = {}) {
+        const isCurrent = typeof options.isCurrent === 'function'
+            ? options.isCurrent
+            : () => true;
         try {
+            if (!isCurrent()) {
+                return false;
+            }
             const manager = ensureBrowseStateManagerForReset();
             if (manager && manager.ready && typeof manager.ready.then === 'function') {
                 await manager.ready;
+                if (!isCurrent()) {
+                    return false;
+                }
             }
             if (typeof global.setupBrowseControls === 'function') {
                 await global.setupBrowseControls();
+                if (!isCurrent()) {
+                    return false;
+                }
             }
-            if (!applyBrowseResetState(null)) {
+            if (!isCurrent() || !applyBrowseResetState(null)) {
                 return false;
             }
 
             if (typeof global.saveBrowseViewPreferences !== 'function'
-                || typeof global.flushBrowsePreferenceWrites !== 'function') {
+                || typeof global.flushBrowsePreferenceWrites !== 'function'
+                || !isCurrent()) {
                 return false;
             }
             global.saveBrowseViewPreferences({
                 lastFilter: { category: 'all', type: 'all' }
             });
             const committedBrowsePreferences = await global.flushBrowsePreferenceWrites();
-            if (!committedBrowsePreferences
+            if (!isCurrent()
+                || !committedBrowsePreferences
                 || !isAllBrowseFilter(committedBrowsePreferences.lastFilter)) {
                 return false;
             }
             if (manager && typeof manager.persistState === 'function') {
+                if (!isCurrent()) {
+                    return false;
+                }
                 await manager.persistState();
+                if (!isCurrent()) {
+                    return false;
+                }
             }
-            if (!await persistBrowseFrequencyReset() || !isBrowseManagerReset(manager)) {
+            if (!isCurrent()
+                || !await persistBrowseFrequencyReset()
+                || !isCurrent()
+                || !isBrowseManagerReset(manager)) {
                 return false;
             }
             const preferences = global.AppData && global.AppData.preferences;
@@ -1193,7 +1216,7 @@
                 return false;
             }
             const persistedBrowse = await preferences.getBrowse();
-            return isPersistedBrowseReset(
+            return isCurrent() && isPersistedBrowseReset(
                 persistedBrowse,
                 !!(manager && typeof manager.persistState === 'function')
             );
@@ -1371,6 +1394,9 @@
         if (Array.isArray(examIndex) && examIndex.length > 0) {
             let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
+            if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                return false;
+            }
             resetIndexSnapshot = closeBrowseResetIntent(
                 resetIntent,
                 resetIndexSnapshotVersion
@@ -1390,6 +1416,9 @@
         }
 
         await beginBrowseResetPersistence();
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
         closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
         console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
         return false;
@@ -1407,12 +1436,35 @@
             && typeof global.__beginBrowseResetIntent === 'function') {
             resetIntent = global.__beginBrowseResetIntent();
         }
+        const functionalResetRecovery = global.AppEntry
+            && typeof global.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+            ? global.AppEntry.captureBrowseFunctionalResetRecovery()
+            : null;
+        let functionalResetRecoverySucceeded = false;
         try {
-            return await performBrowseViewResetToAll(resetIntent);
+            const resetPromise = performBrowseViewResetToAll(resetIntent);
+            if (functionalResetRecovery
+                && global.AppEntry
+                && typeof global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
+                global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest(
+                    functionalResetRecovery
+                );
+            }
+            const result = await resetPromise;
+            functionalResetRecoverySucceeded = result !== false;
+            return result;
         } catch (error) {
             console.warn('[ExamActions] 重置浏览视图失败:', error);
             return false;
         } finally {
+            if (functionalResetRecovery
+                && global.AppEntry
+                && typeof global.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+                global.AppEntry.completeBrowseFunctionalResetRecovery(
+                    functionalResetRecovery,
+                    functionalResetRecoverySucceeded
+                );
+            }
             if (typeof global.__endBrowseResetIntent === 'function') {
                 global.__endBrowseResetIntent(resetIntent);
             }

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1066,16 +1066,54 @@
     async function persistBrowseFrequencyReset() {
         const preferences = global.AppData && global.AppData.preferences;
         if (!preferences || typeof preferences.patchBrowse !== 'function') {
-            return;
+            return false;
         }
         try {
             await preferences.patchBrowse({
                 frequencyFilter: 'all',
                 filter: { category: 'all', type: 'all' }
             });
+            return true;
         } catch (error) {
             console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+            return false;
         }
+    }
+
+    function isAllBrowseFilter(filter) {
+        return !!filter && filter.category === 'all' && filter.type === 'all';
+    }
+
+    function isBrowseManagerReset(manager) {
+        if (!manager) {
+            return true;
+        }
+        const state = manager.state || {};
+        const filters = state.filters || {};
+        return manager.currentFilter === 'all'
+            && state.currentCategory == null
+            && state.currentFrequency == null
+            && (filters.frequency == null || filters.frequency === 'all')
+            && (state.searchQuery == null || state.searchQuery === '');
+    }
+
+    function isPersistedBrowseReset(browse, requireStateManager) {
+        if (!browse || !isAllBrowseFilter(browse.lastFilter)
+            || !isAllBrowseFilter(browse.filter)
+            || browse.frequencyFilter !== 'all') {
+            return false;
+        }
+        if (!requireStateManager) {
+            return true;
+        }
+        const manager = browse.stateManager;
+        const state = manager && manager.state;
+        const filters = state && state.filters;
+        return !!manager && manager.currentFilter === 'all'
+            && state.currentCategory == null
+            && state.currentFrequency == null
+            && !!filters && filters.frequency === 'all'
+            && state.searchQuery === '';
     }
 
     function beginBrowseResetPersistence() {
@@ -1132,19 +1170,33 @@
                 return false;
             }
 
-            if (typeof global.saveBrowseViewPreferences === 'function') {
-                global.saveBrowseViewPreferences({
-                    lastFilter: { category: 'all', type: 'all' }
-                });
+            if (typeof global.saveBrowseViewPreferences !== 'function'
+                || typeof global.flushBrowsePreferenceWrites !== 'function') {
+                return false;
             }
-            if (typeof global.flushBrowsePreferenceWrites === 'function') {
-                await global.flushBrowsePreferenceWrites();
+            global.saveBrowseViewPreferences({
+                lastFilter: { category: 'all', type: 'all' }
+            });
+            const committedBrowsePreferences = await global.flushBrowsePreferenceWrites();
+            if (!committedBrowsePreferences
+                || !isAllBrowseFilter(committedBrowsePreferences.lastFilter)) {
+                return false;
             }
             if (manager && typeof manager.persistState === 'function') {
                 await manager.persistState();
             }
-            await persistBrowseFrequencyReset();
-            return true;
+            if (!await persistBrowseFrequencyReset() || !isBrowseManagerReset(manager)) {
+                return false;
+            }
+            const preferences = global.AppData && global.AppData.preferences;
+            if (!preferences || typeof preferences.getBrowse !== 'function') {
+                return false;
+            }
+            const persistedBrowse = await preferences.getBrowse();
+            return isPersistedBrowseReset(
+                persistedBrowse,
+                !!(manager && typeof manager.persistState === 'function')
+            );
         } catch (error) {
             console.warn('[ExamActions] 激活前重置题库状态失败:', error);
             return false;

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -925,9 +925,30 @@
 
     let browseResetInteractionId = 0;
 
-    function isBrowseResetCurrent(interactionId, renderRequestId) {
+    function isBrowseResetCurrent(
+        interactionId,
+        renderRequestId,
+        navigationIntentGeneration = null
+    ) {
         if (interactionId !== browseResetInteractionId) {
             return false;
+        }
+        if (navigationIntentGeneration != null
+            && typeof global.__getAppNavigationIntentGeneration === 'function') {
+            try {
+                if (global.__getAppNavigationIntentGeneration() !== navigationIntentGeneration) {
+                    return false;
+                }
+            } catch (_) {
+                return false;
+            }
+        }
+        if (typeof document !== 'undefined'
+            && typeof document.querySelector === 'function') {
+            const activeView = document.querySelector('.view.active');
+            if (activeView && activeView.id !== 'browse-view') {
+                return false;
+            }
         }
         return renderRequestId == null
             || typeof global.__isBrowseResultsRequestCurrent !== 'function'
@@ -1045,7 +1066,13 @@
         resetBrowseFilterStateToAll(examIndex);
     }
 
-    async function prepareBrowseReset() {
+    async function prepareBrowseReset(options = {}) {
+        const isCurrent = typeof options.isCurrent === 'function'
+            ? options.isCurrent
+            : () => true;
+        if (!isCurrent()) {
+            return false;
+        }
         const pending = [];
         const manager = global.browseStateManager;
         if (manager && manager.ready && typeof manager.ready.then === 'function') {
@@ -1054,13 +1081,17 @@
             }));
         }
         if (typeof global.setupBrowseControls === 'function') {
-            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls({ isCurrent })).catch((error) => {
                 console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
             }));
         }
         if (pending.length > 0) {
-            await Promise.all(pending);
+            const results = await Promise.all(pending);
+            if (results.some((result) => result === false)) {
+                return false;
+            }
         }
+        return isCurrent();
     }
 
     async function persistBrowseFrequencyReset() {
@@ -1173,8 +1204,8 @@
                 }
             }
             if (typeof global.setupBrowseControls === 'function') {
-                await global.setupBrowseControls();
-                if (!isCurrent()) {
+                const controlsReady = await global.setupBrowseControls({ isCurrent });
+                if (controlsReady === false || !isCurrent()) {
                     return false;
                 }
             }
@@ -1273,6 +1304,9 @@
     async function performBrowseViewResetToAll(resetIntent) {
         try {
         const interactionId = ++browseResetInteractionId;
+        const navigationIntentGeneration = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration()
+            : null;
         if (global.__pendingBrowseFilter) {
             delete global.__pendingBrowseFilter;
         }
@@ -1294,9 +1328,12 @@
             global.clearPendingBrowseAutoScroll();
         }
 
-        await prepareBrowseReset();
-
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        const isCurrent = () => isBrowseResetCurrent(
+            interactionId,
+            renderRequestId,
+            navigationIntentGeneration
+        );
+        if (!await prepareBrowseReset({ isCurrent }) || !isCurrent()) {
             return false;
         }
 
@@ -1322,7 +1359,7 @@
             }
         }
 
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        if (!isCurrent()) {
             return false;
         }
 
@@ -1340,7 +1377,7 @@
                         ? examIndex
                         : null;
                     result = await Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
-                    if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    if (!isCurrent()) {
                         await persistencePromise;
                         return false;
                     }
@@ -1359,7 +1396,7 @@
                     if (!persistenceComplete) {
                         await persistencePromise;
                         persistenceComplete = true;
-                        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                        if (!isCurrent()) {
                             return false;
                         }
                         resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
@@ -1394,7 +1431,7 @@
         if (Array.isArray(examIndex) && examIndex.length > 0) {
             let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
-            if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            if (!isCurrent()) {
                 return false;
             }
             resetIndexSnapshot = closeBrowseResetIntent(
@@ -1416,7 +1453,7 @@
         }
 
         await beginBrowseResetPersistence();
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        if (!isCurrent()) {
             return false;
         }
         closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
@@ -1443,11 +1480,15 @@
         let functionalResetRecoverySucceeded = false;
         try {
             const resetPromise = performBrowseViewResetToAll(resetIntent);
+            const foregroundResultsRequestId = typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null;
             if (functionalResetRecovery
                 && global.AppEntry
                 && typeof global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
                 global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest(
-                    functionalResetRecovery
+                    functionalResetRecovery,
+                    foregroundResultsRequestId
                 );
             }
             const result = await resetPromise;

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -953,39 +953,75 @@
     function setBrowseFrequencyFilter(value) {
         const activeFilter = normalizeBrowseFrequencyFilter(value);
         global.__browseFrequencyFilter = activeFilter;
-        const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-        if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-            frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
-                const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
-                if (button.classList && typeof button.classList.toggle === 'function') {
-                    button.classList.toggle('active', active);
-                }
-                if (typeof button.setAttribute === 'function') {
-                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
-                }
-            });
+        try {
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
+                    if (button.classList && typeof button.classList.toggle === 'function') {
+                        button.classList.toggle('active', active);
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                    }
+                });
+            }
+        } catch (error) {
+            console.warn('[ExamActions] 同步题库频率筛选 UI 失败:', error);
         }
         return activeFilter;
     }
 
-    function resetBrowseFilterStateToAll(examIndex) {
-        global.__browseFilterMode = 'default';
-        global.__browsePath = null;
-        setBrowseFrequencyFilter('all');
+    function resetBrowseFunctionalStateToAll() {
+        try {
+            global.__browseFilterMode = 'default';
+            global.__browsePath = null;
+            setBrowseFrequencyFilter('all');
+        } catch (error) {
+            console.warn('[ExamActions] 重置题库功能状态失败:', error);
+            return false;
+        }
 
         const controller = global.browseController;
         if (controller) {
-            controller.currentMode = 'default';
-            controller.activeFilter = 'all';
-            if (Array.isArray(examIndex) && typeof controller.renderFilterButtons === 'function') {
-                controller.renderFilterButtons(examIndex);
+            try {
+                controller.currentMode = 'default';
+                controller.activeFilter = 'all';
+            } catch (error) {
+                console.warn('[ExamActions] 重置题库控制器状态失败:', error);
             }
         }
 
-        if (typeof global.setBrowseFilterState === 'function') {
-            global.setBrowseFilterState('all', 'all');
-        } else if (controller && typeof controller.setBrowseFilterState === 'function') {
-            controller.setBrowseFilterState('all', 'all');
+        try {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            } else if (controller && typeof controller.setBrowseFilterState === 'function') {
+                controller.setBrowseFilterState('all', 'all');
+            } else {
+                console.warn('[ExamActions] 缺少题库分类状态适配器');
+                return false;
+            }
+        } catch (error) {
+            console.warn('[ExamActions] 重置题库分类状态失败:', error);
+            return false;
+        }
+        return true;
+    }
+
+    const browseFilterStateOwner = {
+        setFrequencyFilter: setBrowseFrequencyFilter,
+        resetToAll: resetBrowseFunctionalStateToAll
+    };
+
+    function resetBrowseFilterStateToAll(examIndex) {
+        if (!browseFilterStateOwner.resetToAll()) {
+            return false;
+        }
+
+        const controller = global.browseController;
+        if (controller && Array.isArray(examIndex)
+            && typeof controller.renderFilterButtons === 'function') {
+            controller.renderFilterButtons(examIndex);
         }
 
         const typeContainer = document.getElementById('type-filter-buttons');
@@ -1001,6 +1037,7 @@
                 }
             });
         }
+        return true;
     }
 
     function syncBrowseFilterUI(examIndex) {
@@ -1739,6 +1776,7 @@
         applyBrowseFrequencyFilter,
         normalizeBrowseFrequencyFilter,
         setBrowseFrequencyFilter,
+        browseFilterStateOwner,
         resetBrowseFilterStateToAll,
         launchReadingMemorizeExam,
         isReadingMemorizeBrowseMode,

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -911,18 +911,20 @@
             ? 'reading-memorize'
             : (isCustomSuiteSelectionActive() ? 'custom-suite' : '');
 
-        // 6. 更新状态并渲染
+        // 6. 先证明 DOM commit，再发布对应的筛选状态。
+        const displayed = displayExams(examsToShow, {
+            selectionMode,
+            customSuiteDraft,
+            commitReceipt: options.commitReceipt
+        });
+        if (displayed !== true) {
+            return false;
+        }
         if (global.appStateService) {
             global.appStateService.setFilteredExams(examsToShow);
         } else if (typeof global.setFilteredExamsState === 'function') {
             global.setFilteredExamsState(examsToShow);
         }
-
-        displayExams(examsToShow, {
-            selectionMode,
-            customSuiteDraft,
-            commitReceipt: options.commitReceipt
-        });
         refreshCustomSuiteSelectionPortal();
 
         // 7. 触发渲染后钩子
@@ -1953,8 +1955,7 @@
         if (!container) {
             return false;
         }
-        displayExams(exams, options);
-        return true;
+        return displayExams(exams, options) === true;
     }
 
     // ============================================================================

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1010,7 +1010,8 @@
 
     const browseFilterStateOwner = {
         setFrequencyFilter: setBrowseFrequencyFilter,
-        resetToAll: resetBrowseFunctionalStateToAll
+        resetToAll: resetBrowseFunctionalStateToAll,
+        resetForActivation: resetBrowseFunctionalStateForActivation
     };
 
     function resetBrowseFilterStateToAll(examIndex) {
@@ -1068,7 +1069,10 @@
             return;
         }
         try {
-            await preferences.patchBrowse({ frequencyFilter: 'all' });
+            await preferences.patchBrowse({
+                frequencyFilter: 'all',
+                filter: { category: 'all', type: 'all' }
+            });
         } catch (error) {
             console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
         }
@@ -1086,7 +1090,7 @@
 
     function applyBrowseResetState(examIndex) {
         clearReadingMemorizeBrowseMode();
-        resetBrowseFilterStateToAll(examIndex);
+        const filterResetSucceeded = resetBrowseFilterStateToAll(examIndex);
 
         if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
             global.browseStateManager.resetToAllExams();
@@ -1096,6 +1100,54 @@
 
         if (typeof global.setBrowseTitle === 'function') {
             global.setBrowseTitle('题库列表');
+        }
+        return filterResetSucceeded;
+    }
+
+    function ensureBrowseStateManagerForReset() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[ExamActions] 初始化题库状态管理器失败:', error);
+            return null;
+        }
+    }
+
+    async function resetBrowseFunctionalStateForActivation() {
+        try {
+            const manager = ensureBrowseStateManagerForReset();
+            if (manager && manager.ready && typeof manager.ready.then === 'function') {
+                await manager.ready;
+            }
+            if (typeof global.setupBrowseControls === 'function') {
+                await global.setupBrowseControls();
+            }
+            if (!applyBrowseResetState(null)) {
+                return false;
+            }
+
+            if (typeof global.saveBrowseViewPreferences === 'function') {
+                global.saveBrowseViewPreferences({
+                    lastFilter: { category: 'all', type: 'all' }
+                });
+            }
+            if (typeof global.flushBrowsePreferenceWrites === 'function') {
+                await global.flushBrowsePreferenceWrites();
+            }
+            if (manager && typeof manager.persistState === 'function') {
+                await manager.persistState();
+            }
+            await persistBrowseFrequencyReset();
+            return true;
+        } catch (error) {
+            console.warn('[ExamActions] 激活前重置题库状态失败:', error);
+            return false;
         }
     }
 

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -974,7 +974,6 @@
             });
         }
 
-        global.__browseFrequencyFilter = 'all';
         if (typeof global.updateBrowseFrequencyButtons === 'function') {
             global.updateBrowseFrequencyButtons('all');
         } else {

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -355,10 +355,17 @@
     function synchronizeActiveBrowseViewAfterLoad() {
         var resetBarrier = browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow();
+            return synchronizeActiveBrowseViewNow().then(function () {
+                return true;
+            });
         }
         return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
-            return resetSucceeded ? synchronizeActiveBrowseViewNow() : undefined;
+            if (!resetSucceeded) {
+                return false;
+            }
+            return synchronizeActiveBrowseViewNow().then(function () {
+                return true;
+            });
         });
     }
 
@@ -388,8 +395,13 @@
                 return synchronizeActiveBrowseViewAfterLoad()
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
+                        return true;
                     })
-                    .then(function browseViewSynchronized() {
+                    .then(function browseViewSynchronized(synchronized) {
+                        if (synchronized === false) {
+                            browseGroupPromise = null;
+                            return false;
+                        }
                         return true;
                     });
             }).catch(function onBrowseLoadError(error) {
@@ -468,6 +480,9 @@
     }
 
     global.__markAppNavigationIntent = markAppNavigationIntent;
+    global.__getAppNavigationIntentGeneration = function getAppNavigationIntentGeneration() {
+        return appNavigationIntentGeneration;
+    };
 
     function initializeNavigationShell() {
         var controller = null;
@@ -716,7 +731,10 @@
                     resultsRequestCaptured = true;
                 });
             }
-            return groupReady.then(function invoke() {
+            return groupReady.then(function invoke(groupSucceeded) {
+                if (groupName === BROWSE_GROUP && groupSucceeded === false) {
+                    return false;
+                }
                 if (groupName === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
                     return false;
                 }
@@ -841,7 +859,10 @@
                     resultsRequestCaptured = true;
                 });
             }
-            return groupReady.then(function () {
+            return groupReady.then(function (groupSucceeded) {
+                if (group === BROWSE_GROUP && groupSucceeded === false) {
+                    return false;
+                }
                 if (group === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
                     return false;
                 }
@@ -1068,7 +1089,10 @@
                     resultsRequestCaptured = true;
                 });
             }
-            browseReady.then(function afterBrowseReady() {
+            browseReady.then(function afterBrowseReady(groupSucceeded) {
+                if (groupSucceeded === false) {
+                    return;
+                }
                 if (refreshGeneration !== examIndexRefreshGeneration
                     || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration
                     || navigationGenerationAtReceipt !== appNavigationIntentGeneration

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -264,6 +264,8 @@
     var browseResetIntentGeneration = 0;
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
+    var appNavigationIntentGeneration = 0;
+    var examIndexRefreshGeneration = 0;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -427,6 +429,21 @@
         return ensureLazyGroup(SETTINGS_GROUP);
     }
 
+    function markAppNavigationIntent(event) {
+        if (event && event.__appEntryNavigationIntentTracked === true) {
+            return appNavigationIntentGeneration;
+        }
+        appNavigationIntentGeneration += 1;
+        if (event) {
+            try {
+                event.__appEntryNavigationIntentTracked = true;
+            } catch (_) { }
+        }
+        return appNavigationIntentGeneration;
+    }
+
+    global.__markAppNavigationIntent = markAppNavigationIntent;
+
     function initializeNavigationShell() {
         var controller = null;
         try {
@@ -438,10 +455,12 @@
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
-                            global.resetBrowseViewToAll();
+                            return global.resetBrowseViewToAll();
                         }
+                        return false;
                     },
-                    onNavigate: function onNavigate(viewName) {
+                    onNavigate: function onNavigate(viewName, event) {
+                        markAppNavigationIntent(event);
                         if (typeof global.showView === 'function') {
                             global.showView(viewName, false);
                             return;
@@ -717,6 +736,12 @@
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
+            var activeViewAtRequest = name === 'browseCategory'
+                ? getActiveViewName()
+                : null;
+            var navigationIntentAtRequest = name === 'browseCategory'
+                ? appNavigationIntentGeneration
+                : null;
             var tracksBrowseResults = group === BROWSE_GROUP && (
                 name === 'filterByType'
                 || name === 'filterByFrequency'
@@ -755,6 +780,11 @@
                         || !isBrowseResultsSnapshotCurrent(
                             resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
                         ))) {
+                    return false;
+                }
+                if (name === 'browseCategory'
+                    && (getActiveViewName() !== activeViewAtRequest
+                        || navigationIntentAtRequest !== appNavigationIntentGeneration)) {
                     return false;
                 }
                 var fn = global[name];
@@ -928,6 +958,8 @@
         var activeView = getActiveViewName();
 
         if (activeView === 'browse') {
+            var refreshGeneration = ++examIndexRefreshGeneration;
+            var resultsProxyGenerationAtReceipt = browseResultsProxyGeneration;
             var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
                 && global.__isBrowseResetIntentInFlight();
             if (resetInFlight) {
@@ -960,6 +992,10 @@
                 });
             }
             browseReady.then(function afterBrowseReady() {
+                if (refreshGeneration !== examIndexRefreshGeneration
+                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration) {
+                    return;
+                }
                 var effectiveRequestId = resultsRequestCaptured
                     ? resultsRequestId
                     : getCurrentBrowseResultsRequest();
@@ -970,6 +1006,9 @@
                     }
                     return;
                 }
+                var refreshRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+                    ? global.__beginBrowseResultsRequest()
+                    : effectiveRequestId;
                 var searchInput = document.getElementById('exam-search-input')
                     || document.querySelector('.search-input');
                 var searchQuery = searchInput && typeof searchInput.value === 'string'
@@ -979,14 +1018,14 @@
                     try {
                         global.searchExams(
                             searchQuery,
-                            effectiveRequestId
+                            refreshRequestId
                         );
                     } catch (_) { }
                 } else if (typeof global.loadExamList === 'function') {
                     try {
                         global.loadExamList(
                             snapshot,
-                            effectiveRequestId
+                            refreshRequestId
                         );
                     } catch (_) { }
                 }

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -273,6 +273,7 @@
     var activeBrowseFunctionalResetRecovery = null;
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
+    var browseFunctionalResetFailureDebt = null;
     var browseFunctionalResetState = {
         generation: 0,
         status: 'idle',
@@ -388,8 +389,8 @@
         completedBrowseFunctionalResetBarrier = null;
         browseFunctionalResetState = {
             generation: ++browseFunctionalResetGeneration,
-            status: 'idle',
-            outcome: null
+            status: browseFunctionalResetFailureDebt ? 'failed' : 'idle',
+            outcome: browseFunctionalResetFailureDebt ? false : null
         };
         return true;
     }
@@ -463,6 +464,10 @@
                     outcome: succeeded
                 };
                 if (!succeeded) {
+                    browseFunctionalResetFailureDebt = {
+                        generation: generation,
+                        outcome: false
+                    };
                     browseFunctionalResetBarrier = null;
                     browseFunctionalResetOwnership = null;
                 }
@@ -498,6 +503,12 @@
             status: succeeded === true ? 'succeeded' : 'failed',
             outcome: succeeded === true
         };
+        browseFunctionalResetFailureDebt = succeeded === true
+            ? null
+            : {
+                generation: completedGeneration,
+                outcome: false
+            };
         browseFunctionalResetBarrier = null;
         browseFunctionalResetOwnership = null;
         completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
@@ -574,6 +585,56 @@
         return true;
     }
 
+    function prepareBrowseFunctionalResetRecoveryForForeground(requestId) {
+        if (requestId == null
+            || getActiveViewName() !== 'browse'
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function') {
+            return null;
+        }
+        try {
+            if (!global.__isBrowseResultsRequestCurrent(requestId)) {
+                return null;
+            }
+        } catch (_) {
+            return null;
+        }
+
+        var barrier = browseFunctionalResetBarrier;
+        if (barrier) {
+            var ownership = browseFunctionalResetOwnership;
+            var ownedRequestId = ownership && ownership.barrier === barrier
+                ? ownership.resultsRequestId
+                : null;
+            if (ownedRequestId != null) {
+                try {
+                    if (global.__isBrowseResultsRequestCurrent(ownedRequestId)) {
+                        // The retry's own canonical render must retain its barrier.
+                        return null;
+                    }
+                } catch (_) {
+                    // An ownership token that cannot be classified is not proven stale.
+                    return null;
+                }
+            }
+            if (!cancelBrowseFunctionalResetBarrier(barrier, false)) {
+                return null;
+            }
+        }
+
+        var recovery = captureBrowseFunctionalResetRecovery();
+        if (!recovery
+            || !updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId)) {
+            if (recovery && activeBrowseFunctionalResetRecovery === recovery) {
+                activeBrowseFunctionalResetRecovery = null;
+            }
+            return null;
+        }
+        return {
+            recovery: recovery,
+            functionalResetGeneration: recovery.functionalResetGeneration
+        };
+    }
+
     function completeBrowseFunctionalResetRecovery(recovery, succeeded) {
         if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
             return false;
@@ -585,9 +646,9 @@
             || browseFunctionalResetState.generation !== recovery.functionalResetGeneration
             || appNavigationIntentGeneration !== recovery.navigationGeneration
             || browseResetIntentGeneration !== recovery.resetGeneration
-            || (recovery.resultsRequestId != null
-                && typeof global.__isBrowseResultsRequestCurrent === 'function'
-                && !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId))
+            || recovery.resultsRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId)
             || getActiveViewName() !== 'browse') {
             return false;
         }
@@ -596,6 +657,7 @@
             status: 'succeeded',
             outcome: true
         };
+        browseFunctionalResetFailureDebt = null;
         completedBrowseFunctionalResetBarrier = null;
         return true;
     }
@@ -620,6 +682,18 @@
         var initialization;
         var initializationRequestId = null;
         var retainedInitializationRequestId = null;
+        var pendingFilterOutcome = canApplyPendingFilter ? 'retryable-failure' : 'not-applicable';
+        function pendingFilterWasSuperseded() {
+            if (!pendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
+                return true;
+            }
+            if (getActiveViewName() !== 'browse') {
+                return true;
+            }
+            return initializationRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(initializationRequestId);
+        }
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
@@ -650,7 +724,8 @@
                 if (!canApplyPendingFilter) {
                     return true;
                 }
-                if (global.__pendingBrowseFilter !== pendingFilter) {
+                if (pendingFilterWasSuperseded()) {
+                    pendingFilterOutcome = 'superseded';
                     return false;
                 }
                 var filterArgs = [
@@ -664,16 +739,32 @@
                 }
                 return Promise.resolve(global.applyBrowseFilter.apply(global, filterArgs))
                     .then(function normalizePendingFilterResult(result) {
-                        return result !== false;
+                        // Legacy filter implementations resolve without a value
+                        // after applying successfully; only explicit null/false
+                        // are retryable non-application outcomes.
+                        if (result !== false && result !== null) {
+                            pendingFilterOutcome = 'applied';
+                            return true;
+                        }
+                        if (pendingFilterWasSuperseded()) {
+                            pendingFilterOutcome = 'superseded';
+                        }
+                        return false;
                     });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
+                if (pendingFilterOutcome !== 'applied' && pendingFilterWasSuperseded()) {
+                    pendingFilterOutcome = 'superseded';
+                }
+                if (pendingFilter
+                    && global.__pendingBrowseFilter === pendingFilter
+                    && (pendingFilterOutcome === 'applied'
+                        || pendingFilterOutcome === 'superseded')) {
+                    delete global.__pendingBrowseFilter;
+                }
                 if (retainedInitializationRequestId != null
                     && typeof global.__endBrowseUserResultsRequest === 'function') {
                     global.__endBrowseUserResultsRequest(retainedInitializationRequestId);
-                }
-                if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
-                    delete global.__pendingBrowseFilter;
                 }
             });
     }
@@ -1640,6 +1731,8 @@
         captureBrowseFunctionalResetRecovery: captureBrowseFunctionalResetRecovery,
         updateBrowseFunctionalResetRecoveryResultsRequest:
             updateBrowseFunctionalResetRecoveryResultsRequest,
+        prepareBrowseFunctionalResetRecoveryForForeground:
+            prepareBrowseFunctionalResetRecoveryForForeground,
         completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -269,6 +269,8 @@
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
+    var browseFunctionalResetOwnership = null;
+    var activeBrowseFunctionalResetRecovery = null;
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
     var browseFunctionalResetState = {
@@ -305,7 +307,110 @@
         }
     }
 
+    function invalidateBrowseResultsForSupersedingIntent() {
+        if (typeof global.__beginBrowseResultsRequest !== 'function') {
+            return;
+        }
+        try {
+            global.__beginBrowseResultsRequest();
+        } catch (_) { }
+    }
+
+    function isBrowseFunctionalResetOwnershipCurrent(barrier, includeResultsRequest) {
+        var ownership = browseFunctionalResetOwnership;
+        if (!barrier
+            || browseFunctionalResetBarrier !== barrier
+            || !ownership
+            || ownership.barrier !== barrier
+            || ownership.navigationGeneration !== appNavigationIntentGeneration
+            || ownership.resetGeneration !== browseResetIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        if (includeResultsRequest && typeof global.__isBrowseResultsRequestCurrent === 'function') {
+            // Once the runtime exposes token arbitration, an unbound cold lease
+            // must fail closed instead of adopting whichever request is current.
+            if (ownership.resultsRequestId == null
+                || !global.__isBrowseResultsRequestCurrent(ownership.resultsRequestId)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function claimBrowseFunctionalResetResultsRequest(barrier) {
+        var ownership = browseFunctionalResetOwnership;
+        if (!barrier
+            || browseFunctionalResetBarrier !== barrier
+            || !ownership
+            || ownership.barrier !== barrier
+            || ownership.navigationGeneration !== appNavigationIntentGeneration
+            || ownership.resetGeneration !== browseResetIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        if (ownership.resultsRequestId != null) {
+            return true;
+        }
+        if (typeof global.__beginBrowseResultsRequest !== 'function') {
+            return false;
+        }
+        if (typeof global.__getBrowseResultsRequestId === 'function') {
+            try {
+                if (global.__getBrowseResultsRequestId() !== 0) {
+                    return false;
+                }
+            } catch (_) {
+                return false;
+            }
+        }
+        try {
+            var resultsRequestId = global.__beginBrowseResultsRequest();
+            if (resultsRequestId == null) {
+                return false;
+            }
+            ownership.resultsRequestId = resultsRequestId;
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function cancelBrowseFunctionalResetBarrier(barrier, invalidateResults) {
+        if (!barrier || browseFunctionalResetBarrier !== barrier) {
+            return false;
+        }
+        if (invalidateResults === true) {
+            invalidateBrowseResultsForSupersedingIntent();
+        }
+        browseFunctionalResetBarrier = null;
+        browseFunctionalResetOwnership = null;
+        completedBrowseFunctionalResetBarrier = null;
+        browseFunctionalResetState = {
+            generation: ++browseFunctionalResetGeneration,
+            status: 'idle',
+            outcome: null
+        };
+        return true;
+    }
+
+    function cancelCurrentBrowseFunctionalResetForSupersedingIntent() {
+        var shouldInvalidateResults = false;
+        if (browseFunctionalResetBarrier) {
+            cancelBrowseFunctionalResetBarrier(browseFunctionalResetBarrier, false);
+            shouldInvalidateResults = true;
+        }
+        if (activeBrowseFunctionalResetRecovery) {
+            activeBrowseFunctionalResetRecovery = null;
+            shouldInvalidateResults = true;
+        }
+        if (shouldInvalidateResults) {
+            invalidateBrowseResultsForSupersedingIntent();
+        }
+    }
+
     function registerBrowseFunctionalResetBarrier(resetPromise) {
+        activeBrowseFunctionalResetRecovery = null;
         var generation = ++browseFunctionalResetGeneration;
         completedBrowseFunctionalResetBarrier = null;
         browseFunctionalResetState = {
@@ -319,11 +424,39 @@
             return false;
         });
         browseFunctionalResetBarrier = barrier;
+        var resultsRequestId = null;
         if (typeof global.__beginBrowseResultsRequest === 'function') {
-            global.__beginBrowseResultsRequest();
+            resultsRequestId = global.__beginBrowseResultsRequest();
+        }
+        browseFunctionalResetOwnership = {
+            barrier: barrier,
+            generation: generation,
+            navigationGeneration: appNavigationIntentGeneration,
+            resetGeneration: browseResetIntentGeneration,
+            resultsRequestId: resultsRequestId,
+            deferredExamIndexSnapshot: null
+        };
+        if (resultsRequestId == null) {
+            // This continuation is registered before the deferred reset body can
+            // attach its lazy-owner continuation, so a cold barrier claims R1
+            // before any later filter or background refresh can own the runtime.
+            ensureBrowseRuntimeGroup().then(function bindColdFunctionalResetResultsRequest() {
+                if (browseFunctionalResetBarrier !== barrier) {
+                    return;
+                }
+                if (!claimBrowseFunctionalResetResultsRequest(barrier)
+                    && browseFunctionalResetBarrier === barrier
+                    && typeof global.__isBrowseResultsRequestCurrent === 'function') {
+                    cancelBrowseFunctionalResetBarrier(barrier, false);
+                }
+            }).catch(function ignoreColdFunctionalResetBindingFailure() { });
         }
         barrier.then(function settleBrowseFunctionalResetState(succeeded) {
             if (browseFunctionalResetBarrier === barrier) {
+                if (!isBrowseFunctionalResetOwnershipCurrent(barrier, false)) {
+                    cancelBrowseFunctionalResetBarrier(barrier, false);
+                    return;
+                }
                 browseFunctionalResetState = {
                     generation: generation,
                     status: succeeded ? 'pending' : 'failed',
@@ -331,6 +464,7 @@
                 };
                 if (!succeeded) {
                     browseFunctionalResetBarrier = null;
+                    browseFunctionalResetOwnership = null;
                 }
             }
         });
@@ -346,18 +480,124 @@
                 && completedBrowseFunctionalResetBarrier === barrier
                 && browseFunctionalResetState.status === 'succeeded';
         }
+        if (!isBrowseFunctionalResetOwnershipCurrent(barrier, true)) {
+            cancelBrowseFunctionalResetBarrier(barrier, false);
+            return false;
+        }
+        var completedOwnership = browseFunctionalResetOwnership;
+        var deferredExamIndexSnapshot = succeeded === true
+            && completedOwnership
+            && Array.isArray(completedOwnership.deferredExamIndexSnapshot)
+            ? completedOwnership.deferredExamIndexSnapshot.slice()
+            : null;
+        var completedGeneration = browseFunctionalResetGeneration;
+        var completedNavigationGeneration = appNavigationIntentGeneration;
+        var completedResetGeneration = browseResetIntentGeneration;
         browseFunctionalResetState = {
-            generation: browseFunctionalResetGeneration,
+            generation: completedGeneration,
             status: succeeded === true ? 'succeeded' : 'failed',
             outcome: succeeded === true
         };
         browseFunctionalResetBarrier = null;
+        browseFunctionalResetOwnership = null;
         completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
+        if (deferredExamIndexSnapshot) {
+            Promise.resolve().then(function replayFunctionalResetIndexSnapshot() {
+                if (browseFunctionalResetGeneration !== completedGeneration
+                    || browseFunctionalResetState.status !== 'succeeded'
+                    || appNavigationIntentGeneration !== completedNavigationGeneration
+                    || browseResetIntentGeneration !== completedResetGeneration
+                    || getActiveViewName() !== 'browse') {
+                    return;
+                }
+                handleExamIndexLoaded(deferredExamIndexSnapshot);
+            });
+        }
         return succeeded === true;
     }
 
     function isBrowseFunctionalResetBarrierCurrent(barrier) {
-        return !!barrier && browseFunctionalResetBarrier === barrier;
+        if (isBrowseFunctionalResetOwnershipCurrent(barrier, true)) {
+            return true;
+        }
+        if (barrier && browseFunctionalResetBarrier === barrier) {
+            cancelBrowseFunctionalResetBarrier(barrier, false);
+        }
+        return false;
+    }
+
+    function updateBrowseFunctionalResetResultsRequest(barrier, requestId) {
+        if (!isBrowseFunctionalResetOwnershipCurrent(barrier, false)) {
+            return false;
+        }
+        var nextRequestId = requestId;
+        if (nextRequestId == null && typeof global.__getBrowseResultsRequestId === 'function') {
+            nextRequestId = global.__getBrowseResultsRequestId();
+        }
+        if (nextRequestId == null) {
+            return false;
+        }
+        browseFunctionalResetOwnership.resultsRequestId = nextRequestId;
+        return true;
+    }
+
+    function captureBrowseFunctionalResetRecovery() {
+        if (browseFunctionalResetBarrier
+            || browseFunctionalResetState.status !== 'failed'
+            || getActiveViewName() !== 'browse') {
+            return null;
+        }
+        var recovery = {
+            functionalResetGeneration: browseFunctionalResetState.generation,
+            navigationGeneration: appNavigationIntentGeneration,
+            resetGeneration: browseResetIntentGeneration,
+            resultsRequestId: typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null
+        };
+        activeBrowseFunctionalResetRecovery = recovery;
+        return recovery;
+    }
+
+    function updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId) {
+        if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
+            return false;
+        }
+        var nextRequestId = requestId;
+        if (nextRequestId == null && typeof global.__getBrowseResultsRequestId === 'function') {
+            nextRequestId = global.__getBrowseResultsRequestId();
+        }
+        if (nextRequestId == null) {
+            return false;
+        }
+        recovery.resultsRequestId = nextRequestId;
+        return true;
+    }
+
+    function completeBrowseFunctionalResetRecovery(recovery, succeeded) {
+        if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
+            return false;
+        }
+        activeBrowseFunctionalResetRecovery = null;
+        if (succeeded !== true
+            || browseFunctionalResetBarrier
+            || browseFunctionalResetState.status !== 'failed'
+            || browseFunctionalResetState.generation !== recovery.functionalResetGeneration
+            || appNavigationIntentGeneration !== recovery.navigationGeneration
+            || browseResetIntentGeneration !== recovery.resetGeneration
+            || (recovery.resultsRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId))
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        browseFunctionalResetState = {
+            generation: ++browseFunctionalResetGeneration,
+            status: 'succeeded',
+            outcome: true
+        };
+        completedBrowseFunctionalResetBarrier = null;
+        return true;
     }
 
     function getBrowseFunctionalResetState() {
@@ -370,7 +610,7 @@
 
     global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
-    function synchronizeActiveBrowseViewNow() {
+    function synchronizeActiveBrowseViewNow(functionalResetBarrier) {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
         }
@@ -387,6 +627,12 @@
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
             }
+            if (functionalResetBarrier) {
+                updateBrowseFunctionalResetResultsRequest(
+                    functionalResetBarrier,
+                    initializationRequestId
+                );
+            }
             if (initializationRequestId != null
                 && typeof global.__retainBrowseUserResultsRequest === 'function') {
                 retainedInitializationRequestId = global.__retainBrowseUserResultsRequest(
@@ -397,9 +643,15 @@
             return Promise.reject(error);
         }
         return Promise.resolve(initialization)
-            .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
-                    return undefined;
+            .then(function applyPendingBrowseFilter(initializationResult) {
+                if (initializationResult === null || initializationResult === false) {
+                    return false;
+                }
+                if (!canApplyPendingFilter) {
+                    return true;
+                }
+                if (global.__pendingBrowseFilter !== pendingFilter) {
+                    return false;
                 }
                 var filterArgs = [
                     pendingFilter.category,
@@ -410,7 +662,10 @@
                 if (initializationRequestId != null) {
                     filterArgs.push(initializationRequestId);
                 }
-                return global.applyBrowseFilter.apply(global, filterArgs);
+                return Promise.resolve(global.applyBrowseFilter.apply(global, filterArgs))
+                    .then(function normalizePendingFilterResult(result) {
+                        return result !== false;
+                    });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
                 if (retainedInitializationRequestId != null
@@ -426,8 +681,8 @@
     function synchronizeActiveBrowseViewAfterLoad() {
         var resetBarrier = browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow().then(function () {
-                return true;
+            return synchronizeActiveBrowseViewNow().then(function (synchronized) {
+                return synchronized !== false;
             });
         }
         return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
@@ -437,9 +692,12 @@
             if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
                 return false;
             }
-            return synchronizeActiveBrowseViewNow().then(function () {
-                completeBrowseFunctionalResetBarrier(resetBarrier, true);
-                return true;
+            return synchronizeActiveBrowseViewNow(resetBarrier).then(function (synchronized) {
+                if (synchronized === false) {
+                    completeBrowseFunctionalResetBarrier(resetBarrier, false);
+                    return false;
+                }
+                return completeBrowseFunctionalResetBarrier(resetBarrier, true);
             }, function (error) {
                 completeBrowseFunctionalResetBarrier(resetBarrier, false);
                 throw error;
@@ -549,6 +807,7 @@
             return appNavigationIntentGeneration;
         }
         appNavigationIntentGeneration += 1;
+        cancelCurrentBrowseFunctionalResetForSupersedingIntent();
         if (event) {
             try {
                 event.__appEntryNavigationIntentTracked = true;
@@ -613,6 +872,7 @@
     function beginBrowseResetIntent() {
         browseResetIntentGeneration += 1;
         browseResultsProxyGeneration += 1;
+        cancelCurrentBrowseFunctionalResetForSupersedingIntent();
         activeBrowseResetIntent = {
             __browseResetIntent: true,
             generation: browseResetIntentGeneration,
@@ -1148,6 +1408,20 @@
                 }
                 return;
             }
+            var functionalResetBarrier = browseFunctionalResetBarrier;
+            if (functionalResetBarrier
+                && isBrowseFunctionalResetOwnershipCurrent(functionalResetBarrier, true)) {
+                browseFunctionalResetOwnership.deferredExamIndexSnapshot = snapshot.slice();
+                var functionalResetLoading = document.querySelector('#browse-view .loading');
+                if (functionalResetLoading) {
+                    functionalResetLoading.style.display = 'none';
+                }
+                return;
+            }
+            if (functionalResetBarrier
+                && browseFunctionalResetBarrier === functionalResetBarrier) {
+                isBrowseFunctionalResetBarrierCurrent(functionalResetBarrier);
+            }
             var hasReplayRequest = arguments.length > 1 && replayRequestId != null;
             if (hasReplayRequest && !isBrowseResultsSnapshotCurrent(replayRequestId)) {
                 var staleReplayLoading = document.querySelector('#browse-view .loading');
@@ -1360,7 +1634,13 @@
         registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
         completeBrowseFunctionalResetBarrier: completeBrowseFunctionalResetBarrier,
         isBrowseFunctionalResetBarrierCurrent: isBrowseFunctionalResetBarrierCurrent,
+        cancelBrowseFunctionalResetBarrier: cancelBrowseFunctionalResetBarrier,
+        updateBrowseFunctionalResetResultsRequest: updateBrowseFunctionalResetResultsRequest,
         getBrowseFunctionalResetState: getBrowseFunctionalResetState,
+        captureBrowseFunctionalResetRecovery: captureBrowseFunctionalResetRecovery,
+        updateBrowseFunctionalResetRecoveryResultsRequest:
+            updateBrowseFunctionalResetRecoveryResultsRequest,
+        completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -266,6 +266,8 @@
     var browseResultsProxyGeneration = 0;
     var appNavigationIntentGeneration = 0;
     var examIndexRefreshGeneration = 0;
+    var deferredBrowseIndexRefresh = null;
+    var browseFunctionalResetBarrier = null;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -295,7 +297,20 @@
         }
     }
 
-    function synchronizeActiveBrowseViewAfterLoad() {
+    function registerBrowseFunctionalResetBarrier(resetPromise) {
+        var barrier = Promise.resolve(resetPromise).catch(function () {
+            return false;
+        });
+        browseFunctionalResetBarrier = barrier;
+        barrier.finally(function clearBrowseFunctionalResetBarrier() {
+            if (browseFunctionalResetBarrier === barrier) {
+                browseFunctionalResetBarrier = null;
+            }
+        });
+        return barrier;
+    }
+
+    function synchronizeActiveBrowseViewNow() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
         }
@@ -335,6 +350,16 @@
                     delete global.__pendingBrowseFilter;
                 }
             });
+    }
+
+    function synchronizeActiveBrowseViewAfterLoad() {
+        var resetBarrier = browseFunctionalResetBarrier;
+        if (!resetBarrier) {
+            return synchronizeActiveBrowseViewNow();
+        }
+        return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
+            return resetSucceeded ? synchronizeActiveBrowseViewNow() : undefined;
+        });
     }
 
     function ensureBrowseRuntimeGroup() {
@@ -619,6 +644,51 @@
         return requestId == null
             || typeof global.__isBrowseResultsRequestCurrent !== 'function'
             || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
+    function isBrowseUserResultsRequestInFlight(requestId) {
+        return requestId != null
+            && typeof global.__isBrowseUserResultsRequestInFlight === 'function'
+            && global.__isBrowseUserResultsRequestInFlight(requestId);
+    }
+
+    function isBrowseUserResultsRequest(requestId) {
+        return requestId != null
+            && typeof global.__isBrowseUserResultsRequest === 'function'
+            && global.__isBrowseUserResultsRequest(requestId);
+    }
+
+    function deferBrowseIndexRefresh(snapshot, refreshGeneration, proxyGeneration, navigationGeneration) {
+        deferredBrowseIndexRefresh = {
+            snapshot: Array.isArray(snapshot) ? snapshot.slice() : [],
+            refreshGeneration: refreshGeneration,
+            proxyGeneration: proxyGeneration,
+            navigationGeneration: navigationGeneration
+        };
+    }
+
+    function replayDeferredBrowseIndexRefresh(settledRequestId) {
+        var deferred = deferredBrowseIndexRefresh;
+        if (!deferred) {
+            return;
+        }
+        if (deferred.refreshGeneration !== examIndexRefreshGeneration
+            || deferred.proxyGeneration !== browseResultsProxyGeneration
+            || deferred.navigationGeneration !== appNavigationIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            deferredBrowseIndexRefresh = null;
+            return;
+        }
+        var currentRequestId = getCurrentBrowseResultsRequest();
+        if (isBrowseUserResultsRequestInFlight(currentRequestId)) {
+            return;
+        }
+        if (currentRequestId !== settledRequestId) {
+            deferredBrowseIndexRefresh = null;
+            return;
+        }
+        deferredBrowseIndexRefresh = null;
+        handleExamIndexLoaded(deferred.snapshot, currentRequestId);
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {
@@ -960,6 +1030,7 @@
         if (activeView === 'browse') {
             var refreshGeneration = ++examIndexRefreshGeneration;
             var resultsProxyGenerationAtReceipt = browseResultsProxyGeneration;
+            var navigationGenerationAtReceipt = appNavigationIntentGeneration;
             var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
                 && global.__isBrowseResetIntentInFlight();
             if (resetInFlight) {
@@ -999,13 +1070,32 @@
             }
             browseReady.then(function afterBrowseReady() {
                 if (refreshGeneration !== examIndexRefreshGeneration
-                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration) {
+                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration
+                    || navigationGenerationAtReceipt !== appNavigationIntentGeneration
+                    || getActiveViewName() !== 'browse') {
                     return;
                 }
                 var effectiveRequestId = resultsRequestCaptured
                     ? resultsRequestId
                     : getCurrentBrowseResultsRequest();
                 if (!isBrowseResultsSnapshotCurrent(effectiveRequestId)) {
+                    var currentRequestId = getCurrentBrowseResultsRequest();
+                    if (isBrowseUserResultsRequestInFlight(currentRequestId)) {
+                        deferBrowseIndexRefresh(
+                            snapshot,
+                            refreshGeneration,
+                            resultsProxyGenerationAtReceipt,
+                            navigationGenerationAtReceipt
+                        );
+                    } else if (isBrowseUserResultsRequest(currentRequestId)) {
+                        deferBrowseIndexRefresh(
+                            snapshot,
+                            refreshGeneration,
+                            resultsProxyGenerationAtReceipt,
+                            navigationGenerationAtReceipt
+                        );
+                        replayDeferredBrowseIndexRefresh(currentRequestId);
+                    }
                     var staleLoading = document.querySelector('#browse-view .loading');
                     if (staleLoading) {
                         staleLoading.style.display = 'none';
@@ -1014,6 +1104,12 @@
                 }
                 if (typeof global.__isBrowseUserResultsRequestInFlight === 'function'
                     && global.__isBrowseUserResultsRequestInFlight(effectiveRequestId)) {
+                    deferBrowseIndexRefresh(
+                        snapshot,
+                        refreshGeneration,
+                        resultsProxyGenerationAtReceipt,
+                        navigationGenerationAtReceipt
+                    );
                     var deferredLoading = document.querySelector('#browse-view .loading');
                     if (deferredLoading) {
                         deferredLoading.style.display = 'none';
@@ -1023,12 +1119,20 @@
                 var refreshRequestId = typeof global.__beginBrowseResultsRequest === 'function'
                     ? global.__beginBrowseResultsRequest()
                     : effectiveRequestId;
+                if (deferredBrowseIndexRefresh
+                    && deferredBrowseIndexRefresh.refreshGeneration <= refreshGeneration) {
+                    deferredBrowseIndexRefresh = null;
+                }
                 var searchInput = document.getElementById('exam-search-input')
                     || document.querySelector('.search-input');
                 var searchQuery = searchInput && typeof searchInput.value === 'string'
                     ? searchInput.value.trim()
                     : '';
-                if (searchQuery && typeof global.searchExams === 'function') {
+                if (typeof global.__renderBrowseResultsForState === 'function') {
+                    try {
+                        global.__renderBrowseResultsForState(snapshot, refreshRequestId);
+                    } catch (_) { }
+                } else if (searchQuery && typeof global.searchExams === 'function') {
                     try {
                         global.searchExams(
                             searchQuery,
@@ -1066,6 +1170,11 @@
 
     global.addEventListener('examIndexLoaded', function onExamIndexLoaded(event) {
         handleExamIndexLoaded(event && event.detail ? event.detail.index : []);
+    });
+
+    global.addEventListener('browseUserResultsRequestSettled', function onBrowseUserResultsRequestSettled(event) {
+        var requestId = event && event.detail ? event.detail.requestId : null;
+        replayDeferredBrowseIndexRefresh(requestId);
     });
 
     global.addEventListener('appCoreReady', function onAppCoreReady() {
@@ -1137,7 +1246,9 @@
     global.AppEntry = Object.assign({}, global.AppEntry || {}, {
         STRICT_ON_DEMAND: STRICT_ON_DEMAND,
         ensureBrowseGroup: ensureBrowseGroup,
+        ensureBrowseRuntimeGroup: ensureBrowseRuntimeGroup,
         ensureBrowseRuntime: ensureBrowseGroup,
+        registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -269,6 +269,13 @@
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
+    var completedBrowseFunctionalResetBarrier = null;
+    var browseFunctionalResetGeneration = 0;
+    var browseFunctionalResetState = {
+        generation: 0,
+        status: 'idle',
+        outcome: null
+    };
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -299,17 +306,69 @@
     }
 
     function registerBrowseFunctionalResetBarrier(resetPromise) {
-        var barrier = Promise.resolve(resetPromise).catch(function () {
+        var generation = ++browseFunctionalResetGeneration;
+        completedBrowseFunctionalResetBarrier = null;
+        browseFunctionalResetState = {
+            generation: generation,
+            status: 'pending',
+            outcome: null
+        };
+        var barrier = Promise.resolve(resetPromise).then(function normalizeResetOutcome(succeeded) {
+            return succeeded === true;
+        }, function normalizeResetFailure() {
             return false;
         });
         browseFunctionalResetBarrier = barrier;
-        barrier.finally(function clearBrowseFunctionalResetBarrier() {
+        if (typeof global.__beginBrowseResultsRequest === 'function') {
+            global.__beginBrowseResultsRequest();
+        }
+        barrier.then(function settleBrowseFunctionalResetState(succeeded) {
             if (browseFunctionalResetBarrier === barrier) {
-                browseFunctionalResetBarrier = null;
+                browseFunctionalResetState = {
+                    generation: generation,
+                    status: succeeded ? 'pending' : 'failed',
+                    outcome: succeeded
+                };
+                if (!succeeded) {
+                    browseFunctionalResetBarrier = null;
+                }
             }
         });
         return barrier;
     }
+
+    function completeBrowseFunctionalResetBarrier(barrier, succeeded) {
+        if (!barrier) {
+            return false;
+        }
+        if (browseFunctionalResetBarrier !== barrier) {
+            return succeeded === true
+                && completedBrowseFunctionalResetBarrier === barrier
+                && browseFunctionalResetState.status === 'succeeded';
+        }
+        browseFunctionalResetState = {
+            generation: browseFunctionalResetGeneration,
+            status: succeeded === true ? 'succeeded' : 'failed',
+            outcome: succeeded === true
+        };
+        browseFunctionalResetBarrier = null;
+        completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
+        return succeeded === true;
+    }
+
+    function isBrowseFunctionalResetBarrierCurrent(barrier) {
+        return !!barrier && browseFunctionalResetBarrier === barrier;
+    }
+
+    function getBrowseFunctionalResetState() {
+        return {
+            generation: browseFunctionalResetState.generation,
+            status: browseFunctionalResetState.status,
+            outcome: browseFunctionalResetState.outcome
+        };
+    }
+
+    global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
     function synchronizeActiveBrowseViewNow() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
@@ -375,8 +434,15 @@
             if (!resetSucceeded) {
                 return false;
             }
+            if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
+                return false;
+            }
             return synchronizeActiveBrowseViewNow().then(function () {
+                completeBrowseFunctionalResetBarrier(resetBarrier, true);
                 return true;
+            }, function (error) {
+                completeBrowseFunctionalResetBarrier(resetBarrier, false);
+                throw error;
             });
         });
     }
@@ -407,7 +473,7 @@
                 return synchronizeActiveBrowseViewAfterLoad()
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
-                        return true;
+                        return false;
                     })
                     .then(function browseViewSynchronized(synchronized) {
                         if (synchronized === false) {
@@ -1292,6 +1358,9 @@
         ensureBrowseRuntimeGroup: ensureBrowseRuntimeGroup,
         ensureBrowseRuntime: ensureBrowseGroup,
         registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
+        completeBrowseFunctionalResetBarrier: completeBrowseFunctionalResetBarrier,
+        isBrowseFunctionalResetBarrierCurrent: isBrowseFunctionalResetBarrierCurrent,
+        getBrowseFunctionalResetState: getBrowseFunctionalResetState,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -265,6 +265,7 @@
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
     var appNavigationIntentGeneration = 0;
+    var activeLibraryGeneration = 0;
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
@@ -494,6 +495,9 @@
     global.__getAppNavigationIntentGeneration = function getAppNavigationIntentGeneration() {
         return appNavigationIntentGeneration;
     };
+    global.__getActiveLibraryGeneration = function getActiveLibraryGeneration() {
+        return activeLibraryGeneration;
+    };
 
     function initializeNavigationShell() {
         var controller = null;
@@ -646,6 +650,9 @@
     global.__closeBrowseResetIntent = closeBrowseResetIntent;
     global.__endBrowseResetIntent = endBrowseResetIntent;
     global.__isBrowseResetIntentInFlight = isBrowseResetIntentInFlight;
+    global.__getBrowseResetIntentGeneration = function getBrowseResetIntentGeneration() {
+        return browseResetIntentGeneration;
+    };
 
     function beginBrowseResultsProxyIntent() {
         browseResultsProxyGeneration += 1;
@@ -1204,6 +1211,7 @@
     }
 
     global.addEventListener('examIndexLoaded', function onExamIndexLoaded(event) {
+        activeLibraryGeneration += 1;
         handleExamIndexLoaded(event && event.detail ? event.detail.index : []);
     });
 

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -361,6 +361,20 @@
             && left.pendingFilterIntentGeneration === right.pendingFilterIntentGeneration;
     }
 
+    function retireCompletedBrowseGroupLeaseBarrier(lease, barrier) {
+        if (!lease
+            || !barrier
+            || browseGroupLease !== lease
+            || lease.functionalResetBarrier !== barrier
+            || browseFunctionalResetBarrier !== null
+            || completedBrowseFunctionalResetBarrier !== barrier
+            || browseFunctionalResetState.status !== 'succeeded') {
+            return false;
+        }
+        lease.functionalResetBarrier = null;
+        return true;
+    }
+
     function isBrowseGroupLeaseCurrent(lease) {
         if (!lease
             || lease.navigationGeneration !== appNavigationIntentGeneration
@@ -940,7 +954,14 @@
                     completeBrowseFunctionalResetBarrier(resetBarrier, false);
                     return false;
                 }
-                return completeBrowseFunctionalResetBarrier(resetBarrier, true);
+                var completed = completeBrowseFunctionalResetBarrier(resetBarrier, true);
+                if (completed) {
+                    retireCompletedBrowseGroupLeaseBarrier(
+                        synchronizationLease,
+                        resetBarrier
+                    );
+                }
+                return completed;
             }, function (error) {
                 completeBrowseFunctionalResetBarrier(resetBarrier, false);
                 throw error;

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -983,7 +983,13 @@
             var browseReady = ensureBrowseGroup();
             var resultsRequestId = hasReplayRequest ? replayRequestId : null;
             var resultsRequestCaptured = hasReplayRequest;
-            if (!hasReplayRequest) {
+            if (!hasReplayRequest && typeof global.__getBrowseResultsRequestId === 'function') {
+                try {
+                    resultsRequestId = global.__getBrowseResultsRequestId();
+                    resultsRequestCaptured = true;
+                } catch (_) { }
+            }
+            if (!hasReplayRequest && !resultsRequestCaptured) {
                 captureBrowseResultsRequest().then(function rememberRequestId(requestId) {
                     resultsRequestId = requestId;
                     resultsRequestCaptured = true;
@@ -1003,6 +1009,14 @@
                     var staleLoading = document.querySelector('#browse-view .loading');
                     if (staleLoading) {
                         staleLoading.style.display = 'none';
+                    }
+                    return;
+                }
+                if (typeof global.__isBrowseUserResultsRequestInFlight === 'function'
+                    && global.__isBrowseUserResultsRequestInFlight(effectiveRequestId)) {
+                    var deferredLoading = document.querySelector('#browse-view .loading');
+                    if (deferredLoading) {
+                        deferredLoading.style.display = 'none';
                     }
                     return;
                 }

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -319,12 +319,19 @@
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
         var initialization;
         var initializationRequestId = null;
+        var retainedInitializationRequestId = null;
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
             initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
+            }
+            if (initializationRequestId != null
+                && typeof global.__retainBrowseUserResultsRequest === 'function') {
+                retainedInitializationRequestId = global.__retainBrowseUserResultsRequest(
+                    initializationRequestId
+                );
             }
         } catch (error) {
             return Promise.reject(error);
@@ -346,6 +353,10 @@
                 return global.applyBrowseFilter.apply(global, filterArgs);
             })
             .finally(function clearConsumedPendingBrowseFilter() {
+                if (retainedInitializationRequestId != null
+                    && typeof global.__endBrowseUserResultsRequest === 'function') {
+                    global.__endBrowseUserResultsRequest(retainedInitializationRequestId);
+                }
                 if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
                     delete global.__pendingBrowseFilter;
                 }

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -259,7 +259,11 @@
             });
     }
 
+    var browseRuntimePromise = null;
     var browseGroupPromise = null;
+    var browseResetIntentGeneration = 0;
+    var activeBrowseResetIntent = null;
+    var browseResultsProxyGeneration = 0;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -296,20 +300,33 @@
 
         var pendingFilter = global.__pendingBrowseFilter || null;
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
-        return Promise.resolve()
-            .then(function initializeActiveBrowseView() {
-                return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
-            })
+        var initialization;
+        var initializationRequestId = null;
+        try {
+            // Start synchronization in this reaction so a queued repeat reset can
+            // acquire the next latest-wins token immediately after it.
+            initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
+            if (typeof global.__getBrowseResultsRequestId === 'function') {
+                initializationRequestId = global.__getBrowseResultsRequestId();
+            }
+        } catch (error) {
+            return Promise.reject(error);
+        }
+        return Promise.resolve(initialization)
             .then(function applyPendingBrowseFilter() {
                 if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
-                return global.applyBrowseFilter(
+                var filterArgs = [
                     pendingFilter.category,
                     pendingFilter.type,
                     pendingFilter.filterMode,
                     pendingFilter.path
-                );
+                ];
+                if (initializationRequestId != null) {
+                    filterArgs.push(initializationRequestId);
+                }
+                return global.applyBrowseFilter.apply(global, filterArgs);
             })
             .finally(function clearConsumedPendingBrowseFilter() {
                 if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
@@ -318,9 +335,19 @@
             });
     }
 
+    function ensureBrowseRuntimeGroup() {
+        if (!browseRuntimePromise) {
+            browseRuntimePromise = ensureLazyGroup(BROWSE_GROUP).catch(function onBrowseRuntimeLoadError(error) {
+                browseRuntimePromise = null;
+                throw error;
+            });
+        }
+        return browseRuntimePromise;
+    }
+
     function ensureBrowseGroup() {
         if (!browseGroupPromise) {
-            browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
+            browseGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
                 reapplyAppMixins();
                 initializeNavigationShell();
                 ensureBrowseStateManager();
@@ -443,13 +470,174 @@
         return controller;
     }
 
+    function beginBrowseResetIntent() {
+        browseResetIntentGeneration += 1;
+        browseResultsProxyGeneration += 1;
+        activeBrowseResetIntent = {
+            __browseResetIntent: true,
+            generation: browseResetIntentGeneration,
+            examIndexSnapshot: null,
+            examIndexSnapshotVersion: 0,
+            resultsRequestId: null
+        };
+        return activeBrowseResetIntent;
+    }
+
+    function isBrowseResetIntentCurrent(intent) {
+        return activeBrowseResetIntent === intent
+            && !!intent
+            && intent.__browseResetIntent === true
+            && intent.generation === browseResetIntentGeneration;
+    }
+
+    function captureBrowseResetIndexSnapshot(index) {
+        if (!isBrowseResetIntentInFlight()) {
+            return false;
+        }
+        activeBrowseResetIntent.examIndexSnapshot = Array.isArray(index)
+            ? index.slice()
+            : [];
+        activeBrowseResetIntent.examIndexSnapshotVersion += 1;
+        return true;
+    }
+
+    function getBrowseResetIndexSnapshot(intent) {
+        if (!isBrowseResetIntentCurrent(intent)
+            || !isBrowseResetIntentInFlight()
+            || intent.examIndexSnapshotVersion < 1) {
+            return null;
+        }
+        return {
+            index: intent.examIndexSnapshot.slice(),
+            version: intent.examIndexSnapshotVersion
+        };
+    }
+
+    function endBrowseResetIntent(intent) {
+        if (activeBrowseResetIntent === intent) {
+            var shouldReplaySnapshot = isBrowseResetIntentInFlight()
+                && intent.examIndexSnapshotVersion > 0;
+            var snapshot = shouldReplaySnapshot
+                ? intent.examIndexSnapshot.slice()
+                : null;
+            var resultsRequestId = intent.resultsRequestId;
+            activeBrowseResetIntent = null;
+            if (snapshot) {
+                handleExamIndexLoaded(snapshot, resultsRequestId);
+            }
+        }
+    }
+
+    function closeBrowseResetIntent(intent, consumedSnapshotVersion) {
+        if (activeBrowseResetIntent !== intent) {
+            return { closed: true, snapshot: null };
+        }
+        if (!isBrowseResetIntentInFlight()) {
+            activeBrowseResetIntent = null;
+            return { closed: true, snapshot: null };
+        }
+        var consumedVersion = Number(consumedSnapshotVersion) || 0;
+        if (intent.examIndexSnapshotVersion > consumedVersion) {
+            return {
+                closed: false,
+                snapshot: {
+                    index: intent.examIndexSnapshot.slice(),
+                    version: intent.examIndexSnapshotVersion
+                }
+            };
+        }
+        activeBrowseResetIntent = null;
+        return { closed: true, snapshot: null };
+    }
+
+    function setBrowseResetResultsRequest(intent, requestId) {
+        if (!isBrowseResetIntentCurrent(intent)) {
+            return false;
+        }
+        intent.resultsRequestId = requestId;
+        return true;
+    }
+
+    function isBrowseResetIntentInFlight() {
+        if (!activeBrowseResetIntent) {
+            return false;
+        }
+        var requestId = activeBrowseResetIntent.resultsRequestId;
+        return requestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
+    global.__beginBrowseResetIntent = beginBrowseResetIntent;
+    global.__isBrowseResetIntentCurrent = isBrowseResetIntentCurrent;
+    global.__captureBrowseResetIndexSnapshot = captureBrowseResetIndexSnapshot;
+    global.__getBrowseResetIndexSnapshot = getBrowseResetIndexSnapshot;
+    global.__setBrowseResetResultsRequest = setBrowseResetResultsRequest;
+    global.__closeBrowseResetIntent = closeBrowseResetIntent;
+    global.__endBrowseResetIntent = endBrowseResetIntent;
+    global.__isBrowseResetIntentInFlight = isBrowseResetIntentInFlight;
+
+    function beginBrowseResultsProxyIntent() {
+        browseResultsProxyGeneration += 1;
+        return browseResultsProxyGeneration;
+    }
+
+    function captureBrowseResultsRequest() {
+        return ensureBrowseRuntimeGroup().then(function captureRequestId() {
+            return typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null;
+        });
+    }
+
+    function getCurrentBrowseResultsRequest() {
+        return typeof global.__getBrowseResultsRequestId === 'function'
+            ? global.__getBrowseResultsRequestId()
+            : null;
+    }
+
+    function isBrowseResultsSnapshotCurrent(requestId) {
+        return requestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
     function proxyAfterGroup(groupName, getter, fallback) {
         return function proxiedCall() {
             var args = Array.prototype.slice.call(arguments);
+            var resultsProxyGeneration = groupName === BROWSE_GROUP
+                ? beginBrowseResultsProxyIntent()
+                : null;
+            var resetGeneration = groupName === BROWSE_GROUP
+                ? browseResetIntentGeneration
+                : null;
             var groupReady = groupName === BROWSE_GROUP
                 ? ensureBrowseGroup()
                 : ensureLazyGroup(groupName);
+            var resultsRequest = groupName === BROWSE_GROUP
+                ? captureBrowseResultsRequest()
+                : Promise.resolve(null);
+            var resultsRequestId = null;
+            var resultsRequestCaptured = false;
+            if (groupName === BROWSE_GROUP) {
+                resultsRequest.then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
             return groupReady.then(function invoke() {
+                if (groupName === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
+                    return false;
+                }
+                if (groupName === BROWSE_GROUP
+                    && (resultsProxyGeneration !== browseResultsProxyGeneration
+                        || !isBrowseResultsSnapshotCurrent(
+                            resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
+                        ))) {
+                    return false;
+                }
                 var fn = getter();
                 if (typeof fn === 'function') {
                     return fn.apply(global, args);
@@ -460,6 +648,33 @@
                 return undefined;
             });
         };
+    }
+
+    function proxyAfterBrowseRuntime(getter, fallback) {
+        var proxy = function proxiedBrowseRuntimeCall() {
+            var args = Array.prototype.slice.call(arguments);
+            var resetIntent = beginBrowseResetIntent();
+            // Start the full handoff, but let repeat reset acquire its latest-wins
+            // token as soon as the raw runtime is available instead of waiting for
+            // an older initializeBrowseView synchronization to finish.
+            ensureBrowseGroup().catch(function swallowBrowseHandoffError() {});
+            return ensureBrowseRuntimeGroup().then(function invoke() {
+                if (!isBrowseResetIntentCurrent(resetIntent)) {
+                    return false;
+                }
+                var fn = getter();
+                if (typeof fn === 'function' && fn !== proxy) {
+                    return fn.apply(global, args.concat([resetIntent]));
+                }
+                if (typeof fallback === 'function') {
+                    return fallback.apply(global, args);
+                }
+                return undefined;
+            }).finally(function finishBrowseResetIntent() {
+                endBrowseResetIntent(resetIntent);
+            });
+        };
+        return proxy;
     }
 
     // 保持对外接口
@@ -502,10 +717,46 @@
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
+            var tracksBrowseResults = group === BROWSE_GROUP && (
+                name === 'filterByType'
+                || name === 'filterByFrequency'
+                || name === 'searchExams'
+                || name === 'clearSearch'
+                || name === 'browseCategory'
+            );
+            var resultsProxyGeneration = tracksBrowseResults
+                ? beginBrowseResultsProxyIntent()
+                : null;
+            var resetGeneration = group === BROWSE_GROUP
+                ? browseResetIntentGeneration
+                : null;
             var groupReady = group === BROWSE_GROUP
                 ? ensureBrowseGroup()
                 : ensureLazyGroup(group);
+            var resultsRequest = tracksBrowseResults
+                ? captureBrowseResultsRequest()
+                : Promise.resolve(null);
+            var resultsRequestId = null;
+            var resultsRequestCaptured = false;
+            if (tracksBrowseResults) {
+                resultsRequest.then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
             return groupReady.then(function () {
+                if (group === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
+                    return false;
+                }
+                if (tracksBrowseResults
+                    && (resultsProxyGeneration !== browseResultsProxyGeneration
+                        || !isBrowseResultsSnapshotCurrent(
+                            resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
+                        ))) {
+                    return false;
+                }
                 var fn = global[name];
                 if (typeof fn === 'function' && fn !== proxy) {
                     return fn.apply(global, args);
@@ -642,7 +893,7 @@
     }
 
     if (typeof global.resetBrowseViewToAll !== 'function') {
-        global.resetBrowseViewToAll = proxyAfterGroup(BROWSE_GROUP, function () {
+        global.resetBrowseViewToAll = proxyAfterBrowseRuntime(function () {
             return global.__legacyResetBrowseViewToAll || global.resetBrowseViewToAll;
         });
     }
@@ -671,15 +922,73 @@
         }
     }
 
-    function handleExamIndexLoaded(index) {
+    function handleExamIndexLoaded(index, replayRequestId) {
         var snapshot = Array.isArray(index) ? index : [];
         syncOverviewAfterIndexLoad(snapshot);
         var activeView = getActiveViewName();
 
         if (activeView === 'browse') {
-            ensureBrowseGroup().then(function afterBrowseReady() {
-                if (typeof global.loadExamList === 'function') {
-                    try { global.loadExamList(snapshot); } catch (_) { }
+            var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
+                && global.__isBrowseResetIntentInFlight();
+            if (resetInFlight) {
+                if (typeof global.__captureBrowseResetIndexSnapshot === 'function') {
+                    global.__captureBrowseResetIndexSnapshot(snapshot);
+                }
+                var resetLoading = document.querySelector('#browse-view .loading');
+                if (resetLoading) {
+                    resetLoading.style.display = 'none';
+                }
+                return;
+            }
+            var hasReplayRequest = arguments.length > 1 && replayRequestId != null;
+            if (hasReplayRequest && !isBrowseResultsSnapshotCurrent(replayRequestId)) {
+                var staleReplayLoading = document.querySelector('#browse-view .loading');
+                if (staleReplayLoading) {
+                    staleReplayLoading.style.display = 'none';
+                }
+                return;
+            }
+            var browseReady = ensureBrowseGroup();
+            var resultsRequestId = hasReplayRequest ? replayRequestId : null;
+            var resultsRequestCaptured = hasReplayRequest;
+            if (!hasReplayRequest) {
+                captureBrowseResultsRequest().then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
+            browseReady.then(function afterBrowseReady() {
+                var effectiveRequestId = resultsRequestCaptured
+                    ? resultsRequestId
+                    : getCurrentBrowseResultsRequest();
+                if (!isBrowseResultsSnapshotCurrent(effectiveRequestId)) {
+                    var staleLoading = document.querySelector('#browse-view .loading');
+                    if (staleLoading) {
+                        staleLoading.style.display = 'none';
+                    }
+                    return;
+                }
+                var searchInput = document.getElementById('exam-search-input')
+                    || document.querySelector('.search-input');
+                var searchQuery = searchInput && typeof searchInput.value === 'string'
+                    ? searchInput.value.trim()
+                    : '';
+                if (searchQuery && typeof global.searchExams === 'function') {
+                    try {
+                        global.searchExams(
+                            searchQuery,
+                            effectiveRequestId
+                        );
+                    } catch (_) { }
+                } else if (typeof global.loadExamList === 'function') {
+                    try {
+                        global.loadExamList(
+                            snapshot,
+                            effectiveRequestId
+                        );
+                    } catch (_) { }
                 }
                 var loading = document.querySelector('#browse-view .loading');
                 if (loading) {

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -260,7 +260,9 @@
     }
 
     var browseRuntimePromise = null;
+    var browseRuntimePrepared = false;
     var browseGroupPromise = null;
+    var browseGroupLease = null;
     var browseResetIntentGeneration = 0;
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
@@ -274,6 +276,10 @@
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
     var browseFunctionalResetFailureDebt = null;
+    var browsePendingFilterIntentGeneration = 0;
+    var browsePendingFilterConsumerGeneration = 0;
+    var activeBrowsePendingFilterConsumer = null;
+    var browsePendingFilterIntentMetadata = new WeakMap();
     var browseFunctionalResetState = {
         generation: 0,
         status: 'idle',
@@ -282,6 +288,111 @@
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
+
+    function getOrCreateBrowsePendingFilterIntent(pendingFilter, navigationGeneration) {
+        if (!pendingFilter || typeof pendingFilter !== 'object') {
+            return null;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(pendingFilter);
+        if (!intent) {
+            intent = {
+                generation: ++browsePendingFilterIntentGeneration,
+                navigationGeneration: navigationGeneration
+            };
+            browsePendingFilterIntentMetadata.set(pendingFilter, intent);
+        }
+        return intent;
+    }
+
+    function beginBrowsePendingFilterConsumer(pendingFilter, navigationGeneration) {
+        var effectiveNavigationGeneration = navigationGeneration == null
+            ? appNavigationIntentGeneration
+            : navigationGeneration;
+        var intent = getOrCreateBrowsePendingFilterIntent(
+            pendingFilter,
+            effectiveNavigationGeneration
+        );
+        if (!intent) {
+            return null;
+        }
+        var consumer = {
+            generation: ++browsePendingFilterConsumerGeneration,
+            pendingFilter: pendingFilter,
+            intentGeneration: intent.generation,
+            navigationGeneration: intent.navigationGeneration
+        };
+        activeBrowsePendingFilterConsumer = consumer;
+        return consumer;
+    }
+
+    function isBrowsePendingFilterConsumerCurrent(consumer) {
+        return !!consumer
+            && activeBrowsePendingFilterConsumer === consumer
+            && global.__pendingBrowseFilter === consumer.pendingFilter;
+    }
+
+    function isBrowsePendingFilterIntentCurrent(consumer) {
+        return isBrowsePendingFilterConsumerCurrent(consumer)
+            && consumer.navigationGeneration === appNavigationIntentGeneration
+            && getActiveViewName() === 'browse';
+    }
+
+    function captureBrowseGroupLease() {
+        var pendingFilter = global.__pendingBrowseFilter || null;
+        var intent = getOrCreateBrowsePendingFilterIntent(
+            pendingFilter,
+            appNavigationIntentGeneration
+        );
+        return {
+            navigationGeneration: appNavigationIntentGeneration,
+            activeView: getActiveViewName(),
+            functionalResetBarrier: browseFunctionalResetBarrier,
+            pendingFilter: pendingFilter,
+            pendingFilterIntentGeneration: intent ? intent.generation : null
+        };
+    }
+
+    function areBrowseGroupLeasesEquivalent(left, right) {
+        return !!left
+            && !!right
+            && left.navigationGeneration === right.navigationGeneration
+            && left.functionalResetBarrier === right.functionalResetBarrier
+            && left.pendingFilter === right.pendingFilter
+            && left.pendingFilterIntentGeneration === right.pendingFilterIntentGeneration;
+    }
+
+    function isBrowseGroupLeaseCurrent(lease) {
+        if (!lease
+            || lease.navigationGeneration !== appNavigationIntentGeneration
+            || getActiveViewName() !== lease.activeView
+            || (global.__pendingBrowseFilter || null) !== lease.pendingFilter) {
+            return false;
+        }
+        if (!lease.pendingFilter) {
+            return true;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(lease.pendingFilter);
+        return !!intent
+            && intent.generation === lease.pendingFilterIntentGeneration
+            && intent.navigationGeneration === lease.navigationGeneration;
+    }
+
+    function discardSupersededBrowseGroupPendingFilter(lease) {
+        if (!lease
+            || !lease.pendingFilter
+            || lease.navigationGeneration === appNavigationIntentGeneration
+            || global.__pendingBrowseFilter !== lease.pendingFilter) {
+            return false;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(lease.pendingFilter);
+        if (!intent
+            || intent.generation !== lease.pendingFilterIntentGeneration
+            || intent.navigationGeneration !== lease.navigationGeneration) {
+            return false;
+        }
+        delete global.__pendingBrowseFilter;
+        return true;
+    }
 
     function reapplyAppMixins() {
         if (global.ExamSystemAppMixins && typeof global.ExamSystemAppMixins.__applyToApp === 'function') {
@@ -425,6 +536,13 @@
             return false;
         });
         browseFunctionalResetBarrier = barrier;
+        // A Browse handoff may already be waiting for the raw runtime. Bind a
+        // reset registered during that wait to the same synchronization lease
+        // so its eventual failure cannot be skipped after the barrier pointer
+        // is retired.
+        if (browseGroupLease && browseGroupPromise) {
+            browseGroupLease.functionalResetBarrier = barrier;
+        }
         var resultsRequestId = null;
         if (typeof global.__beginBrowseResultsRequest === 'function') {
             resultsRequestId = global.__beginBrowseResultsRequest();
@@ -672,22 +790,42 @@
 
     global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
-    function synchronizeActiveBrowseViewNow(functionalResetBarrier) {
-        if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
-            return Promise.resolve();
+    function synchronizeActiveBrowseViewNow(functionalResetBarrier, synchronizationLease) {
+        if (!isBrowseGroupLeaseCurrent(synchronizationLease)) {
+            return Promise.resolve(false);
+        }
+        if (synchronizationLease.activeView !== 'browse') {
+            return Promise.resolve(true);
+        }
+        if (typeof global.initializeBrowseView !== 'function') {
+            return Promise.resolve(false);
         }
 
-        var pendingFilter = global.__pendingBrowseFilter || null;
+        var pendingFilter = synchronizationLease.pendingFilter || null;
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
+        var pendingFilterConsumer = canApplyPendingFilter
+            ? beginBrowsePendingFilterConsumer(
+                pendingFilter,
+                synchronizationLease.navigationGeneration
+            )
+            : null;
         var initialization;
         var initializationRequestId = null;
         var retainedInitializationRequestId = null;
         var pendingFilterOutcome = canApplyPendingFilter ? 'retryable-failure' : 'not-applicable';
-        function pendingFilterWasSuperseded() {
-            if (!pendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
-                return true;
+        function pendingFilterAttemptIsCurrent() {
+            return !canApplyPendingFilter
+                || (isBrowsePendingFilterIntentCurrent(pendingFilterConsumer)
+                    && (initializationRequestId == null
+                        || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+                        || global.__isBrowseResultsRequestCurrent(initializationRequestId)));
+        }
+        function currentConsumerWasSuperseded() {
+            if (!canApplyPendingFilter
+                || !isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer)) {
+                return false;
             }
-            if (getActiveViewName() !== 'browse') {
+            if (!isBrowsePendingFilterIntentCurrent(pendingFilterConsumer)) {
                 return true;
             }
             return initializationRequestId != null
@@ -697,6 +835,11 @@
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
+            if (!isBrowseGroupLeaseCurrent(synchronizationLease)
+                || (canApplyPendingFilter
+                    && !isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer))) {
+                return Promise.resolve(false);
+            }
             initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
@@ -724,8 +867,10 @@
                 if (!canApplyPendingFilter) {
                     return true;
                 }
-                if (pendingFilterWasSuperseded()) {
-                    pendingFilterOutcome = 'superseded';
+                if (!pendingFilterAttemptIsCurrent()) {
+                    if (currentConsumerWasSuperseded()) {
+                        pendingFilterOutcome = 'superseded';
+                    }
                     return false;
                 }
                 var filterArgs = [
@@ -746,17 +891,22 @@
                             pendingFilterOutcome = 'applied';
                             return true;
                         }
-                        if (pendingFilterWasSuperseded()) {
+                        if (currentConsumerWasSuperseded()) {
                             pendingFilterOutcome = 'superseded';
                         }
                         return false;
                     });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
-                if (pendingFilterOutcome !== 'applied' && pendingFilterWasSuperseded()) {
+                var ownsCurrentConsumer = !canApplyPendingFilter
+                    || isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer);
+                if (ownsCurrentConsumer
+                    && pendingFilterOutcome !== 'applied'
+                    && currentConsumerWasSuperseded()) {
                     pendingFilterOutcome = 'superseded';
                 }
-                if (pendingFilter
+                if (ownsCurrentConsumer
+                    && pendingFilter
                     && global.__pendingBrowseFilter === pendingFilter
                     && (pendingFilterOutcome === 'applied'
                         || pendingFilterOutcome === 'superseded')) {
@@ -769,10 +919,12 @@
             });
     }
 
-    function synchronizeActiveBrowseViewAfterLoad() {
-        var resetBarrier = browseFunctionalResetBarrier;
+    function synchronizeActiveBrowseViewAfterLoad(synchronizationLease) {
+        var resetBarrier = synchronizationLease
+            ? synchronizationLease.functionalResetBarrier
+            : browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow().then(function (synchronized) {
+            return synchronizeActiveBrowseViewNow(null, synchronizationLease).then(function (synchronized) {
                 return synchronized !== false;
             });
         }
@@ -783,7 +935,7 @@
             if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
                 return false;
             }
-            return synchronizeActiveBrowseViewNow(resetBarrier).then(function (synchronized) {
+            return synchronizeActiveBrowseViewNow(resetBarrier, synchronizationLease).then(function (synchronized) {
                 if (synchronized === false) {
                     completeBrowseFunctionalResetBarrier(resetBarrier, false);
                     return false;
@@ -806,35 +958,76 @@
         return browseRuntimePromise;
     }
 
+    function prepareLoadedBrowseRuntime() {
+        reapplyAppMixins();
+        initializeNavigationShell();
+        ensureBrowseStateManager();
+        if (typeof global.setupBrowsePreferenceUI === 'function') {
+            try {
+                global.setupBrowsePreferenceUI();
+            } catch (error) {
+                console.warn('[MainEntry] 初始化题库偏好 UI 失败:', error);
+            }
+        }
+        browseRuntimePrepared = true;
+        return true;
+    }
+
+    function prepareBrowseRuntimeAfterLoad() {
+        return ensureBrowseRuntimeGroup().then(prepareLoadedBrowseRuntime);
+    }
+
+    function prepareBrowseRuntimeForBackgroundRefresh() {
+        var activeSynchronization = browseGroupPromise;
+        if (!activeSynchronization && !browseRuntimePrepared) {
+            return ensureBrowseGroup();
+        }
+        var runtimeReady = prepareBrowseRuntimeAfterLoad();
+        if (!activeSynchronization) {
+            return runtimeReady;
+        }
+        return Promise.all([runtimeReady, activeSynchronization]).then(function afterExistingSync(values) {
+            return values[1] === false ? false : true;
+        });
+    }
+
     function ensureBrowseGroup() {
-        if (!browseGroupPromise) {
-            browseGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
-                reapplyAppMixins();
-                initializeNavigationShell();
-                ensureBrowseStateManager();
-                if (typeof global.setupBrowsePreferenceUI === 'function') {
-                    try {
-                        global.setupBrowsePreferenceUI();
-                    } catch (error) {
-                        console.warn('[MainEntry] 初始化题库偏好 UI 失败:', error);
+        var requestedLease = captureBrowseGroupLease();
+        if (!browseGroupPromise || !areBrowseGroupLeasesEquivalent(browseGroupLease, requestedLease)) {
+            browseGroupLease = requestedLease;
+            var requestedGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
+                prepareLoadedBrowseRuntime();
+                if (!isBrowseGroupLeaseCurrent(requestedLease)) {
+                    discardSupersededBrowseGroupPendingFilter(requestedLease);
+                    if (browseGroupPromise === requestedGroupPromise) {
+                        browseGroupPromise = null;
+                        browseGroupLease = null;
                     }
+                    return false;
                 }
-                return synchronizeActiveBrowseViewAfterLoad()
+                return synchronizeActiveBrowseViewAfterLoad(requestedLease)
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
                         return false;
                     })
                     .then(function browseViewSynchronized(synchronized) {
                         if (synchronized === false) {
-                            browseGroupPromise = null;
+                            if (browseGroupPromise === requestedGroupPromise) {
+                                browseGroupPromise = null;
+                                browseGroupLease = null;
+                            }
                             return false;
                         }
                         return true;
                     });
             }).catch(function onBrowseLoadError(error) {
-                browseGroupPromise = null;
+                if (browseGroupPromise === requestedGroupPromise) {
+                    browseGroupPromise = null;
+                    browseGroupLease = null;
+                }
                 throw error;
             });
+            browseGroupPromise = requestedGroupPromise;
         }
         return browseGroupPromise;
     }
@@ -1521,7 +1714,10 @@
                 }
                 return;
             }
-            var browseReady = ensureBrowseGroup();
+            // Index publication is background work. It needs the loaded
+            // runtime, but must not start or consume a foreground activation
+            // synchronization lease.
+            var browseReady = prepareBrowseRuntimeForBackgroundRefresh();
             var resultsRequestId = hasReplayRequest ? replayRequestId : null;
             var resultsRequestCaptured = hasReplayRequest;
             if (!hasReplayRequest && typeof global.__getBrowseResultsRequestId === 'function') {
@@ -1734,12 +1930,15 @@
         prepareBrowseFunctionalResetRecoveryForForeground:
             prepareBrowseFunctionalResetRecoveryForForeground,
         completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
+        beginBrowsePendingFilterConsumer: beginBrowsePendingFilterConsumer,
+        isBrowsePendingFilterConsumerCurrent: isBrowsePendingFilterConsumerCurrent,
+        isBrowsePendingFilterIntentCurrent: isBrowsePendingFilterIntentCurrent,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,
         ensureStateCoreGroup: ensureStateCoreGroup,
         ensureSessionSuiteReady: ensureSessionSuiteReady,
-        browseReady: function () { return browseGroupPromise || ensureBrowseGroup(); },
+        browseReady: function () { return ensureBrowseGroup(); },
         examDataReady: ensureExamData
     });
 })(typeof window !== 'undefined' ? window : this);

--- a/js/app/main-entry.js
+++ b/js/app/main-entry.js
@@ -274,6 +274,21 @@
         }
     }
 
+    function ensureBrowseStateManager() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[MainEntry] 初始化浏览状态管理器失败:', error);
+            return null;
+        }
+    }
+
     function synchronizeActiveBrowseViewAfterLoad() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
@@ -286,7 +301,7 @@
                 return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             })
             .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter) {
+                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
                 return global.applyBrowseFilter(
@@ -307,6 +322,8 @@
         if (!browseGroupPromise) {
             browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
                 reapplyAppMixins();
+                initializeNavigationShell();
+                ensureBrowseStateManager();
                 if (typeof global.setupBrowsePreferenceUI === 'function') {
                     try {
                         global.setupBrowsePreferenceUI();
@@ -384,12 +401,13 @@
     }
 
     function initializeNavigationShell() {
+        var controller = null;
         try {
             if (global.NavigationController && typeof global.NavigationController.ensure === 'function') {
-                global.NavigationController.ensure({
+                controller = global.NavigationController.ensure({
                     containerSelector: '.main-nav',
                     activeClass: 'active',
-                    initialView: 'overview',
+                    initialView: getActiveViewName() || 'overview',
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
@@ -398,7 +416,7 @@
                     },
                     onNavigate: function onNavigate(viewName) {
                         if (typeof global.showView === 'function') {
-                            global.showView(viewName);
+                            global.showView(viewName, false);
                             return;
                         }
                         if (global.app && typeof global.app.navigateToView === 'function') {
@@ -410,6 +428,19 @@
         } catch (error) {
             console.warn('[MainEntry] 初始化导航失败:', error);
         }
+        if (controller && typeof document !== 'undefined') {
+            var navRoot = document.querySelector('.main-nav');
+            var fallbackHandler = navRoot && navRoot._legacyNavHandler;
+            if (typeof fallbackHandler === 'function' && typeof navRoot.removeEventListener === 'function') {
+                navRoot.removeEventListener('click', fallbackHandler);
+                try {
+                    delete navRoot._legacyNavHandler;
+                } catch (_) {
+                    navRoot._legacyNavHandler = null;
+                }
+            }
+        }
+        return controller;
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {
@@ -471,7 +502,10 @@
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
-            return ensureLazyGroup(group).then(function () {
+            var groupReady = group === BROWSE_GROUP
+                ? ensureBrowseGroup()
+                : ensureLazyGroup(group);
+            return groupReady.then(function () {
                 var fn = global[name];
                 if (typeof fn === 'function' && fn !== proxy) {
                     return fn.apply(global, args);

--- a/js/app/state-service.js
+++ b/js/app/state-service.js
@@ -143,6 +143,7 @@
             this.app = null;
             this.globalRef = global;
             this.globalBindingsInstalled = false;
+            this.browseFilterMutationRevision = 0;
 
             this.state = {
                 filteredExams: Array.isArray(global.filteredExams) ? global.filteredExams : [],
@@ -238,7 +239,7 @@
                     this.setFilteredExams(value, { syncApp: false });
                     break;
                 case 'ui.browseFilter':
-                    this.setBrowseFilter(value, { syncApp: false });
+                    this.setBrowseFilter(value, { syncApp: false, trackMutation: false });
                     break;
                 case 'exam.currentCategory':
                     this.setBrowseFilter({
@@ -290,7 +291,14 @@
             return this.state.browseFilter;
         }
 
+        getBrowseFilterMutationRevision() {
+            return this.browseFilterMutationRevision;
+        }
+
         setBrowseFilter(filter, options = {}) {
+            if (options.trackMutation !== false) {
+                this.browseFilterMutationRevision += 1;
+            }
             this.state.browseFilter = normalizeFilter(filter);
             if (options.syncApp !== false) {
                 this.applyToApp();
@@ -535,6 +543,9 @@
             };
             globalRef.getBrowseFilterState = function getBrowseFilterState() {
                 return service.getBrowseFilter();
+            };
+            globalRef.getBrowseFilterMutationRevision = function getBrowseFilterMutationRevision() {
+                return service.getBrowseFilterMutationRevision();
             };
             globalRef.setBrowseFilterState = function setBrowseFilterState(category, type) {
                 return service.setBrowseFilter({ category, type });

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -178,6 +178,29 @@
         console.warn('[Fallback] 未找到视图节点:', normalized);
         return;
       }
+      var browseFunctionalReset = null;
+      var browseFunctionalResetBarrier = null;
+      var browseResetBarrierRegistered = false;
+      if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
+        // Register the functional barrier before Browse becomes active. Deferring
+        // the reset body closes the synchronous activation-to-registration gap.
+        browseFunctionalReset = Promise.resolve().then(function beginBrowseFunctionalReset() {
+          return resetBrowseFunctionalStateForFallback();
+        });
+        if (window.AppEntry
+          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
+          try {
+            browseFunctionalResetBarrier = window.AppEntry.registerBrowseFunctionalResetBarrier(
+              Promise.resolve(browseFunctionalReset).then(function (result) {
+                return !!(result && result.succeeded === true);
+              })
+            );
+            browseResetBarrierRegistered = true;
+          } catch (error) {
+            console.warn('[Fallback] 注册题库重置屏障失败:', error);
+          }
+        }
+      }
       Array.prototype.forEach.call(document.querySelectorAll('.view.active'), function (v) {
         v.classList.remove('active');
       });
@@ -210,23 +233,7 @@
         }
       }
 
-      var browseFunctionalReset = null;
-      var browseResetBarrierRegistered = false;
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
-        browseFunctionalReset = resetBrowseFunctionalStateForFallback();
-        if (window.AppEntry
-          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
-          try {
-            window.AppEntry.registerBrowseFunctionalResetBarrier(
-              Promise.resolve(browseFunctionalReset).then(function (result) {
-                return !!(result && result.succeeded === true);
-              })
-            );
-            browseResetBarrierRegistered = true;
-          } catch (error) {
-            console.warn('[Fallback] 注册题库重置屏障失败:', error);
-          }
-        }
         if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
           window.browseStateManager.clearSearchState();
         } else {
@@ -266,12 +273,20 @@
               console.warn('[Fallback] 题库功能状态未能安全重置，跳过刷新');
               return false;
             }
+            if (browseFunctionalResetBarrier
+              && window.AppEntry
+              && typeof window.AppEntry.isBrowseFunctionalResetBarrierCurrent === 'function'
+              && !window.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+                browseFunctionalResetBarrier
+              )) {
+              return false;
+            }
             if (resetResult.ownerLoaded === true
               && browseResetBarrierRegistered
               && window.AppEntry
               && typeof window.AppEntry.ensureBrowseGroup === 'function') {
-              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function () {
-                return true;
+              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function (result) {
+                return result !== false;
               });
             }
             return runBrowseRefresh();
@@ -285,14 +300,24 @@
             return false;
           });
         }
+        if (browseFunctionalResetBarrier
+          && window.AppEntry
+          && typeof window.AppEntry.completeBrowseFunctionalResetBarrier === 'function') {
+          browseRefresh = Promise.resolve(browseRefresh).then(function completeFunctionalReset(result) {
+            var completed = window.AppEntry.completeBrowseFunctionalResetBarrier(
+              browseFunctionalResetBarrier,
+              result !== false
+            );
+            return completed ? result : false;
+          });
+        }
       }
       if (normalized === 'practice' && window.AppActions && typeof window.AppActions.ensurePracticeSuite === 'function') {
         window.AppActions.ensurePracticeSuite();
       }
       if (normalized === 'practice' && typeof window.startPracticeRecordsSyncInBackground === 'function') {
         window.startPracticeRecordsSyncInBackground('practice-view');
-      }
-      if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
+      } else if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
         window.ensurePracticeRecordsSync('practice-view').catch(function () { });
       }
       return browseRefresh;

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -29,6 +29,19 @@
 
   ensureCompatPatch(window);
 
+  function runRepeatedBrowseReset(viewName) {
+    if (viewName !== 'browse') {
+      return false;
+    }
+    if (typeof window.resetBrowseViewToAll === 'function') {
+      return window.resetBrowseViewToAll();
+    }
+    if (typeof window.showView === 'function') {
+      return window.showView('browse', true);
+    }
+    return true;
+  }
+
   if (window.CompatPatch && typeof window.CompatPatch.register === 'function') {
     window.CompatPatch.register('boot-fallbacks', {
       owner: 'runtime',
@@ -40,6 +53,9 @@
   // Fallback for navigation
   if (typeof window.showView !== 'function') {
     window.showView = function (viewName, resetCategory) {
+      if (typeof window.__markAppNavigationIntent === 'function') {
+        window.__markAppNavigationIntent();
+      }
       if (typeof document === 'undefined') {
         return;
       }
@@ -84,10 +100,66 @@
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
         window.currentCategory = 'all';
         window.currentExamType = 'all';
-        if (typeof window.setBrowseTitle === 'function') { window.setBrowseTitle('题库浏览'); return; }
-        var t = document.getElementById('browse-title'); if (t) t.textContent = '题库浏览';
+        var browseFilterStateReset = false;
+        if (typeof window.resetBrowseFilterStateToAll === 'function') {
+          try {
+            window.resetBrowseFilterStateToAll();
+            browseFilterStateReset = true;
+          } catch (error) {
+            console.warn('[Fallback] 重置题库筛选状态失败:', error);
+          }
+        }
+        if (!browseFilterStateReset) {
+          if (typeof window.setBrowseFilterState === 'function') {
+            try {
+              window.setBrowseFilterState('all', 'all');
+            } catch (error) {
+              console.warn('[Fallback] 重置题库分类状态失败:', error);
+            }
+          }
+          if (window.browseController) {
+            window.browseController.currentMode = 'default';
+            window.browseController.activeFilter = 'all';
+          }
+          var frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+          if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+            Array.prototype.forEach.call(
+              frequencyContainer.querySelectorAll('[data-frequency-filter]'),
+              function (button) {
+                if (button.classList) button.classList.remove('active');
+                if (typeof button.setAttribute === 'function') button.setAttribute('aria-pressed', 'false');
+              }
+            );
+          }
+        }
+        if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
+          window.browseStateManager.clearSearchState();
+        } else {
+          var searchInput = document.getElementById('exam-search-input') || document.querySelector('.search-input');
+          if (searchInput) searchInput.value = '';
+          var searchClearButton = document.getElementById('search-clear-btn');
+          if (searchClearButton) searchClearButton.hidden = true;
+        }
+        if (typeof window.setBrowseTitle === 'function') {
+          window.setBrowseTitle('题库浏览');
+        } else {
+          var t = document.getElementById('browse-title'); if (t) t.textContent = '题库浏览';
+        }
       }
-      if (normalized === 'browse' && typeof window.loadExamList === 'function') window.loadExamList();
+      var browseRefresh = null;
+      if (normalized === 'browse') {
+        if (typeof window.refreshBrowseResults === 'function') {
+          browseRefresh = window.refreshBrowseResults();
+        } else if (typeof window.loadExamList === 'function') {
+          browseRefresh = window.loadExamList();
+        }
+        if (browseRefresh && typeof browseRefresh.then === 'function') {
+          browseRefresh = Promise.resolve(browseRefresh).catch(function (error) {
+            console.warn('[Fallback] 刷新题库视图失败:', error);
+            return false;
+          });
+        }
+      }
       if (normalized === 'practice' && window.AppActions && typeof window.AppActions.ensurePracticeSuite === 'function') {
         window.AppActions.ensurePracticeSuite();
       }
@@ -97,6 +169,7 @@
       if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
         window.ensurePracticeRecordsSync('practice-view').catch(function () { });
       }
+      return browseRefresh;
     };
   }
 
@@ -105,6 +178,7 @@
       window.ensureLegacyNavigationController({
         containerSelector: '.main-nav',
         syncOnNavigate: true,
+        onRepeatNavigate: runRepeatedBrowseReset,
         onNavigate: function onNavigate(viewName) {
           if (typeof window.showView === 'function') {
             window.showView(viewName, false);
@@ -122,9 +196,9 @@
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
           var alreadyActive = !!(button.classList && button.classList.contains('active'));
-          if (viewName === 'browse' && alreadyActive && typeof window.resetBrowseViewToAll === 'function') {
+          if (viewName === 'browse' && alreadyActive) {
             try {
-              Promise.resolve(window.resetBrowseViewToAll()).catch(function (error) {
+              Promise.resolve(runRepeatedBrowseReset(viewName)).catch(function (error) {
                 console.warn('[Fallback] 重复题库导航重置失败:', error);
               });
             } catch (error) {

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -107,7 +107,7 @@
         syncOnNavigate: true,
         onNavigate: function onNavigate(viewName) {
           if (typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
           }
         }
       });
@@ -121,8 +121,19 @@
           }
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
+          var alreadyActive = !!(button.classList && button.classList.contains('active'));
+          if (viewName === 'browse' && alreadyActive && typeof window.resetBrowseViewToAll === 'function') {
+            try {
+              Promise.resolve(window.resetBrowseViewToAll()).catch(function (error) {
+                console.warn('[Fallback] 重复题库导航重置失败:', error);
+              });
+            } catch (error) {
+              console.warn('[Fallback] 重复题库导航重置失败:', error);
+            }
+            return;
+          }
           if (viewName && typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
           }
         };
         navRoot._legacyNavHandler = handler;
@@ -1589,7 +1600,7 @@
   function bootInitialView() {
     const targetView = resolveInitialView();
     if (typeof window.showView === 'function') {
-      window.showView(targetView);
+      window.showView(targetView, false);
       return;
     }
     if (typeof window.app !== 'undefined' && typeof window.app.navigateToView === 'function') {

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -109,6 +109,15 @@
             console.warn('[Fallback] 重置题库筛选状态失败:', error);
           }
         }
+        if (!browseFilterStateReset && window.ExamActions
+          && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
+          try {
+            window.ExamActions.resetBrowseFilterStateToAll();
+            browseFilterStateReset = true;
+          } catch (error) {
+            console.warn('[Fallback] 通过题库状态 owner 重置失败:', error);
+          }
+        }
         if (!browseFilterStateReset) {
           if (typeof window.setBrowseFilterState === 'function') {
             try {
@@ -195,6 +204,11 @@
           }
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
+          if (viewName === 'browse') {
+            try {
+              event.__browseNavigationHandled = true;
+            } catch (_) { }
+          }
           var alreadyActive = !!(button.classList && button.classList.contains('active'));
           if (viewName === 'browse' && alreadyActive) {
             try {

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -29,6 +29,108 @@
 
   ensureCompatPatch(window);
 
+  function getBrowseFilterStateOwner() {
+    var actions = window.ExamActions;
+    var owner = actions && actions.browseFilterStateOwner;
+    return owner && typeof owner.resetToAll === 'function' ? owner : null;
+  }
+
+  function invokeBrowseResetDelegate(delegate, context, label) {
+    if (typeof delegate !== 'function') {
+      return Promise.resolve(false);
+    }
+    try {
+      return Promise.resolve(delegate.call(context)).then(function (result) {
+        return result !== false;
+      }).catch(function (error) {
+        console.warn('[Fallback] ' + label + '失败:', error);
+        return false;
+      });
+    } catch (error) {
+      console.warn('[Fallback] ' + label + '失败:', error);
+      return Promise.resolve(false);
+    }
+  }
+
+  function ensureBrowseFilterStateOwner() {
+    var owner = getBrowseFilterStateOwner();
+    if (owner) {
+      return Promise.resolve({ owner: owner, loaded: true });
+    }
+    var loading = null;
+    try {
+      if (window.AppEntry && typeof window.AppEntry.ensureBrowseRuntimeGroup === 'function') {
+        loading = window.AppEntry.ensureBrowseRuntimeGroup();
+      } else if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
+        loading = window.AppLazyLoader.ensureGroup('browse-runtime');
+      }
+    } catch (error) {
+      console.warn('[Fallback] 加载题库状态 owner 失败:', error);
+      return Promise.resolve(null);
+    }
+    if (!loading) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(loading).then(function () {
+      var loadedOwner = getBrowseFilterStateOwner();
+      return loadedOwner ? { owner: loadedOwner, loaded: true } : null;
+    }).catch(function (error) {
+      console.warn('[Fallback] 加载题库状态 owner 失败:', error);
+      return null;
+    });
+  }
+
+  function resetBrowseFunctionalStateForFallback() {
+    var delegates = [
+      {
+        fn: window.resetBrowseFilterStateToAll,
+        context: window,
+        label: '重置题库筛选状态'
+      },
+      {
+        fn: window.ExamActions && window.ExamActions.resetBrowseFilterStateToAll,
+        context: window.ExamActions,
+        label: '通过题库状态 owner 重置'
+      }
+    ];
+
+    function tryDelegate(index) {
+      if (index >= delegates.length) {
+        var existingOwner = getBrowseFilterStateOwner();
+        if (existingOwner) {
+          return invokeBrowseResetDelegate(
+            existingOwner.resetToAll,
+            existingOwner,
+            '通过稳定题库状态 owner 重置'
+          ).then(function (succeeded) {
+            return { succeeded: succeeded, ownerLoaded: false };
+          });
+        }
+        return ensureBrowseFilterStateOwner().then(function (loaded) {
+          if (!loaded || !loaded.owner) {
+            return { succeeded: false, ownerLoaded: false };
+          }
+          return invokeBrowseResetDelegate(
+            loaded.owner.resetToAll,
+            loaded.owner,
+            '通过延迟加载的题库状态 owner 重置'
+          ).then(function (succeeded) {
+            return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
+          });
+        });
+      }
+      var candidate = delegates[index];
+      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label)
+        .then(function (succeeded) {
+          return succeeded
+            ? { succeeded: true, ownerLoaded: false }
+            : tryDelegate(index + 1);
+        });
+    }
+
+    return tryDelegate(0);
+  }
+
   function runRepeatedBrowseReset(viewName) {
     if (viewName !== 'browse') {
       return false;
@@ -97,48 +199,21 @@
         }
       }
 
+      var browseFunctionalReset = null;
+      var browseResetBarrierRegistered = false;
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
-        window.currentCategory = 'all';
-        window.currentExamType = 'all';
-        var browseFilterStateReset = false;
-        if (typeof window.resetBrowseFilterStateToAll === 'function') {
+        browseFunctionalReset = resetBrowseFunctionalStateForFallback();
+        if (window.AppEntry
+          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
           try {
-            window.resetBrowseFilterStateToAll();
-            browseFilterStateReset = true;
-          } catch (error) {
-            console.warn('[Fallback] 重置题库筛选状态失败:', error);
-          }
-        }
-        if (!browseFilterStateReset && window.ExamActions
-          && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
-          try {
-            window.ExamActions.resetBrowseFilterStateToAll();
-            browseFilterStateReset = true;
-          } catch (error) {
-            console.warn('[Fallback] 通过题库状态 owner 重置失败:', error);
-          }
-        }
-        if (!browseFilterStateReset) {
-          if (typeof window.setBrowseFilterState === 'function') {
-            try {
-              window.setBrowseFilterState('all', 'all');
-            } catch (error) {
-              console.warn('[Fallback] 重置题库分类状态失败:', error);
-            }
-          }
-          if (window.browseController) {
-            window.browseController.currentMode = 'default';
-            window.browseController.activeFilter = 'all';
-          }
-          var frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-          if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-            Array.prototype.forEach.call(
-              frequencyContainer.querySelectorAll('[data-frequency-filter]'),
-              function (button) {
-                if (button.classList) button.classList.remove('active');
-                if (typeof button.setAttribute === 'function') button.setAttribute('aria-pressed', 'false');
-              }
+            window.AppEntry.registerBrowseFunctionalResetBarrier(
+              Promise.resolve(browseFunctionalReset).then(function (result) {
+                return !!(result && result.succeeded === true);
+              })
             );
+            browseResetBarrierRegistered = true;
+          } catch (error) {
+            console.warn('[Fallback] 注册题库重置屏障失败:', error);
           }
         }
         if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
@@ -157,10 +232,36 @@
       }
       var browseRefresh = null;
       if (normalized === 'browse') {
-        if (typeof window.refreshBrowseResults === 'function') {
-          browseRefresh = window.refreshBrowseResults();
-        } else if (typeof window.loadExamList === 'function') {
-          browseRefresh = window.loadExamList();
+        var runBrowseRefresh = function runBrowseRefresh() {
+          if (resetCategory === false && typeof window.activateBrowseView === 'function') {
+            return window.activateBrowseView();
+          }
+          if (typeof window.refreshBrowseResults === 'function') {
+            return window.refreshBrowseResults();
+          }
+          if (typeof window.loadExamList === 'function') {
+            return window.loadExamList();
+          }
+          return false;
+        };
+        if (browseFunctionalReset) {
+          browseRefresh = Promise.resolve(browseFunctionalReset).then(function (resetResult) {
+            if (!resetResult || resetResult.succeeded !== true) {
+              console.warn('[Fallback] 题库功能状态未能安全重置，跳过刷新');
+              return false;
+            }
+            if (resetResult.ownerLoaded === true
+              && browseResetBarrierRegistered
+              && window.AppEntry
+              && typeof window.AppEntry.ensureBrowseGroup === 'function') {
+              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function () {
+                return true;
+              });
+            }
+            return runBrowseRefresh();
+          });
+        } else {
+          browseRefresh = runBrowseRefresh();
         }
         if (browseRefresh && typeof browseRefresh.then === 'function') {
           browseRefresh = Promise.resolve(browseRefresh).catch(function (error) {

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -35,23 +35,29 @@
     return owner && typeof owner.resetToAll === 'function' ? owner : null;
   }
 
-  function invokeBrowseStateOwnerReset(owner, label) {
+  function isBrowseResetAttemptCurrent(options) {
+    return !options
+      || typeof options.isCurrent !== 'function'
+      || options.isCurrent() === true;
+  }
+
+  function invokeBrowseStateOwnerReset(owner, label, options) {
     if (!owner) {
       return Promise.resolve(false);
     }
     var reset = typeof owner.resetForActivation === 'function'
       ? owner.resetForActivation
       : owner.resetToAll;
-    return invokeBrowseResetDelegate(reset, owner, label);
+    return invokeBrowseResetDelegate(reset, owner, label, options);
   }
 
-  function invokeBrowseResetDelegate(delegate, context, label) {
-    if (typeof delegate !== 'function') {
+  function invokeBrowseResetDelegate(delegate, context, label, options) {
+    if (typeof delegate !== 'function' || !isBrowseResetAttemptCurrent(options)) {
       return Promise.resolve(false);
     }
     try {
-      return Promise.resolve(delegate.call(context)).then(function (result) {
-        return result !== false;
+      return Promise.resolve(delegate.call(context, options)).then(function (result) {
+        return isBrowseResetAttemptCurrent(options) && result !== false;
       }).catch(function (error) {
         console.warn('[Fallback] ' + label + '失败:', error);
         return false;
@@ -90,10 +96,14 @@
     });
   }
 
-  function resetBrowseFunctionalStateForFallback() {
+  function resetBrowseFunctionalStateForFallback(options) {
     var activationOwner = getBrowseFilterStateOwner();
     if (activationOwner && typeof activationOwner.resetForActivation === 'function') {
-      return invokeBrowseStateOwnerReset(activationOwner, '通过题库状态 owner 完成激活前重置')
+      return invokeBrowseStateOwnerReset(
+        activationOwner,
+        '通过题库状态 owner 完成激活前重置',
+        options
+      )
         .then(function (succeeded) {
           return { succeeded: succeeded, ownerLoaded: false };
         });
@@ -115,7 +125,11 @@
       if (index >= delegates.length) {
         var existingOwner = getBrowseFilterStateOwner();
         if (existingOwner) {
-          return invokeBrowseStateOwnerReset(existingOwner, '通过稳定题库状态 owner 重置')
+          return invokeBrowseStateOwnerReset(
+            existingOwner,
+            '通过稳定题库状态 owner 重置',
+            options
+          )
             .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: false };
           });
@@ -124,14 +138,18 @@
           if (!loaded || !loaded.owner) {
             return { succeeded: false, ownerLoaded: false };
           }
-          return invokeBrowseStateOwnerReset(loaded.owner, '通过延迟加载的题库状态 owner 重置')
+          return invokeBrowseStateOwnerReset(
+            loaded.owner,
+            '通过延迟加载的题库状态 owner 重置',
+            options
+          )
             .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
           });
         });
       }
       var candidate = delegates[index];
-      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label)
+      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label, options)
         .then(function (succeeded) {
           return succeeded
             ? { succeeded: true, ownerLoaded: false }
@@ -185,7 +203,17 @@
         // Register the functional barrier before Browse becomes active. Deferring
         // the reset body closes the synchronous activation-to-registration gap.
         browseFunctionalReset = Promise.resolve().then(function beginBrowseFunctionalReset() {
-          return resetBrowseFunctionalStateForFallback();
+          return resetBrowseFunctionalStateForFallback({
+            isCurrent: function isFunctionalResetCurrent() {
+              return !browseResetBarrierRegistered
+                || (!!browseFunctionalResetBarrier
+                && !!window.AppEntry
+                && typeof window.AppEntry.isBrowseFunctionalResetBarrierCurrent === 'function'
+                && window.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+                  browseFunctionalResetBarrier
+                ));
+            }
+          });
         });
         if (window.AppEntry
           && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
@@ -285,11 +313,25 @@
               && browseResetBarrierRegistered
               && window.AppEntry
               && typeof window.AppEntry.ensureBrowseGroup === 'function') {
-              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function (result) {
+              var groupRefresh = window.AppEntry.ensureBrowseGroup();
+              if (typeof window.AppEntry.updateBrowseFunctionalResetResultsRequest === 'function') {
+                window.AppEntry.updateBrowseFunctionalResetResultsRequest(
+                  browseFunctionalResetBarrier
+                );
+              }
+              return Promise.resolve(groupRefresh).then(function (result) {
                 return result !== false;
               });
             }
-            return runBrowseRefresh();
+            var refreshResult = runBrowseRefresh();
+            if (browseFunctionalResetBarrier
+              && window.AppEntry
+              && typeof window.AppEntry.updateBrowseFunctionalResetResultsRequest === 'function') {
+              window.AppEntry.updateBrowseFunctionalResetResultsRequest(
+                browseFunctionalResetBarrier
+              );
+            }
+            return refreshResult;
           });
         } else {
           browseRefresh = runBrowseRefresh();

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -35,6 +35,16 @@
     return owner && typeof owner.resetToAll === 'function' ? owner : null;
   }
 
+  function invokeBrowseStateOwnerReset(owner, label) {
+    if (!owner) {
+      return Promise.resolve(false);
+    }
+    var reset = typeof owner.resetForActivation === 'function'
+      ? owner.resetForActivation
+      : owner.resetToAll;
+    return invokeBrowseResetDelegate(reset, owner, label);
+  }
+
   function invokeBrowseResetDelegate(delegate, context, label) {
     if (typeof delegate !== 'function') {
       return Promise.resolve(false);
@@ -81,6 +91,13 @@
   }
 
   function resetBrowseFunctionalStateForFallback() {
+    var activationOwner = getBrowseFilterStateOwner();
+    if (activationOwner && typeof activationOwner.resetForActivation === 'function') {
+      return invokeBrowseStateOwnerReset(activationOwner, '通过题库状态 owner 完成激活前重置')
+        .then(function (succeeded) {
+          return { succeeded: succeeded, ownerLoaded: false };
+        });
+    }
     var delegates = [
       {
         fn: window.resetBrowseFilterStateToAll,
@@ -98,11 +115,8 @@
       if (index >= delegates.length) {
         var existingOwner = getBrowseFilterStateOwner();
         if (existingOwner) {
-          return invokeBrowseResetDelegate(
-            existingOwner.resetToAll,
-            existingOwner,
-            '通过稳定题库状态 owner 重置'
-          ).then(function (succeeded) {
+          return invokeBrowseStateOwnerReset(existingOwner, '通过稳定题库状态 owner 重置')
+            .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: false };
           });
         }
@@ -110,11 +124,8 @@
           if (!loaded || !loaded.owner) {
             return { succeeded: false, ownerLoaded: false };
           }
-          return invokeBrowseResetDelegate(
-            loaded.owner.resetToAll,
-            loaded.owner,
-            '通过延迟加载的题库状态 owner 重置'
-          ).then(function (succeeded) {
+          return invokeBrowseStateOwnerReset(loaded.owner, '通过延迟加载的题库状态 owner 重置')
+            .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
           });
         });
@@ -235,6 +246,11 @@
         var runBrowseRefresh = function runBrowseRefresh() {
           if (resetCategory === false && typeof window.activateBrowseView === 'function') {
             return window.activateBrowseView();
+          }
+          if (resetCategory === false
+            && window.AppEntry
+            && typeof window.AppEntry.ensureBrowseGroup === 'function') {
+            return window.AppEntry.ensureBrowseGroup();
           }
           if (typeof window.refreshBrowseResults === 'function') {
             return window.refreshBrowseResults();

--- a/js/boot-fallbacks.js
+++ b/js/boot-fallbacks.js
@@ -1475,6 +1475,9 @@
         }
       } catch (_) { }
       try { window.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { key: key, index: snapshot } })); } catch (_) { }
+      if (typeof window.startPracticeRecordsSyncInBackground === 'function') {
+        window.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
+      }
       return true;
     }
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -2660,7 +2660,7 @@
         options = options || {};
         var container = this._getContainer();
         if (!container) {
-            return;
+            return false;
         }
 
         var loadingSelector = options.loadingSelector || this.loadingSelector;
@@ -2670,7 +2670,7 @@
         if (normalizedExams.length === 0) {
             this._renderEmptyState(container, options.emptyState);
             this._hideLoading(loadingIndicator);
-            return;
+            return true;
         }
 
         var examList = this._createExamList();
@@ -2689,6 +2689,7 @@
 
         this._replaceContent(container, [examList]);
         this._hideLoading(loadingIndicator);
+        return true;
     };
 
     LegacyExamListView.prototype._createExamList = function _createExamList() {
@@ -5719,11 +5720,14 @@
         }
 
         if (view) {
-            view.render(renderExams, {
+            const committed = view.render(renderExams, {
                 loadingSelector: '#browse-view .loading',
                 selectionMode: effectiveOptions.selectionMode || '',
                 customSuiteDraft: effectiveOptions.customSuiteDraft || null
             });
+            if (committed !== true) {
+                return false;
+            }
             setupExamActionHandlers();
             if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
                 global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
@@ -17875,8 +17879,7 @@ async function syncPracticeRecords(options = {}) {
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const practiceProjectionInvocation = ++browsePracticeProjectionInvocationSequence;
     const browseProgressSourceEpoch = {
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceProjectionGeneration: null
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -17949,14 +17952,25 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    // Publish Browse ownership only after this invocation has produced a
-    // complete snapshot. A failed newer invocation therefore cannot strand a
-    // successful repaint queued behind a foreground request. Conversely, an
-    // older success that settles after a newer success remains stale.
+    // Publish Browse ownership only after the derived completion state,
+    // anchors, and any active-view repaint have accepted this snapshot. A
+    // newer invocation that reads successfully but fails publication must not
+    // invalidate an older repaint already queued behind a foreground request.
     if (practiceProjectionInvocation > browsePracticeProjectionGeneration) {
-        browsePracticeProjectionGeneration = practiceProjectionInvocation;
-        browseProgressSourceEpoch.practiceProjectionGeneration = practiceProjectionInvocation;
-        refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+        const projectionAccepted = refreshBrowseProgressFromRecords(
+            records,
+            examIndex,
+            browseProgressSourceEpoch,
+            { practiceProjectionGeneration: practiceProjectionInvocation }
+        );
+        if (projectionAccepted) {
+            browsePracticeProjectionGeneration = practiceProjectionInvocation;
+            Promise.resolve().then(() => {
+                flushPendingBrowseProgressRefresh();
+            }).catch((error) => {
+                console.warn('[Browse] 刷新浏览进度列表失败:', error);
+            });
+        }
     }
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
@@ -19642,13 +19656,32 @@ function flushPendingBrowseProgressRefresh() {
     });
 }
 
-function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = null) {
+function refreshBrowseProgressFromRecords(
+    records,
+    examIndex,
+    refreshEpoch = null,
+    publication = null
+) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
+        const candidateValue = publication && publication.practiceProjectionGeneration;
+        const candidatePracticeProjectionGeneration = candidateValue != null
+            && Number.isFinite(Number(candidateValue))
+            ? Number(candidateValue)
+            : null;
+        if (candidatePracticeProjectionGeneration != null
+            && candidatePracticeProjectionGeneration <= browsePracticeProjectionGeneration) {
+            return false;
+        }
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
         if (!isBrowseProgressRefreshEpochCurrent(pendingEpoch)) {
-            return;
+            return false;
+        }
+        const browseView = document.getElementById('browse-view');
+        const isBrowseActive = browseView && browseView.classList.contains('active');
+        if (isBrowseActive && typeof renderBrowseResultsForState !== 'function') {
+            return false;
         }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
             rebuildBrowseCompletionIndex(recordSnapshot);
@@ -19656,17 +19689,25 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
         if (typeof updateBrowseAnchorsFromRecords === 'function') {
             updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
         }
-        const browseView = document.getElementById('browse-view');
-        const isBrowseActive = browseView && browseView.classList.contains('active');
-        if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
+        if (isBrowseActive) {
+            if (candidatePracticeProjectionGeneration != null) {
+                pendingEpoch.practiceProjectionGeneration =
+                    candidatePracticeProjectionGeneration;
+            }
             pendingBrowseProgressRefresh = {
                 index: indexSnapshot,
                 epoch: pendingEpoch
             };
-            flushPendingBrowseProgressRefresh();
+            // Candidate projections are flushed by syncPracticeRecords only
+            // after their accepted generation becomes the public watermark.
+            if (candidatePracticeProjectionGeneration == null) {
+                flushPendingBrowseProgressRefresh();
+            }
         }
+        return true;
     } catch (error) {
         console.warn('[Browse] 刷新浏览进度失败:', error);
+        return false;
     }
 }
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -17719,11 +17719,46 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
+let practiceRecordsSyncInvocationGeneration = 0;
+let practiceRecordsDataGeneration = 0;
+let practiceRecordsCommitSubscriptionAttached = false;
+const PRACTICE_RECORD_ENTITY_STORES = new Set([
+    'practiceSummaries',
+    'practiceDetails',
+    'practiceAnnotations'
+]);
+
+function ensurePracticeRecordsCommitSubscription() {
+    if (practiceRecordsCommitSubscriptionAttached) {
+        return;
+    }
+    const backups = window.AppData && window.AppData.backups;
+    if (!backups || typeof backups.onDataCommitted !== 'function') {
+        return;
+    }
+    backups.onDataCommitted((event) => {
+        const targets = event && Array.isArray(event.targets) ? event.targets : [];
+        const touchesPracticeRecords = targets.some((target) => {
+            const store = typeof target === 'string'
+                ? target
+                : target && (target.store || target.logicalKey);
+            return PRACTICE_RECORD_ENTITY_STORES.has(store);
+        });
+        if (touchesPracticeRecords) {
+            practiceRecordsDataGeneration += 1;
+        }
+    });
+    practiceRecordsCommitSubscriptionAttached = true;
+}
+
 async function syncPracticeRecords(options = {}) {
+    ensurePracticeRecordsCommitSubscription();
+    const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -17783,6 +17818,16 @@ async function syncPracticeRecords(options = {}) {
         });
     } catch (e) { console.warn('[System] normalize durations failed:', e); }
 
+    const sourceLibraryIsCurrent = isBrowseProgressRefreshEpochCurrent({
+        activeLibraryGeneration: browseProgressSourceEpoch.activeLibraryGeneration
+    });
+    if (invocationGeneration !== practiceRecordsSyncInvocationGeneration
+        || !sourceLibraryIsCurrent
+        || browseProgressSourceEpoch.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+        console.log('[System] 丢弃已过期的练习记录同步投影');
+        return records;
+    }
+
     // Avoid resetting the list when the authoritative light projection is unchanged.
     try {
         const renderer = window.PracticeHistoryRenderer;
@@ -17807,18 +17852,90 @@ async function syncPracticeRecords(options = {}) {
 
 let practiceRecordsLoadPromise = null;
 let pendingPracticeRecordsSyncRequest = null;
+let activePracticeRecordsSyncRequest = null;
 
-function queuePendingPracticeRecordsSync(trigger, options = {}) {
+function normalizePracticeRecordsSyncOptions(options = {}) {
+    const normalized = Object.assign({}, options || {});
+    normalized.forceRender = !!normalized.forceRender;
+    normalized.mode = normalized.mode === 'full' ? 'full' : 'summary';
+    return normalized;
+}
+
+function capturePracticeRecordsSyncRequest(trigger, options = {}) {
+    return {
+        trigger,
+        options: normalizePracticeRecordsSyncOptions(options),
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration
+    };
+}
+
+function practiceRecordsSyncGenerationCovers(existing, incoming, key) {
+    if (incoming[key] == null) {
+        return true;
+    }
+    return existing[key] != null && existing[key] >= incoming[key];
+}
+
+function practiceRecordsSyncRequestCovers(existing, incoming) {
+    if (!existing || !incoming) {
+        return false;
+    }
+    const existingOptions = existing.options || {};
+    const incomingOptions = incoming.options || {};
+    return practiceRecordsSyncGenerationCovers(existing, incoming, 'activeLibraryGeneration')
+        && practiceRecordsSyncGenerationCovers(existing, incoming, 'practiceRecordsDataGeneration')
+        && (existingOptions.forceRender || !incomingOptions.forceRender)
+        && (existingOptions.mode === 'full' || incomingOptions.mode !== 'full');
+}
+
+function activePracticeRecordsSyncRequestCovers(incoming) {
+    return !!activePracticeRecordsSyncRequest
+        && activePracticeRecordsSyncRequest.invocationGeneration
+            === practiceRecordsSyncInvocationGeneration
+        && practiceRecordsSyncRequestCovers(activePracticeRecordsSyncRequest, incoming);
+}
+
+function mergePracticeRecordsSyncGeneration(previousValue, nextValue) {
+    if (previousValue == null) {
+        return nextValue;
+    }
+    if (nextValue == null) {
+        return previousValue;
+    }
+    return Math.max(previousValue, nextValue);
+}
+
+function queuePendingPracticeRecordsSync(incoming) {
     const previous = pendingPracticeRecordsSyncRequest;
+    const activeOptions = activePracticeRecordsSyncRequest
+        && activePracticeRecordsSyncRequest.options
+        ? activePracticeRecordsSyncRequest.options
+        : {};
     const previousOptions = previous && previous.options ? previous.options : {};
-    const nextOptions = Object.assign({}, previousOptions, options || {});
-    nextOptions.forceRender = !!(previousOptions.forceRender || (options && options.forceRender));
-    nextOptions.mode = previousOptions.mode === 'full' || (options && options.mode === 'full')
+    const incomingOptions = incoming && incoming.options ? incoming.options : {};
+    const nextOptions = Object.assign({}, activeOptions, previousOptions, incomingOptions);
+    nextOptions.forceRender = !!(
+        activeOptions.forceRender
+        || previousOptions.forceRender
+        || incomingOptions.forceRender
+    );
+    nextOptions.mode = activeOptions.mode === 'full'
+        || previousOptions.mode === 'full'
+        || incomingOptions.mode === 'full'
         ? 'full'
         : 'summary';
     pendingPracticeRecordsSyncRequest = {
-        trigger,
-        options: nextOptions
+        trigger: incoming.trigger,
+        options: nextOptions,
+        activeLibraryGeneration: mergePracticeRecordsSyncGeneration(
+            previous && previous.activeLibraryGeneration,
+            incoming.activeLibraryGeneration
+        ),
+        practiceRecordsDataGeneration: mergePracticeRecordsSyncGeneration(
+            previous && previous.practiceRecordsDataGeneration,
+            incoming.practiceRecordsDataGeneration
+        )
     };
 }
 
@@ -17827,12 +17944,19 @@ async function drainPracticeRecordsSyncQueue(initialRequest) {
     let result = null;
     try {
         while (request) {
+            activePracticeRecordsSyncRequest = request;
             let syncError = null;
             try {
-                result = await syncPracticeRecords(Object.assign(
+                request.activeLibraryGeneration = readBrowseProgressGeneration(
+                    '__getActiveLibraryGeneration'
+                );
+                request.practiceRecordsDataGeneration = practiceRecordsDataGeneration;
+                request.invocationGeneration = practiceRecordsSyncInvocationGeneration + 1;
+                const syncPromise = syncPracticeRecords(Object.assign(
                     { mode: 'summary' },
                     request.options || {}
                 ));
+                result = await syncPromise;
             } catch (error) {
                 syncError = error;
             }
@@ -17851,20 +17975,22 @@ async function drainPracticeRecordsSyncQueue(initialRequest) {
         }
         return result;
     } finally {
+        activePracticeRecordsSyncRequest = null;
         practiceRecordsLoadPromise = null;
     }
 }
 
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
+    ensurePracticeRecordsCommitSubscription();
+    const incomingRequest = capturePracticeRecordsSyncRequest(trigger, options);
     if (practiceRecordsLoadPromise) {
-        queuePendingPracticeRecordsSync(trigger, options);
+        if (!activePracticeRecordsSyncRequestCovers(incomingRequest)
+            && !practiceRecordsSyncRequestCovers(pendingPracticeRecordsSyncRequest, incomingRequest)) {
+            queuePendingPracticeRecordsSync(incomingRequest);
+        }
         return practiceRecordsLoadPromise;
     }
-    const initialRequest = {
-        trigger,
-        options: Object.assign({}, options || {})
-    };
-    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(initialRequest);
+    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(incomingRequest);
     return practiceRecordsLoadPromise;
 }
 
@@ -19330,18 +19456,41 @@ function readBrowseProgressGeneration(getterName) {
     }
 }
 
+function readBrowseFunctionalResetState() {
+    const getter = window && typeof window.__getBrowseFunctionalResetState === 'function'
+        ? window.__getBrowseFunctionalResetState
+        : null;
+    if (!getter) {
+        return { generation: null, status: 'idle', outcome: null };
+    }
+    try {
+        const state = getter();
+        const generation = Number(state && state.generation);
+        return {
+            generation: Number.isFinite(generation) ? generation : null,
+            status: state && typeof state.status === 'string' ? state.status : 'idle',
+            outcome: state && typeof state.outcome === 'boolean' ? state.outcome : null
+        };
+    } catch (_) {
+        return { generation: null, status: 'idle', outcome: null };
+    }
+}
+
 function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
     const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
     const hasSourceLibraryGeneration = Object.prototype.hasOwnProperty.call(
         source,
         'activeLibraryGeneration'
     );
+    const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration')
+        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
+        functionalResetGeneration: functionalResetState.generation,
+        functionalResetWasPending: functionalResetState.status === 'pending'
     };
 }
 
@@ -19352,12 +19501,16 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
         activeLibraryGeneration: '__getActiveLibraryGeneration',
         resetGeneration: '__getBrowseResetIntentGeneration'
     };
-    return Object.keys(generationGetters).every((key) => {
+    const ordinaryGenerationsAreCurrent = Object.keys(generationGetters).every((key) => {
         if (captured[key] == null) {
             return true;
         }
         return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
     });
+    if (!ordinaryGenerationsAreCurrent || captured.functionalResetGeneration == null) {
+        return ordinaryGenerationsAreCurrent;
+    }
+    return readBrowseFunctionalResetState().generation === captured.functionalResetGeneration;
 }
 
 function clearPendingBrowseProgressRefresh() {
@@ -19387,6 +19540,21 @@ function flushPendingBrowseProgressRefresh() {
         clearPendingBrowseProgressRefresh();
         return;
     }
+    const functionalResetState = readBrowseFunctionalResetState();
+    if (functionalResetState.status === 'failed') {
+        clearPendingBrowseProgressRefresh();
+        return;
+    }
+    if (functionalResetState.status === 'pending') {
+        retryPendingBrowseProgressRefresh();
+        return;
+    }
+    if (pending.epoch && pending.epoch.functionalResetWasPending) {
+        // The post-reset activation owns the canonical render. A progress
+        // snapshot observed during the barrier must never replay afterward.
+        clearPendingBrowseProgressRefresh();
+        return;
+    }
     const browseView = document.getElementById('browse-view');
     const isBrowseActive = browseView && browseView.classList.contains('active');
     if (!isBrowseActive) {
@@ -19413,14 +19581,14 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
-        if (typeof rebuildBrowseCompletionIndex === 'function') {
-            rebuildBrowseCompletionIndex(recordSnapshot);
-        }
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
         if (!isBrowseProgressRefreshEpochCurrent({
             activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
         })) {
             return;
+        }
+        if (typeof rebuildBrowseCompletionIndex === 'function') {
+            rebuildBrowseCompletionIndex(recordSnapshot);
         }
         if (typeof updateBrowseAnchorsFromRecords === 'function') {
             updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -3550,6 +3550,11 @@
         }
 
         event.preventDefault();
+        if (viewName === 'browse') {
+            try {
+                event.__browseNavigationHandled = true;
+            } catch (_) { }
+        }
         if (alreadyActive && typeof this.options.onRepeatNavigate === 'function') {
             var repeatHandled = true;
             try {
@@ -5112,14 +5117,42 @@
         }
     }
 
-    function syncBrowseFilterUI(examIndex) {
+    function setBrowseFrequencyFilter(value) {
+        const activeFilter = normalizeBrowseFrequencyFilter(value);
+        global.__browseFrequencyFilter = activeFilter;
+        const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+        if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+            frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
+        return activeFilter;
+    }
+
+    function resetBrowseFilterStateToAll(examIndex) {
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+        setBrowseFrequencyFilter('all');
+
         const controller = global.browseController;
         if (controller) {
             controller.currentMode = 'default';
             controller.activeFilter = 'all';
-            if (typeof controller.renderFilterButtons === 'function') {
-                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            if (Array.isArray(examIndex) && typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(examIndex);
             }
+        }
+
+        if (typeof global.setBrowseFilterState === 'function') {
+            global.setBrowseFilterState('all', 'all');
+        } else if (controller && typeof controller.setBrowseFilterState === 'function') {
+            controller.setBrowseFilterState('all', 'all');
         }
 
         const typeContainer = document.getElementById('type-filter-buttons');
@@ -5135,22 +5168,10 @@
                 }
             });
         }
+    }
 
-        if (typeof global.updateBrowseFrequencyButtons === 'function') {
-            global.updateBrowseFrequencyButtons('all');
-        } else {
-            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
-                    if (button.classList && typeof button.classList.remove === 'function') {
-                        button.classList.remove('active');
-                    }
-                    if (typeof button.setAttribute === 'function') {
-                        button.setAttribute('aria-pressed', 'false');
-                    }
-                });
-            }
-        }
+    function syncBrowseFilterUI(examIndex) {
+        resetBrowseFilterStateToAll(examIndex);
     }
 
     async function prepareBrowseReset() {
@@ -5195,19 +5216,14 @@
 
     function applyBrowseResetState(examIndex) {
         clearReadingMemorizeBrowseMode();
-        global.__browseFilterMode = 'default';
-        global.__browsePath = null;
+        resetBrowseFilterStateToAll(examIndex);
 
         if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
             global.browseStateManager.resetToAllExams();
         } else {
-            if (typeof global.setBrowseFilterState === 'function') {
-                global.setBrowseFilterState('all', 'all');
-            }
             clearBrowseSearchUI();
         }
 
-        syncBrowseFilterUI(examIndex);
         if (typeof global.setBrowseTitle === 'function') {
             global.setBrowseTitle('题库列表');
         }
@@ -5889,6 +5905,8 @@
         applyBrowsePostFilters,
         applyBrowseFrequencyFilter,
         normalizeBrowseFrequencyFilter,
+        setBrowseFrequencyFilter,
+        resetBrowseFilterStateToAll,
         launchReadingMemorizeExam,
         isReadingMemorizeBrowseMode,
         isReadingMemorizeExam
@@ -13843,7 +13861,7 @@
          * 设置浏览模式
          * @param {string} mode - 模式ID (default | frequency-p1 | frequency-p4)
          */
-        setMode(mode, examIndex = [], renderRequestId = null) {
+        setMode(mode, examIndex = [], renderRequestId = null, options = {}) {
             if (isReadingMemorizeBrowseMode()) {
                 mode = 'default';
             }
@@ -13865,7 +13883,10 @@
             this.renderFilterButtons(examIndex);
 
             // 应用筛选
-            this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+            if (!options.skipApply) {
+                return this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+            }
+            return undefined;
         }
 
         /**
@@ -13919,9 +13940,11 @@
                 // 绑定点击事件
                 button.addEventListener('click', async () => {
                     const interactionId = ++this.filterInteractionId;
-                    const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
-                        ? global.__beginBrowseResultsRequest()
-                        : null;
+                    const renderRequestId = typeof global.__beginBrowseUserResultsRequest === 'function'
+                        ? global.__beginBrowseUserResultsRequest()
+                        : (typeof global.__beginBrowseResultsRequest === 'function'
+                            ? global.__beginBrowseResultsRequest()
+                            : null);
                     try {
                         const index = await global.resolveActiveLibraryIndex();
                         if (interactionId !== this.filterInteractionId) {
@@ -13932,9 +13955,13 @@
                             && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
                             return;
                         }
-                        this.handleFilterClick(filter.id, index, renderRequestId);
+                        await Promise.resolve(this.handleFilterClick(filter.id, index, renderRequestId));
                     } catch (error) {
                         console.error('[BrowseController] 读取活动题库失败:', error);
+                    } finally {
+                        if (typeof global.__endBrowseUserResultsRequest === 'function') {
+                            global.__endBrowseUserResultsRequest(renderRequestId);
+                        }
                     }
                 });
 
@@ -13973,7 +14000,7 @@
             this.updateButtonStates();
 
             // 应用筛选
-            this.applyFilter(filterId, examIndex, renderRequestId);
+            return this.applyFilter(filterId, examIndex, renderRequestId);
         }
 
         /**
@@ -14006,11 +14033,12 @@
 
             if (config.filterLogic === 'type-based') {
                 // 默认模式：按类型筛选
-                this.filterByType(filterId, examIndex, renderRequestId);
+                return this.filterByType(filterId, examIndex, renderRequestId);
             } else if (config.filterLogic === 'folder-based') {
                 // 频率模式：按文件夹筛选
-                this.filterByFolder(filterId, examIndex, renderRequestId);
+                return this.filterByFolder(filterId, examIndex, renderRequestId);
             }
+            return undefined;
         }
 
         /**
@@ -14020,10 +14048,11 @@
         filterByType(type, examIndex = [], renderRequestId = null) {
             // 调用全局的 filterByType 函数
             if (typeof global.filterByType === 'function') {
-                global.filterByType(type, examIndex, renderRequestId);
+                return global.filterByType(type, examIndex, renderRequestId);
             } else {
                 console.warn('[BrowseController] filterByType 函数未定义');
             }
+            return undefined;
         }
 
         /**
@@ -14068,8 +14097,12 @@
                 });
             });
 
-            // 显示筛选结果
+            // 活动搜索必须继续约束当前文件夹结果。
+            if (typeof global.__renderBrowseResultsForState === 'function') {
+                return global.__renderBrowseResultsForState(filtered, renderRequestId);
+            }
             this.displayFilteredExams(filtered);
+            return filtered;
         }
         /**
          * 显示筛选后的题目
@@ -14124,8 +14157,8 @@
         /**
          * 重置为默认模式
          */
-        resetToDefault(examIndex = [], renderRequestId = null) {
-            this.setMode('default', examIndex, renderRequestId);
+        resetToDefault(examIndex = [], renderRequestId = null, options = {}) {
+            return this.setMode('default', examIndex, renderRequestId, options);
         }
 
         // ============================================================================
@@ -19255,6 +19288,7 @@ function browseCategory(category, type = 'reading', filterMode = null, path = nu
 }
 
 let browseResultsRequestId = 0;
+const browseUserResultsRequestRetains = new Map();
 
 function beginBrowseResultsRequest() {
     browseResultsRequestId += 1;
@@ -19265,88 +19299,127 @@ function isBrowseResultsRequestCurrent(requestId) {
     return requestId == null || requestId === browseResultsRequestId;
 }
 
+function retainBrowseUserResultsRequest(requestId) {
+    if (requestId == null || !isBrowseResultsRequestCurrent(requestId)) {
+        return null;
+    }
+    const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
+    browseUserResultsRequestRetains.set(requestId, retainCount + 1);
+    return requestId;
+}
+
+function beginBrowseUserResultsRequest() {
+    return retainBrowseUserResultsRequest(beginBrowseResultsRequest());
+}
+
+function endBrowseUserResultsRequest(requestId) {
+    if (requestId == null) {
+        return;
+    }
+    const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
+    if (retainCount <= 1) {
+        browseUserResultsRequestRetains.delete(requestId);
+        return;
+    }
+    browseUserResultsRequestRetains.set(requestId, retainCount - 1);
+}
+
+function isBrowseUserResultsRequestInFlight(requestId) {
+    return requestId != null && (browseUserResultsRequestRetains.get(requestId) || 0) > 0;
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
     return browseResultsRequestId;
 };
+window.__beginBrowseUserResultsRequest = beginBrowseUserResultsRequest;
+window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
+window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
+window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
-    const requestedType = type;
-    let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(renderRequestId);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
-        if (!Array.isArray(examIndexOverride)) {
-            examIndex = await resolveActiveExamIndex();
-        }
-        const listeningAvailable = typeof window.hasActiveListeningLibrary === 'function'
-            ? window.hasActiveListeningLibrary(examIndex)
-            : examIndex.some((exam) => exam && exam.type === 'listening');
-        if (requestedType === 'listening' && !listeningAvailable) {
-            type = 'all';
-            if (typeof window.showMessage === 'function') {
-                window.showMessage('听力题库尚未加载', 'warning');
+        const requestedType = type;
+        let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
+        try {
+            if (!Array.isArray(examIndexOverride)) {
+                examIndex = await resolveActiveExamIndex();
+            }
+            const listeningAvailable = typeof window.hasActiveListeningLibrary === 'function'
+                ? window.hasActiveListeningLibrary(examIndex)
+                : examIndex.some((exam) => exam && exam.type === 'listening');
+            if (requestedType === 'listening' && !listeningAvailable) {
+                type = 'all';
+                if (typeof window.showMessage === 'function') {
+                    window.showMessage('听力题库尚未加载', 'warning');
+                }
+            }
+        } catch (_) {
+            if (requestedType === 'listening') {
+                type = 'all';
             }
         }
-    } catch (_) {
-        if (requestedType === 'listening') {
-            type = 'all';
+
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return;
         }
-    }
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
-    }
+        // 重置筛选器状态
+        setBrowseFilterState('all', type);
+        setBrowseTitle(formatBrowseTitle('all', type));
 
-    // 重置筛选器状态
-    setBrowseFilterState('all', type);
-    setBrowseTitle(formatBrowseTitle('all', type));
+        // 重置浏览模式和路径（清除频率模式残留）
+        window.__browseFilterMode = 'default';
+        window.__browsePath = null;
 
-    // 重置浏览模式和路径（清除频率模式残留）
-    window.__browseFilterMode = 'default';
-    window.__browsePath = null;
+        // 重置 browseController 到默认模式
+        // 关键修复：仅在当前不是默认模式时才调用 resetToDefault，防止死循环
+        // (resetToDefault -> setMode -> applyFilter -> filterByType -> global.filterByType)
+        if (window.browseController &&
+            window.browseController.currentMode !== 'default' &&
+            typeof window.browseController.resetToDefault === 'function') {
+            window.browseController.resetToDefault(examIndex, activeRequestId, { skipApply: true });
+        }
 
-    // 重置 browseController 到默认模式
-    // 关键修复：仅在当前不是默认模式时才调用 resetToDefault，防止死循环
-    // (resetToDefault -> setMode -> applyFilter -> filterByType -> global.filterByType)
-    if (window.browseController &&
-        window.browseController.currentMode !== 'default' &&
-        typeof window.browseController.resetToDefault === 'function') {
-        window.browseController.resetToDefault(examIndex, activeRequestId);
-    }
-
-    // 更新题库浏览筛选按钮的 active 状态
-    var container = document.getElementById('type-filter-buttons');
-    if (container) {
-        var buttons = container.querySelectorAll('.shui-segmented-btn');
-        for (var i = 0; i < buttons.length; i++) {
-            var btn = buttons[i];
-            if (btn.dataset.filterType === type || btn.dataset.filterId === type) {
-                btn.classList.add('active');
-                btn.setAttribute('aria-pressed', 'true');
-            } else {
-                btn.classList.remove('active');
-                btn.setAttribute('aria-pressed', 'false');
+        // 更新题库浏览筛选按钮的 active 状态
+        var container = document.getElementById('type-filter-buttons');
+        if (container) {
+            var buttons = container.querySelectorAll('.shui-segmented-btn');
+            for (var i = 0; i < buttons.length; i++) {
+                var btn = buttons[i];
+                if (btn.dataset.filterType === type || btn.dataset.filterId === type) {
+                    btn.classList.add('active');
+                    btn.setAttribute('aria-pressed', 'true');
+                } else {
+                    btn.classList.remove('active');
+                    btn.setAttribute('aria-pressed', 'false');
+                }
             }
         }
-    }
 
-    // 触发滑块指示器同步
-    if (typeof window.updateSegmentedIndicators === 'function') {
-        setTimeout(window.updateSegmentedIndicators, 10);
-    }
+        // 触发滑块指示器同步
+        if (typeof window.updateSegmentedIndicators === 'function') {
+            setTimeout(window.updateSegmentedIndicators, 10);
+        }
 
-    // 刷新题库列表
-    await loadExamList(examIndex, activeRequestId);
+        // 保留活动搜索与新类型筛选的交集。
+        await renderBrowseResultsForState(examIndex, activeRequestId);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
+    }
 }
 
 // 应用分类筛选（供 App/总览调用）
 async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(renderRequestId);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
@@ -19400,7 +19473,12 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
                     if (!window.browseController.buttonContainer) {
                         window.browseController.initialize('type-filter-buttons', indexSnapshot);
                     }
-                    window.browseController.setMode(effectiveFilterMode, indexSnapshot, activeRequestId);
+                    window.browseController.setMode(
+                        effectiveFilterMode,
+                        indexSnapshot,
+                        activeRequestId,
+                        { skipApply: true }
+                    );
                 } catch (error) {
                     console.warn('[Browse] 切换浏览模式失败:', error);
                 }
@@ -19412,7 +19490,11 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             if (window.browseController &&
                 window.browseController.currentMode !== 'default' &&
                 typeof window.browseController.resetToDefault === 'function') {
-                window.browseController.resetToDefault(indexSnapshot, activeRequestId);
+                window.browseController.resetToDefault(
+                    indexSnapshot,
+                    activeRequestId,
+                    { skipApply: true }
+                );
             }
         }
 
@@ -19426,12 +19508,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
 
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
 
-        // 3. 刷新题库列表
-        // 如果是频率模式，setMode 已经处理了刷新，不需要再次调用 loadExamList
-        // 只有在默认模式下才显式调用
-        if (!effectiveFilterMode) {
-            await loadExamList(indexSnapshot, activeRequestId);
-        }
+        // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
+        await renderBrowseResultsForState(indexSnapshot, activeRequestId);
 
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
             return;
@@ -19448,15 +19526,17 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
         setBrowseFilterState('all', 'all');
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
-            window.browseController.resetToDefault(null, activeRequestId);
+            window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
         }
         // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
         setTimeout(() => {
             if (!isBrowseResultsRequestCurrent(activeRequestId)) {
                 return;
             }
-            try { loadExamList(null, activeRequestId); } catch (_) { }
+            try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
         }, 0);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
 }
 
@@ -19497,7 +19577,7 @@ async function initializeBrowseView(options = {}) {
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
     if (!options.skipLoad) {
-        await loadExamList(examIndex, activeRequestId);
+        await renderBrowseResultsForState(examIndex, activeRequestId);
     }
 }
 
@@ -19511,13 +19591,21 @@ function getBrowseSearchQuery() {
     return input && typeof input.value === 'string' ? input.value.trim() : '';
 }
 
-function refreshBrowseResults() {
-    const activeRequestId = beginBrowseResultsRequest();
+function renderBrowseResultsForState(examIndexOverride = null, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
     const query = getBrowseSearchQuery();
     if (query) {
-        return performSearch(query, activeRequestId);
+        return performSearch(query, activeRequestId, examIndexOverride);
     }
-    return loadExamList(null, activeRequestId);
+    return loadExamList(examIndexOverride, activeRequestId);
+}
+
+window.__renderBrowseResultsForState = renderBrowseResultsForState;
+
+function refreshBrowseResults() {
+    return renderBrowseResultsForState();
 }
 
 let browseControlsSeeded = false;
@@ -19530,7 +19618,9 @@ async function setupBrowseControls() {
                     const browse = await window.AppData.preferences.getBrowse();
                     if (browse) {
                         window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                        updateBrowseFrequencyButtons(
+                            browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
+                        );
                     }
                 } catch (_) { /* defaults remain active */ }
                 browseControlsSeeded = true;
@@ -19575,19 +19665,25 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
-    window.__browseFrequencyFilter = activeFilter;
+    if (window.ExamActions && typeof window.ExamActions.setBrowseFrequencyFilter === 'function') {
+        return window.ExamActions.setBrowseFrequencyFilter(activeFilter);
+    }
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
-        return;
+        return activeFilter;
     }
     container.querySelectorAll('[data-frequency-filter]').forEach((button) => {
         const isActive = button.dataset.frequencyFilter === activeFilter;
         button.classList.toggle('active', isActive);
         button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
+    return activeFilter;
 }
 
 function resetBrowseFilterStateToAll() {
+    if (window.ExamActions && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
+        return window.ExamActions.resetBrowseFilterStateToAll();
+    }
     window.__browseFilterMode = 'default';
     window.__browsePath = null;
     updateBrowseFrequencyButtons('all');
@@ -19607,7 +19703,6 @@ function setupBrowseFrequencyFilterControl() {
         return;
     }
     let savedFilter = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
-    window.__browseFrequencyFilter = savedFilter;
     updateBrowseFrequencyButtons(savedFilter);
 }
 
@@ -19615,7 +19710,6 @@ function filterByFrequency(filter) {
     const requested = normalizeBrowseFrequencyFilter(filter);
     const current = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
     const next = requested !== 'all' && requested === current ? 'all' : requested;
-    window.__browseFrequencyFilter = next;
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
     refreshBrowseResults();
@@ -20350,18 +20444,20 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
     return list;
 }
 
-async function performSearch(query, renderRequestId = null) {
+async function performSearch(query, renderRequestId = null, examIndexOverride = null) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
     const normalizedQuery = String(query || '').toLowerCase().trim();
     if (!normalizedQuery) {
-        return loadExamList(null, activeRequestId);
+        return loadExamList(examIndexOverride, activeRequestId);
     }
 
     // 调试日志
     console.log('[Search] 执行搜索，查询词:', normalizedQuery);
-    const examIndexSnapshot = await resolveActiveExamIndex();
+    const examIndexSnapshot = Array.isArray(examIndexOverride)
+        ? examIndexOverride
+        : await resolveActiveExamIndex();
     if (!isBrowseResultsRequestCurrent(activeRequestId)) {
         return;
     }

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5120,39 +5120,75 @@
     function setBrowseFrequencyFilter(value) {
         const activeFilter = normalizeBrowseFrequencyFilter(value);
         global.__browseFrequencyFilter = activeFilter;
-        const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-        if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-            frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
-                const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
-                if (button.classList && typeof button.classList.toggle === 'function') {
-                    button.classList.toggle('active', active);
-                }
-                if (typeof button.setAttribute === 'function') {
-                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
-                }
-            });
+        try {
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    const active = button.dataset && button.dataset.frequencyFilter === activeFilter;
+                    if (button.classList && typeof button.classList.toggle === 'function') {
+                        button.classList.toggle('active', active);
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                    }
+                });
+            }
+        } catch (error) {
+            console.warn('[ExamActions] 同步题库频率筛选 UI 失败:', error);
         }
         return activeFilter;
     }
 
-    function resetBrowseFilterStateToAll(examIndex) {
-        global.__browseFilterMode = 'default';
-        global.__browsePath = null;
-        setBrowseFrequencyFilter('all');
+    function resetBrowseFunctionalStateToAll() {
+        try {
+            global.__browseFilterMode = 'default';
+            global.__browsePath = null;
+            setBrowseFrequencyFilter('all');
+        } catch (error) {
+            console.warn('[ExamActions] 重置题库功能状态失败:', error);
+            return false;
+        }
 
         const controller = global.browseController;
         if (controller) {
-            controller.currentMode = 'default';
-            controller.activeFilter = 'all';
-            if (Array.isArray(examIndex) && typeof controller.renderFilterButtons === 'function') {
-                controller.renderFilterButtons(examIndex);
+            try {
+                controller.currentMode = 'default';
+                controller.activeFilter = 'all';
+            } catch (error) {
+                console.warn('[ExamActions] 重置题库控制器状态失败:', error);
             }
         }
 
-        if (typeof global.setBrowseFilterState === 'function') {
-            global.setBrowseFilterState('all', 'all');
-        } else if (controller && typeof controller.setBrowseFilterState === 'function') {
-            controller.setBrowseFilterState('all', 'all');
+        try {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            } else if (controller && typeof controller.setBrowseFilterState === 'function') {
+                controller.setBrowseFilterState('all', 'all');
+            } else {
+                console.warn('[ExamActions] 缺少题库分类状态适配器');
+                return false;
+            }
+        } catch (error) {
+            console.warn('[ExamActions] 重置题库分类状态失败:', error);
+            return false;
+        }
+        return true;
+    }
+
+    const browseFilterStateOwner = {
+        setFrequencyFilter: setBrowseFrequencyFilter,
+        resetToAll: resetBrowseFunctionalStateToAll
+    };
+
+    function resetBrowseFilterStateToAll(examIndex) {
+        if (!browseFilterStateOwner.resetToAll()) {
+            return false;
+        }
+
+        const controller = global.browseController;
+        if (controller && Array.isArray(examIndex)
+            && typeof controller.renderFilterButtons === 'function') {
+            controller.renderFilterButtons(examIndex);
         }
 
         const typeContainer = document.getElementById('type-filter-buttons');
@@ -5168,6 +5204,7 @@
                 }
             });
         }
+        return true;
     }
 
     function syncBrowseFilterUI(examIndex) {
@@ -5906,6 +5943,7 @@
         applyBrowseFrequencyFilter,
         normalizeBrowseFrequencyFilter,
         setBrowseFrequencyFilter,
+        browseFilterStateOwner,
         resetBrowseFilterStateToAll,
         launchReadingMemorizeExam,
         isReadingMemorizeBrowseMode,
@@ -14059,12 +14097,7 @@
          * 按文件夹筛选（频率模式）
          * @param {string} filterId - 筛选器ID
          */
-        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
-            if (renderRequestId != null
-                && typeof global.__isBrowseResultsRequestCurrent === 'function'
-                && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
-                return;
-            }
+        filterExamsByFolder(examIndex = [], filterId = this.activeFilter) {
             const config = this.getCurrentModeConfig();
             const basePath = global.__browsePath || config.basePath || null;
             const folders = config.folderMap[filterId];
@@ -14072,12 +14105,10 @@
             // 允许“全部”入口只按 basePath 过滤（frequency-p1 无全量按钮）
             const isAllFilter = filterId === 'all';
             if (!folders && !isAllFilter) {
-                console.warn('[BrowseController] 未找到文件夹映射:', filterId);
-                return;
+                return null;
             }
 
-            // 筛选题目
-            const filtered = (Array.isArray(examIndex) ? examIndex : []).filter(exam => {
+            return (Array.isArray(examIndex) ? examIndex : []).filter(exam => {
                 if (!exam || !exam.path) {
                     return false;
                 }
@@ -14096,9 +14127,30 @@
                     return exam.path.includes(folder);
                 });
             });
+        }
 
-            // 活动搜索必须继续约束当前文件夹结果。
-            if (typeof global.__renderBrowseResultsForState === 'function') {
+        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
+            if (renderRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
+                return;
+            }
+            const filtered = this.filterExamsByFolder(examIndex, filterId);
+            if (!Array.isArray(filtered)) {
+                console.warn('[BrowseController] 未找到文件夹映射:', filterId);
+                return;
+            }
+
+            // 活动搜索必须继续约束当前文件夹结果；无查询时在控制器层终止
+            // 渲染，避免 main -> ExamActions -> controller -> main 的递归刷新。
+            const searchInput = document.getElementById('exam-search-input')
+                || (typeof document.querySelector === 'function'
+                    ? document.querySelector('.search-input')
+                    : null);
+            const hasActiveQuery = !!(searchInput
+                && typeof searchInput.value === 'string'
+                && searchInput.value.trim());
+            if (hasActiveQuery && typeof global.__renderBrowseResultsForState === 'function') {
                 return global.__renderBrowseResultsForState(filtered, renderRequestId);
             }
             this.displayFilteredExams(filtered);
@@ -19289,6 +19341,7 @@ function browseCategory(category, type = 'reading', filterMode = null, path = nu
 
 let browseResultsRequestId = 0;
 const browseUserResultsRequestRetains = new Map();
+let lastBrowseUserResultsRequestId = null;
 
 function beginBrowseResultsRequest() {
     browseResultsRequestId += 1;
@@ -19305,6 +19358,7 @@ function retainBrowseUserResultsRequest(requestId) {
     }
     const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
     browseUserResultsRequestRetains.set(requestId, retainCount + 1);
+    lastBrowseUserResultsRequestId = requestId;
     return requestId;
 }
 
@@ -19319,6 +19373,15 @@ function endBrowseUserResultsRequest(requestId) {
     const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
     if (retainCount <= 1) {
         browseUserResultsRequestRetains.delete(requestId);
+        if (retainCount === 1
+            && typeof window.dispatchEvent === 'function'
+            && typeof window.CustomEvent === 'function') {
+            try {
+                window.dispatchEvent(new window.CustomEvent('browseUserResultsRequestSettled', {
+                    detail: { requestId }
+                }));
+            } catch (_) { }
+        }
         return;
     }
     browseUserResultsRequestRetains.set(requestId, retainCount - 1);
@@ -19326,6 +19389,10 @@ function endBrowseUserResultsRequest(requestId) {
 
 function isBrowseUserResultsRequestInFlight(requestId) {
     return requestId != null && (browseUserResultsRequestRetains.get(requestId) || 0) > 0;
+}
+
+function isBrowseUserResultsRequest(requestId) {
+    return requestId != null && requestId === lastBrowseUserResultsRequestId;
 }
 
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
@@ -19337,6 +19404,7 @@ window.__beginBrowseUserResultsRequest = beginBrowseUserResultsRequest;
 window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
 window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
 window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
+window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
     const userRequestId = renderRequestId == null
@@ -19554,7 +19622,7 @@ async function initializeBrowseView(options = {}) {
     ]);
 
     if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+        return null;
     }
 
     // 初始化 browseController
@@ -19579,7 +19647,24 @@ async function initializeBrowseView(options = {}) {
     if (!options.skipLoad) {
         await renderBrowseResultsForState(examIndex, activeRequestId);
     }
+    return examIndex;
 }
+
+async function activateBrowseView(options = {}) {
+    const activeRequestId = options.renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : options.renderRequestId;
+    const examIndex = await initializeBrowseView({
+        skipLoad: true,
+        renderRequestId: activeRequestId
+    });
+    if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+        return false;
+    }
+    return renderBrowseResultsForState(examIndex, activeRequestId);
+}
+
+window.activateBrowseView = activateBrowseView;
 
 function normalizeBrowseFrequencyFilter(value) {
     const raw = String(value || '').trim().toLowerCase();
@@ -19668,6 +19753,10 @@ function updateBrowseFrequencyButtons(filter) {
     if (window.ExamActions && typeof window.ExamActions.setBrowseFrequencyFilter === 'function') {
         return window.ExamActions.setBrowseFrequencyFilter(activeFilter);
     }
+    const stateOwner = window.ExamActions && window.ExamActions.browseFilterStateOwner;
+    if (stateOwner && typeof stateOwner.setFrequencyFilter === 'function') {
+        return stateOwner.setFrequencyFilter(activeFilter);
+    }
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return activeFilter;
@@ -19684,17 +19773,11 @@ function resetBrowseFilterStateToAll() {
     if (window.ExamActions && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
         return window.ExamActions.resetBrowseFilterStateToAll();
     }
-    window.__browseFilterMode = 'default';
-    window.__browsePath = null;
-    updateBrowseFrequencyButtons('all');
-
-    if (window.browseController) {
-        window.browseController.currentMode = 'default';
-        window.browseController.activeFilter = 'all';
+    const stateOwner = window.ExamActions && window.ExamActions.browseFilterStateOwner;
+    if (stateOwner && typeof stateOwner.resetToAll === 'function') {
+        return stateOwner.resetToAll();
     }
-    if (typeof setBrowseFilterState === 'function') {
-        setBrowseFilterState('all', 'all');
-    }
+    return false;
 }
 
 function setupBrowseFrequencyFilterControl() {
@@ -20417,7 +20500,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         : null;
 
     if (window.ExamFilterService && typeof window.ExamFilterService.filterExams === 'function') {
-        return window.ExamFilterService.filterExams(examIndex, {
+        const filtered = window.ExamFilterService.filterExams(examIndex, {
             activeCategory,
             activeExamType,
             browseFilterMode: window.__browseFilterMode,
@@ -20426,6 +20509,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             sortMode: window.__browseSortMode,
             frequencyFilter: window.__browseFrequencyFilter
         });
+        return applyActiveBrowseFolderFilter(filtered);
     }
 
     let list = Array.isArray(examIndex) ? examIndex.slice() : [];
@@ -20439,9 +20523,32 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         list = list.filter((exam) => typeof exam?.path === 'string' && exam.path.includes(basePathFilter));
     }
     if (window.ExamActions && typeof window.ExamActions.applyBrowsePostFilters === 'function') {
-        return window.ExamActions.applyBrowsePostFilters(list, window.__browseSortMode, window.__browseFrequencyFilter);
+        list = window.ExamActions.applyBrowsePostFilters(
+            list,
+            window.__browseSortMode,
+            window.__browseFrequencyFilter
+        );
     }
-    return list;
+    return applyActiveBrowseFolderFilter(list);
+}
+
+function applyActiveBrowseFolderFilter(exams) {
+    const list = Array.isArray(exams) ? exams : [];
+    const controller = window.browseController;
+    if (!controller
+        || typeof controller.getCurrentModeConfig !== 'function'
+        || typeof controller.filterExamsByFolder !== 'function') {
+        return list;
+    }
+    const config = controller.getCurrentModeConfig();
+    if (!config || config.filterLogic !== 'folder-based') {
+        return list;
+    }
+    const folderFiltered = controller.filterExamsByFolder(
+        list,
+        controller.activeFilter || 'all'
+    );
+    return Array.isArray(folderFiltered) ? folderFiltered : list;
 }
 
 async function performSearch(query, renderRequestId = null, examIndexOverride = null) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -4975,7 +4975,7 @@
     /**
      * 加载并渲染题库列表
      */
-    function loadExamList(examIndex = []) {
+    function loadExamList(examIndex = [], options = {}) {
         console.log('[ExamActions] loadExamList called');
 
         if (typeof global.setupBrowseControls === 'function') {
@@ -4998,12 +4998,21 @@
                     global.browseController.initialize('type-filter-buttons', examIndex);
                 }
                 if (global.browseController.currentMode !== global.__browseFilterMode) {
-                    global.browseController.setMode(global.__browseFilterMode, examIndex);
+                    return global.browseController.setMode(
+                        global.__browseFilterMode,
+                        examIndex,
+                        options.renderRequestId,
+                        options
+                    );
                 } else {
                     const activeFilter = global.browseController.activeFilter || 'all';
-                    global.browseController.applyFilter(activeFilter, examIndex);
+                    return global.browseController.applyFilter(
+                        activeFilter,
+                        examIndex,
+                        options.renderRequestId,
+                        options
+                    );
                 }
-                return;
             } catch (error) {
                 console.warn('[Browse] 频率模式刷新失败，回退到默认逻辑:', error);
             }
@@ -5078,7 +5087,8 @@
 
         displayExams(examsToShow, {
             selectionMode,
-            customSuiteDraft
+            customSuiteDraft,
+            commitReceipt: options.commitReceipt
         });
         refreshCustomSuiteSelectionPortal();
 
@@ -5715,13 +5725,16 @@
                 customSuiteDraft: effectiveOptions.customSuiteDraft || null
             });
             setupExamActionHandlers();
-            return;
+            if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+                global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+            }
+            return true;
         }
 
         // 2. 降级：直接 DOM 操作 (从 main.js 迁移)
         const container = document.getElementById('exam-list-container');
         if (!container) {
-            return;
+            return false;
         }
 
         while (container.firstChild) {
@@ -5737,7 +5750,10 @@
         const normalizedExams = Array.isArray(renderExams) ? renderExams : [];
         if (normalizedExams.length === 0) {
             renderEmptyState(container);
-            return;
+            if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+                global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+            }
+            return true;
         }
 
         const list = document.createElement('div');
@@ -5751,6 +5767,10 @@
 
         container.appendChild(list);
         setupExamActionHandlers();
+        if (typeof global.__markBrowseRenderCommitReceipt === 'function') {
+            global.__markBrowseRenderCommitReceipt(effectiveOptions.commitReceipt);
+        }
+        return true;
     }
 
     /**
@@ -14119,7 +14139,7 @@
 
             // 应用筛选
             if (!options.skipApply) {
-                return this.applyFilter(this.activeFilter, examIndex, renderRequestId);
+                return this.applyFilter(this.activeFilter, examIndex, renderRequestId, options);
             }
             return undefined;
         }
@@ -14180,6 +14200,9 @@
                         : (typeof global.__beginBrowseResultsRequest === 'function'
                             ? global.__beginBrowseResultsRequest()
                             : null);
+                    const foregroundEpoch = typeof global.__captureBrowseForegroundRenderEpoch === 'function'
+                        ? global.__captureBrowseForegroundRenderEpoch()
+                        : null;
                     try {
                         const index = await global.resolveActiveLibraryIndex();
                         if (interactionId !== this.filterInteractionId) {
@@ -14190,7 +14213,12 @@
                             && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
                             return;
                         }
-                        await Promise.resolve(this.handleFilterClick(filter.id, index, renderRequestId));
+                        await Promise.resolve(this.handleFilterClick(
+                            filter.id,
+                            index,
+                            renderRequestId,
+                            { foregroundEpoch }
+                        ));
                     } catch (error) {
                         console.error('[BrowseController] 读取活动题库失败:', error);
                     } finally {
@@ -14228,14 +14256,14 @@
          * 处理筛选按钮点击
          * @param {string} filterId - 筛选器ID
          */
-        handleFilterClick(filterId, examIndex = [], renderRequestId = null) {
+        handleFilterClick(filterId, examIndex = [], renderRequestId = null, options = {}) {
             this.activeFilter = filterId;
 
             // 更新按钮激活状态
             this.updateButtonStates();
 
             // 应用筛选
-            return this.applyFilter(filterId, examIndex, renderRequestId);
+            return this.applyFilter(filterId, examIndex, renderRequestId, options);
         }
 
         /**
@@ -14263,15 +14291,15 @@
          * 应用筛选
          * @param {string} filterId - 筛选器ID
          */
-        applyFilter(filterId, examIndex = [], renderRequestId = null) {
+        applyFilter(filterId, examIndex = [], renderRequestId = null, options = {}) {
             const config = this.getCurrentModeConfig();
 
             if (config.filterLogic === 'type-based') {
                 // 默认模式：按类型筛选
-                return this.filterByType(filterId, examIndex, renderRequestId);
+                return this.filterByType(filterId, examIndex, renderRequestId, options);
             } else if (config.filterLogic === 'folder-based') {
                 // 频率模式：按文件夹筛选
-                return this.filterByFolder(filterId, examIndex, renderRequestId);
+                return this.filterByFolder(filterId, examIndex, renderRequestId, options);
             }
             return undefined;
         }
@@ -14280,10 +14308,10 @@
          * 按类型筛选（默认模式）
          * @param {string} type - 类型 (all | reading | listening)
          */
-        filterByType(type, examIndex = [], renderRequestId = null) {
+        filterByType(type, examIndex = [], renderRequestId = null, options = {}) {
             // 调用全局的 filterByType 函数
             if (typeof global.filterByType === 'function') {
-                return global.filterByType(type, examIndex, renderRequestId);
+                return global.filterByType(type, examIndex, renderRequestId, options);
             } else {
                 console.warn('[BrowseController] filterByType 函数未定义');
             }
@@ -14326,7 +14354,7 @@
             });
         }
 
-        filterByFolder(filterId, examIndex = [], renderRequestId = null) {
+        filterByFolder(filterId, examIndex = [], renderRequestId = null, options = {}) {
             if (renderRequestId != null
                 && typeof global.__isBrowseResultsRequestCurrent === 'function'
                 && !global.__isBrowseResultsRequestCurrent(renderRequestId)) {
@@ -14348,24 +14376,46 @@
                 && typeof searchInput.value === 'string'
                 && searchInput.value.trim());
             if (hasActiveQuery && typeof global.__renderBrowseResultsForState === 'function') {
-                return global.__renderBrowseResultsForState(filtered, renderRequestId);
+                return global.__renderBrowseResultsForState(filtered, renderRequestId, {
+                    foregroundEpoch: options.foregroundEpoch
+                });
             }
-            this.displayFilteredExams(filtered);
+            if (!options.recoveryManaged
+                && renderRequestId != null
+                && typeof global.__commitForegroundBrowseResults === 'function') {
+                return global.__commitForegroundBrowseResults(
+                    renderRequestId,
+                    options.foregroundEpoch,
+                    (commitReceipt) => {
+                        const committed = this.displayFilteredExams(filtered, { commitReceipt });
+                        return committed === false ? false : filtered;
+                    }
+                );
+            }
+            const committed = this.displayFilteredExams(filtered, {
+                commitReceipt: options.commitReceipt
+            });
+            if (committed === false) {
+                return false;
+            }
             return filtered;
         }
         /**
          * 显示筛选后的题目
          * @param {Array} exams - 题目数组
          */
-        displayFilteredExams(exams) {
-            // 更新筛选状态
-            if (typeof global.setFilteredExamsState === 'function') {
-                global.setFilteredExamsState(exams);
+        displayFilteredExams(exams, options = {}) {
+            // DOM commit is the authority. Do not publish filtered state or
+            // post-render effects when no renderer/container accepted it.
+            const displayed = typeof global.displayExams === 'function'
+                ? global.displayExams(exams, { commitReceipt: options.commitReceipt })
+                : false;
+            if (displayed !== true) {
+                return false;
             }
 
-            // 显示题目
-            if (typeof global.displayExams === 'function') {
-                global.displayExams(exams);
+            if (typeof global.setFilteredExamsState === 'function') {
+                global.setFilteredExamsState(exams);
             }
 
             // 处理渲染后逻辑
@@ -14374,6 +14424,7 @@
                 const type = global.getCurrentExamType ? global.getCurrentExamType() : 'all';
                 global.handlePostExamListRender(exams, { category, type });
             }
+            return true;
         }
 
         /**
@@ -17812,16 +17863,20 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
-// Browse progress is a derived projection. This generation orders only that
-// projection; it never changes syncPracticeRecords' public return value or the
-// Practice-history single-flight contract below.
+// Browse progress is a derived projection. Invocation order and the accepted
+// projection watermark are intentionally separate: a newer sync that merely
+// starts must not invalidate an already successful projection if it later
+// fails. Neither counter changes syncPracticeRecords' public return value or
+// the Practice-history single-flight contract below.
+let browsePracticeProjectionInvocationSequence = 0;
 let browsePracticeProjectionGeneration = 0;
 async function syncPracticeRecords(options = {}) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
+    const practiceProjectionInvocation = ++browsePracticeProjectionInvocationSequence;
     const browseProgressSourceEpoch = {
         activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceProjectionGeneration: ++browsePracticeProjectionGeneration
+        practiceProjectionGeneration: null
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -17894,7 +17949,15 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+    // Publish Browse ownership only after this invocation has produced a
+    // complete snapshot. A failed newer invocation therefore cannot strand a
+    // successful repaint queued behind a foreground request. Conversely, an
+    // older success that settles after a newer success remains stale.
+    if (practiceProjectionInvocation > browsePracticeProjectionGeneration) {
+        browsePracticeProjectionGeneration = practiceProjectionInvocation;
+        browseProgressSourceEpoch.practiceProjectionGeneration = practiceProjectionInvocation;
+        refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+    }
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
@@ -19913,6 +19976,56 @@ function completeCurrentForegroundBrowseRecovery(recovery, succeeded) {
     return appEntry.completeBrowseFunctionalResetRecovery(recovery, succeeded === true);
 }
 
+const browseRenderCommitReceiptMarker = {};
+
+function createBrowseRenderCommitReceipt(requestId, foregroundEpoch) {
+    return {
+        marker: browseRenderCommitReceiptMarker,
+        requestId,
+        foregroundEpoch,
+        committed: false
+    };
+}
+
+function markBrowseRenderCommitReceipt(receipt) {
+    if (!receipt || receipt.marker !== browseRenderCommitReceiptMarker) {
+        return false;
+    }
+    receipt.committed = true;
+    return true;
+}
+
+function commitForegroundBrowseResults(
+    renderRequestId,
+    sourceEpoch,
+    commit
+) {
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch(sourceEpoch);
+    if (!isBrowseResultsRequestCurrent(renderRequestId)
+        || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)
+        || typeof commit !== 'function') {
+        return false;
+    }
+    const foregroundRecovery = captureCurrentForegroundBrowseRecovery(renderRequestId, false);
+    const preparedFunctionalResetState = readBrowseFunctionalResetState();
+    foregroundEpoch.functionalResetGeneration = preparedFunctionalResetState.generation;
+    const receipt = createBrowseRenderCommitReceipt(renderRequestId, foregroundEpoch);
+    let committed = false;
+    try {
+        if (!isBrowseResultsRequestCurrent(renderRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        const result = commit(receipt);
+        committed = receipt.committed === true
+            && isBrowseResultsRequestCurrent(renderRequestId)
+            && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        return committed ? result : false;
+    } finally {
+        completeCurrentForegroundBrowseRecovery(foregroundRecovery, committed);
+    }
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
@@ -19923,13 +20036,16 @@ window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
 window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
 window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
+window.__captureBrowseForegroundRenderEpoch = captureBrowseForegroundRenderEpoch;
+window.__markBrowseRenderCommitReceipt = markBrowseRenderCommitReceipt;
+window.__commitForegroundBrowseResults = commitForegroundBrowseResults;
 
-async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
+async function filterByType(type, examIndexOverride = null, renderRequestId = null, options = {}) {
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
-    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch(options.foregroundEpoch);
     try {
         const requestedType = type;
         let listeningUnavailable = false;
@@ -19945,10 +20061,9 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
                 type = 'all';
                 listeningUnavailable = true;
             }
-        } catch (_) {
-            if (requestedType === 'listening') {
-                type = 'all';
-            }
+        } catch (error) {
+            console.warn('[Browse] 读取活动题库失败，已取消类型筛选提交:', error);
+            return false;
         }
 
         if (!isBrowseResultsRequestCurrent(activeRequestId)
@@ -20396,6 +20511,7 @@ async function renderBrowseResultsForState(
         : null;
     let foregroundRecovery = null;
     let renderSucceeded = false;
+    let commitReceipt = null;
     try {
         if (!isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
@@ -20414,14 +20530,21 @@ async function renderBrowseResultsForState(
         }
         const isRenderCurrent = () => isBrowseResultsRequestCurrent(activeRequestId)
             && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        commitReceipt = createBrowseRenderCommitReceipt(activeRequestId, foregroundEpoch);
         const result = query
             ? await performSearch(query, activeRequestId, examIndexOverride, {
-                isCurrent: isRenderCurrent
+                isCurrent: isRenderCurrent,
+                commitReceipt,
+                foregroundEpoch
             })
             : await loadExamList(examIndexOverride, activeRequestId, {
-                isCurrent: isRenderCurrent
+                isCurrent: isRenderCurrent,
+                commitReceipt,
+                foregroundEpoch
             });
         if (result === false
+            || !commitReceipt
+            || commitReceipt.committed !== true
             || !isBrowseResultsRequestCurrent(activeRequestId)
             || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
@@ -20443,7 +20566,6 @@ function refreshBrowseResults(options = {}) {
 let browseControlsSeeded = false;
 let browseControlsSeedPromise = null;
 let browseControlsSeedReadRevision = null;
-let browseControlsSeedReadEpoch = null;
 let browseControlsMutationRevision = 0;
 
 function isBrowseControlsSetupCurrent(options = {}) {
@@ -20464,7 +20586,6 @@ async function setupBrowseControls(options = {}) {
     if (!browseControlsSeeded) {
         if (!browseControlsSeedPromise) {
             browseControlsSeedReadRevision = browseControlsMutationRevision;
-            browseControlsSeedReadEpoch = captureBrowseForegroundRenderEpoch();
             browseControlsSeedPromise = (async () => {
                 try {
                     return await window.AppData.preferences.getBrowse();
@@ -20475,20 +20596,12 @@ async function setupBrowseControls(options = {}) {
         const seedPromise = browseControlsSeedPromise;
         const browse = await seedPromise;
         if (!isBrowseControlsSetupCurrent(options)) {
-            if (!browseControlsSeeded && browseControlsSeedPromise === seedPromise) {
-                browseControlsSeedPromise = null;
-                browseControlsSeedReadRevision = null;
-                browseControlsSeedReadEpoch = null;
-            }
+            // Caller cancellation is local. The promise and its immutable
+            // mutation fence belong to the shared hydration transaction; a
+            // stale waiter must not force a current waiter to reread storage.
             return false;
         }
         if (browseControlsSeedPromise !== seedPromise) {
-            return setupBrowseControls(options);
-        }
-        if (!isBrowseForegroundRenderEpochCurrent(browseControlsSeedReadEpoch)) {
-            browseControlsSeedPromise = null;
-            browseControlsSeedReadRevision = null;
-            browseControlsSeedReadEpoch = null;
             return setupBrowseControls(options);
         }
         if (!browseControlsSeeded) {
@@ -20502,6 +20615,8 @@ async function setupBrowseControls(options = {}) {
                 );
             }
             browseControlsSeeded = true;
+            browseControlsSeedPromise = null;
+            browseControlsSeedReadRevision = null;
         }
     }
     if (!isBrowseControlsSetupCurrent(options)) {
@@ -20671,7 +20786,12 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null, op
     }
 
     if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-        return window.ExamActions.loadExamList(examIndex);
+        return window.ExamActions.loadExamList(examIndex, {
+            commitReceipt: options.commitReceipt,
+            renderRequestId: activeRequestId,
+            foregroundEpoch: options.foregroundEpoch,
+            recoveryManaged: true
+        });
     }
     console.warn('[main.js] ExamActions.loadExamList 未就绪，尝试加载 browse-view 组');
     if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
@@ -20684,21 +20804,26 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null, op
                 return false;
             }
             if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-                return window.ExamActions.loadExamList(examIndex);
+                return window.ExamActions.loadExamList(examIndex, {
+                    commitReceipt: options.commitReceipt,
+                    renderRequestId: activeRequestId,
+                    foregroundEpoch: options.foregroundEpoch,
+                    recoveryManaged: true
+                });
             } else {
                 // 最终降级：直接 DOM 渲染
-                return loadExamListFallback(examIndex);
+                return loadExamListFallback(examIndex, options);
             }
         }).catch(function (err) {
             if (!isCurrent()) {
                 return false;
             }
             console.error('[main.js] browse-view 组加载失败:', err);
-            return loadExamListFallback(examIndex);
+            return loadExamListFallback(examIndex, options);
         });
     } else {
         // 无懒加载器，直接降级
-        return loadExamListFallback(examIndex);
+        return loadExamListFallback(examIndex, options);
     }
 }
 
@@ -20848,12 +20973,12 @@ function createFallbackExamCard(exam, options = {}) {
     return item;
 }
 
-function loadExamListFallback(examIndexSnapshot = []) {
+function loadExamListFallback(examIndexSnapshot = [], options = {}) {
     console.warn('[main.js] 使用降级渲染逻辑');
     try {
         let examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
         const container = document.getElementById('exam-list-container');
-        if (!container) return;
+        if (!container) return false;
 
         // 清除 loading 指示器
         const loadingEl = document.querySelector('#browse-view .loading');
@@ -20865,7 +20990,8 @@ function loadExamListFallback(examIndexSnapshot = []) {
 
         if (examIndex.length === 0) {
             container.innerHTML = '<div class="exam-list-empty"><p>暂无题目</p></div>';
-            return;
+            markBrowseRenderCommitReceipt(options.commitReceipt);
+            return [];
         }
 
         // 应用当前筛选状态（修复 P2 bug）
@@ -20933,7 +21059,8 @@ function loadExamListFallback(examIndexSnapshot = []) {
 
         if (filtered.length === 0) {
             container.innerHTML = '<div class="exam-list-empty"><p>未找到匹配的题目</p></div>';
-            return;
+            markBrowseRenderCommitReceipt(options.commitReceipt);
+            return filtered;
         }
 
         const list = document.createElement('div');
@@ -20947,8 +21074,11 @@ function loadExamListFallback(examIndexSnapshot = []) {
         });
         container.innerHTML = '';
         container.appendChild(list);
+        markBrowseRenderCommitReceipt(options.commitReceipt);
+        return filtered;
     } catch (err) {
         console.error('[main.js] 降级渲染失败:', err);
+        return false;
     }
 }
 
@@ -21467,11 +21597,17 @@ async function performSearch(
     if (!isCurrent()) {
         return false;
     }
+    let committed = false;
     if (window.ExamActions && typeof window.ExamActions.displayExams === 'function') {
-        window.ExamActions.displayExams(searchResults);
+        committed = window.ExamActions.displayExams(searchResults, {
+            commitReceipt: options.commitReceipt
+        }) === true;
     } else if (typeof window.displayExams === 'function') {
-        window.displayExams(searchResults);
+        committed = window.displayExams(searchResults, {
+            commitReceipt: options.commitReceipt
+        }) === true;
     }
+    return committed ? searchResults : false;
 }
 
 async function toggleBulkDelete() {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5092,9 +5092,30 @@
 
     let browseResetInteractionId = 0;
 
-    function isBrowseResetCurrent(interactionId, renderRequestId) {
+    function isBrowseResetCurrent(
+        interactionId,
+        renderRequestId,
+        navigationIntentGeneration = null
+    ) {
         if (interactionId !== browseResetInteractionId) {
             return false;
+        }
+        if (navigationIntentGeneration != null
+            && typeof global.__getAppNavigationIntentGeneration === 'function') {
+            try {
+                if (global.__getAppNavigationIntentGeneration() !== navigationIntentGeneration) {
+                    return false;
+                }
+            } catch (_) {
+                return false;
+            }
+        }
+        if (typeof document !== 'undefined'
+            && typeof document.querySelector === 'function') {
+            const activeView = document.querySelector('.view.active');
+            if (activeView && activeView.id !== 'browse-view') {
+                return false;
+            }
         }
         return renderRequestId == null
             || typeof global.__isBrowseResultsRequestCurrent !== 'function'
@@ -5212,7 +5233,13 @@
         resetBrowseFilterStateToAll(examIndex);
     }
 
-    async function prepareBrowseReset() {
+    async function prepareBrowseReset(options = {}) {
+        const isCurrent = typeof options.isCurrent === 'function'
+            ? options.isCurrent
+            : () => true;
+        if (!isCurrent()) {
+            return false;
+        }
         const pending = [];
         const manager = global.browseStateManager;
         if (manager && manager.ready && typeof manager.ready.then === 'function') {
@@ -5221,13 +5248,17 @@
             }));
         }
         if (typeof global.setupBrowseControls === 'function') {
-            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls({ isCurrent })).catch((error) => {
                 console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
             }));
         }
         if (pending.length > 0) {
-            await Promise.all(pending);
+            const results = await Promise.all(pending);
+            if (results.some((result) => result === false)) {
+                return false;
+            }
         }
+        return isCurrent();
     }
 
     async function persistBrowseFrequencyReset() {
@@ -5340,8 +5371,8 @@
                 }
             }
             if (typeof global.setupBrowseControls === 'function') {
-                await global.setupBrowseControls();
-                if (!isCurrent()) {
+                const controlsReady = await global.setupBrowseControls({ isCurrent });
+                if (controlsReady === false || !isCurrent()) {
                     return false;
                 }
             }
@@ -5440,6 +5471,9 @@
     async function performBrowseViewResetToAll(resetIntent) {
         try {
         const interactionId = ++browseResetInteractionId;
+        const navigationIntentGeneration = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration()
+            : null;
         if (global.__pendingBrowseFilter) {
             delete global.__pendingBrowseFilter;
         }
@@ -5461,9 +5495,12 @@
             global.clearPendingBrowseAutoScroll();
         }
 
-        await prepareBrowseReset();
-
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        const isCurrent = () => isBrowseResetCurrent(
+            interactionId,
+            renderRequestId,
+            navigationIntentGeneration
+        );
+        if (!await prepareBrowseReset({ isCurrent }) || !isCurrent()) {
             return false;
         }
 
@@ -5489,7 +5526,7 @@
             }
         }
 
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        if (!isCurrent()) {
             return false;
         }
 
@@ -5507,7 +5544,7 @@
                         ? examIndex
                         : null;
                     result = await Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
-                    if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    if (!isCurrent()) {
                         await persistencePromise;
                         return false;
                     }
@@ -5526,7 +5563,7 @@
                     if (!persistenceComplete) {
                         await persistencePromise;
                         persistenceComplete = true;
-                        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                        if (!isCurrent()) {
                             return false;
                         }
                         resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
@@ -5561,7 +5598,7 @@
         if (Array.isArray(examIndex) && examIndex.length > 0) {
             let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
-            if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            if (!isCurrent()) {
                 return false;
             }
             resetIndexSnapshot = closeBrowseResetIntent(
@@ -5583,7 +5620,7 @@
         }
 
         await beginBrowseResetPersistence();
-        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+        if (!isCurrent()) {
             return false;
         }
         closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
@@ -5610,11 +5647,15 @@
         let functionalResetRecoverySucceeded = false;
         try {
             const resetPromise = performBrowseViewResetToAll(resetIntent);
+            const foregroundResultsRequestId = typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null;
             if (functionalResetRecovery
                 && global.AppEntry
                 && typeof global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
                 global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest(
-                    functionalResetRecovery
+                    functionalResetRecovery,
+                    foregroundResultsRequestId
                 );
             }
             const result = await resetPromise;
@@ -17771,67 +17812,16 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
-let practiceRecordsSyncInvocationGeneration = 0;
-let practiceRecordsDataGeneration = 0;
-let practiceRecordsCommitSubscriptionAttached = false;
-const activePracticeRecordsSyncInvocations = new Map();
-const PRACTICE_RECORD_ENTITY_STORES = new Set([
-    'practiceSummaries',
-    'practiceDetails'
-]);
-
-function ensurePracticeRecordsCommitSubscription() {
-    if (practiceRecordsCommitSubscriptionAttached) {
-        return;
-    }
-    const backups = window.AppData && window.AppData.backups;
-    if (!backups || typeof backups.onDataCommitted !== 'function') {
-        return;
-    }
-    backups.onDataCommitted((event) => {
-        const targets = event && Array.isArray(event.targets) ? event.targets : [];
-        const touchesPracticeRecords = targets.some((target) => {
-            const store = typeof target === 'string'
-                ? target
-                : target && (target.store || target.logicalKey);
-            return PRACTICE_RECORD_ENTITY_STORES.has(store);
-        });
-        if (touchesPracticeRecords) {
-            practiceRecordsDataGeneration += 1;
-            if (activePracticeRecordsSyncInvocations.size > 0) {
-                const replacementMode = Array.from(
-                    activePracticeRecordsSyncInvocations.values()
-                ).some((activeOptions) => activeOptions && activeOptions.mode === 'full')
-                    ? 'full'
-                    : 'summary';
-                startPracticeRecordsSyncInBackground('practice-data-committed', {
-                    forceRender: true,
-                    mode: replacementMode
-                });
-            }
-        }
-    });
-    practiceRecordsCommitSubscriptionAttached = true;
-}
-
+// Browse progress is a derived projection. This generation orders only that
+// projection; it never changes syncPracticeRecords' public return value or the
+// Practice-history single-flight contract below.
+let browsePracticeProjectionGeneration = 0;
 async function syncPracticeRecords(options = {}) {
-    ensurePracticeRecordsCommitSubscription();
-    const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
-    const normalizedOptions = normalizePracticeRecordsSyncOptions(options);
-    activePracticeRecordsSyncInvocations.set(invocationGeneration, normalizedOptions);
-    try {
-        return await executePracticeRecordsSync(normalizedOptions, invocationGeneration);
-    } finally {
-        activePracticeRecordsSyncInvocations.delete(invocationGeneration);
-    }
-}
-
-async function executePracticeRecordsSync(options, invocationGeneration) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
         activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration
+        practiceProjectionGeneration: ++browsePracticeProjectionGeneration
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -17891,16 +17881,6 @@ async function executePracticeRecordsSync(options, invocationGeneration) {
         });
     } catch (e) { console.warn('[System] normalize durations failed:', e); }
 
-    const sourceLibraryIsCurrent = isBrowseProgressRefreshEpochCurrent({
-        activeLibraryGeneration: browseProgressSourceEpoch.activeLibraryGeneration
-    });
-    if (invocationGeneration !== practiceRecordsSyncInvocationGeneration
-        || !sourceLibraryIsCurrent
-        || browseProgressSourceEpoch.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
-        console.log('[System] 丢弃已过期的练习记录同步投影');
-        return records;
-    }
-
     // Avoid resetting the list when the authoritative light projection is unchanged.
     try {
         const renderer = window.PracticeHistoryRenderer;
@@ -17924,146 +17904,85 @@ async function executePracticeRecordsSync(options, invocationGeneration) {
 }
 
 let practiceRecordsLoadPromise = null;
-let pendingPracticeRecordsSyncRequest = null;
-let activePracticeRecordsSyncRequest = null;
+let activeBrowseProgressSyncLibraryGeneration = null;
+let pendingBrowseProgressLibrarySync = null;
 
-function normalizePracticeRecordsSyncOptions(options = {}) {
-    const normalized = Object.assign({}, options || {});
-    normalized.forceRender = !!normalized.forceRender;
-    normalized.mode = normalized.mode === 'full' ? 'full' : 'summary';
-    return normalized;
-}
-
-function capturePracticeRecordsSyncRequest(trigger, options = {}) {
-    return {
-        trigger,
-        options: normalizePracticeRecordsSyncOptions(options),
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration
-    };
-}
-
-function practiceRecordsSyncGenerationCovers(existing, incoming, key) {
-    if (incoming[key] == null) {
-        return true;
-    }
-    return existing[key] != null && existing[key] >= incoming[key];
-}
-
-function practiceRecordsSyncRequestCovers(existing, incoming) {
-    if (!existing || !incoming) {
-        return false;
-    }
-    const existingOptions = existing.options || {};
-    const incomingOptions = incoming.options || {};
-    return practiceRecordsSyncGenerationCovers(existing, incoming, 'activeLibraryGeneration')
-        && practiceRecordsSyncGenerationCovers(existing, incoming, 'practiceRecordsDataGeneration')
-        && (existingOptions.forceRender || !incomingOptions.forceRender)
-        && (existingOptions.mode === 'full' || incomingOptions.mode !== 'full');
-}
-
-function activePracticeRecordsSyncRequestCovers(incoming) {
-    return !!activePracticeRecordsSyncRequest
-        && activePracticeRecordsSyncRequest.invocationGeneration
-            === practiceRecordsSyncInvocationGeneration
-        && practiceRecordsSyncRequestCovers(activePracticeRecordsSyncRequest, incoming);
-}
-
-function mergePracticeRecordsSyncGeneration(previousValue, nextValue) {
-    if (previousValue == null) {
-        return nextValue;
-    }
-    if (nextValue == null) {
-        return previousValue;
-    }
-    return Math.max(previousValue, nextValue);
-}
-
-function queuePendingPracticeRecordsSync(incoming) {
-    const previous = pendingPracticeRecordsSyncRequest;
-    const activeOptions = activePracticeRecordsSyncRequest
-        && activePracticeRecordsSyncRequest.options
-        ? activePracticeRecordsSyncRequest.options
-        : {};
+function mergeBrowseProgressLibrarySyncRequest(trigger, options, libraryGeneration) {
+    const previous = pendingBrowseProgressLibrarySync;
     const previousOptions = previous && previous.options ? previous.options : {};
-    const incomingOptions = incoming && incoming.options ? incoming.options : {};
-    const nextOptions = Object.assign({}, activeOptions, previousOptions, incomingOptions);
-    nextOptions.forceRender = !!(
-        activeOptions.forceRender
-        || previousOptions.forceRender
-        || incomingOptions.forceRender
-    );
-    nextOptions.mode = activeOptions.mode === 'full'
-        || previousOptions.mode === 'full'
-        || incomingOptions.mode === 'full'
-        ? 'full'
-        : 'summary';
-    pendingPracticeRecordsSyncRequest = {
-        trigger: incoming.trigger,
-        options: nextOptions,
-        activeLibraryGeneration: mergePracticeRecordsSyncGeneration(
-            previous && previous.activeLibraryGeneration,
-            incoming.activeLibraryGeneration
-        ),
-        practiceRecordsDataGeneration: mergePracticeRecordsSyncGeneration(
-            previous && previous.practiceRecordsDataGeneration,
-            incoming.practiceRecordsDataGeneration
-        )
+    const incomingOptions = options || {};
+    pendingBrowseProgressLibrarySync = {
+        trigger,
+        libraryGeneration,
+        options: {
+            forceRender: !!(previousOptions.forceRender || incomingOptions.forceRender),
+            mode: previousOptions.mode === 'full' || incomingOptions.mode === 'full'
+                ? 'full'
+                : 'summary'
+        }
     };
 }
 
-async function drainPracticeRecordsSyncQueue(initialRequest) {
+async function drainBrowseProgressLibrarySync(initialRequest) {
     let request = initialRequest;
     let result = null;
     try {
         while (request) {
-            activePracticeRecordsSyncRequest = request;
+            activeBrowseProgressSyncLibraryGeneration = readBrowseProgressGeneration(
+                '__getActiveLibraryGeneration'
+            );
             let syncError = null;
             try {
-                request.activeLibraryGeneration = readBrowseProgressGeneration(
-                    '__getActiveLibraryGeneration'
-                );
-                request.practiceRecordsDataGeneration = practiceRecordsDataGeneration;
-                request.invocationGeneration = practiceRecordsSyncInvocationGeneration + 1;
-                const syncPromise = syncPracticeRecords(Object.assign(
+                result = await syncPracticeRecords(Object.assign(
                     { mode: 'summary' },
                     request.options || {}
                 ));
-                result = await syncPromise;
             } catch (error) {
                 syncError = error;
             }
-            const nextRequest = pendingPracticeRecordsSyncRequest;
-            pendingPracticeRecordsSyncRequest = null;
-            if (syncError && !nextRequest) {
+            request = pendingBrowseProgressLibrarySync;
+            pendingBrowseProgressLibrarySync = null;
+            if (syncError && !request) {
                 throw syncError;
             }
             if (syncError) {
                 console.warn(
-                    `[System] 练习记录同步失败(${request.trigger})，继续处理已排队的最新请求:`,
+                    `[System] 练习记录同步失败(${initialRequest.trigger})，继续刷新最新题库进度:`,
                     syncError
                 );
             }
-            request = nextRequest;
         }
         return result;
     } finally {
-        activePracticeRecordsSyncRequest = null;
+        activeBrowseProgressSyncLibraryGeneration = null;
+        pendingBrowseProgressLibrarySync = null;
         practiceRecordsLoadPromise = null;
     }
 }
 
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
-    ensurePracticeRecordsCommitSubscription();
-    const incomingRequest = capturePracticeRecordsSyncRequest(trigger, options);
+    const requestedLibraryGeneration = readBrowseProgressGeneration(
+        '__getActiveLibraryGeneration'
+    );
     if (practiceRecordsLoadPromise) {
-        if (!activePracticeRecordsSyncRequestCovers(incomingRequest)
-            && !practiceRecordsSyncRequestCovers(pendingPracticeRecordsSyncRequest, incomingRequest)) {
-            queuePendingPracticeRecordsSync(incomingRequest);
+        // Keep the baseline single-flight contract for same-library calls. Only
+        // a newer active library earns one coalesced Browse-progress tail; this
+        // is not a generic Practice-data replacement scheduler.
+        if (requestedLibraryGeneration != null
+            && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration) {
+            mergeBrowseProgressLibrarySyncRequest(
+                trigger,
+                options,
+                requestedLibraryGeneration
+            );
         }
         return practiceRecordsLoadPromise;
     }
-    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(incomingRequest);
+    practiceRecordsLoadPromise = drainBrowseProgressLibrarySync({
+        trigger,
+        options: Object.assign({}, options || {}),
+        libraryGeneration: requestedLibraryGeneration
+    });
     return practiceRecordsLoadPromise;
 }
 
@@ -19555,19 +19474,15 @@ function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
         source,
         'activeLibraryGeneration'
     );
-    const hasSourcePracticeRecordsDataGeneration = Object.prototype.hasOwnProperty.call(
-        source,
-        'practiceRecordsDataGeneration'
-    );
     const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration: hasSourcePracticeRecordsDataGeneration
-            ? source.practiceRecordsDataGeneration
-            : practiceRecordsDataGeneration,
+        practiceProjectionGeneration: Number.isFinite(Number(source.practiceProjectionGeneration))
+            ? Number(source.practiceProjectionGeneration)
+            : browsePracticeProjectionGeneration,
         resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
         functionalResetGeneration: functionalResetState.generation,
         functionalResetWasPending: functionalResetState.status === 'pending'
@@ -19590,8 +19505,8 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
     if (!ordinaryGenerationsAreCurrent) {
         return false;
     }
-    if (captured.practiceRecordsDataGeneration != null
-        && captured.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+    if (captured.practiceProjectionGeneration != null
+        && captured.practiceProjectionGeneration !== browsePracticeProjectionGeneration) {
         return false;
     }
     if (captured.functionalResetGeneration == null) {
@@ -19669,9 +19584,7 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
-        if (!isBrowseProgressRefreshEpochCurrent({
-            activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
-        })) {
+        if (!isBrowseProgressRefreshEpochCurrent(pendingEpoch)) {
             return;
         }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
@@ -19917,6 +19830,89 @@ function isBrowseUserResultsRequest(requestId) {
     return requestId != null && requestId === lastBrowseUserResultsRequestId;
 }
 
+function captureBrowseForegroundRenderEpoch(sourceEpoch = null) {
+    const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
+    const functionalResetState = readBrowseFunctionalResetState();
+    const readSourceOrGeneration = (key, getterName) => Object.prototype.hasOwnProperty.call(source, key)
+        ? source[key]
+        : readBrowseProgressGeneration(getterName);
+    return {
+        navigationGeneration: readSourceOrGeneration(
+            'navigationGeneration',
+            '__getAppNavigationIntentGeneration'
+        ),
+        activeLibraryGeneration: readSourceOrGeneration(
+            'activeLibraryGeneration',
+            '__getActiveLibraryGeneration'
+        ),
+        resetGeneration: readSourceOrGeneration(
+            'resetGeneration',
+            '__getBrowseResetIntentGeneration'
+        ),
+        functionalResetGeneration: Object.prototype.hasOwnProperty.call(
+            source,
+            'functionalResetGeneration'
+        )
+            ? source.functionalResetGeneration
+            : functionalResetState.generation
+    };
+}
+
+function isBrowseForegroundRenderEpochCurrent(epoch) {
+    if (!epoch || typeof epoch !== 'object') {
+        return true;
+    }
+    const generations = {
+        navigationGeneration: '__getAppNavigationIntentGeneration',
+        activeLibraryGeneration: '__getActiveLibraryGeneration',
+        resetGeneration: '__getBrowseResetIntentGeneration'
+    };
+    const ordinaryGenerationsAreCurrent = Object.keys(generations).every((key) => {
+        if (epoch[key] == null) {
+            return true;
+        }
+        return readBrowseProgressGeneration(generations[key]) === epoch[key];
+    });
+    if (!ordinaryGenerationsAreCurrent || epoch.functionalResetGeneration == null) {
+        return ordinaryGenerationsAreCurrent;
+    }
+    return readBrowseFunctionalResetState().generation === epoch.functionalResetGeneration;
+}
+
+function captureCurrentForegroundBrowseRecovery(requestId, explicitlyForeground = false) {
+    const isForeground = explicitlyForeground
+        || isBrowseUserResultsRequestInFlight(requestId);
+    if (!isForeground || !isBrowseResultsRequestCurrent(requestId)) {
+        return null;
+    }
+    const appEntry = window.AppEntry;
+    if (appEntry
+        && typeof appEntry.prepareBrowseFunctionalResetRecoveryForForeground === 'function') {
+        const prepared = appEntry.prepareBrowseFunctionalResetRecoveryForForeground(requestId);
+        return prepared && prepared.recovery ? prepared.recovery : prepared;
+    }
+    if (!appEntry
+        || typeof appEntry.captureBrowseFunctionalResetRecovery !== 'function') {
+        return null;
+    }
+    const recovery = appEntry.captureBrowseFunctionalResetRecovery();
+    if (recovery
+        && typeof appEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
+        appEntry.updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId);
+    }
+    return recovery;
+}
+
+function completeCurrentForegroundBrowseRecovery(recovery, succeeded) {
+    const appEntry = window.AppEntry;
+    if (!recovery
+        || !appEntry
+        || typeof appEntry.completeBrowseFunctionalResetRecovery !== 'function') {
+        return false;
+    }
+    return appEntry.completeBrowseFunctionalResetRecovery(recovery, succeeded === true);
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
@@ -19933,8 +19929,10 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     try {
         const requestedType = type;
+        let listeningUnavailable = false;
         let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
         try {
             if (!Array.isArray(examIndexOverride)) {
@@ -19945,9 +19943,7 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
                 : examIndex.some((exam) => exam && exam.type === 'listening');
             if (requestedType === 'listening' && !listeningAvailable) {
                 type = 'all';
-                if (typeof window.showMessage === 'function') {
-                    window.showMessage('听力题库尚未加载', 'warning');
-                }
+                listeningUnavailable = true;
             }
         } catch (_) {
             if (requestedType === 'listening') {
@@ -19955,8 +19951,12 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        if (listeningUnavailable && typeof window.showMessage === 'function') {
+            window.showMessage('听力题库尚未加载', 'warning');
         }
 
         // 重置筛选器状态
@@ -19999,7 +19999,9 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         }
 
         // 保留活动搜索与新类型筛选的交集。
-        await renderBrowseResultsForState(examIndex, activeRequestId);
+        return await renderBrowseResultsForState(examIndex, activeRequestId, {
+            foregroundEpoch
+        });
     } finally {
         endBrowseUserResultsRequest(userRequestId);
     }
@@ -20037,14 +20039,12 @@ async function applyBrowseFilter(
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
-    const functionalResetRecovery = window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     try {
         const indexSnapshot = await resolveActiveExamIndex();
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
         const memorizeSelectionActive = isReadingMemorizeBrowseMode();
@@ -20120,7 +20120,9 @@ async function applyBrowseFilter(
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
 
@@ -20132,9 +20134,13 @@ async function applyBrowseFilter(
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
 
         // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
-        await renderBrowseResultsForState(indexSnapshot, activeRequestId);
+        const renderResult = await renderBrowseResultsForState(indexSnapshot, activeRequestId, {
+            foregroundEpoch
+        });
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (renderResult === false
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()) {
             return false;
         }
 
@@ -20142,10 +20148,11 @@ async function applyBrowseFilter(
         if (typeof window.showView === 'function' && !document.getElementById('browse-view')?.classList.contains('active')) {
             window.showView('browse', false);
         }
-        functionalResetRecoverySucceeded = true;
         return true;
     } catch (e) {
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
@@ -20154,23 +20161,19 @@ async function applyBrowseFilter(
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
             window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
         }
-        // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
-        setTimeout(() => {
-            if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
-                return;
-            }
-            try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
-        }, 0);
+        // Break the failing call stack while retaining this foreground lease.
+        // The original epoch must still be current before the fallback may write.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        try {
+            await renderBrowseResultsForState(null, activeRequestId, { foregroundEpoch });
+        } catch (_) { }
         return false;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -20254,12 +20257,9 @@ async function initializeBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
-    const functionalResetRecovery = !options.skipLoad
-        && window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = options.foregroundEpoch
+        ? captureBrowseForegroundRenderEpoch(options.foregroundEpoch)
+        : captureBrowseForegroundRenderEpoch();
     try {
         console.log('[System] Initializing browse view...');
         const [examIndex] = await Promise.all([
@@ -20269,7 +20269,8 @@ async function initializeBrowseView(options = {}) {
                 : Promise.resolve()
         ]);
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return null;
         }
 
@@ -20288,7 +20289,9 @@ async function initializeBrowseView(options = {}) {
             const persistedAuthoritativeFilter = await persistAuthoritativeBrowseFilterBeforeHydration(
                 activeRequestId
             );
-            if (!persistedAuthoritativeFilter || !isBrowseResultsRequestCurrent(activeRequestId)) {
+            if (!persistedAuthoritativeFilter
+                || !isBrowseResultsRequestCurrent(activeRequestId)
+                || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
                 console.warn('[Browse] 权威筛选尚未持久化，已推迟首次 hydration');
                 return null;
             }
@@ -20307,23 +20310,20 @@ async function initializeBrowseView(options = {}) {
 
         setupBrowseSortControl();
         setupBrowseFrequencyFilterControl();
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return null;
+        }
         if (!options.skipLoad) {
-            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId);
+            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId, {
+                foregroundEpoch
+            });
             if (renderResult === false || !isBrowseResultsRequestCurrent(activeRequestId)) {
                 return null;
             }
-            functionalResetRecoverySucceeded = true;
         }
         return examIndex;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -20335,32 +20335,25 @@ async function activateBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
-    const functionalResetRecovery = window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = options.foregroundEpoch
+        ? captureBrowseForegroundRenderEpoch(options.foregroundEpoch)
+        : captureBrowseForegroundRenderEpoch();
     try {
         const examIndex = await initializeBrowseView({
             skipLoad: true,
-            renderRequestId: activeRequestId
+            renderRequestId: activeRequestId,
+            foregroundEpoch
         });
-        if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+        if (!Array.isArray(examIndex)
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
-        const result = await renderBrowseResultsForState(examIndex, activeRequestId);
-        functionalResetRecoverySucceeded = result !== false
-            && isBrowseResultsRequestCurrent(activeRequestId);
+        const result = await renderBrowseResultsForState(examIndex, activeRequestId, {
+            foregroundEpoch
+        });
         return result;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -20377,45 +20370,146 @@ function getBrowseSearchQuery() {
     return input && typeof input.value === 'string' ? input.value.trim() : '';
 }
 
-function renderBrowseResultsForState(examIndexOverride = null, renderRequestId = null) {
+async function renderBrowseResultsForState(
+    examIndexOverride = null,
+    renderRequestId = null,
+    options = {}
+) {
+    const hasQueryOverride = Object.prototype.hasOwnProperty.call(options || {}, 'query');
+    const query = hasQueryOverride ? String(options.query || '').trim() : getBrowseSearchQuery();
+    const explicitlyForeground = options && options.foreground === true;
+    const foregroundRetainId = explicitlyForeground
+        ? (renderRequestId == null
+            ? beginBrowseUserResultsRequest()
+            : retainBrowseUserResultsRequest(renderRequestId))
+        : null;
     const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? (explicitlyForeground ? foregroundRetainId : beginBrowseResultsRequest())
         : renderRequestId;
-    const query = getBrowseSearchQuery();
-    if (query) {
-        return performSearch(query, activeRequestId, examIndexOverride);
+    if (explicitlyForeground && foregroundRetainId == null) {
+        return false;
     }
-    return loadExamList(examIndexOverride, activeRequestId);
+    const isForeground = explicitlyForeground
+        || isBrowseUserResultsRequestInFlight(activeRequestId);
+    const foregroundEpoch = isForeground
+        ? captureBrowseForegroundRenderEpoch(options && options.foregroundEpoch)
+        : null;
+    let foregroundRecovery = null;
+    let renderSucceeded = false;
+    try {
+        if (!isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        foregroundRecovery = captureCurrentForegroundBrowseRecovery(
+            activeRequestId,
+            explicitlyForeground
+        );
+        if (foregroundEpoch) {
+            // Atomic preparation may neutrally cancel a stale retry barrier and
+            // restore its durable failure debt (or idle state). Adopt only that
+            // synchronous internal generation; navigation/library/reset
+            // ownership remains the foreground intent captured by the caller.
+            const preparedFunctionalResetState = readBrowseFunctionalResetState();
+            foregroundEpoch.functionalResetGeneration = preparedFunctionalResetState.generation;
+        }
+        const isRenderCurrent = () => isBrowseResultsRequestCurrent(activeRequestId)
+            && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        const result = query
+            ? await performSearch(query, activeRequestId, examIndexOverride, {
+                isCurrent: isRenderCurrent
+            })
+            : await loadExamList(examIndexOverride, activeRequestId, {
+                isCurrent: isRenderCurrent
+            });
+        if (result === false
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        renderSucceeded = true;
+        return result;
+    } finally {
+        completeCurrentForegroundBrowseRecovery(foregroundRecovery, renderSucceeded);
+        endBrowseUserResultsRequest(foregroundRetainId);
+    }
 }
 
 window.__renderBrowseResultsForState = renderBrowseResultsForState;
 
-function refreshBrowseResults() {
-    return renderBrowseResultsForState();
+function refreshBrowseResults(options = {}) {
+    return renderBrowseResultsForState(null, null, options);
 }
 
 let browseControlsSeeded = false;
 let browseControlsSeedPromise = null;
-async function setupBrowseControls() {
+let browseControlsSeedReadRevision = null;
+let browseControlsSeedReadEpoch = null;
+let browseControlsMutationRevision = 0;
+
+function isBrowseControlsSetupCurrent(options = {}) {
+    if (!options || typeof options.isCurrent !== 'function') {
+        return true;
+    }
+    try {
+        return options.isCurrent() !== false;
+    } catch (_) {
+        return false;
+    }
+}
+
+async function setupBrowseControls(options = {}) {
+    if (!isBrowseControlsSetupCurrent(options)) {
+        return false;
+    }
     if (!browseControlsSeeded) {
         if (!browseControlsSeedPromise) {
+            browseControlsSeedReadRevision = browseControlsMutationRevision;
+            browseControlsSeedReadEpoch = captureBrowseForegroundRenderEpoch();
             browseControlsSeedPromise = (async () => {
                 try {
-                    const browse = await window.AppData.preferences.getBrowse();
-                    if (browse) {
-                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                        updateBrowseFrequencyButtons(
-                            browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
-                        );
-                    }
+                    return await window.AppData.preferences.getBrowse();
                 } catch (_) { /* defaults remain active */ }
-                browseControlsSeeded = true;
+                return null;
             })();
         }
-        await browseControlsSeedPromise;
+        const seedPromise = browseControlsSeedPromise;
+        const browse = await seedPromise;
+        if (!isBrowseControlsSetupCurrent(options)) {
+            if (!browseControlsSeeded && browseControlsSeedPromise === seedPromise) {
+                browseControlsSeedPromise = null;
+                browseControlsSeedReadRevision = null;
+                browseControlsSeedReadEpoch = null;
+            }
+            return false;
+        }
+        if (browseControlsSeedPromise !== seedPromise) {
+            return setupBrowseControls(options);
+        }
+        if (!isBrowseForegroundRenderEpochCurrent(browseControlsSeedReadEpoch)) {
+            browseControlsSeedPromise = null;
+            browseControlsSeedReadRevision = null;
+            browseControlsSeedReadEpoch = null;
+            return setupBrowseControls(options);
+        }
+        if (!browseControlsSeeded) {
+            // A user frequency/sort intent that happened while storage was being
+            // read owns the controls. The older preference snapshot must not
+            // overwrite it when the await settles.
+            if (browseControlsSeedReadRevision === browseControlsMutationRevision && browse) {
+                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                updateBrowseFrequencyButtons(
+                    browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
+                );
+            }
+            browseControlsSeeded = true;
+        }
+    }
+    if (!isBrowseControlsSetupCurrent(options)) {
+        return false;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
+    return true;
 }
 
 async function persistBrowsePreference(patch) {
@@ -20442,9 +20536,10 @@ function setupBrowseSortControl() {
     sortSelect.value = normalizeSortMode(savedMode);
     window.__browseSortMode = sortSelect.value;
     sortSelect.addEventListener('change', () => {
+        browseControlsMutationRevision += 1;
         window.__browseSortMode = normalizeSortMode(sortSelect.value);
         persistBrowsePreference({ sortMode: window.__browseSortMode }).catch(console.warn);
-        refreshBrowseResults();
+        refreshBrowseResults({ foreground: true });
     });
     sortSelect.dataset.bound = 'true';
 }
@@ -20494,9 +20589,12 @@ function filterByFrequency(filter) {
     const requested = normalizeBrowseFrequencyFilter(filter);
     const current = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
     const next = requested !== 'all' && requested === current ? 'all' : requested;
+    browseControlsMutationRevision += 1;
+    // Record the live intent before any async preference write or lazy owner
+    // delegation so an older control-seed read cannot become authoritative.
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
-    refreshBrowseResults();
+    refreshBrowseResults({ foreground: true });
 }
 
 // 全局桥接：HTML 按钮 onclick="browseCategory('P1','reading')"
@@ -20543,20 +20641,33 @@ function filterRecordsByType(type) {
 }
 
 
-async function loadExamList(examIndexOverride = null, renderRequestId = null) {
+async function loadExamList(examIndexOverride = null, renderRequestId = null, options = {}) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
-    await setupBrowseControls();
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    const isCurrent = () => {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        if (!options || typeof options.isCurrent !== 'function') {
+            return true;
+        }
+        try {
+            return options.isCurrent() !== false;
+        } catch (_) {
+            return false;
+        }
+    };
+    const controlsReady = await setupBrowseControls({ isCurrent });
+    if (controlsReady === false || !isCurrent()) {
+        return false;
     }
     const examIndex = Array.isArray(examIndexOverride)
         ? examIndexOverride
         : await resolveActiveExamIndex();
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
 
     if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
@@ -20564,27 +20675,30 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null) {
     }
     console.warn('[main.js] ExamActions.loadExamList 未就绪，尝试加载 browse-view 组');
     if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
-        return window.AppLazyLoader.ensureGroup('browse-view').then(function () {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-                return;
+        return window.AppLazyLoader.ensureGroup('browse-view').then(async function () {
+            if (!isCurrent()) {
+                return false;
             }
-            setupBrowseControls();
+            const lazyControlsReady = await setupBrowseControls({ isCurrent });
+            if (lazyControlsReady === false || !isCurrent()) {
+                return false;
+            }
             if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-                window.ExamActions.loadExamList(examIndex);
+                return window.ExamActions.loadExamList(examIndex);
             } else {
                 // 最终降级：直接 DOM 渲染
-                loadExamListFallback(examIndex);
+                return loadExamListFallback(examIndex);
             }
         }).catch(function (err) {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-                return;
+            if (!isCurrent()) {
+                return false;
             }
             console.error('[main.js] browse-view 组加载失败:', err);
-            loadExamListFallback(examIndex);
+            return loadExamListFallback(examIndex);
         });
     } else {
         // 无懒加载器，直接降级
-        loadExamListFallback(examIndex);
+        return loadExamListFallback(examIndex);
     }
 }
 
@@ -21146,25 +21260,76 @@ async function setActiveLibraryConfiguration(key) {
 
 
 let debouncedExamSearch = null;
+let pendingDebouncedExamSearchRequestId = null;
 
 function searchExams(query, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+    const explicitRequestIsForeground = renderRequestId != null
+        && isBrowseUserResultsRequestInFlight(renderRequestId);
+    const isForegroundIntent = renderRequestId == null || explicitRequestIsForeground;
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : (explicitRequestIsForeground
+            ? retainBrowseUserResultsRequest(renderRequestId)
+            : null);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    if (activeRequestId == null
+        || !isBrowseResultsRequestCurrent(activeRequestId)
+        || (isForegroundIntent && userRequestId == null)) {
+        endBrowseUserResultsRequest(userRequestId);
         return false;
     }
+    // Capture navigation/reset/library ownership at input time, before the
+    // debounce delay. A later callback must not adopt an intervening intent.
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     toggleSearchClearButton(query);
     if (window.performanceOptimizer && typeof window.performanceOptimizer.debounce === 'function') {
         // 跨 input 事件复用同一个 debounce 闭包，避免每个字符都排队一次搜索。
         if (!debouncedExamSearch) {
-            debouncedExamSearch = window.performanceOptimizer.debounce(performSearch, 300, 'exam_search');
+            debouncedExamSearch = window.performanceOptimizer.debounce((
+                nextQuery,
+                nextRequestId,
+                retainedRequestId,
+                intentEpoch,
+                foregroundIntent
+            ) => {
+                if (pendingDebouncedExamSearchRequestId === retainedRequestId) {
+                    pendingDebouncedExamSearchRequestId = null;
+                }
+                Promise.resolve(renderBrowseResultsForState(null, nextRequestId, {
+                    foreground: foregroundIntent,
+                    foregroundEpoch: intentEpoch,
+                    query: nextQuery
+                })).catch((error) => {
+                    console.warn('[Search] 搜索结果刷新失败:', error);
+                }).finally(() => {
+                    endBrowseUserResultsRequest(retainedRequestId);
+                });
+            }, 300, 'exam_search');
         }
-        debouncedExamSearch(query, activeRequestId);
+        if (pendingDebouncedExamSearchRequestId != null) {
+            endBrowseUserResultsRequest(pendingDebouncedExamSearchRequestId);
+        }
+        pendingDebouncedExamSearchRequestId = userRequestId;
+        debouncedExamSearch(
+            query,
+            activeRequestId,
+            userRequestId,
+            foregroundEpoch,
+            isForegroundIntent
+        );
     } else {
         // Fallback: direct call if optimizer not available
-        performSearch(query, activeRequestId);
+        Promise.resolve(renderBrowseResultsForState(null, activeRequestId, {
+            foreground: isForegroundIntent,
+            foregroundEpoch,
+            query
+        })).catch((error) => {
+            console.warn('[Search] 搜索结果刷新失败:', error);
+        }).finally(() => {
+            endBrowseUserResultsRequest(userRequestId);
+        });
     }
+    return true;
 }
 
 function toggleSearchClearButton(query) {
@@ -21252,13 +21417,31 @@ function applyActiveBrowseFolderFilter(exams) {
     return Array.isArray(folderFiltered) ? folderFiltered : list;
 }
 
-async function performSearch(query, renderRequestId = null, examIndexOverride = null) {
+async function performSearch(
+    query,
+    renderRequestId = null,
+    examIndexOverride = null,
+    options = {}
+) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
+    const isCurrent = () => {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        if (!options || typeof options.isCurrent !== 'function') {
+            return true;
+        }
+        try {
+            return options.isCurrent() !== false;
+        } catch (_) {
+            return false;
+        }
+    };
     const normalizedQuery = String(query || '').toLowerCase().trim();
     if (!normalizedQuery) {
-        return loadExamList(examIndexOverride, activeRequestId);
+        return loadExamList(examIndexOverride, activeRequestId, { isCurrent });
     }
 
     // 调试日志
@@ -21266,8 +21449,8 @@ async function performSearch(query, renderRequestId = null, examIndexOverride = 
     const examIndexSnapshot = Array.isArray(examIndexOverride)
         ? examIndexOverride
         : await resolveActiveExamIndex();
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
     const searchBase = getBrowseFilteredExamBase(examIndexSnapshot);
     console.log('[Search] 当前筛选后索引数量:', searchBase.length);
@@ -21281,8 +21464,8 @@ async function performSearch(query, renderRequestId = null, examIndexOverride = 
     });
 
     console.log('[Search] 搜索结果数量:', searchResults.length);
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
     if (window.ExamActions && typeof window.ExamActions.displayExams === 'function') {
         window.ExamActions.displayExams(searchResults);

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5233,16 +5233,54 @@
     async function persistBrowseFrequencyReset() {
         const preferences = global.AppData && global.AppData.preferences;
         if (!preferences || typeof preferences.patchBrowse !== 'function') {
-            return;
+            return false;
         }
         try {
             await preferences.patchBrowse({
                 frequencyFilter: 'all',
                 filter: { category: 'all', type: 'all' }
             });
+            return true;
         } catch (error) {
             console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+            return false;
         }
+    }
+
+    function isAllBrowseFilter(filter) {
+        return !!filter && filter.category === 'all' && filter.type === 'all';
+    }
+
+    function isBrowseManagerReset(manager) {
+        if (!manager) {
+            return true;
+        }
+        const state = manager.state || {};
+        const filters = state.filters || {};
+        return manager.currentFilter === 'all'
+            && state.currentCategory == null
+            && state.currentFrequency == null
+            && (filters.frequency == null || filters.frequency === 'all')
+            && (state.searchQuery == null || state.searchQuery === '');
+    }
+
+    function isPersistedBrowseReset(browse, requireStateManager) {
+        if (!browse || !isAllBrowseFilter(browse.lastFilter)
+            || !isAllBrowseFilter(browse.filter)
+            || browse.frequencyFilter !== 'all') {
+            return false;
+        }
+        if (!requireStateManager) {
+            return true;
+        }
+        const manager = browse.stateManager;
+        const state = manager && manager.state;
+        const filters = state && state.filters;
+        return !!manager && manager.currentFilter === 'all'
+            && state.currentCategory == null
+            && state.currentFrequency == null
+            && !!filters && filters.frequency === 'all'
+            && state.searchQuery === '';
     }
 
     function beginBrowseResetPersistence() {
@@ -5299,19 +5337,33 @@
                 return false;
             }
 
-            if (typeof global.saveBrowseViewPreferences === 'function') {
-                global.saveBrowseViewPreferences({
-                    lastFilter: { category: 'all', type: 'all' }
-                });
+            if (typeof global.saveBrowseViewPreferences !== 'function'
+                || typeof global.flushBrowsePreferenceWrites !== 'function') {
+                return false;
             }
-            if (typeof global.flushBrowsePreferenceWrites === 'function') {
-                await global.flushBrowsePreferenceWrites();
+            global.saveBrowseViewPreferences({
+                lastFilter: { category: 'all', type: 'all' }
+            });
+            const committedBrowsePreferences = await global.flushBrowsePreferenceWrites();
+            if (!committedBrowsePreferences
+                || !isAllBrowseFilter(committedBrowsePreferences.lastFilter)) {
+                return false;
             }
             if (manager && typeof manager.persistState === 'function') {
                 await manager.persistState();
             }
-            await persistBrowseFrequencyReset();
-            return true;
+            if (!await persistBrowseFrequencyReset() || !isBrowseManagerReset(manager)) {
+                return false;
+            }
+            const preferences = global.AppData && global.AppData.preferences;
+            if (!preferences || typeof preferences.getBrowse !== 'function') {
+                return false;
+            }
+            const persistedBrowse = await preferences.getBrowse();
+            return isPersistedBrowseReset(
+                persistedBrowse,
+                !!(manager && typeof manager.persistState === 'function')
+            );
         } catch (error) {
             console.warn('[ExamActions] 激活前重置题库状态失败:', error);
             return false;
@@ -19208,6 +19260,45 @@ function clearPracticeHistorySearch() {
     searchPracticeHistory('');
 }
 
+let pendingBrowseProgressRefreshIndex = null;
+let browseProgressRefreshRetryTimer = null;
+
+function retryPendingBrowseProgressRefresh() {
+    if (browseProgressRefreshRetryTimer != null) {
+        return;
+    }
+    browseProgressRefreshRetryTimer = setTimeout(() => {
+        browseProgressRefreshRetryTimer = null;
+        flushPendingBrowseProgressRefresh();
+    }, 50);
+}
+
+function flushPendingBrowseProgressRefresh() {
+    if (!Array.isArray(pendingBrowseProgressRefreshIndex)) {
+        return;
+    }
+    const browseView = document.getElementById('browse-view');
+    const isBrowseActive = browseView && browseView.classList.contains('active');
+    if (!isBrowseActive) {
+        pendingBrowseProgressRefreshIndex = null;
+        return;
+    }
+    const resetInFlight = typeof window.__isBrowseResetIntentInFlight === 'function'
+        && window.__isBrowseResetIntentInFlight();
+    if (resetInFlight) {
+        retryPendingBrowseProgressRefresh();
+        return;
+    }
+    if (isBrowseUserResultsRequestInFlight(browseResultsRequestId)) {
+        return;
+    }
+    const indexSnapshot = pendingBrowseProgressRefreshIndex;
+    pendingBrowseProgressRefreshIndex = null;
+    Promise.resolve(renderBrowseResultsForState(indexSnapshot)).catch((error) => {
+        console.warn('[Browse] 刷新浏览进度列表失败:', error);
+    });
+}
+
 function refreshBrowseProgressFromRecords(records, examIndex) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
@@ -19220,8 +19311,9 @@ function refreshBrowseProgressFromRecords(records, examIndex) {
         }
         const browseView = document.getElementById('browse-view');
         const isBrowseActive = browseView && browseView.classList.contains('active');
-        if (isBrowseActive && typeof loadExamList === 'function') {
-            loadExamList(indexSnapshot);
+        if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
+            pendingBrowseProgressRefreshIndex = indexSnapshot;
+            flushPendingBrowseProgressRefresh();
         }
     } catch (error) {
         console.warn('[Browse] 刷新浏览进度失败:', error);
@@ -19435,6 +19527,9 @@ function endBrowseUserResultsRequest(requestId) {
                 }));
             } catch (_) { }
         }
+        if (retainCount === 1) {
+            flushPendingBrowseProgressRefresh();
+        }
         return;
     }
     browseUserResultsRequestRetains.set(requestId, retainCount - 1);
@@ -19460,7 +19555,6 @@ window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
-    browseInitialFilterHydrationConsumed = true;
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
@@ -19492,6 +19586,7 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         }
 
         // 重置筛选器状态
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState('all', type);
         setBrowseTitle(formatBrowseTitle('all', type));
 
@@ -19545,7 +19640,6 @@ async function applyBrowseFilter(
     renderRequestId = null,
     navigationIntentGeneration = null
 ) {
-    browseInitialFilterHydrationConsumed = true;
     const getActiveViewId = () => {
         const activeView = typeof document.querySelector === 'function'
             ? document.querySelector('.view.active')
@@ -19652,6 +19746,7 @@ async function applyBrowseFilter(
         }
 
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState(normalizedCategory, effectiveType);
 
 
@@ -19673,6 +19768,7 @@ async function applyBrowseFilter(
             return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState('all', 'all');
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
             window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
@@ -19691,61 +19787,80 @@ async function applyBrowseFilter(
 
 // Initialize browse view when it's activated
 async function initializeBrowseView(options = {}) {
+    const userRequestId = options.renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(options.renderRequestId);
     const activeRequestId = options.renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? userRequestId
         : options.renderRequestId;
-    console.log('[System] Initializing browse view...');
-    const [examIndex] = await Promise.all([
-        resolveActiveExamIndex(),
-        typeof window.whenBrowseViewPreferencesReady === 'function'
-            ? window.whenBrowseViewPreferencesReady()
-            : Promise.resolve()
-    ]);
+    try {
+        console.log('[System] Initializing browse view...');
+        const [examIndex] = await Promise.all([
+            resolveActiveExamIndex(),
+            typeof window.whenBrowseViewPreferencesReady === 'function'
+                ? window.whenBrowseViewPreferencesReady()
+                : Promise.resolve()
+        ]);
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return null;
-    }
-
-    // 初始化 browseController
-    if (window.browseController && !window.browseController.buttonContainer) {
-        window.browseController.initialize('type-filter-buttons', examIndex);
-    }
-    if (typeof window.refreshListeningAvailabilityUI === 'function') {
-        window.refreshListeningAvailabilityUI(examIndex);
-    }
-
-    if (!browseInitialFilterHydrationConsumed) {
-        const persisted = getPersistedBrowseFilter();
-        if (persisted) {
-            setBrowseFilterState(persisted.category, persisted.type);
-            setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
-        } else {
-            setBrowseFilterState('all', 'all');
-            setBrowseTitle(formatBrowseTitle('all', 'all'));
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return null;
         }
-        browseInitialFilterHydrationConsumed = true;
-    }
 
-    setupBrowseSortControl();
-    setupBrowseFrequencyFilterControl();
-    if (!options.skipLoad) {
-        await renderBrowseResultsForState(examIndex, activeRequestId);
+        // 初始化 browseController
+        if (window.browseController && !window.browseController.buttonContainer) {
+            window.browseController.initialize('type-filter-buttons', examIndex);
+        }
+        if (typeof window.refreshListeningAvailabilityUI === 'function') {
+            window.refreshListeningAvailabilityUI(examIndex);
+        }
+
+        const browseFilterMutationRevision = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : 0;
+        if (!browseInitialFilterHydrationConsumed && browseFilterMutationRevision > 0) {
+            browseInitialFilterHydrationConsumed = true;
+        } else if (!browseInitialFilterHydrationConsumed) {
+            const persisted = getPersistedBrowseFilter();
+            browseInitialFilterHydrationConsumed = true;
+            if (persisted) {
+                setBrowseFilterState(persisted.category, persisted.type);
+                setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
+            } else {
+                setBrowseFilterState('all', 'all');
+                setBrowseTitle(formatBrowseTitle('all', 'all'));
+            }
+        }
+
+        setupBrowseSortControl();
+        setupBrowseFrequencyFilterControl();
+        if (!options.skipLoad) {
+            await renderBrowseResultsForState(examIndex, activeRequestId);
+        }
+        return examIndex;
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
-    return examIndex;
 }
 
 async function activateBrowseView(options = {}) {
+    const userRequestId = options.renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(options.renderRequestId);
     const activeRequestId = options.renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? userRequestId
         : options.renderRequestId;
-    const examIndex = await initializeBrowseView({
-        skipLoad: true,
-        renderRequestId: activeRequestId
-    });
-    if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
-        return false;
+    try {
+        const examIndex = await initializeBrowseView({
+            skipLoad: true,
+            renderRequestId: activeRequestId
+        });
+        if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        return renderBrowseResultsForState(examIndex, activeRequestId);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
-    return renderBrowseResultsForState(examIndex, activeRequestId);
 }
 
 window.activateBrowseView = activateBrowseView;

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -3486,7 +3486,7 @@
         }
 
         if (typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
             return;
         }
 
@@ -5071,50 +5071,232 @@
         return examsToShow;
     }
 
-    /**
-     * 重置浏览视图
-     */
-    function resetBrowseViewToAll() {
-        clearReadingMemorizeBrowseMode();
-        // 1. 清除频率模式标记（关键修复）
-        if (typeof global.__browseFilterMode !== 'undefined') {
-            global.__browseFilterMode = 'default';
+    let browseResetInteractionId = 0;
+
+    function isBrowseResetCurrent(interactionId, renderRequestId) {
+        if (interactionId !== browseResetInteractionId) {
+            return false;
         }
-        if (typeof global.__browsePath !== 'undefined') {
-            global.__browsePath = null;
+        return renderRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(renderRequestId);
+    }
+
+    function clearBrowseSearchUI() {
+        if (global.browseStateManager && typeof global.browseStateManager.clearSearchState === 'function') {
+            global.browseStateManager.clearSearchState();
+            return;
+        }
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
+        if (searchInput) {
+            searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
+        }
+    }
+
+    function syncBrowseFilterUI(examIndex) {
+        const controller = global.browseController;
+        if (controller) {
+            controller.currentMode = 'default';
+            controller.activeFilter = 'all';
+            if (typeof controller.renderFilterButtons === 'function') {
+                controller.renderFilterButtons(Array.isArray(examIndex) ? examIndex : []);
+            }
         }
 
-        // 2. 重置 browseController 到默认模式
-        if (global.browseController) {
-            global.browseController.clearPendingBrowseAutoScroll();
+        const typeContainer = document.getElementById('type-filter-buttons');
+        if (typeContainer && typeof typeContainer.querySelectorAll === 'function') {
+            typeContainer.querySelectorAll('.shui-segmented-btn').forEach((button) => {
+                const filterId = button.dataset && (button.dataset.filterId || button.dataset.filterType);
+                const active = filterId === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        }
 
-            // 恢复默认模式（消除频率模式）
-            if (typeof global.browseController.resetToDefault === 'function') {
-                global.browseController.resetToDefault();
-            } else {
-                // 降级：手动重置
-                global.browseController.currentMode = 'default';
-                global.browseController.activeFilter = 'all';
-            }
-
-            const currentCategory = global.browseController.getCurrentCategory();
-            const currentType = global.browseController.getCurrentExamType();
-
-            if (currentCategory === 'all' && currentType === 'all') {
-                if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-                loadExamList();
-                return;
-            }
-
-            global.browseController.setBrowseFilterState('all', 'all');
+        global.__browseFrequencyFilter = 'all';
+        if (typeof global.updateBrowseFrequencyButtons === 'function') {
+            global.updateBrowseFrequencyButtons('all');
         } else {
-            // 降级
-            if (typeof global.clearPendingBrowseAutoScroll === 'function') global.clearPendingBrowseAutoScroll();
-            if (typeof global.setBrowseFilterState === 'function') global.setBrowseFilterState('all', 'all');
+            const frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+            if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+                frequencyContainer.querySelectorAll('[data-frequency-filter]').forEach((button) => {
+                    if (button.classList && typeof button.classList.remove === 'function') {
+                        button.classList.remove('active');
+                    }
+                    if (typeof button.setAttribute === 'function') {
+                        button.setAttribute('aria-pressed', 'false');
+                    }
+                });
+            }
+        }
+    }
+
+    async function prepareBrowseReset() {
+        const pending = [];
+        const manager = global.browseStateManager;
+        if (manager && manager.ready && typeof manager.ready.then === 'function') {
+            pending.push(Promise.resolve(manager.ready).catch((error) => {
+                console.warn('[ExamActions] 等待浏览状态恢复失败:', error);
+            }));
+        }
+        if (typeof global.setupBrowseControls === 'function') {
+            pending.push(Promise.resolve().then(() => global.setupBrowseControls()).catch((error) => {
+                console.warn('[ExamActions] 初始化浏览筛选控件失败:', error);
+            }));
+        }
+        if (pending.length > 0) {
+            await Promise.all(pending);
+        }
+    }
+
+    async function persistBrowseFrequencyReset() {
+        const preferences = global.AppData && global.AppData.preferences;
+        if (!preferences || typeof preferences.patchBrowse !== 'function') {
+            return;
+        }
+        try {
+            await preferences.patchBrowse({ frequencyFilter: 'all' });
+        } catch (error) {
+            console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
+        }
+    }
+
+    function beginBrowseResetPersistence() {
+        const pending = [persistBrowseFrequencyReset()];
+        if (typeof global.flushBrowsePreferenceWrites === 'function') {
+            pending.push(Promise.resolve().then(() => global.flushBrowsePreferenceWrites()).catch((error) => {
+                console.warn('[ExamActions] 等待浏览筛选偏好写入失败:', error);
+            }));
+        }
+        return Promise.all(pending);
+    }
+
+    function applyBrowseResetState(examIndex) {
+        clearReadingMemorizeBrowseMode();
+        global.__browseFilterMode = 'default';
+        global.__browsePath = null;
+
+        if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
+            global.browseStateManager.resetToAllExams();
+        } else {
+            if (typeof global.setBrowseFilterState === 'function') {
+                global.setBrowseFilterState('all', 'all');
+            }
+            clearBrowseSearchUI();
         }
 
-        if (global.setBrowseTitle) global.setBrowseTitle('题库列表');
-        loadExamList();
+        syncBrowseFilterUI(examIndex);
+        if (typeof global.setBrowseTitle === 'function') {
+            global.setBrowseTitle('题库列表');
+        }
+    }
+
+    /**
+     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
+     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     */
+    async function performBrowseViewResetToAll() {
+        const interactionId = ++browseResetInteractionId;
+        if (global.__pendingBrowseFilter) {
+            delete global.__pendingBrowseFilter;
+        }
+        const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+            ? global.__beginBrowseResultsRequest()
+            : null;
+
+        if (global.browseController) {
+            if (typeof global.browseController.filterInteractionId === 'number') {
+                global.browseController.filterInteractionId += 1;
+            }
+            if (typeof global.browseController.clearPendingBrowseAutoScroll === 'function') {
+                global.browseController.clearPendingBrowseAutoScroll();
+            }
+        } else if (typeof global.clearPendingBrowseAutoScroll === 'function') {
+            global.clearPendingBrowseAutoScroll();
+        }
+
+        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+            ? global.resolveActiveLibraryIndex
+            : global.resolveActiveExamIndex;
+        const indexPromise = typeof resolver === 'function'
+            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                Array.isArray(resolved) ? resolved : null
+            )).catch((error) => {
+                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                return null;
+            })
+            : Promise.resolve(null);
+        const [examIndex] = await Promise.all([
+            indexPromise,
+            prepareBrowseReset()
+        ]);
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        applyBrowseResetState(examIndex);
+
+        const globalLoader = global.loadExamList;
+        if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
+            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
+            let renderPromise;
+            try {
+                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+            } catch (error) {
+                renderPromise = Promise.reject(error);
+            }
+            const persistencePromise = beginBrowseResetPersistence();
+            try {
+                const result = await renderPromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    await persistencePromise;
+                    return false;
+                }
+                if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                    && Array.isArray(result)) {
+                    syncBrowseFilterUI(result);
+                }
+                await persistencePromise;
+                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                    return false;
+                }
+                return result;
+            } catch (error) {
+                console.warn('[ExamActions] 重置浏览视图加载失败:', error);
+                await persistencePromise;
+                return false;
+            }
+        }
+
+        if (Array.isArray(examIndex) && examIndex.length > 0) {
+            const result = loadExamList(examIndex);
+            await beginBrowseResetPersistence();
+            return result;
+        }
+
+        await beginBrowseResetPersistence();
+        console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
+        return false;
+    }
+
+    async function resetBrowseViewToAll() {
+        try {
+            return await performBrowseViewResetToAll();
+        } catch (error) {
+            console.warn('[ExamActions] 重置浏览视图失败:', error);
+            return false;
+        }
     }
 
     /**
@@ -14496,19 +14678,16 @@ class BrowseStateManager {
      * 处理浏览导航
      */
     handleBrowseNavigation() {
-        console.log('[BrowseStateManager] 处理浏览导航，重置为显示所有考试');
+        console.log('[BrowseStateManager] 记录题库浏览导航');
 
-        if (typeof window.clearPendingBrowseAutoScroll === 'function') {
-            try { window.clearPendingBrowseAutoScroll(); } catch (_) {}
-        }
-
-        // 重置到全部考试视图
-        this.resetToAllExams();
+        // 导航控制器单独区分“进入 Browse”和“重复点击 Browse”。
+        // 普通进入时保留待处理的分类与持久化偏好；重复导航才由
+        // ExamActions.resetBrowseViewToAll 执行原子重置。
 
         // 记录导航历史
         this.addToHistory({
             action: 'navigate_to_browse',
-            filter: 'all',
+            filter: this.currentFilter,
             timestamp: Date.now()
         });
     }
@@ -14718,6 +14897,11 @@ class BrowseStateManager {
         this.setState({
             currentCategory: null,
             currentFrequency: null,
+            filters: {
+                frequency: 'all',
+                status: 'all',
+                difficulty: 'all'
+            },
             searchQuery: '',
             pagination: {
                 page: 1,
@@ -14767,9 +14951,14 @@ class BrowseStateManager {
      * 清除搜索状态
      */
     clearSearchState() {
-        const searchInput = document.querySelector('.search-input');
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
         if (searchInput) {
             searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
         }
     }
 
@@ -17143,7 +17332,7 @@ function ensureLegacyNavigation(options) {
         },
         onNavigate: function onNavigate(viewName) {
             if (typeof window.showView === 'function') {
-                window.showView(viewName);
+                window.showView(viewName, false);
                 return;
             }
             if (window.app && typeof window.app.navigateToView === 'function') {
@@ -17170,7 +17359,11 @@ async function initializeLegacyComponents() {
     try { showMessage('系统准备就绪', 'success'); } catch (_) { }
 
     try {
-        ensureLegacyNavigation({ initialView: 'overview' });
+        const activeView = document.querySelector('.view.active');
+        const activeViewName = activeView && activeView.id
+            ? activeView.id.replace(/-view$/, '')
+            : 'overview';
+        ensureLegacyNavigation({ initialView: activeViewName });
     } catch (error) {
         console.warn('[Navigation] 初始化导航控制器失败:', error);
     }
@@ -17183,8 +17376,8 @@ async function initializeLegacyComponents() {
         console.log('[System] PDF处理器已初始化');
     }
     if (window.BrowseStateManager) {
-        browseStateManager = new BrowseStateManager();
-        console.log('[System] 浏览状态管理器已初始化');
+        browseStateManager = window.browseStateManager || new window.BrowseStateManager();
+        console.log('[System] 浏览状态管理器已就绪');
     }
     // 性能优化器已拆到 diagnostics-tools；浏览页保留无依赖降级路径。
     if (window.PerformanceOptimizer) {
@@ -19193,22 +19386,33 @@ function refreshBrowseResults() {
 }
 
 let browseControlsSeeded = false;
+let browseControlsSeedPromise = null;
 async function setupBrowseControls() {
     if (!browseControlsSeeded) {
-        try {
-            const browse = await window.AppData.preferences.getBrowse();
-            if (browse) {
-                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
-            }
-        } catch (_) { /* defaults remain active */ }
-        browseControlsSeeded = true;
+        if (!browseControlsSeedPromise) {
+            browseControlsSeedPromise = (async () => {
+                try {
+                    const browse = await window.AppData.preferences.getBrowse();
+                    if (browse) {
+                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                    }
+                } catch (_) { /* defaults remain active */ }
+                browseControlsSeeded = true;
+            })();
+        }
+        await browseControlsSeedPromise;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
 }
 
 async function persistBrowsePreference(patch) {
+    if (window.AppData && window.AppData.preferences
+        && typeof window.AppData.preferences.patchBrowse === 'function') {
+        await window.AppData.preferences.patchBrowse(patch);
+        return;
+    }
     const current = await window.AppData.preferences.getBrowse() || {};
     await window.AppData.preferences.setBrowse(Object.assign({}, current, patch));
 }
@@ -19236,6 +19440,7 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
+    window.__browseFrequencyFilter = activeFilter;
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return;

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -3550,14 +3550,28 @@
         }
 
         event.preventDefault();
-        this.navigate(viewName, event);
         if (alreadyActive && typeof this.options.onRepeatNavigate === 'function') {
+            var repeatHandled = true;
             try {
-                this.options.onRepeatNavigate(viewName, event);
+                var repeatResult = this.options.onRepeatNavigate(viewName, event);
+                if (repeatResult === false) {
+                    repeatHandled = false;
+                } else if (repeatResult && typeof repeatResult.then === 'function') {
+                    Promise.resolve(repeatResult).catch(function handleRepeatFailure(repeatError) {
+                        console.warn('[LegacyNavigationController] onRepeatNavigate 执行失败', repeatError);
+                    });
+                }
             } catch (repeatError) {
                 console.warn('[LegacyNavigationController] onRepeatNavigate 执行失败', repeatError);
             }
+            if (repeatHandled) {
+                if (this.options.syncOnNavigate !== false) {
+                    this.syncActive(viewName);
+                }
+                return;
+            }
         }
+        this.navigate(viewName, event);
         if (this.options.syncOnNavigate !== false) {
             this.syncActive(viewName);
         }
@@ -5122,7 +5136,6 @@
             });
         }
 
-        global.__browseFrequencyFilter = 'all';
         if (typeof global.updateBrowseFrequencyButtons === 'function') {
             global.updateBrowseFrequencyButtons('all');
         } else {
@@ -17441,11 +17454,12 @@ function ensureLegacyNavigation(options) {
         onRepeatNavigate: function onRepeatNavigate(viewName) {
             if (viewName === 'browse') {
                 if (window.ExamActions && typeof window.ExamActions.resetBrowseViewToAll === 'function') {
-                    window.ExamActions.resetBrowseViewToAll();
+                    return window.ExamActions.resetBrowseViewToAll();
                 } else if (typeof window.resetBrowseViewToAll === 'function') {
-                    window.resetBrowseViewToAll();
+                    return window.resetBrowseViewToAll();
                 }
             }
+            return false;
         },
         onNavigate: function onNavigate(viewName) {
             if (typeof window.showView === 'function') {
@@ -19501,10 +19515,9 @@ function refreshBrowseResults() {
     const activeRequestId = beginBrowseResultsRequest();
     const query = getBrowseSearchQuery();
     if (query) {
-        performSearch(query, activeRequestId);
-        return;
+        return performSearch(query, activeRequestId);
     }
-    loadExamList(null, activeRequestId);
+    return loadExamList(null, activeRequestId);
 }
 
 let browseControlsSeeded = false;
@@ -19572,6 +19585,20 @@ function updateBrowseFrequencyButtons(filter) {
         button.classList.toggle('active', isActive);
         button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
+}
+
+function resetBrowseFilterStateToAll() {
+    window.__browseFilterMode = 'default';
+    window.__browsePath = null;
+    updateBrowseFrequencyButtons('all');
+
+    if (window.browseController) {
+        window.browseController.currentMode = 'default';
+        window.browseController.activeFilter = 'all';
+    }
+    if (typeof setBrowseFilterState === 'function') {
+        setBrowseFilterState('all', 'all');
+    }
 }
 
 function setupBrowseFrequencyFilterControl() {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5324,35 +5324,58 @@
         }
     }
 
-    async function resetBrowseFunctionalStateForActivation() {
+    async function resetBrowseFunctionalStateForActivation(options = {}) {
+        const isCurrent = typeof options.isCurrent === 'function'
+            ? options.isCurrent
+            : () => true;
         try {
+            if (!isCurrent()) {
+                return false;
+            }
             const manager = ensureBrowseStateManagerForReset();
             if (manager && manager.ready && typeof manager.ready.then === 'function') {
                 await manager.ready;
+                if (!isCurrent()) {
+                    return false;
+                }
             }
             if (typeof global.setupBrowseControls === 'function') {
                 await global.setupBrowseControls();
+                if (!isCurrent()) {
+                    return false;
+                }
             }
-            if (!applyBrowseResetState(null)) {
+            if (!isCurrent() || !applyBrowseResetState(null)) {
                 return false;
             }
 
             if (typeof global.saveBrowseViewPreferences !== 'function'
-                || typeof global.flushBrowsePreferenceWrites !== 'function') {
+                || typeof global.flushBrowsePreferenceWrites !== 'function'
+                || !isCurrent()) {
                 return false;
             }
             global.saveBrowseViewPreferences({
                 lastFilter: { category: 'all', type: 'all' }
             });
             const committedBrowsePreferences = await global.flushBrowsePreferenceWrites();
-            if (!committedBrowsePreferences
+            if (!isCurrent()
+                || !committedBrowsePreferences
                 || !isAllBrowseFilter(committedBrowsePreferences.lastFilter)) {
                 return false;
             }
             if (manager && typeof manager.persistState === 'function') {
+                if (!isCurrent()) {
+                    return false;
+                }
                 await manager.persistState();
+                if (!isCurrent()) {
+                    return false;
+                }
             }
-            if (!await persistBrowseFrequencyReset() || !isBrowseManagerReset(manager)) {
+            if (!isCurrent()
+                || !await persistBrowseFrequencyReset()
+                || !isCurrent()
+                || !isBrowseManagerReset(manager)) {
                 return false;
             }
             const preferences = global.AppData && global.AppData.preferences;
@@ -5360,7 +5383,7 @@
                 return false;
             }
             const persistedBrowse = await preferences.getBrowse();
-            return isPersistedBrowseReset(
+            return isCurrent() && isPersistedBrowseReset(
                 persistedBrowse,
                 !!(manager && typeof manager.persistState === 'function')
             );
@@ -5538,6 +5561,9 @@
         if (Array.isArray(examIndex) && examIndex.length > 0) {
             let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
+            if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                return false;
+            }
             resetIndexSnapshot = closeBrowseResetIntent(
                 resetIntent,
                 resetIndexSnapshotVersion
@@ -5557,6 +5583,9 @@
         }
 
         await beginBrowseResetPersistence();
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
         closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
         console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
         return false;
@@ -5574,12 +5603,35 @@
             && typeof global.__beginBrowseResetIntent === 'function') {
             resetIntent = global.__beginBrowseResetIntent();
         }
+        const functionalResetRecovery = global.AppEntry
+            && typeof global.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+            ? global.AppEntry.captureBrowseFunctionalResetRecovery()
+            : null;
+        let functionalResetRecoverySucceeded = false;
         try {
-            return await performBrowseViewResetToAll(resetIntent);
+            const resetPromise = performBrowseViewResetToAll(resetIntent);
+            if (functionalResetRecovery
+                && global.AppEntry
+                && typeof global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
+                global.AppEntry.updateBrowseFunctionalResetRecoveryResultsRequest(
+                    functionalResetRecovery
+                );
+            }
+            const result = await resetPromise;
+            functionalResetRecoverySucceeded = result !== false;
+            return result;
         } catch (error) {
             console.warn('[ExamActions] 重置浏览视图失败:', error);
             return false;
         } finally {
+            if (functionalResetRecovery
+                && global.AppEntry
+                && typeof global.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+                global.AppEntry.completeBrowseFunctionalResetRecovery(
+                    functionalResetRecovery,
+                    functionalResetRecoverySucceeded
+                );
+            }
             if (typeof global.__endBrowseResetIntent === 'function') {
                 global.__endBrowseResetIntent(resetIntent);
             }
@@ -17722,10 +17774,10 @@ let lastPracticeRecordsSignature = null;
 let practiceRecordsSyncInvocationGeneration = 0;
 let practiceRecordsDataGeneration = 0;
 let practiceRecordsCommitSubscriptionAttached = false;
+const activePracticeRecordsSyncInvocations = new Map();
 const PRACTICE_RECORD_ENTITY_STORES = new Set([
     'practiceSummaries',
-    'practiceDetails',
-    'practiceAnnotations'
+    'practiceDetails'
 ]);
 
 function ensurePracticeRecordsCommitSubscription() {
@@ -17746,6 +17798,17 @@ function ensurePracticeRecordsCommitSubscription() {
         });
         if (touchesPracticeRecords) {
             practiceRecordsDataGeneration += 1;
+            if (activePracticeRecordsSyncInvocations.size > 0) {
+                const replacementMode = Array.from(
+                    activePracticeRecordsSyncInvocations.values()
+                ).some((activeOptions) => activeOptions && activeOptions.mode === 'full')
+                    ? 'full'
+                    : 'summary';
+                startPracticeRecordsSyncInBackground('practice-data-committed', {
+                    forceRender: true,
+                    mode: replacementMode
+                });
+            }
         }
     });
     practiceRecordsCommitSubscriptionAttached = true;
@@ -17754,6 +17817,16 @@ function ensurePracticeRecordsCommitSubscription() {
 async function syncPracticeRecords(options = {}) {
     ensurePracticeRecordsCommitSubscription();
     const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
+    const normalizedOptions = normalizePracticeRecordsSyncOptions(options);
+    activePracticeRecordsSyncInvocations.set(invocationGeneration, normalizedOptions);
+    try {
+        return await executePracticeRecordsSync(normalizedOptions, invocationGeneration);
+    } finally {
+        activePracticeRecordsSyncInvocations.delete(invocationGeneration);
+    }
+}
+
+async function executePracticeRecordsSync(options, invocationGeneration) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
@@ -19482,12 +19555,19 @@ function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
         source,
         'activeLibraryGeneration'
     );
+    const hasSourcePracticeRecordsDataGeneration = Object.prototype.hasOwnProperty.call(
+        source,
+        'practiceRecordsDataGeneration'
+    );
     const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration: hasSourcePracticeRecordsDataGeneration
+            ? source.practiceRecordsDataGeneration
+            : practiceRecordsDataGeneration,
         resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
         functionalResetGeneration: functionalResetState.generation,
         functionalResetWasPending: functionalResetState.status === 'pending'
@@ -19507,8 +19587,15 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
         }
         return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
     });
-    if (!ordinaryGenerationsAreCurrent || captured.functionalResetGeneration == null) {
-        return ordinaryGenerationsAreCurrent;
+    if (!ordinaryGenerationsAreCurrent) {
+        return false;
+    }
+    if (captured.practiceRecordsDataGeneration != null
+        && captured.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+        return false;
+    }
+    if (captured.functionalResetGeneration == null) {
+        return true;
     }
     return readBrowseFunctionalResetState().generation === captured.functionalResetGeneration;
 }
@@ -19950,6 +20037,11 @@ async function applyBrowseFilter(
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    const functionalResetRecovery = window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
@@ -20050,6 +20142,8 @@ async function applyBrowseFilter(
         if (typeof window.showView === 'function' && !document.getElementById('browse-view')?.classList.contains('active')) {
             window.showView('browse', false);
         }
+        functionalResetRecoverySucceeded = true;
+        return true;
     } catch (e) {
         if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
             return false;
@@ -20067,7 +20161,16 @@ async function applyBrowseFilter(
             }
             try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
         }, 0);
+        return false;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -20151,6 +20254,12 @@ async function initializeBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
+    const functionalResetRecovery = !options.skipLoad
+        && window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         console.log('[System] Initializing browse view...');
         const [examIndex] = await Promise.all([
@@ -20199,10 +20308,22 @@ async function initializeBrowseView(options = {}) {
         setupBrowseSortControl();
         setupBrowseFrequencyFilterControl();
         if (!options.skipLoad) {
-            await renderBrowseResultsForState(examIndex, activeRequestId);
+            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId);
+            if (renderResult === false || !isBrowseResultsRequestCurrent(activeRequestId)) {
+                return null;
+            }
+            functionalResetRecoverySucceeded = true;
         }
         return examIndex;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -20214,6 +20335,11 @@ async function activateBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
+    const functionalResetRecovery = window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         const examIndex = await initializeBrowseView({
             skipLoad: true,
@@ -20222,8 +20348,19 @@ async function activateBrowseView(options = {}) {
         if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
             return false;
         }
-        return renderBrowseResultsForState(examIndex, activeRequestId);
+        const result = await renderBrowseResultsForState(examIndex, activeRequestId);
+        functionalResetRecoverySucceeded = result !== false
+            && isBrowseResultsRequestCurrent(activeRequestId);
+        return result;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -16757,6 +16757,9 @@ window.BrowseStateManager = BrowseStateManager;
     let browsePreferencesReady = null;
     let browsePreferenceWriteQueue = Promise.resolve();
     const pendingBrowsePreferenceWrites = [];
+    let browseAnchorProjection = null;
+    let browseAnchorProjectionRevision = 0;
+    let browseAnchorPersistenceDebt = null;
     let currentBrowseScrollElement = null;
     let removeBrowseScrollListener = null;
     let pendingBrowseAutoScroll = null;
@@ -16918,7 +16921,16 @@ window.BrowseStateManager = BrowseStateManager;
         if (!browsePreferencesCache) {
             browsePreferencesCache = loadBrowsePreferencesFromStorage();
         }
-        return browsePreferencesCache;
+        if (!browseAnchorProjection) {
+            return browsePreferencesCache;
+        }
+        return Object.assign({}, browsePreferencesCache, {
+            // Anchors are a derived live projection. Keep the accepted
+            // generation visible while its durable write is still pending or
+            // has failed; user-authored preferences remain committed-cache
+            // values until their existing write contract completes.
+            listAnchors: mergeBrowseAnchors({}, browseAnchorProjection.anchors)
+        });
     }
 
     async function whenBrowseViewPreferencesReady() {
@@ -16929,10 +16941,13 @@ window.BrowseStateManager = BrowseStateManager;
         return getBrowseViewPreferences();
     }
 
-    function mergeBrowsePreferences(current, partial = {}) {
+    function mergeBrowsePreferences(current, partial = {}, options = {}) {
+        const replaceListAnchors = options.replaceListAnchors === true;
         return {
             scrollPositions: Object.assign({}, current.scrollPositions, partial.scrollPositions || {}),
-            listAnchors: mergeBrowseAnchors(current.listAnchors, partial.listAnchors),
+            listAnchors: replaceListAnchors
+                ? mergeBrowseAnchors({}, partial.listAnchors)
+                : mergeBrowseAnchors(current.listAnchors, partial.listAnchors),
             autoScrollEnabled: Object.prototype.hasOwnProperty.call(partial, 'autoScrollEnabled')
                 ? !!partial.autoScrollEnabled
                 : current.autoScrollEnabled,
@@ -16942,33 +16957,75 @@ window.BrowseStateManager = BrowseStateManager;
         };
     }
 
-    function saveBrowseViewPreferences(partial = {}) {
-        const request = { partial: Object.assign({}, partial) };
+    function removePendingBrowsePreferenceWrite(request) {
+        const index = pendingBrowsePreferenceWrites.indexOf(request);
+        if (index >= 0) {
+            pendingBrowsePreferenceWrites.splice(index, 1);
+        }
+    }
+
+    function enqueueBrowsePreferenceWrite(partial = {}, options = {}) {
+        const request = {
+            partial: Object.assign({}, partial),
+            replaceListAnchors: options.replaceListAnchors === true,
+            anchorRevision: Number.isFinite(Number(options.anchorRevision))
+                ? Number(options.anchorRevision)
+                : null
+        };
         pendingBrowsePreferenceWrites.push(request);
         const preview = pendingBrowsePreferenceWrites.reduce(
-            (current, pending) => mergeBrowsePreferences(current, pending.partial),
+            (current, pending) => mergeBrowsePreferences(
+                current,
+                pending.partial,
+                pending
+            ),
             getBrowseViewPreferences()
         );
 
         if (!global.AppData || !global.AppData.preferences) {
-            pendingBrowsePreferenceWrites.splice(pendingBrowsePreferenceWrites.indexOf(request), 1);
+            removePendingBrowsePreferenceWrite(request);
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
             console.warn('[BrowsePreferences] AppData.preferences 不可用，偏好未保存');
-            return preview;
+            return { preview, outcome: Promise.resolve(false) };
         }
 
-        browsePreferenceWriteQueue = browsePreferenceWriteQueue.then(async () => {
+        const outcome = browsePreferenceWriteQueue.then(async () => {
             await global.AppData.ready;
             if (browsePreferencesReady) await browsePreferencesReady;
-            const next = mergeBrowsePreferences(getBrowseViewPreferences(), request.partial);
+            const next = mergeBrowsePreferences(
+                getBrowseViewPreferences(),
+                request.partial,
+                request
+            );
             await global.AppData.preferences.patchBrowse(next);
             browsePreferencesCache = next;
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt = null;
+            }
+            return true;
         }).catch((error) => {
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
             console.warn('[BrowsePreferences] 保存浏览偏好失败，保留上次已提交值', error);
+            return false;
         }).finally(() => {
-            const index = pendingBrowsePreferenceWrites.indexOf(request);
-            if (index >= 0) pendingBrowsePreferenceWrites.splice(index, 1);
+            removePendingBrowsePreferenceWrite(request);
         });
-        return preview;
+        browsePreferenceWriteQueue = outcome.then(() => undefined);
+        return { preview, outcome };
+    }
+
+    function saveBrowseViewPreferences(partial = {}) {
+        return enqueueBrowsePreferenceWrite(partial).preview;
     }
 
     function flushBrowsePreferenceWrites() {
@@ -17511,7 +17568,6 @@ window.BrowseStateManager = BrowseStateManager;
         const list = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const updates = {};
-        const seenKeys = new Set();
 
         list.forEach((record) => {
             const info = resolveRecordExamInfo(record, indexSnapshot);
@@ -17532,32 +17588,95 @@ window.BrowseStateManager = BrowseStateManager;
             if (!existing || timestamp > existing.timestamp) {
                 updates[key] = anchor;
             }
-            seenKeys.add(key);
         });
 
-        const currentAnchors = getBrowseViewPreferences().listAnchors || {};
-        Object.keys(currentAnchors || {}).forEach((key) => {
-            if (!seenKeys.has(key)) {
-                updates[key] = null;
-            }
-        });
-
-        return updates;
+        // The Practice record list is authoritative, so stage a complete
+        // immutable projection instead of a delta against possibly stale
+        // durable preferences. A newer snapshot therefore replaces every
+        // anchor omitted from it without relying on deletion tombstones.
+        return mergeBrowseAnchors({}, updates);
     }
 
-    function commitBrowseAnchorUpdates(updates) {
+    function readBrowseAnchorPublicationGeneration(publication) {
+        const raw = publication && typeof publication === 'object'
+            ? publication.practiceProjectionGeneration
+            : publication;
+        if (raw == null) {
+            return null;
+        }
+        const generation = Number(raw);
+        return Number.isFinite(generation) ? generation : null;
+    }
+
+    function getBrowseAnchorProjectionState() {
+        if (!browseAnchorProjection) {
+            return { revision: 0, generation: null, persistence: 'idle' };
+        }
+        const debt = browseAnchorPersistenceDebt
+            && browseAnchorPersistenceDebt.revision === browseAnchorProjection.revision
+            ? browseAnchorPersistenceDebt
+            : null;
+        return {
+            revision: browseAnchorProjection.revision,
+            generation: browseAnchorProjection.generation,
+            persistence: debt ? debt.status : 'persisted'
+        };
+    }
+
+    function commitBrowseAnchorUpdates(updates, publication = null) {
         if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
             return false;
         }
-        if (Object.keys(updates).length > 0) {
-            saveBrowseViewPreferences({ listAnchors: updates });
+        let anchors;
+        try {
+            anchors = mergeBrowseAnchors({}, updates);
+        } catch (_) {
+            return false;
+        }
+        const generation = readBrowseAnchorPublicationGeneration(publication);
+        if (generation != null
+            && browseAnchorProjection
+            && browseAnchorProjection.generation != null
+            && generation <= browseAnchorProjection.generation) {
+            return false;
+        }
+
+        const revision = browseAnchorProjectionRevision + 1;
+        const acceptedProjection = {
+            anchors,
+            generation: generation != null
+                ? generation
+                : (browseAnchorProjection ? browseAnchorProjection.generation : null),
+            revision
+        };
+        // This is the anchor publication point: one synchronous assignment
+        // makes the newest full snapshot visible to consumers and subsequent
+        // preparation before any durable write can settle.
+        browseAnchorProjectionRevision = revision;
+        browseAnchorProjection = acceptedProjection;
+        // Keep only the current projection debt. A later accepted full
+        // snapshot supersedes it and retries through the same preference
+        // queue; no independent retry scheduler is introduced here.
+        browseAnchorPersistenceDebt = { revision, status: 'pending' };
+
+        try {
+            enqueueBrowsePreferenceWrite(
+                { listAnchors: anchors },
+                { replaceListAnchors: true, anchorRevision: revision }
+            );
+        } catch (error) {
+            if (browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === revision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
+            console.warn('[BrowsePreferences] 浏览锚点持久化排队失败', error);
         }
         return true;
     }
 
-    function updateBrowseAnchorsFromRecords(records, examIndex) {
+    function updateBrowseAnchorsFromRecords(records, examIndex, publication = null) {
         const updates = prepareBrowseAnchorUpdates(records, examIndex);
-        commitBrowseAnchorUpdates(updates);
+        commitBrowseAnchorUpdates(updates, publication);
         return updates;
     }
 
@@ -17589,6 +17708,7 @@ window.BrowseStateManager = BrowseStateManager;
     global.getPersistedBrowseFilter = getPersistedBrowseFilter;
     global.prepareBrowseAnchorUpdates = prepareBrowseAnchorUpdates;
     global.commitBrowseAnchorUpdates = commitBrowseAnchorUpdates;
+    global.getBrowseAnchorProjectionState = getBrowseAnchorProjectionState;
     global.updateBrowseAnchorsFromRecords = updateBrowseAnchorsFromRecords;
 
     global.setBrowseTitle = setBrowseTitle;
@@ -19734,8 +19854,10 @@ function refreshBrowseProgressFromRecords(
             return false;
         }
         // Both derived states are built without mutation. Validate the
-        // completion candidate before accepting the anchor queue; the later
-        // completion commit is then one non-throwing assignment.
+        // completion candidate before publishing the generation-fenced live
+        // anchor snapshot; durable anchor persistence remains downstream of
+        // that accepted projection. The completion commit is then one
+        // non-throwing assignment.
         const preparedCompletionIndex = prepareBrowseCompletionIndex(recordSnapshot);
         if (!isPreparedBrowseCompletionIndex(preparedCompletionIndex)) {
             return false;
@@ -19744,7 +19866,13 @@ function refreshBrowseProgressFromRecords(
             recordSnapshot,
             indexSnapshot
         );
-        if (commitBrowseAnchorUpdates(preparedAnchorUpdates) !== true) {
+        const anchorPublication = candidatePracticeProjectionGeneration != null
+            ? { practiceProjectionGeneration: candidatePracticeProjectionGeneration }
+            : null;
+        if (commitBrowseAnchorUpdates(
+            preparedAnchorUpdates,
+            anchorPublication
+        ) !== true) {
             return false;
         }
         commitBrowseCompletionIndex(preparedCompletionIndex);

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -17722,6 +17722,9 @@ let lastPracticeRecordsSignature = null;
 async function syncPracticeRecords(options = {}) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
+    const browseProgressSourceEpoch = {
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
+    };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
     let [records, insightRecords, examIndex] = await Promise.all([
@@ -17793,7 +17796,7 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    refreshBrowseProgressFromRecords(records, examIndex);
+    refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
@@ -17803,16 +17806,65 @@ async function syncPracticeRecords(options = {}) {
 }
 
 let practiceRecordsLoadPromise = null;
+let pendingPracticeRecordsSyncRequest = null;
+
+function queuePendingPracticeRecordsSync(trigger, options = {}) {
+    const previous = pendingPracticeRecordsSyncRequest;
+    const previousOptions = previous && previous.options ? previous.options : {};
+    const nextOptions = Object.assign({}, previousOptions, options || {});
+    nextOptions.forceRender = !!(previousOptions.forceRender || (options && options.forceRender));
+    nextOptions.mode = previousOptions.mode === 'full' || (options && options.mode === 'full')
+        ? 'full'
+        : 'summary';
+    pendingPracticeRecordsSyncRequest = {
+        trigger,
+        options: nextOptions
+    };
+}
+
+async function drainPracticeRecordsSyncQueue(initialRequest) {
+    let request = initialRequest;
+    let result = null;
+    try {
+        while (request) {
+            let syncError = null;
+            try {
+                result = await syncPracticeRecords(Object.assign(
+                    { mode: 'summary' },
+                    request.options || {}
+                ));
+            } catch (error) {
+                syncError = error;
+            }
+            const nextRequest = pendingPracticeRecordsSyncRequest;
+            pendingPracticeRecordsSyncRequest = null;
+            if (syncError && !nextRequest) {
+                throw syncError;
+            }
+            if (syncError) {
+                console.warn(
+                    `[System] 练习记录同步失败(${request.trigger})，继续处理已排队的最新请求:`,
+                    syncError
+                );
+            }
+            request = nextRequest;
+        }
+        return result;
+    } finally {
+        practiceRecordsLoadPromise = null;
+    }
+}
+
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
     if (practiceRecordsLoadPromise) {
+        queuePendingPracticeRecordsSync(trigger, options);
         return practiceRecordsLoadPromise;
     }
-    const loadTask = (async () => {
-        return syncPracticeRecords(Object.assign({ mode: 'summary' }, options || {}));
-    })();
-    practiceRecordsLoadPromise = loadTask.finally(() => {
-        practiceRecordsLoadPromise = null;
-    });
+    const initialRequest = {
+        trigger,
+        options: Object.assign({}, options || {})
+    };
+    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(initialRequest);
     return practiceRecordsLoadPromise;
 }
 
@@ -19260,8 +19312,61 @@ function clearPracticeHistorySearch() {
     searchPracticeHistory('');
 }
 
-let pendingBrowseProgressRefreshIndex = null;
+let pendingBrowseProgressRefresh = null;
 let browseProgressRefreshRetryTimer = null;
+
+function readBrowseProgressGeneration(getterName) {
+    const getter = window && typeof window[getterName] === 'function'
+        ? window[getterName]
+        : null;
+    if (!getter) {
+        return null;
+    }
+    try {
+        const value = Number(getter());
+        return Number.isFinite(value) ? value : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
+    const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
+    const hasSourceLibraryGeneration = Object.prototype.hasOwnProperty.call(
+        source,
+        'activeLibraryGeneration'
+    );
+    return {
+        navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
+        activeLibraryGeneration: hasSourceLibraryGeneration
+            ? source.activeLibraryGeneration
+            : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration')
+    };
+}
+
+function isBrowseProgressRefreshEpochCurrent(epoch) {
+    const captured = epoch && typeof epoch === 'object' ? epoch : {};
+    const generationGetters = {
+        navigationGeneration: '__getAppNavigationIntentGeneration',
+        activeLibraryGeneration: '__getActiveLibraryGeneration',
+        resetGeneration: '__getBrowseResetIntentGeneration'
+    };
+    return Object.keys(generationGetters).every((key) => {
+        if (captured[key] == null) {
+            return true;
+        }
+        return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
+    });
+}
+
+function clearPendingBrowseProgressRefresh() {
+    pendingBrowseProgressRefresh = null;
+    if (browseProgressRefreshRetryTimer != null) {
+        clearTimeout(browseProgressRefreshRetryTimer);
+        browseProgressRefreshRetryTimer = null;
+    }
+}
 
 function retryPendingBrowseProgressRefresh() {
     if (browseProgressRefreshRetryTimer != null) {
@@ -19274,13 +19379,18 @@ function retryPendingBrowseProgressRefresh() {
 }
 
 function flushPendingBrowseProgressRefresh() {
-    if (!Array.isArray(pendingBrowseProgressRefreshIndex)) {
+    const pending = pendingBrowseProgressRefresh;
+    if (!pending || !Array.isArray(pending.index)) {
+        return;
+    }
+    if (!isBrowseProgressRefreshEpochCurrent(pending.epoch)) {
+        clearPendingBrowseProgressRefresh();
         return;
     }
     const browseView = document.getElementById('browse-view');
     const isBrowseActive = browseView && browseView.classList.contains('active');
     if (!isBrowseActive) {
-        pendingBrowseProgressRefreshIndex = null;
+        clearPendingBrowseProgressRefresh();
         return;
     }
     const resetInFlight = typeof window.__isBrowseResetIntentInFlight === 'function'
@@ -19292,27 +19402,36 @@ function flushPendingBrowseProgressRefresh() {
     if (isBrowseUserResultsRequestInFlight(browseResultsRequestId)) {
         return;
     }
-    const indexSnapshot = pendingBrowseProgressRefreshIndex;
-    pendingBrowseProgressRefreshIndex = null;
+    const indexSnapshot = pending.index;
+    clearPendingBrowseProgressRefresh();
     Promise.resolve(renderBrowseResultsForState(indexSnapshot)).catch((error) => {
         console.warn('[Browse] 刷新浏览进度列表失败:', error);
     });
 }
 
-function refreshBrowseProgressFromRecords(records, examIndex) {
+function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = null) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
-        if (typeof updateBrowseAnchorsFromRecords === 'function') {
-            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
-        }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
             rebuildBrowseCompletionIndex(recordSnapshot);
+        }
+        const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
+        if (!isBrowseProgressRefreshEpochCurrent({
+            activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
+        })) {
+            return;
+        }
+        if (typeof updateBrowseAnchorsFromRecords === 'function') {
+            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
         }
         const browseView = document.getElementById('browse-view');
         const isBrowseActive = browseView && browseView.classList.contains('active');
         if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
-            pendingBrowseProgressRefreshIndex = indexSnapshot;
+            pendingBrowseProgressRefresh = {
+                index: indexSnapshot,
+                epoch: pendingEpoch
+            };
             flushPendingBrowseProgressRefresh();
         }
     } catch (error) {
@@ -19785,6 +19904,77 @@ async function applyBrowseFilter(
     }
 }
 
+function getLiveBrowseFilterSnapshot() {
+    let filter = null;
+    if (typeof window.getBrowseFilterState === 'function') {
+        try {
+            filter = window.getBrowseFilterState();
+        } catch (_) { }
+    }
+    const rawCategory = filter && typeof filter.category === 'string'
+        ? filter.category
+        : (typeof window.getCurrentCategory === 'function' ? window.getCurrentCategory() : 'all');
+    const rawType = filter && typeof filter.type === 'string'
+        ? filter.type
+        : (typeof window.getCurrentExamType === 'function' ? window.getCurrentExamType() : 'all');
+    const category = typeof window.normalizeCategoryKey === 'function'
+        ? window.normalizeCategoryKey(rawCategory)
+        : (typeof rawCategory === 'string' && rawCategory.trim() ? rawCategory.trim() : 'all');
+    const type = typeof window.normalizeExamType === 'function'
+        ? window.normalizeExamType(rawType)
+        : (rawType === 'reading' || rawType === 'listening' ? rawType : 'all');
+    return { category, type };
+}
+
+function browseFiltersMatch(left, right) {
+    return !!left && !!right
+        && left.category === right.category
+        && left.type === right.type;
+}
+
+async function persistAuthoritativeBrowseFilterBeforeHydration(activeRequestId) {
+    if (typeof window.persistBrowseFilter !== 'function'
+        || typeof window.flushBrowsePreferenceWrites !== 'function'
+        || !window.AppData
+        || !window.AppData.preferences
+        || typeof window.AppData.preferences.getBrowse !== 'function') {
+        return false;
+    }
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        const revisionBefore = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : 0;
+        const filterSnapshot = getLiveBrowseFilterSnapshot();
+        let durablePreferences;
+        try {
+            window.persistBrowseFilter(filterSnapshot.category, filterSnapshot.type);
+            await window.flushBrowsePreferenceWrites();
+            durablePreferences = await window.AppData.preferences.getBrowse();
+        } catch (error) {
+            console.warn('[Browse] 持久化权威筛选失败:', error);
+            return false;
+        }
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        const revisionAfter = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : revisionBefore;
+        const currentFilter = getLiveBrowseFilterSnapshot();
+        if (revisionAfter !== revisionBefore || !browseFiltersMatch(currentFilter, filterSnapshot)) {
+            continue;
+        }
+        return browseFiltersMatch(
+            durablePreferences && durablePreferences.lastFilter,
+            filterSnapshot
+        );
+    }
+    return false;
+}
+
 // Initialize browse view when it's activated
 async function initializeBrowseView(options = {}) {
     const userRequestId = options.renderRequestId == null
@@ -19818,6 +20008,13 @@ async function initializeBrowseView(options = {}) {
             ? Number(window.getBrowseFilterMutationRevision()) || 0
             : 0;
         if (!browseInitialFilterHydrationConsumed && browseFilterMutationRevision > 0) {
+            const persistedAuthoritativeFilter = await persistAuthoritativeBrowseFilterBeforeHydration(
+                activeRequestId
+            );
+            if (!persistedAuthoritativeFilter || !isBrowseResultsRequestCurrent(activeRequestId)) {
+                console.warn('[Browse] 权威筛选尚未持久化，已推迟首次 hydration');
+                return null;
+            }
             browseInitialFilterHydrationConsumed = true;
         } else if (!browseInitialFilterHydrationConsumed) {
             const persisted = getPersistedBrowseFilter();

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5200,11 +5200,52 @@
         }
     }
 
+    function getBrowseResetIndexSnapshot(resetIntent) {
+        if (typeof global.__getBrowseResetIndexSnapshot !== 'function') {
+            return null;
+        }
+        try {
+            const snapshot = global.__getBrowseResetIndexSnapshot(resetIntent);
+            if (!snapshot || !Array.isArray(snapshot.index)) {
+                return null;
+            }
+            return {
+                index: snapshot.index,
+                version: Number(snapshot.version) || 0
+            };
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function closeBrowseResetIntent(resetIntent, consumedSnapshotVersion) {
+        if (typeof global.__closeBrowseResetIntent !== 'function') {
+            return null;
+        }
+        try {
+            const finalization = global.__closeBrowseResetIntent(
+                resetIntent,
+                consumedSnapshotVersion
+            );
+            if (!finalization || !finalization.snapshot
+                || !Array.isArray(finalization.snapshot.index)) {
+                return null;
+            }
+            return {
+                index: finalization.snapshot.index,
+                version: Number(finalization.snapshot.version) || 0
+            };
+        } catch (_) {
+            return null;
+        }
+    }
+
     /**
-     * 重置浏览视图。先解析活动题库快照，再一次性更新 UI/状态并交给
-     * 全局 loadExamList 适配器渲染，避免 IIFE 内部默认 [] 覆盖列表。
+     * 重置浏览视图。先等待浏览状态恢复，再解析活动题库快照并一次性更新
+     * UI/状态，避免恢复期间的题库切换被较早快照覆盖。
      */
-    async function performBrowseViewResetToAll() {
+    async function performBrowseViewResetToAll(resetIntent) {
+        try {
         const interactionId = ++browseResetInteractionId;
         if (global.__pendingBrowseFilter) {
             delete global.__pendingBrowseFilter;
@@ -5212,6 +5253,9 @@
         const renderRequestId = typeof global.__beginBrowseResultsRequest === 'function'
             ? global.__beginBrowseResultsRequest()
             : null;
+        if (typeof global.__setBrowseResetResultsRequest === 'function') {
+            global.__setBrowseResetResultsRequest(resetIntent, renderRequestId);
+        }
 
         if (global.browseController) {
             if (typeof global.browseController.filterInteractionId === 'number') {
@@ -5224,21 +5268,33 @@
             global.clearPendingBrowseAutoScroll();
         }
 
-        const resolver = typeof global.resolveActiveLibraryIndex === 'function'
-            ? global.resolveActiveLibraryIndex
-            : global.resolveActiveExamIndex;
-        const indexPromise = typeof resolver === 'function'
-            ? Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
-                Array.isArray(resolved) ? resolved : null
-            )).catch((error) => {
-                console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
-                return null;
-            })
-            : Promise.resolve(null);
-        const [examIndex] = await Promise.all([
-            indexPromise,
-            prepareBrowseReset()
-        ]);
+        await prepareBrowseReset();
+
+        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+            return false;
+        }
+
+        let resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+        let examIndex = resetIndexSnapshot ? resetIndexSnapshot.index : null;
+        let resetIndexSnapshotVersion = resetIndexSnapshot ? resetIndexSnapshot.version : 0;
+        if (!resetIndexSnapshot) {
+            const resolver = typeof global.resolveActiveLibraryIndex === 'function'
+                ? global.resolveActiveLibraryIndex
+                : global.resolveActiveExamIndex;
+            examIndex = typeof resolver === 'function'
+                ? await Promise.resolve().then(() => resolver.call(global)).then((resolved) => (
+                    Array.isArray(resolved) ? resolved : null
+                )).catch((error) => {
+                    console.warn('[ExamActions] 重置浏览视图时无法预取活动题库:', error);
+                    return null;
+                })
+                : null;
+            resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+            if (resetIndexSnapshot) {
+                examIndex = resetIndexSnapshot.index;
+                resetIndexSnapshotVersion = resetIndexSnapshot.version;
+            }
+        }
 
         if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
             return false;
@@ -5248,30 +5304,60 @@
 
         const globalLoader = global.loadExamList;
         if (typeof globalLoader === 'function' && globalLoader !== loadExamList) {
-            // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
-            const indexOverride = Array.isArray(examIndex) && examIndex.length > 0 ? examIndex : null;
-            let renderPromise;
-            try {
-                renderPromise = Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
-            } catch (error) {
-                renderPromise = Promise.reject(error);
-            }
             const persistencePromise = beginBrowseResetPersistence();
             try {
-                const result = await renderPromise;
-                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
-                    await persistencePromise;
-                    return false;
+                let result;
+                let persistenceComplete = false;
+                while (true) {
+                    // 空索引也交由适配器自行解析；绝不把 [] 当作重置结果渲染。
+                    const indexOverride = Array.isArray(examIndex) && examIndex.length > 0
+                        ? examIndex
+                        : null;
+                    result = await Promise.resolve(globalLoader.call(global, indexOverride, renderRequestId));
+                    if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                        await persistencePromise;
+                        return false;
+                    }
+                    if ((!Array.isArray(examIndex) || examIndex.length === 0)
+                        && Array.isArray(result)) {
+                        syncBrowseFilterUI(result);
+                    }
+                    resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+                    if (resetIndexSnapshot
+                        && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                        examIndex = resetIndexSnapshot.index;
+                        resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                        syncBrowseFilterUI(examIndex);
+                        continue;
+                    }
+                    if (!persistenceComplete) {
+                        await persistencePromise;
+                        persistenceComplete = true;
+                        if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
+                            return false;
+                        }
+                        resetIndexSnapshot = getBrowseResetIndexSnapshot(resetIntent);
+                        if (resetIndexSnapshot
+                            && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                            examIndex = resetIndexSnapshot.index;
+                            resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                            syncBrowseFilterUI(examIndex);
+                            continue;
+                        }
+                    }
+                    resetIndexSnapshot = closeBrowseResetIntent(
+                        resetIntent,
+                        resetIndexSnapshotVersion
+                    );
+                    if (resetIndexSnapshot
+                        && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                        examIndex = resetIndexSnapshot.index;
+                        resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                        syncBrowseFilterUI(examIndex);
+                        continue;
+                    }
+                    return result;
                 }
-                if ((!Array.isArray(examIndex) || examIndex.length === 0)
-                    && Array.isArray(result)) {
-                    syncBrowseFilterUI(result);
-                }
-                await persistencePromise;
-                if (!isBrowseResetCurrent(interactionId, renderRequestId)) {
-                    return false;
-                }
-                return result;
             } catch (error) {
                 console.warn('[ExamActions] 重置浏览视图加载失败:', error);
                 await persistencePromise;
@@ -5280,22 +5366,53 @@
         }
 
         if (Array.isArray(examIndex) && examIndex.length > 0) {
-            const result = loadExamList(examIndex);
+            let result = loadExamList(examIndex);
             await beginBrowseResetPersistence();
+            resetIndexSnapshot = closeBrowseResetIntent(
+                resetIntent,
+                resetIndexSnapshotVersion
+            );
+            if (resetIndexSnapshot && resetIndexSnapshot.version > resetIndexSnapshotVersion) {
+                examIndex = resetIndexSnapshot.index;
+                resetIndexSnapshotVersion = resetIndexSnapshot.version;
+                if (examIndex.length > 0) {
+                    syncBrowseFilterUI(examIndex);
+                    result = loadExamList(examIndex);
+                } else {
+                    result = false;
+                }
+                closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
+            }
             return result;
         }
 
         await beginBrowseResetPersistence();
+        closeBrowseResetIntent(resetIntent, resetIndexSnapshotVersion);
         console.warn('[ExamActions] 全局题库加载适配器不可用，已跳过空数组渲染');
         return false;
+        } finally {
+            if (typeof global.__endBrowseResetIntent === 'function') {
+                global.__endBrowseResetIntent(resetIntent);
+            }
+        }
     }
 
     async function resetBrowseViewToAll() {
+        var resetIntent = arguments.length > 0 ? arguments[arguments.length - 1] : null;
+        if (typeof global.__isBrowseResetIntentCurrent === 'function'
+            && !global.__isBrowseResetIntentCurrent(resetIntent)
+            && typeof global.__beginBrowseResetIntent === 'function') {
+            resetIntent = global.__beginBrowseResetIntent();
+        }
         try {
-            return await performBrowseViewResetToAll();
+            return await performBrowseViewResetToAll(resetIntent);
         } catch (error) {
             console.warn('[ExamActions] 重置浏览视图失败:', error);
             return false;
+        } finally {
+            if (typeof global.__endBrowseResetIntent === 'function') {
+                global.__endBrowseResetIntent(resetIntent);
+            }
         }
     }
 
@@ -19136,6 +19253,9 @@ function isBrowseResultsRequestCurrent(requestId) {
 
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
+window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+    return browseResultsRequestId;
+};
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
     const activeRequestId = renderRequestId == null
@@ -19209,8 +19329,10 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
 }
 
 // 应用分类筛选（供 App/总览调用）
-async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null) {
-    const activeRequestId = beginBrowseResultsRequest();
+async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
@@ -20120,8 +20242,13 @@ async function setActiveLibraryConfiguration(key) {
 
 let debouncedExamSearch = null;
 
-function searchExams(query) {
-    const activeRequestId = beginBrowseResultsRequest();
+function searchExams(query, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
+    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+        return false;
+    }
     toggleSearchClearButton(query);
     if (window.performanceOptimizer && typeof window.performanceOptimizer.debounce === 'function') {
         // 跨 input 事件复用同一个 debounce 闭包，避免每个字符都排队一次搜索。

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -5177,7 +5177,8 @@
 
     const browseFilterStateOwner = {
         setFrequencyFilter: setBrowseFrequencyFilter,
-        resetToAll: resetBrowseFunctionalStateToAll
+        resetToAll: resetBrowseFunctionalStateToAll,
+        resetForActivation: resetBrowseFunctionalStateForActivation
     };
 
     function resetBrowseFilterStateToAll(examIndex) {
@@ -5235,7 +5236,10 @@
             return;
         }
         try {
-            await preferences.patchBrowse({ frequencyFilter: 'all' });
+            await preferences.patchBrowse({
+                frequencyFilter: 'all',
+                filter: { category: 'all', type: 'all' }
+            });
         } catch (error) {
             console.warn('[ExamActions] 持久化浏览频率重置失败:', error);
         }
@@ -5253,7 +5257,7 @@
 
     function applyBrowseResetState(examIndex) {
         clearReadingMemorizeBrowseMode();
-        resetBrowseFilterStateToAll(examIndex);
+        const filterResetSucceeded = resetBrowseFilterStateToAll(examIndex);
 
         if (global.browseStateManager && typeof global.browseStateManager.resetToAllExams === 'function') {
             global.browseStateManager.resetToAllExams();
@@ -5263,6 +5267,54 @@
 
         if (typeof global.setBrowseTitle === 'function') {
             global.setBrowseTitle('题库列表');
+        }
+        return filterResetSucceeded;
+    }
+
+    function ensureBrowseStateManagerForReset() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[ExamActions] 初始化题库状态管理器失败:', error);
+            return null;
+        }
+    }
+
+    async function resetBrowseFunctionalStateForActivation() {
+        try {
+            const manager = ensureBrowseStateManagerForReset();
+            if (manager && manager.ready && typeof manager.ready.then === 'function') {
+                await manager.ready;
+            }
+            if (typeof global.setupBrowseControls === 'function') {
+                await global.setupBrowseControls();
+            }
+            if (!applyBrowseResetState(null)) {
+                return false;
+            }
+
+            if (typeof global.saveBrowseViewPreferences === 'function') {
+                global.saveBrowseViewPreferences({
+                    lastFilter: { category: 'all', type: 'all' }
+                });
+            }
+            if (typeof global.flushBrowsePreferenceWrites === 'function') {
+                await global.flushBrowsePreferenceWrites();
+            }
+            if (manager && typeof manager.persistState === 'function') {
+                await manager.persistState();
+            }
+            await persistBrowseFrequencyReset();
+            return true;
+        } catch (error) {
+            console.warn('[ExamActions] 激活前重置题库状态失败:', error);
+            return false;
         }
     }
 
@@ -17322,6 +17374,7 @@ let practiceListScroller = null;
 let app = null;
 let pdfHandler = null;
 let browseStateManager = null;
+let browseInitialFilterHydrationConsumed = false;
 
 function normalizeRecordId(id) {
     if (id == null) {
@@ -19407,6 +19460,7 @@ window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
+    browseInitialFilterHydrationConsumed = true;
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
@@ -19483,15 +19537,42 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
 }
 
 // 应用分类筛选（供 App/总览调用）
-async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
+async function applyBrowseFilter(
+    category = 'all',
+    type = null,
+    filterMode = null,
+    path = null,
+    renderRequestId = null,
+    navigationIntentGeneration = null
+) {
+    browseInitialFilterHydrationConsumed = true;
+    const getActiveViewId = () => {
+        const activeView = typeof document.querySelector === 'function'
+            ? document.querySelector('.view.active')
+            : null;
+        return activeView ? activeView.id : null;
+    };
+    const activeViewIdAtRequest = getActiveViewId();
+    const capturedNavigationIntentGeneration = navigationIntentGeneration == null
+        && typeof window.__getAppNavigationIntentGeneration === 'function'
+        ? window.__getAppNavigationIntentGeneration()
+        : navigationIntentGeneration;
+    const isNavigationIntentCurrent = () => {
+        if (capturedNavigationIntentGeneration != null
+            && typeof window.__getAppNavigationIntentGeneration === 'function'
+            && window.__getAppNavigationIntentGeneration() !== capturedNavigationIntentGeneration) {
+            return false;
+        }
+        return getActiveViewId() === activeViewIdAtRequest;
+    };
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
         const memorizeSelectionActive = isReadingMemorizeBrowseMode();
         if (memorizeSelectionActive) {
@@ -19566,8 +19647,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
 
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
@@ -19579,8 +19660,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
         await renderBrowseResultsForState(indexSnapshot, activeRequestId);
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
 
         // 若未在浏览视图，则尽力切换
@@ -19588,8 +19669,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             window.showView('browse', false);
         }
     } catch (e) {
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
         setBrowseFilterState('all', 'all');
@@ -19598,7 +19679,7 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         }
         // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
         setTimeout(() => {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
                 return;
             }
             try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
@@ -19633,13 +19714,16 @@ async function initializeBrowseView(options = {}) {
         window.refreshListeningAvailabilityUI(examIndex);
     }
 
-    const persisted = getPersistedBrowseFilter();
-    if (persisted) {
-        setBrowseFilterState(persisted.category, persisted.type);
-        setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
-    } else {
-        setBrowseFilterState('all', 'all');
-        setBrowseTitle(formatBrowseTitle('all', 'all'));
+    if (!browseInitialFilterHydrationConsumed) {
+        const persisted = getPersistedBrowseFilter();
+        if (persisted) {
+            setBrowseFilterState(persisted.category, persisted.type);
+            setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
+        } else {
+            setBrowseFilterState('all', 'all');
+            setBrowseTitle(formatBrowseTitle('all', 'all'));
+        }
+        browseInitialFilterHydrationConsumed = true;
     }
 
     setupBrowseSortControl();
@@ -20492,6 +20576,7 @@ function clearSearch() {
 
 function getBrowseFilteredExamBase(examIndexSnapshot = []) {
     const examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
+    const folderScopedExamIndex = applyActiveBrowseFolderFilter(examIndex);
     const activeCategory = typeof getCurrentCategory === 'function' ? getCurrentCategory() : 'all';
     const activeExamType = typeof getCurrentExamType === 'function' ? getCurrentExamType() : 'all';
     const isFrequencyMode = window.__browseFilterMode && window.__browseFilterMode !== 'default';
@@ -20500,7 +20585,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         : null;
 
     if (window.ExamFilterService && typeof window.ExamFilterService.filterExams === 'function') {
-        const filtered = window.ExamFilterService.filterExams(examIndex, {
+        return window.ExamFilterService.filterExams(folderScopedExamIndex, {
             activeCategory,
             activeExamType,
             browseFilterMode: window.__browseFilterMode,
@@ -20509,10 +20594,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             sortMode: window.__browseSortMode,
             frequencyFilter: window.__browseFrequencyFilter
         });
-        return applyActiveBrowseFolderFilter(filtered);
     }
 
-    let list = Array.isArray(examIndex) ? examIndex.slice() : [];
+    let list = folderScopedExamIndex.slice();
     if (activeExamType !== 'all') {
         list = list.filter((exam) => exam && exam.type === activeExamType);
     }
@@ -20529,7 +20613,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             window.__browseFrequencyFilter
         );
     }
-    return applyActiveBrowseFolderFilter(list);
+    return list;
 }
 
 function applyActiveBrowseFolderFilter(exams) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -3292,7 +3292,7 @@
         return Array.isArray(record.suiteEntries) ? record.suiteEntries : [];
     }
 
-    function rebuildBrowseCompletionIndex(records) {
+    function prepareBrowseCompletionIndex(records) {
         var byExamId = new Map();
         var byTitle = new Map();
         var recordSnapshot = ensureArray(records).slice();
@@ -3326,13 +3326,37 @@
                 }
             });
         });
-        browseCompletionIndex = {
+        return {
             byExamId: byExamId,
             byTitle: byTitle,
             records: recordSnapshot,
             ready: true
         };
-        return browseCompletionIndex;
+    }
+
+    function isPreparedBrowseCompletionIndex(preparedIndex) {
+        return !!preparedIndex
+            && preparedIndex.byExamId instanceof Map
+            && preparedIndex.byTitle instanceof Map
+            && Array.isArray(preparedIndex.records)
+            && preparedIndex.ready === true;
+    }
+
+    function commitBrowseCompletionIndex(preparedIndex) {
+        if (!isPreparedBrowseCompletionIndex(preparedIndex)) {
+            return false;
+        }
+        // Preparation performs every operation that can fail. Publication is
+        // deliberately one assignment so later stages cannot observe a
+        // partially rebuilt completion map.
+        browseCompletionIndex = preparedIndex;
+        return true;
+    }
+
+    function rebuildBrowseCompletionIndex(records) {
+        var preparedIndex = prepareBrowseCompletionIndex(records);
+        commitBrowseCompletionIndex(preparedIndex);
+        return preparedIndex;
     }
 
     function ensureBrowseCompletionIndex() {
@@ -3402,6 +3426,9 @@
         };
     };
 
+    global.prepareBrowseCompletionIndex = prepareBrowseCompletionIndex;
+    global.isPreparedBrowseCompletionIndex = isPreparedBrowseCompletionIndex;
+    global.commitBrowseCompletionIndex = commitBrowseCompletionIndex;
     global.rebuildBrowseCompletionIndex = rebuildBrowseCompletionIndex;
 
     // --- Legacy navigation controller ---
@@ -5079,18 +5106,20 @@
             ? 'reading-memorize'
             : (isCustomSuiteSelectionActive() ? 'custom-suite' : '');
 
-        // 6. 更新状态并渲染
+        // 6. 先证明 DOM commit，再发布对应的筛选状态。
+        const displayed = displayExams(examsToShow, {
+            selectionMode,
+            customSuiteDraft,
+            commitReceipt: options.commitReceipt
+        });
+        if (displayed !== true) {
+            return false;
+        }
         if (global.appStateService) {
             global.appStateService.setFilteredExams(examsToShow);
         } else if (typeof global.setFilteredExamsState === 'function') {
             global.setFilteredExamsState(examsToShow);
         }
-
-        displayExams(examsToShow, {
-            selectionMode,
-            customSuiteDraft,
-            commitReceipt: options.commitReceipt
-        });
         refreshCustomSuiteSelectionPortal();
 
         // 7. 触发渲染后钩子
@@ -6121,8 +6150,7 @@
         if (!container) {
             return false;
         }
-        displayExams(exams, options);
-        return true;
+        return displayExams(exams, options) === true;
     }
 
     // ============================================================================
@@ -17479,7 +17507,7 @@ window.BrowseStateManager = BrowseStateManager;
         }
     }
 
-    function updateBrowseAnchorsFromRecords(records, examIndex) {
+    function prepareBrowseAnchorUpdates(records, examIndex) {
         const list = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const updates = {};
@@ -17514,11 +17542,23 @@ window.BrowseStateManager = BrowseStateManager;
             }
         });
 
-        if (Object.keys(updates).length === 0) {
-            return;
-        }
+        return updates;
+    }
 
-        saveBrowseViewPreferences({ listAnchors: updates });
+    function commitBrowseAnchorUpdates(updates) {
+        if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+            return false;
+        }
+        if (Object.keys(updates).length > 0) {
+            saveBrowseViewPreferences({ listAnchors: updates });
+        }
+        return true;
+    }
+
+    function updateBrowseAnchorsFromRecords(records, examIndex) {
+        const updates = prepareBrowseAnchorUpdates(records, examIndex);
+        commitBrowseAnchorUpdates(updates);
+        return updates;
     }
 
     // --- Global Event Listeners ---
@@ -17547,6 +17587,8 @@ window.BrowseStateManager = BrowseStateManager;
     global.flushBrowsePreferenceWrites = flushBrowsePreferenceWrites;
     global.persistBrowseFilter = persistBrowseFilter;
     global.getPersistedBrowseFilter = getPersistedBrowseFilter;
+    global.prepareBrowseAnchorUpdates = prepareBrowseAnchorUpdates;
+    global.commitBrowseAnchorUpdates = commitBrowseAnchorUpdates;
     global.updateBrowseAnchorsFromRecords = updateBrowseAnchorsFromRecords;
 
     global.setBrowseTitle = setBrowseTitle;
@@ -19683,12 +19725,29 @@ function refreshBrowseProgressFromRecords(
         if (isBrowseActive && typeof renderBrowseResultsForState !== 'function') {
             return false;
         }
-        if (typeof rebuildBrowseCompletionIndex === 'function') {
-            rebuildBrowseCompletionIndex(recordSnapshot);
+        const canStageProjection = typeof prepareBrowseCompletionIndex === 'function'
+            && typeof isPreparedBrowseCompletionIndex === 'function'
+            && typeof commitBrowseCompletionIndex === 'function'
+            && typeof prepareBrowseAnchorUpdates === 'function'
+            && typeof commitBrowseAnchorUpdates === 'function';
+        if (!canStageProjection) {
+            return false;
         }
-        if (typeof updateBrowseAnchorsFromRecords === 'function') {
-            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
+        // Both derived states are built without mutation. Validate the
+        // completion candidate before accepting the anchor queue; the later
+        // completion commit is then one non-throwing assignment.
+        const preparedCompletionIndex = prepareBrowseCompletionIndex(recordSnapshot);
+        if (!isPreparedBrowseCompletionIndex(preparedCompletionIndex)) {
+            return false;
         }
+        const preparedAnchorUpdates = prepareBrowseAnchorUpdates(
+            recordSnapshot,
+            indexSnapshot
+        );
+        if (commitBrowseAnchorUpdates(preparedAnchorUpdates) !== true) {
+            return false;
+        }
+        commitBrowseCompletionIndex(preparedCompletionIndex);
         if (isBrowseActive) {
             if (candidatePracticeProjectionGeneration != null) {
                 pendingEpoch.practiceProjectionGeneration =
@@ -19701,7 +19760,11 @@ function refreshBrowseProgressFromRecords(
             // Candidate projections are flushed by syncPracticeRecords only
             // after their accepted generation becomes the public watermark.
             if (candidatePracticeProjectionGeneration == null) {
-                flushPendingBrowseProgressRefresh();
+                Promise.resolve().then(() => {
+                    flushPendingBrowseProgressRefresh();
+                }).catch((error) => {
+                    console.warn('[Browse] 刷新浏览进度列表失败:', error);
+                });
             }
         }
         return true;

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -13982,12 +13982,12 @@
             }
             try { global.updateOverview && global.updateOverview(index); } catch (_) { }
             refreshListeningAvailabilityUI(index);
-            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
-                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
-            }
             try {
                 global.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { index: cloneArray(index) } }));
             } catch (_) { }
+            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
+                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
+            }
             return loadTime;
         }
 
@@ -14455,6 +14455,9 @@
                 global.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { key, index: cloneArray(exams) } }));
             } catch (error) {
                 console.warn('[LibraryManager] 题库切换事件派发失败', error);
+            }
+            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
+                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
             }
 
             if (!options.skipConfigRefresh && typeof global.renderLibraryConfigList === 'function') {

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -12459,6 +12459,7 @@
             this.app = null;
             this.globalRef = global;
             this.globalBindingsInstalled = false;
+            this.browseFilterMutationRevision = 0;
 
             this.state = {
                 filteredExams: Array.isArray(global.filteredExams) ? global.filteredExams : [],
@@ -12554,7 +12555,7 @@
                     this.setFilteredExams(value, { syncApp: false });
                     break;
                 case 'ui.browseFilter':
-                    this.setBrowseFilter(value, { syncApp: false });
+                    this.setBrowseFilter(value, { syncApp: false, trackMutation: false });
                     break;
                 case 'exam.currentCategory':
                     this.setBrowseFilter({
@@ -12606,7 +12607,14 @@
             return this.state.browseFilter;
         }
 
+        getBrowseFilterMutationRevision() {
+            return this.browseFilterMutationRevision;
+        }
+
         setBrowseFilter(filter, options = {}) {
+            if (options.trackMutation !== false) {
+                this.browseFilterMutationRevision += 1;
+            }
             this.state.browseFilter = normalizeFilter(filter);
             if (options.syncApp !== false) {
                 this.applyToApp();
@@ -12851,6 +12859,9 @@
             };
             globalRef.getBrowseFilterState = function getBrowseFilterState() {
                 return service.getBrowseFilter();
+            };
+            globalRef.getBrowseFilterMutationRevision = function getBrowseFilterMutationRevision() {
+                return service.getBrowseFilterMutationRevision();
             };
             globalRef.setBrowseFilterState = function setBrowseFilterState(category, type) {
                 return service.setBrowseFilter({ category, type });

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -32,6 +32,108 @@
 
   ensureCompatPatch(window);
 
+  function getBrowseFilterStateOwner() {
+    var actions = window.ExamActions;
+    var owner = actions && actions.browseFilterStateOwner;
+    return owner && typeof owner.resetToAll === 'function' ? owner : null;
+  }
+
+  function invokeBrowseResetDelegate(delegate, context, label) {
+    if (typeof delegate !== 'function') {
+      return Promise.resolve(false);
+    }
+    try {
+      return Promise.resolve(delegate.call(context)).then(function (result) {
+        return result !== false;
+      }).catch(function (error) {
+        console.warn('[Fallback] ' + label + '失败:', error);
+        return false;
+      });
+    } catch (error) {
+      console.warn('[Fallback] ' + label + '失败:', error);
+      return Promise.resolve(false);
+    }
+  }
+
+  function ensureBrowseFilterStateOwner() {
+    var owner = getBrowseFilterStateOwner();
+    if (owner) {
+      return Promise.resolve({ owner: owner, loaded: true });
+    }
+    var loading = null;
+    try {
+      if (window.AppEntry && typeof window.AppEntry.ensureBrowseRuntimeGroup === 'function') {
+        loading = window.AppEntry.ensureBrowseRuntimeGroup();
+      } else if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
+        loading = window.AppLazyLoader.ensureGroup('browse-runtime');
+      }
+    } catch (error) {
+      console.warn('[Fallback] 加载题库状态 owner 失败:', error);
+      return Promise.resolve(null);
+    }
+    if (!loading) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(loading).then(function () {
+      var loadedOwner = getBrowseFilterStateOwner();
+      return loadedOwner ? { owner: loadedOwner, loaded: true } : null;
+    }).catch(function (error) {
+      console.warn('[Fallback] 加载题库状态 owner 失败:', error);
+      return null;
+    });
+  }
+
+  function resetBrowseFunctionalStateForFallback() {
+    var delegates = [
+      {
+        fn: window.resetBrowseFilterStateToAll,
+        context: window,
+        label: '重置题库筛选状态'
+      },
+      {
+        fn: window.ExamActions && window.ExamActions.resetBrowseFilterStateToAll,
+        context: window.ExamActions,
+        label: '通过题库状态 owner 重置'
+      }
+    ];
+
+    function tryDelegate(index) {
+      if (index >= delegates.length) {
+        var existingOwner = getBrowseFilterStateOwner();
+        if (existingOwner) {
+          return invokeBrowseResetDelegate(
+            existingOwner.resetToAll,
+            existingOwner,
+            '通过稳定题库状态 owner 重置'
+          ).then(function (succeeded) {
+            return { succeeded: succeeded, ownerLoaded: false };
+          });
+        }
+        return ensureBrowseFilterStateOwner().then(function (loaded) {
+          if (!loaded || !loaded.owner) {
+            return { succeeded: false, ownerLoaded: false };
+          }
+          return invokeBrowseResetDelegate(
+            loaded.owner.resetToAll,
+            loaded.owner,
+            '通过延迟加载的题库状态 owner 重置'
+          ).then(function (succeeded) {
+            return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
+          });
+        });
+      }
+      var candidate = delegates[index];
+      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label)
+        .then(function (succeeded) {
+          return succeeded
+            ? { succeeded: true, ownerLoaded: false }
+            : tryDelegate(index + 1);
+        });
+    }
+
+    return tryDelegate(0);
+  }
+
   function runRepeatedBrowseReset(viewName) {
     if (viewName !== 'browse') {
       return false;
@@ -100,48 +202,21 @@
         }
       }
 
+      var browseFunctionalReset = null;
+      var browseResetBarrierRegistered = false;
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
-        window.currentCategory = 'all';
-        window.currentExamType = 'all';
-        var browseFilterStateReset = false;
-        if (typeof window.resetBrowseFilterStateToAll === 'function') {
+        browseFunctionalReset = resetBrowseFunctionalStateForFallback();
+        if (window.AppEntry
+          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
           try {
-            window.resetBrowseFilterStateToAll();
-            browseFilterStateReset = true;
-          } catch (error) {
-            console.warn('[Fallback] 重置题库筛选状态失败:', error);
-          }
-        }
-        if (!browseFilterStateReset && window.ExamActions
-          && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
-          try {
-            window.ExamActions.resetBrowseFilterStateToAll();
-            browseFilterStateReset = true;
-          } catch (error) {
-            console.warn('[Fallback] 通过题库状态 owner 重置失败:', error);
-          }
-        }
-        if (!browseFilterStateReset) {
-          if (typeof window.setBrowseFilterState === 'function') {
-            try {
-              window.setBrowseFilterState('all', 'all');
-            } catch (error) {
-              console.warn('[Fallback] 重置题库分类状态失败:', error);
-            }
-          }
-          if (window.browseController) {
-            window.browseController.currentMode = 'default';
-            window.browseController.activeFilter = 'all';
-          }
-          var frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
-          if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
-            Array.prototype.forEach.call(
-              frequencyContainer.querySelectorAll('[data-frequency-filter]'),
-              function (button) {
-                if (button.classList) button.classList.remove('active');
-                if (typeof button.setAttribute === 'function') button.setAttribute('aria-pressed', 'false');
-              }
+            window.AppEntry.registerBrowseFunctionalResetBarrier(
+              Promise.resolve(browseFunctionalReset).then(function (result) {
+                return !!(result && result.succeeded === true);
+              })
             );
+            browseResetBarrierRegistered = true;
+          } catch (error) {
+            console.warn('[Fallback] 注册题库重置屏障失败:', error);
           }
         }
         if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
@@ -160,10 +235,36 @@
       }
       var browseRefresh = null;
       if (normalized === 'browse') {
-        if (typeof window.refreshBrowseResults === 'function') {
-          browseRefresh = window.refreshBrowseResults();
-        } else if (typeof window.loadExamList === 'function') {
-          browseRefresh = window.loadExamList();
+        var runBrowseRefresh = function runBrowseRefresh() {
+          if (resetCategory === false && typeof window.activateBrowseView === 'function') {
+            return window.activateBrowseView();
+          }
+          if (typeof window.refreshBrowseResults === 'function') {
+            return window.refreshBrowseResults();
+          }
+          if (typeof window.loadExamList === 'function') {
+            return window.loadExamList();
+          }
+          return false;
+        };
+        if (browseFunctionalReset) {
+          browseRefresh = Promise.resolve(browseFunctionalReset).then(function (resetResult) {
+            if (!resetResult || resetResult.succeeded !== true) {
+              console.warn('[Fallback] 题库功能状态未能安全重置，跳过刷新');
+              return false;
+            }
+            if (resetResult.ownerLoaded === true
+              && browseResetBarrierRegistered
+              && window.AppEntry
+              && typeof window.AppEntry.ensureBrowseGroup === 'function') {
+              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function () {
+                return true;
+              });
+            }
+            return runBrowseRefresh();
+          });
+        } else {
+          browseRefresh = runBrowseRefresh();
         }
         if (browseRefresh && typeof browseRefresh.then === 'function') {
           browseRefresh = Promise.resolve(browseRefresh).catch(function (error) {

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -38,6 +38,16 @@
     return owner && typeof owner.resetToAll === 'function' ? owner : null;
   }
 
+  function invokeBrowseStateOwnerReset(owner, label) {
+    if (!owner) {
+      return Promise.resolve(false);
+    }
+    var reset = typeof owner.resetForActivation === 'function'
+      ? owner.resetForActivation
+      : owner.resetToAll;
+    return invokeBrowseResetDelegate(reset, owner, label);
+  }
+
   function invokeBrowseResetDelegate(delegate, context, label) {
     if (typeof delegate !== 'function') {
       return Promise.resolve(false);
@@ -84,6 +94,13 @@
   }
 
   function resetBrowseFunctionalStateForFallback() {
+    var activationOwner = getBrowseFilterStateOwner();
+    if (activationOwner && typeof activationOwner.resetForActivation === 'function') {
+      return invokeBrowseStateOwnerReset(activationOwner, '通过题库状态 owner 完成激活前重置')
+        .then(function (succeeded) {
+          return { succeeded: succeeded, ownerLoaded: false };
+        });
+    }
     var delegates = [
       {
         fn: window.resetBrowseFilterStateToAll,
@@ -101,11 +118,8 @@
       if (index >= delegates.length) {
         var existingOwner = getBrowseFilterStateOwner();
         if (existingOwner) {
-          return invokeBrowseResetDelegate(
-            existingOwner.resetToAll,
-            existingOwner,
-            '通过稳定题库状态 owner 重置'
-          ).then(function (succeeded) {
+          return invokeBrowseStateOwnerReset(existingOwner, '通过稳定题库状态 owner 重置')
+            .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: false };
           });
         }
@@ -113,11 +127,8 @@
           if (!loaded || !loaded.owner) {
             return { succeeded: false, ownerLoaded: false };
           }
-          return invokeBrowseResetDelegate(
-            loaded.owner.resetToAll,
-            loaded.owner,
-            '通过延迟加载的题库状态 owner 重置'
-          ).then(function (succeeded) {
+          return invokeBrowseStateOwnerReset(loaded.owner, '通过延迟加载的题库状态 owner 重置')
+            .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
           });
         });
@@ -238,6 +249,11 @@
         var runBrowseRefresh = function runBrowseRefresh() {
           if (resetCategory === false && typeof window.activateBrowseView === 'function') {
             return window.activateBrowseView();
+          }
+          if (resetCategory === false
+            && window.AppEntry
+            && typeof window.AppEntry.ensureBrowseGroup === 'function') {
+            return window.AppEntry.ensureBrowseGroup();
           }
           if (typeof window.refreshBrowseResults === 'function') {
             return window.refreshBrowseResults();
@@ -1817,6 +1833,7 @@
 class ExamSystemApp {
     constructor() {
         this.currentView = 'overview';
+        this._navigationIntentGeneration = 0;
         this.components = {};
         this.isInitialized = false;
 
@@ -2431,11 +2448,20 @@ class ExamSystemApp {
             this.navigateToView(initialView);
         },
         navigateToView(viewName) {
+            const navigationIntentGeneration = ++this._navigationIntentGeneration;
+            let sharedNavigationIntentGeneration = null;
             if (typeof window.__markAppNavigationIntent === 'function') {
-                window.__markAppNavigationIntent();
+                sharedNavigationIntentGeneration = window.__markAppNavigationIntent();
+            }
+            if (sharedNavigationIntentGeneration == null
+                && typeof window.__getAppNavigationIntentGeneration === 'function') {
+                sharedNavigationIntentGeneration = window.__getAppNavigationIntentGeneration();
+            }
+            if (viewName !== 'browse' && window.__pendingBrowseFilter) {
+                delete window.__pendingBrowseFilter;
             }
             if (this.currentView === viewName) {
-                return;
+                return { navigationIntentGeneration, sharedNavigationIntentGeneration };
             }
             document.querySelectorAll('.view').forEach((view) => {
                 view.classList.remove('active');
@@ -2454,10 +2480,21 @@ class ExamSystemApp {
                 const url = new URL(window.location);
                 url.searchParams.set('view', viewName);
                 window.history.replaceState({}, '', url);
-                this.onViewActivated(viewName);
+                this.onViewActivated(
+                    viewName,
+                    navigationIntentGeneration,
+                    sharedNavigationIntentGeneration
+                );
             }
+            return { navigationIntentGeneration, sharedNavigationIntentGeneration };
         },
-        onViewActivated(viewName) {
+        onViewActivated(
+            viewName,
+            navigationIntentGeneration = this._navigationIntentGeneration,
+            sharedNavigationIntentGeneration = (typeof window.__getAppNavigationIntentGeneration === 'function'
+                ? window.__getAppNavigationIntentGeneration()
+                : null)
+        ) {
             switch (viewName) {
                 case 'overview':
                     this.refreshOverviewData();
@@ -2471,10 +2508,23 @@ class ExamSystemApp {
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
                         ).then(() => {
-                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                            const activeView = typeof document.querySelector === 'function'
+                                ? document.querySelector('.view.active')
+                                : null;
+                            if (window.__pendingBrowseFilter !== pendingFilter
+                                || navigationIntentGeneration !== this._navigationIntentGeneration
+                                || this.currentView !== 'browse'
+                                || (activeView && activeView.id !== 'browse-view')
+                                || (sharedNavigationIntentGeneration != null
+                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
+                                    && window.__getAppNavigationIntentGeneration() !== sharedNavigationIntentGeneration)) {
                                 return undefined;
                             }
-                            return window.applyBrowseFilter(category, type, filterMode, path);
+                            const filterArgs = [category, type, filterMode, path];
+                            if (sharedNavigationIntentGeneration != null) {
+                                filterArgs.push(null, sharedNavigationIntentGeneration);
+                            }
+                            return window.applyBrowseFilter(...filterArgs);
                         })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -110,7 +110,7 @@
         syncOnNavigate: true,
         onNavigate: function onNavigate(viewName) {
           if (typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
           }
         }
       });
@@ -124,8 +124,19 @@
           }
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
+          var alreadyActive = !!(button.classList && button.classList.contains('active'));
+          if (viewName === 'browse' && alreadyActive && typeof window.resetBrowseViewToAll === 'function') {
+            try {
+              Promise.resolve(window.resetBrowseViewToAll()).catch(function (error) {
+                console.warn('[Fallback] 重复题库导航重置失败:', error);
+              });
+            } catch (error) {
+              console.warn('[Fallback] 重复题库导航重置失败:', error);
+            }
+            return;
+          }
           if (viewName && typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
           }
         };
         navRoot._legacyNavHandler = handler;
@@ -1592,7 +1603,7 @@
   function bootInitialView() {
     const targetView = resolveInitialView();
     if (typeof window.showView === 'function') {
-      window.showView(targetView);
+      window.showView(targetView, false);
       return;
     }
     if (typeof window.app !== 'undefined' && typeof window.app.navigateToView === 'function') {
@@ -2261,17 +2272,25 @@ class ExamSystemApp {
                     break;
                 case 'browse':
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
-                        const { category, type, filterMode, path } = window.__pendingBrowseFilter;
+                        const pendingFilter = window.__pendingBrowseFilter;
+                        const { category, type, filterMode, path } = pendingFilter;
                         Promise.resolve(
                             typeof window.initializeBrowseView === 'function'
                                 ? window.initializeBrowseView({ skipLoad: true })
                                 : null
-                        ).then(() => window.applyBrowseFilter(category, type, filterMode, path))
+                        ).then(() => {
+                            if (window.__pendingBrowseFilter !== pendingFilter) {
+                                return undefined;
+                            }
+                            return window.applyBrowseFilter(category, type, filterMode, path);
+                        })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                delete window.__pendingBrowseFilter;
+                                if (window.__pendingBrowseFilter === pendingFilter) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {
                         window.initializeBrowseView();

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -112,6 +112,15 @@
             console.warn('[Fallback] 重置题库筛选状态失败:', error);
           }
         }
+        if (!browseFilterStateReset && window.ExamActions
+          && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
+          try {
+            window.ExamActions.resetBrowseFilterStateToAll();
+            browseFilterStateReset = true;
+          } catch (error) {
+            console.warn('[Fallback] 通过题库状态 owner 重置失败:', error);
+          }
+        }
         if (!browseFilterStateReset) {
           if (typeof window.setBrowseFilterState === 'function') {
             try {
@@ -198,6 +207,11 @@
           }
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
+          if (viewName === 'browse') {
+            try {
+              event.__browseNavigationHandled = true;
+            } catch (_) { }
+          }
           var alreadyActive = !!(button.classList && button.classList.contains('active'));
           if (viewName === 'browse' && alreadyActive) {
             try {
@@ -2628,7 +2642,21 @@ class ExamSystemApp {
                 if (navBtn) {
                     const view = navBtn.dataset.view;
                     if (view) {
-                        this.navigateToView(view);
+                        const browseViewAlreadyActive = view === 'browse'
+                            && e.__browseNavigationHandled === true
+                            && document.getElementById('browse-view')?.classList.contains('active');
+                        if (browseViewAlreadyActive) {
+                            // The main-nav controller already activated and refreshed Browse.
+                            // Keep app state/URL in sync without starting a second render.
+                            this.currentView = view;
+                            try {
+                                const url = new URL(window.location);
+                                url.searchParams.set('view', view);
+                                window.history.replaceState({}, '', url);
+                            } catch (_) { }
+                        } else {
+                            this.navigateToView(view);
+                        }
                     }
                 }
                 const backBtn = e.target.closest('.btn-back');

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -32,6 +32,19 @@
 
   ensureCompatPatch(window);
 
+  function runRepeatedBrowseReset(viewName) {
+    if (viewName !== 'browse') {
+      return false;
+    }
+    if (typeof window.resetBrowseViewToAll === 'function') {
+      return window.resetBrowseViewToAll();
+    }
+    if (typeof window.showView === 'function') {
+      return window.showView('browse', true);
+    }
+    return true;
+  }
+
   if (window.CompatPatch && typeof window.CompatPatch.register === 'function') {
     window.CompatPatch.register('boot-fallbacks', {
       owner: 'runtime',
@@ -43,6 +56,9 @@
   // Fallback for navigation
   if (typeof window.showView !== 'function') {
     window.showView = function (viewName, resetCategory) {
+      if (typeof window.__markAppNavigationIntent === 'function') {
+        window.__markAppNavigationIntent();
+      }
       if (typeof document === 'undefined') {
         return;
       }
@@ -87,10 +103,66 @@
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
         window.currentCategory = 'all';
         window.currentExamType = 'all';
-        if (typeof window.setBrowseTitle === 'function') { window.setBrowseTitle('题库浏览'); return; }
-        var t = document.getElementById('browse-title'); if (t) t.textContent = '题库浏览';
+        var browseFilterStateReset = false;
+        if (typeof window.resetBrowseFilterStateToAll === 'function') {
+          try {
+            window.resetBrowseFilterStateToAll();
+            browseFilterStateReset = true;
+          } catch (error) {
+            console.warn('[Fallback] 重置题库筛选状态失败:', error);
+          }
+        }
+        if (!browseFilterStateReset) {
+          if (typeof window.setBrowseFilterState === 'function') {
+            try {
+              window.setBrowseFilterState('all', 'all');
+            } catch (error) {
+              console.warn('[Fallback] 重置题库分类状态失败:', error);
+            }
+          }
+          if (window.browseController) {
+            window.browseController.currentMode = 'default';
+            window.browseController.activeFilter = 'all';
+          }
+          var frequencyContainer = document.getElementById('browse-frequency-filter-buttons');
+          if (frequencyContainer && typeof frequencyContainer.querySelectorAll === 'function') {
+            Array.prototype.forEach.call(
+              frequencyContainer.querySelectorAll('[data-frequency-filter]'),
+              function (button) {
+                if (button.classList) button.classList.remove('active');
+                if (typeof button.setAttribute === 'function') button.setAttribute('aria-pressed', 'false');
+              }
+            );
+          }
+        }
+        if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
+          window.browseStateManager.clearSearchState();
+        } else {
+          var searchInput = document.getElementById('exam-search-input') || document.querySelector('.search-input');
+          if (searchInput) searchInput.value = '';
+          var searchClearButton = document.getElementById('search-clear-btn');
+          if (searchClearButton) searchClearButton.hidden = true;
+        }
+        if (typeof window.setBrowseTitle === 'function') {
+          window.setBrowseTitle('题库浏览');
+        } else {
+          var t = document.getElementById('browse-title'); if (t) t.textContent = '题库浏览';
+        }
       }
-      if (normalized === 'browse' && typeof window.loadExamList === 'function') window.loadExamList();
+      var browseRefresh = null;
+      if (normalized === 'browse') {
+        if (typeof window.refreshBrowseResults === 'function') {
+          browseRefresh = window.refreshBrowseResults();
+        } else if (typeof window.loadExamList === 'function') {
+          browseRefresh = window.loadExamList();
+        }
+        if (browseRefresh && typeof browseRefresh.then === 'function') {
+          browseRefresh = Promise.resolve(browseRefresh).catch(function (error) {
+            console.warn('[Fallback] 刷新题库视图失败:', error);
+            return false;
+          });
+        }
+      }
       if (normalized === 'practice' && window.AppActions && typeof window.AppActions.ensurePracticeSuite === 'function') {
         window.AppActions.ensurePracticeSuite();
       }
@@ -100,6 +172,7 @@
       if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
         window.ensurePracticeRecordsSync('practice-view').catch(function () { });
       }
+      return browseRefresh;
     };
   }
 
@@ -108,6 +181,7 @@
       window.ensureLegacyNavigationController({
         containerSelector: '.main-nav',
         syncOnNavigate: true,
+        onRepeatNavigate: runRepeatedBrowseReset,
         onNavigate: function onNavigate(viewName) {
           if (typeof window.showView === 'function') {
             window.showView(viewName, false);
@@ -125,9 +199,9 @@
           event.preventDefault();
           var viewName = button.getAttribute('data-view');
           var alreadyActive = !!(button.classList && button.classList.contains('active'));
-          if (viewName === 'browse' && alreadyActive && typeof window.resetBrowseViewToAll === 'function') {
+          if (viewName === 'browse' && alreadyActive) {
             try {
-              Promise.resolve(window.resetBrowseViewToAll()).catch(function (error) {
+              Promise.resolve(runRepeatedBrowseReset(viewName)).catch(function (error) {
                 console.warn('[Fallback] 重复题库导航重置失败:', error);
               });
             } catch (error) {
@@ -2242,6 +2316,9 @@ class ExamSystemApp {
             this.navigateToView(initialView);
         },
         navigateToView(viewName) {
+            if (typeof window.__markAppNavigationIntent === 'function') {
+                window.__markAppNavigationIntent();
+            }
             if (this.currentView === viewName) {
                 return;
             }

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -181,6 +181,29 @@
         console.warn('[Fallback] 未找到视图节点:', normalized);
         return;
       }
+      var browseFunctionalReset = null;
+      var browseFunctionalResetBarrier = null;
+      var browseResetBarrierRegistered = false;
+      if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
+        // Register the functional barrier before Browse becomes active. Deferring
+        // the reset body closes the synchronous activation-to-registration gap.
+        browseFunctionalReset = Promise.resolve().then(function beginBrowseFunctionalReset() {
+          return resetBrowseFunctionalStateForFallback();
+        });
+        if (window.AppEntry
+          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
+          try {
+            browseFunctionalResetBarrier = window.AppEntry.registerBrowseFunctionalResetBarrier(
+              Promise.resolve(browseFunctionalReset).then(function (result) {
+                return !!(result && result.succeeded === true);
+              })
+            );
+            browseResetBarrierRegistered = true;
+          } catch (error) {
+            console.warn('[Fallback] 注册题库重置屏障失败:', error);
+          }
+        }
+      }
       Array.prototype.forEach.call(document.querySelectorAll('.view.active'), function (v) {
         v.classList.remove('active');
       });
@@ -213,23 +236,7 @@
         }
       }
 
-      var browseFunctionalReset = null;
-      var browseResetBarrierRegistered = false;
       if (normalized === 'browse' && (resetCategory === undefined || resetCategory === true)) {
-        browseFunctionalReset = resetBrowseFunctionalStateForFallback();
-        if (window.AppEntry
-          && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
-          try {
-            window.AppEntry.registerBrowseFunctionalResetBarrier(
-              Promise.resolve(browseFunctionalReset).then(function (result) {
-                return !!(result && result.succeeded === true);
-              })
-            );
-            browseResetBarrierRegistered = true;
-          } catch (error) {
-            console.warn('[Fallback] 注册题库重置屏障失败:', error);
-          }
-        }
         if (window.browseStateManager && typeof window.browseStateManager.clearSearchState === 'function') {
           window.browseStateManager.clearSearchState();
         } else {
@@ -269,12 +276,20 @@
               console.warn('[Fallback] 题库功能状态未能安全重置，跳过刷新');
               return false;
             }
+            if (browseFunctionalResetBarrier
+              && window.AppEntry
+              && typeof window.AppEntry.isBrowseFunctionalResetBarrierCurrent === 'function'
+              && !window.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+                browseFunctionalResetBarrier
+              )) {
+              return false;
+            }
             if (resetResult.ownerLoaded === true
               && browseResetBarrierRegistered
               && window.AppEntry
               && typeof window.AppEntry.ensureBrowseGroup === 'function') {
-              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function () {
-                return true;
+              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function (result) {
+                return result !== false;
               });
             }
             return runBrowseRefresh();
@@ -288,14 +303,24 @@
             return false;
           });
         }
+        if (browseFunctionalResetBarrier
+          && window.AppEntry
+          && typeof window.AppEntry.completeBrowseFunctionalResetBarrier === 'function') {
+          browseRefresh = Promise.resolve(browseRefresh).then(function completeFunctionalReset(result) {
+            var completed = window.AppEntry.completeBrowseFunctionalResetBarrier(
+              browseFunctionalResetBarrier,
+              result !== false
+            );
+            return completed ? result : false;
+          });
+        }
       }
       if (normalized === 'practice' && window.AppActions && typeof window.AppActions.ensurePracticeSuite === 'function') {
         window.AppActions.ensurePracticeSuite();
       }
       if (normalized === 'practice' && typeof window.startPracticeRecordsSyncInBackground === 'function') {
         window.startPracticeRecordsSyncInBackground('practice-view');
-      }
-      if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
+      } else if (normalized === 'practice' && typeof window.ensurePracticeRecordsSync === 'function') {
         window.ensurePracticeRecordsSync('practice-view').catch(function () { });
       }
       return browseRefresh;

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -1478,6 +1478,9 @@
         }
       } catch (_) { }
       try { window.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { key: key, index: snapshot } })); } catch (_) { }
+      if (typeof window.startPracticeRecordsSyncInBackground === 'function') {
+        window.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
+      }
       return true;
     }
 

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2585,26 +2585,34 @@ class ExamSystemApp {
                             && typeof window.__retainBrowseUserResultsRequest === 'function'
                             ? window.__retainBrowseUserResultsRequest(initializationRequestId)
                             : null;
-                        Promise.resolve(initialization).then((initializationResult) => {
-                            if (hasInitializer && initializationResult === null) {
-                                return undefined;
-                            }
-                            if (initializationRequestId != null
-                                && typeof window.__isBrowseResultsRequestCurrent === 'function'
-                                && !window.__isBrowseResultsRequestCurrent(initializationRequestId)) {
-                                return undefined;
-                            }
+                        let pendingFilterOutcome = 'retryable-failure';
+                        const pendingFilterWasSuperseded = () => {
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
-                            if (window.__pendingBrowseFilter !== pendingFilter
+                            return window.__pendingBrowseFilter !== pendingFilter
                                 || navigationIntentGeneration !== this._navigationIntentGeneration
                                 || this.currentView !== 'browse'
                                 || (activeView && activeView.id !== 'browse-view')
                                 || (sharedNavigationIntentGeneration != null
                                     && typeof window.__getAppNavigationIntentGeneration === 'function'
-                                    && window.__getAppNavigationIntentGeneration() !== sharedNavigationIntentGeneration)) {
-                                return undefined;
+                                    && window.__getAppNavigationIntentGeneration()
+                                        !== sharedNavigationIntentGeneration)
+                                || (initializationRequestId != null
+                                    && typeof window.__isBrowseResultsRequestCurrent === 'function'
+                                    && !window.__isBrowseResultsRequestCurrent(
+                                        initializationRequestId
+                                    ));
+                        };
+                        Promise.resolve(initialization).then((initializationResult) => {
+                            if (hasInitializer
+                                && (initializationResult === null
+                                    || initializationResult === false)) {
+                                return false;
+                            }
+                            if (pendingFilterWasSuperseded()) {
+                                pendingFilterOutcome = 'superseded';
+                                return false;
                             }
                             const filterArgs = [category, type, filterMode, path];
                             if (initializationRequestId != null || sharedNavigationIntentGeneration != null) {
@@ -2615,16 +2623,35 @@ class ExamSystemApp {
                             }
                             return window.applyBrowseFilter(...filterArgs);
                         })
+                            .then((result) => {
+                                // Legacy filter implementations resolve without a
+                                // value after applying; null/false mean it did not
+                                // reach an authoritative commit.
+                                if (result !== false && result !== null) {
+                                    pendingFilterOutcome = 'applied';
+                                    return true;
+                                }
+                                if (pendingFilterWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
+                                return false;
+                            })
                             .catch((error) => {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
+                                if (pendingFilterOutcome !== 'applied'
+                                    && pendingFilterWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
+                                if (window.__pendingBrowseFilter === pendingFilter
+                                    && (pendingFilterOutcome === 'applied'
+                                        || pendingFilterOutcome === 'superseded')) {
+                                    delete window.__pendingBrowseFilter;
+                                }
                                 if (retainedInitializationRequestId != null
                                     && typeof window.__endBrowseUserResultsRequest === 'function') {
                                     window.__endBrowseUserResultsRequest(retainedInitializationRequestId);
-                                }
-                                if (window.__pendingBrowseFilter === pendingFilter) {
-                                    delete window.__pendingBrowseFilter;
                                 }
                             });
                     } else if (typeof window.initializeBrowseView === 'function') {

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2503,11 +2503,27 @@ class ExamSystemApp {
                     if (window.__pendingBrowseFilter && typeof window.applyBrowseFilter === 'function') {
                         const pendingFilter = window.__pendingBrowseFilter;
                         const { category, type, filterMode, path } = pendingFilter;
-                        Promise.resolve(
-                            typeof window.initializeBrowseView === 'function'
-                                ? window.initializeBrowseView({ skipLoad: true })
-                                : null
-                        ).then(() => {
+                        const hasInitializer = typeof window.initializeBrowseView === 'function';
+                        const initialization = hasInitializer
+                            ? window.initializeBrowseView({ skipLoad: true })
+                            : null;
+                        const initializationRequestId = hasInitializer
+                            && typeof window.__getBrowseResultsRequestId === 'function'
+                            ? window.__getBrowseResultsRequestId()
+                            : null;
+                        const retainedInitializationRequestId = initializationRequestId != null
+                            && typeof window.__retainBrowseUserResultsRequest === 'function'
+                            ? window.__retainBrowseUserResultsRequest(initializationRequestId)
+                            : null;
+                        Promise.resolve(initialization).then((initializationResult) => {
+                            if (hasInitializer && initializationResult === null) {
+                                return undefined;
+                            }
+                            if (initializationRequestId != null
+                                && typeof window.__isBrowseResultsRequestCurrent === 'function'
+                                && !window.__isBrowseResultsRequestCurrent(initializationRequestId)) {
+                                return undefined;
+                            }
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
@@ -2521,8 +2537,11 @@ class ExamSystemApp {
                                 return undefined;
                             }
                             const filterArgs = [category, type, filterMode, path];
+                            if (initializationRequestId != null || sharedNavigationIntentGeneration != null) {
+                                filterArgs.push(initializationRequestId);
+                            }
                             if (sharedNavigationIntentGeneration != null) {
-                                filterArgs.push(null, sharedNavigationIntentGeneration);
+                                filterArgs.push(sharedNavigationIntentGeneration);
                             }
                             return window.applyBrowseFilter(...filterArgs);
                         })
@@ -2530,6 +2549,10 @@ class ExamSystemApp {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
+                                if (retainedInitializationRequestId != null
+                                    && typeof window.__endBrowseUserResultsRequest === 'function') {
+                                    window.__endBrowseUserResultsRequest(retainedInitializationRequestId);
+                                }
                                 if (window.__pendingBrowseFilter === pendingFilter) {
                                     delete window.__pendingBrowseFilter;
                                 }

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2574,6 +2574,19 @@ class ExamSystemApp {
                         const pendingFilter = window.__pendingBrowseFilter;
                         const { category, type, filterMode, path } = pendingFilter;
                         const hasInitializer = typeof window.initializeBrowseView === 'function';
+                        const appEntry = window.AppEntry || null;
+                        const consumerNavigationGeneration = sharedNavigationIntentGeneration != null
+                            ? sharedNavigationIntentGeneration
+                            : (typeof window.__getAppNavigationIntentGeneration === 'function'
+                                ? window.__getAppNavigationIntentGeneration()
+                                : null);
+                        const pendingFilterConsumer = appEntry
+                            && typeof appEntry.beginBrowsePendingFilterConsumer === 'function'
+                            ? appEntry.beginBrowsePendingFilterConsumer(
+                                pendingFilter,
+                                consumerNavigationGeneration
+                            )
+                            : null;
                         const initialization = hasInitializer
                             ? window.initializeBrowseView({ skipLoad: true })
                             : null;
@@ -2586,32 +2599,50 @@ class ExamSystemApp {
                             ? window.__retainBrowseUserResultsRequest(initializationRequestId)
                             : null;
                         let pendingFilterOutcome = 'retryable-failure';
-                        const pendingFilterWasSuperseded = () => {
+                        const ownsPendingFilterConsumer = () => !pendingFilterConsumer
+                            || !appEntry
+                            || typeof appEntry.isBrowsePendingFilterConsumerCurrent !== 'function'
+                            || appEntry.isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer);
+                        const pendingFilterIntentIsCurrent = () => {
                             const activeView = typeof document.querySelector === 'function'
                                 ? document.querySelector('.view.active')
                                 : null;
-                            return window.__pendingBrowseFilter !== pendingFilter
-                                || navigationIntentGeneration !== this._navigationIntentGeneration
-                                || this.currentView !== 'browse'
-                                || (activeView && activeView.id !== 'browse-view')
-                                || (sharedNavigationIntentGeneration != null
-                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
-                                    && window.__getAppNavigationIntentGeneration()
-                                        !== sharedNavigationIntentGeneration)
+                            const sharedIntentIsCurrent = !pendingFilterConsumer
+                                || !appEntry
+                                || typeof appEntry.isBrowsePendingFilterIntentCurrent !== 'function'
+                                || appEntry.isBrowsePendingFilterIntentCurrent(pendingFilterConsumer);
+                            return sharedIntentIsCurrent
+                                && window.__pendingBrowseFilter === pendingFilter
+                                && navigationIntentGeneration === this._navigationIntentGeneration
+                                && this.currentView === 'browse'
+                                && (!activeView || activeView.id === 'browse-view')
+                                && (sharedNavigationIntentGeneration == null
+                                    || typeof window.__getAppNavigationIntentGeneration !== 'function'
+                                    || window.__getAppNavigationIntentGeneration()
+                                        === sharedNavigationIntentGeneration);
+                        };
+                        const pendingFilterAttemptIsCurrent = () => ownsPendingFilterConsumer()
+                            && pendingFilterIntentIsCurrent()
+                            && (initializationRequestId == null
+                                || typeof window.__isBrowseResultsRequestCurrent !== 'function'
+                                || window.__isBrowseResultsRequestCurrent(initializationRequestId));
+                        const currentConsumerWasSuperseded = () => ownsPendingFilterConsumer()
+                            && (!pendingFilterIntentIsCurrent()
                                 || (initializationRequestId != null
                                     && typeof window.__isBrowseResultsRequestCurrent === 'function'
                                     && !window.__isBrowseResultsRequestCurrent(
                                         initializationRequestId
-                                    ));
-                        };
+                                    )));
                         Promise.resolve(initialization).then((initializationResult) => {
                             if (hasInitializer
                                 && (initializationResult === null
                                     || initializationResult === false)) {
                                 return false;
                             }
-                            if (pendingFilterWasSuperseded()) {
-                                pendingFilterOutcome = 'superseded';
+                            if (!pendingFilterAttemptIsCurrent()) {
+                                if (currentConsumerWasSuperseded()) {
+                                    pendingFilterOutcome = 'superseded';
+                                }
                                 return false;
                             }
                             const filterArgs = [category, type, filterMode, path];
@@ -2631,7 +2662,7 @@ class ExamSystemApp {
                                     pendingFilterOutcome = 'applied';
                                     return true;
                                 }
-                                if (pendingFilterWasSuperseded()) {
+                                if (currentConsumerWasSuperseded()) {
                                     pendingFilterOutcome = 'superseded';
                                 }
                                 return false;
@@ -2640,11 +2671,14 @@ class ExamSystemApp {
                                 console.warn('[App] 应用待处理题库筛选失败:', error);
                             })
                             .finally(() => {
-                                if (pendingFilterOutcome !== 'applied'
-                                    && pendingFilterWasSuperseded()) {
+                                const ownsCurrentConsumer = ownsPendingFilterConsumer();
+                                if (ownsCurrentConsumer
+                                    && pendingFilterOutcome !== 'applied'
+                                    && currentConsumerWasSuperseded()) {
                                     pendingFilterOutcome = 'superseded';
                                 }
-                                if (window.__pendingBrowseFilter === pendingFilter
+                                if (ownsCurrentConsumer
+                                    && window.__pendingBrowseFilter === pendingFilter
                                     && (pendingFilterOutcome === 'applied'
                                         || pendingFilterOutcome === 'superseded')) {
                                     delete window.__pendingBrowseFilter;

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -38,23 +38,29 @@
     return owner && typeof owner.resetToAll === 'function' ? owner : null;
   }
 
-  function invokeBrowseStateOwnerReset(owner, label) {
+  function isBrowseResetAttemptCurrent(options) {
+    return !options
+      || typeof options.isCurrent !== 'function'
+      || options.isCurrent() === true;
+  }
+
+  function invokeBrowseStateOwnerReset(owner, label, options) {
     if (!owner) {
       return Promise.resolve(false);
     }
     var reset = typeof owner.resetForActivation === 'function'
       ? owner.resetForActivation
       : owner.resetToAll;
-    return invokeBrowseResetDelegate(reset, owner, label);
+    return invokeBrowseResetDelegate(reset, owner, label, options);
   }
 
-  function invokeBrowseResetDelegate(delegate, context, label) {
-    if (typeof delegate !== 'function') {
+  function invokeBrowseResetDelegate(delegate, context, label, options) {
+    if (typeof delegate !== 'function' || !isBrowseResetAttemptCurrent(options)) {
       return Promise.resolve(false);
     }
     try {
-      return Promise.resolve(delegate.call(context)).then(function (result) {
-        return result !== false;
+      return Promise.resolve(delegate.call(context, options)).then(function (result) {
+        return isBrowseResetAttemptCurrent(options) && result !== false;
       }).catch(function (error) {
         console.warn('[Fallback] ' + label + '失败:', error);
         return false;
@@ -93,10 +99,14 @@
     });
   }
 
-  function resetBrowseFunctionalStateForFallback() {
+  function resetBrowseFunctionalStateForFallback(options) {
     var activationOwner = getBrowseFilterStateOwner();
     if (activationOwner && typeof activationOwner.resetForActivation === 'function') {
-      return invokeBrowseStateOwnerReset(activationOwner, '通过题库状态 owner 完成激活前重置')
+      return invokeBrowseStateOwnerReset(
+        activationOwner,
+        '通过题库状态 owner 完成激活前重置',
+        options
+      )
         .then(function (succeeded) {
           return { succeeded: succeeded, ownerLoaded: false };
         });
@@ -118,7 +128,11 @@
       if (index >= delegates.length) {
         var existingOwner = getBrowseFilterStateOwner();
         if (existingOwner) {
-          return invokeBrowseStateOwnerReset(existingOwner, '通过稳定题库状态 owner 重置')
+          return invokeBrowseStateOwnerReset(
+            existingOwner,
+            '通过稳定题库状态 owner 重置',
+            options
+          )
             .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: false };
           });
@@ -127,14 +141,18 @@
           if (!loaded || !loaded.owner) {
             return { succeeded: false, ownerLoaded: false };
           }
-          return invokeBrowseStateOwnerReset(loaded.owner, '通过延迟加载的题库状态 owner 重置')
+          return invokeBrowseStateOwnerReset(
+            loaded.owner,
+            '通过延迟加载的题库状态 owner 重置',
+            options
+          )
             .then(function (succeeded) {
             return { succeeded: succeeded, ownerLoaded: loaded.loaded === true };
           });
         });
       }
       var candidate = delegates[index];
-      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label)
+      return invokeBrowseResetDelegate(candidate.fn, candidate.context, candidate.label, options)
         .then(function (succeeded) {
           return succeeded
             ? { succeeded: true, ownerLoaded: false }
@@ -188,7 +206,17 @@
         // Register the functional barrier before Browse becomes active. Deferring
         // the reset body closes the synchronous activation-to-registration gap.
         browseFunctionalReset = Promise.resolve().then(function beginBrowseFunctionalReset() {
-          return resetBrowseFunctionalStateForFallback();
+          return resetBrowseFunctionalStateForFallback({
+            isCurrent: function isFunctionalResetCurrent() {
+              return !browseResetBarrierRegistered
+                || (!!browseFunctionalResetBarrier
+                && !!window.AppEntry
+                && typeof window.AppEntry.isBrowseFunctionalResetBarrierCurrent === 'function'
+                && window.AppEntry.isBrowseFunctionalResetBarrierCurrent(
+                  browseFunctionalResetBarrier
+                ));
+            }
+          });
         });
         if (window.AppEntry
           && typeof window.AppEntry.registerBrowseFunctionalResetBarrier === 'function') {
@@ -288,11 +316,25 @@
               && browseResetBarrierRegistered
               && window.AppEntry
               && typeof window.AppEntry.ensureBrowseGroup === 'function') {
-              return Promise.resolve(window.AppEntry.ensureBrowseGroup()).then(function (result) {
+              var groupRefresh = window.AppEntry.ensureBrowseGroup();
+              if (typeof window.AppEntry.updateBrowseFunctionalResetResultsRequest === 'function') {
+                window.AppEntry.updateBrowseFunctionalResetResultsRequest(
+                  browseFunctionalResetBarrier
+                );
+              }
+              return Promise.resolve(groupRefresh).then(function (result) {
                 return result !== false;
               });
             }
-            return runBrowseRefresh();
+            var refreshResult = runBrowseRefresh();
+            if (browseFunctionalResetBarrier
+              && window.AppEntry
+              && typeof window.AppEntry.updateBrowseFunctionalResetResultsRequest === 'function') {
+              window.AppEntry.updateBrowseFunctionalResetResultsRequest(
+                browseFunctionalResetBarrier
+              );
+            }
+            return refreshResult;
           });
         } else {
           browseRefresh = runBrowseRefresh();

--- a/js/bundles/runtime-entry.bundle.js
+++ b/js/bundles/runtime-entry.bundle.js
@@ -1351,7 +1351,7 @@
 
     var prefetchTriggered = false;
     var attachedPrefetchHandlers = false;
-    var browsePrefetchTriggered = false;
+    var browsePrefetchPromise = null;
     var morePrefetchTriggered = false;
 
     function ensurePracticeSuite() {
@@ -1400,15 +1400,20 @@
     }
 
     function triggerBrowsePrefetch() {
-        if (browsePrefetchTriggered) {
-            return;
+        if (browsePrefetchPromise) {
+            return browsePrefetchPromise;
         }
-        browsePrefetchTriggered = true;
-        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
-            global.AppLazyLoader.ensureGroup('browse-runtime').catch(function swallow(error) {
-                console.warn('[AppActions] 浏览模块预加载失败:', error);
-            });
+        if (typeof global.ensureBrowseGroup === 'function') {
+            browsePrefetchPromise = Promise.resolve(global.ensureBrowseGroup());
+        } else if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+            browsePrefetchPromise = Promise.resolve(global.AppLazyLoader.ensureGroup('browse-runtime'));
+        } else {
+            browsePrefetchPromise = Promise.resolve();
         }
+        browsePrefetchPromise = browsePrefetchPromise.catch(function swallow(error) {
+            console.warn('[AppActions] 浏览模块预加载失败:', error);
+        });
+        return browsePrefetchPromise;
     }
 
     function triggerMorePrefetch() {
@@ -1848,6 +1853,10 @@
         var tasks = [];
         if (loader) {
             tasks.push(loader.ensureGroup('exam-data'));
+        }
+        if (typeof global.ensureBrowseGroup === 'function') {
+            tasks.push(global.ensureBrowseGroup().catch(function () { return undefined; }));
+        } else if (loader) {
             tasks.push(loader.ensureGroup('browse-runtime').catch(function () { return undefined; }));
         }
         return Promise.all(tasks).then(function () {

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -2440,7 +2440,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             var browseReady = ensureBrowseGroup();
             var resultsRequestId = hasReplayRequest ? replayRequestId : null;
             var resultsRequestCaptured = hasReplayRequest;
-            if (!hasReplayRequest) {
+            if (!hasReplayRequest && typeof global.__getBrowseResultsRequestId === 'function') {
+                try {
+                    resultsRequestId = global.__getBrowseResultsRequestId();
+                    resultsRequestCaptured = true;
+                } catch (_) { }
+            }
+            if (!hasReplayRequest && !resultsRequestCaptured) {
                 captureBrowseResultsRequest().then(function rememberRequestId(requestId) {
                     resultsRequestId = requestId;
                     resultsRequestCaptured = true;
@@ -2460,6 +2466,14 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     var staleLoading = document.querySelector('#browse-view .loading');
                     if (staleLoading) {
                         staleLoading.style.display = 'none';
+                    }
+                    return;
+                }
+                if (typeof global.__isBrowseUserResultsRequestInFlight === 'function'
+                    && global.__isBrowseUserResultsRequestInFlight(effectiveRequestId)) {
+                    var deferredLoading = document.querySelector('#browse-view .loading');
+                    if (deferredLoading) {
+                        deferredLoading.style.display = 'none';
                     }
                     return;
                 }

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1716,7 +1716,11 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             });
     }
 
+    var browseRuntimePromise = null;
     var browseGroupPromise = null;
+    var browseResetIntentGeneration = 0;
+    var activeBrowseResetIntent = null;
+    var browseResultsProxyGeneration = 0;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -1753,20 +1757,33 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 
         var pendingFilter = global.__pendingBrowseFilter || null;
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
-        return Promise.resolve()
-            .then(function initializeActiveBrowseView() {
-                return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
-            })
+        var initialization;
+        var initializationRequestId = null;
+        try {
+            // Start synchronization in this reaction so a queued repeat reset can
+            // acquire the next latest-wins token immediately after it.
+            initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
+            if (typeof global.__getBrowseResultsRequestId === 'function') {
+                initializationRequestId = global.__getBrowseResultsRequestId();
+            }
+        } catch (error) {
+            return Promise.reject(error);
+        }
+        return Promise.resolve(initialization)
             .then(function applyPendingBrowseFilter() {
                 if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
-                return global.applyBrowseFilter(
+                var filterArgs = [
                     pendingFilter.category,
                     pendingFilter.type,
                     pendingFilter.filterMode,
                     pendingFilter.path
-                );
+                ];
+                if (initializationRequestId != null) {
+                    filterArgs.push(initializationRequestId);
+                }
+                return global.applyBrowseFilter.apply(global, filterArgs);
             })
             .finally(function clearConsumedPendingBrowseFilter() {
                 if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
@@ -1775,9 +1792,19 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             });
     }
 
+    function ensureBrowseRuntimeGroup() {
+        if (!browseRuntimePromise) {
+            browseRuntimePromise = ensureLazyGroup(BROWSE_GROUP).catch(function onBrowseRuntimeLoadError(error) {
+                browseRuntimePromise = null;
+                throw error;
+            });
+        }
+        return browseRuntimePromise;
+    }
+
     function ensureBrowseGroup() {
         if (!browseGroupPromise) {
-            browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
+            browseGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
                 reapplyAppMixins();
                 initializeNavigationShell();
                 ensureBrowseStateManager();
@@ -1900,13 +1927,174 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         return controller;
     }
 
+    function beginBrowseResetIntent() {
+        browseResetIntentGeneration += 1;
+        browseResultsProxyGeneration += 1;
+        activeBrowseResetIntent = {
+            __browseResetIntent: true,
+            generation: browseResetIntentGeneration,
+            examIndexSnapshot: null,
+            examIndexSnapshotVersion: 0,
+            resultsRequestId: null
+        };
+        return activeBrowseResetIntent;
+    }
+
+    function isBrowseResetIntentCurrent(intent) {
+        return activeBrowseResetIntent === intent
+            && !!intent
+            && intent.__browseResetIntent === true
+            && intent.generation === browseResetIntentGeneration;
+    }
+
+    function captureBrowseResetIndexSnapshot(index) {
+        if (!isBrowseResetIntentInFlight()) {
+            return false;
+        }
+        activeBrowseResetIntent.examIndexSnapshot = Array.isArray(index)
+            ? index.slice()
+            : [];
+        activeBrowseResetIntent.examIndexSnapshotVersion += 1;
+        return true;
+    }
+
+    function getBrowseResetIndexSnapshot(intent) {
+        if (!isBrowseResetIntentCurrent(intent)
+            || !isBrowseResetIntentInFlight()
+            || intent.examIndexSnapshotVersion < 1) {
+            return null;
+        }
+        return {
+            index: intent.examIndexSnapshot.slice(),
+            version: intent.examIndexSnapshotVersion
+        };
+    }
+
+    function endBrowseResetIntent(intent) {
+        if (activeBrowseResetIntent === intent) {
+            var shouldReplaySnapshot = isBrowseResetIntentInFlight()
+                && intent.examIndexSnapshotVersion > 0;
+            var snapshot = shouldReplaySnapshot
+                ? intent.examIndexSnapshot.slice()
+                : null;
+            var resultsRequestId = intent.resultsRequestId;
+            activeBrowseResetIntent = null;
+            if (snapshot) {
+                handleExamIndexLoaded(snapshot, resultsRequestId);
+            }
+        }
+    }
+
+    function closeBrowseResetIntent(intent, consumedSnapshotVersion) {
+        if (activeBrowseResetIntent !== intent) {
+            return { closed: true, snapshot: null };
+        }
+        if (!isBrowseResetIntentInFlight()) {
+            activeBrowseResetIntent = null;
+            return { closed: true, snapshot: null };
+        }
+        var consumedVersion = Number(consumedSnapshotVersion) || 0;
+        if (intent.examIndexSnapshotVersion > consumedVersion) {
+            return {
+                closed: false,
+                snapshot: {
+                    index: intent.examIndexSnapshot.slice(),
+                    version: intent.examIndexSnapshotVersion
+                }
+            };
+        }
+        activeBrowseResetIntent = null;
+        return { closed: true, snapshot: null };
+    }
+
+    function setBrowseResetResultsRequest(intent, requestId) {
+        if (!isBrowseResetIntentCurrent(intent)) {
+            return false;
+        }
+        intent.resultsRequestId = requestId;
+        return true;
+    }
+
+    function isBrowseResetIntentInFlight() {
+        if (!activeBrowseResetIntent) {
+            return false;
+        }
+        var requestId = activeBrowseResetIntent.resultsRequestId;
+        return requestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
+    global.__beginBrowseResetIntent = beginBrowseResetIntent;
+    global.__isBrowseResetIntentCurrent = isBrowseResetIntentCurrent;
+    global.__captureBrowseResetIndexSnapshot = captureBrowseResetIndexSnapshot;
+    global.__getBrowseResetIndexSnapshot = getBrowseResetIndexSnapshot;
+    global.__setBrowseResetResultsRequest = setBrowseResetResultsRequest;
+    global.__closeBrowseResetIntent = closeBrowseResetIntent;
+    global.__endBrowseResetIntent = endBrowseResetIntent;
+    global.__isBrowseResetIntentInFlight = isBrowseResetIntentInFlight;
+
+    function beginBrowseResultsProxyIntent() {
+        browseResultsProxyGeneration += 1;
+        return browseResultsProxyGeneration;
+    }
+
+    function captureBrowseResultsRequest() {
+        return ensureBrowseRuntimeGroup().then(function captureRequestId() {
+            return typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null;
+        });
+    }
+
+    function getCurrentBrowseResultsRequest() {
+        return typeof global.__getBrowseResultsRequestId === 'function'
+            ? global.__getBrowseResultsRequestId()
+            : null;
+    }
+
+    function isBrowseResultsSnapshotCurrent(requestId) {
+        return requestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
     function proxyAfterGroup(groupName, getter, fallback) {
         return function proxiedCall() {
             var args = Array.prototype.slice.call(arguments);
+            var resultsProxyGeneration = groupName === BROWSE_GROUP
+                ? beginBrowseResultsProxyIntent()
+                : null;
+            var resetGeneration = groupName === BROWSE_GROUP
+                ? browseResetIntentGeneration
+                : null;
             var groupReady = groupName === BROWSE_GROUP
                 ? ensureBrowseGroup()
                 : ensureLazyGroup(groupName);
+            var resultsRequest = groupName === BROWSE_GROUP
+                ? captureBrowseResultsRequest()
+                : Promise.resolve(null);
+            var resultsRequestId = null;
+            var resultsRequestCaptured = false;
+            if (groupName === BROWSE_GROUP) {
+                resultsRequest.then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
             return groupReady.then(function invoke() {
+                if (groupName === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
+                    return false;
+                }
+                if (groupName === BROWSE_GROUP
+                    && (resultsProxyGeneration !== browseResultsProxyGeneration
+                        || !isBrowseResultsSnapshotCurrent(
+                            resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
+                        ))) {
+                    return false;
+                }
                 var fn = getter();
                 if (typeof fn === 'function') {
                     return fn.apply(global, args);
@@ -1917,6 +2105,33 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return undefined;
             });
         };
+    }
+
+    function proxyAfterBrowseRuntime(getter, fallback) {
+        var proxy = function proxiedBrowseRuntimeCall() {
+            var args = Array.prototype.slice.call(arguments);
+            var resetIntent = beginBrowseResetIntent();
+            // Start the full handoff, but let repeat reset acquire its latest-wins
+            // token as soon as the raw runtime is available instead of waiting for
+            // an older initializeBrowseView synchronization to finish.
+            ensureBrowseGroup().catch(function swallowBrowseHandoffError() {});
+            return ensureBrowseRuntimeGroup().then(function invoke() {
+                if (!isBrowseResetIntentCurrent(resetIntent)) {
+                    return false;
+                }
+                var fn = getter();
+                if (typeof fn === 'function' && fn !== proxy) {
+                    return fn.apply(global, args.concat([resetIntent]));
+                }
+                if (typeof fallback === 'function') {
+                    return fallback.apply(global, args);
+                }
+                return undefined;
+            }).finally(function finishBrowseResetIntent() {
+                endBrowseResetIntent(resetIntent);
+            });
+        };
+        return proxy;
     }
 
     // 保持对外接口
@@ -1959,10 +2174,46 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
+            var tracksBrowseResults = group === BROWSE_GROUP && (
+                name === 'filterByType'
+                || name === 'filterByFrequency'
+                || name === 'searchExams'
+                || name === 'clearSearch'
+                || name === 'browseCategory'
+            );
+            var resultsProxyGeneration = tracksBrowseResults
+                ? beginBrowseResultsProxyIntent()
+                : null;
+            var resetGeneration = group === BROWSE_GROUP
+                ? browseResetIntentGeneration
+                : null;
             var groupReady = group === BROWSE_GROUP
                 ? ensureBrowseGroup()
                 : ensureLazyGroup(group);
+            var resultsRequest = tracksBrowseResults
+                ? captureBrowseResultsRequest()
+                : Promise.resolve(null);
+            var resultsRequestId = null;
+            var resultsRequestCaptured = false;
+            if (tracksBrowseResults) {
+                resultsRequest.then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
             return groupReady.then(function () {
+                if (group === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
+                    return false;
+                }
+                if (tracksBrowseResults
+                    && (resultsProxyGeneration !== browseResultsProxyGeneration
+                        || !isBrowseResultsSnapshotCurrent(
+                            resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
+                        ))) {
+                    return false;
+                }
                 var fn = global[name];
                 if (typeof fn === 'function' && fn !== proxy) {
                     return fn.apply(global, args);
@@ -2099,7 +2350,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     if (typeof global.resetBrowseViewToAll !== 'function') {
-        global.resetBrowseViewToAll = proxyAfterGroup(BROWSE_GROUP, function () {
+        global.resetBrowseViewToAll = proxyAfterBrowseRuntime(function () {
             return global.__legacyResetBrowseViewToAll || global.resetBrowseViewToAll;
         });
     }
@@ -2128,15 +2379,73 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
     }
 
-    function handleExamIndexLoaded(index) {
+    function handleExamIndexLoaded(index, replayRequestId) {
         var snapshot = Array.isArray(index) ? index : [];
         syncOverviewAfterIndexLoad(snapshot);
         var activeView = getActiveViewName();
 
         if (activeView === 'browse') {
-            ensureBrowseGroup().then(function afterBrowseReady() {
-                if (typeof global.loadExamList === 'function') {
-                    try { global.loadExamList(snapshot); } catch (_) { }
+            var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
+                && global.__isBrowseResetIntentInFlight();
+            if (resetInFlight) {
+                if (typeof global.__captureBrowseResetIndexSnapshot === 'function') {
+                    global.__captureBrowseResetIndexSnapshot(snapshot);
+                }
+                var resetLoading = document.querySelector('#browse-view .loading');
+                if (resetLoading) {
+                    resetLoading.style.display = 'none';
+                }
+                return;
+            }
+            var hasReplayRequest = arguments.length > 1 && replayRequestId != null;
+            if (hasReplayRequest && !isBrowseResultsSnapshotCurrent(replayRequestId)) {
+                var staleReplayLoading = document.querySelector('#browse-view .loading');
+                if (staleReplayLoading) {
+                    staleReplayLoading.style.display = 'none';
+                }
+                return;
+            }
+            var browseReady = ensureBrowseGroup();
+            var resultsRequestId = hasReplayRequest ? replayRequestId : null;
+            var resultsRequestCaptured = hasReplayRequest;
+            if (!hasReplayRequest) {
+                captureBrowseResultsRequest().then(function rememberRequestId(requestId) {
+                    resultsRequestId = requestId;
+                    resultsRequestCaptured = true;
+                }).catch(function ignoreRequestCaptureError() {
+                    resultsRequestCaptured = true;
+                });
+            }
+            browseReady.then(function afterBrowseReady() {
+                var effectiveRequestId = resultsRequestCaptured
+                    ? resultsRequestId
+                    : getCurrentBrowseResultsRequest();
+                if (!isBrowseResultsSnapshotCurrent(effectiveRequestId)) {
+                    var staleLoading = document.querySelector('#browse-view .loading');
+                    if (staleLoading) {
+                        staleLoading.style.display = 'none';
+                    }
+                    return;
+                }
+                var searchInput = document.getElementById('exam-search-input')
+                    || document.querySelector('.search-input');
+                var searchQuery = searchInput && typeof searchInput.value === 'string'
+                    ? searchInput.value.trim()
+                    : '';
+                if (searchQuery && typeof global.searchExams === 'function') {
+                    try {
+                        global.searchExams(
+                            searchQuery,
+                            effectiveRequestId
+                        );
+                    } catch (_) { }
+                } else if (typeof global.loadExamList === 'function') {
+                    try {
+                        global.loadExamList(
+                            snapshot,
+                            effectiveRequestId
+                        );
+                    } catch (_) { }
                 }
                 var loading = document.querySelector('#browse-view .loading');
                 if (loading) {

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1730,6 +1730,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var activeBrowseFunctionalResetRecovery = null;
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
+    var browseFunctionalResetFailureDebt = null;
     var browseFunctionalResetState = {
         generation: 0,
         status: 'idle',
@@ -1845,8 +1846,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         completedBrowseFunctionalResetBarrier = null;
         browseFunctionalResetState = {
             generation: ++browseFunctionalResetGeneration,
-            status: 'idle',
-            outcome: null
+            status: browseFunctionalResetFailureDebt ? 'failed' : 'idle',
+            outcome: browseFunctionalResetFailureDebt ? false : null
         };
         return true;
     }
@@ -1920,6 +1921,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     outcome: succeeded
                 };
                 if (!succeeded) {
+                    browseFunctionalResetFailureDebt = {
+                        generation: generation,
+                        outcome: false
+                    };
                     browseFunctionalResetBarrier = null;
                     browseFunctionalResetOwnership = null;
                 }
@@ -1955,6 +1960,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             status: succeeded === true ? 'succeeded' : 'failed',
             outcome: succeeded === true
         };
+        browseFunctionalResetFailureDebt = succeeded === true
+            ? null
+            : {
+                generation: completedGeneration,
+                outcome: false
+            };
         browseFunctionalResetBarrier = null;
         browseFunctionalResetOwnership = null;
         completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
@@ -2031,6 +2042,56 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         return true;
     }
 
+    function prepareBrowseFunctionalResetRecoveryForForeground(requestId) {
+        if (requestId == null
+            || getActiveViewName() !== 'browse'
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function') {
+            return null;
+        }
+        try {
+            if (!global.__isBrowseResultsRequestCurrent(requestId)) {
+                return null;
+            }
+        } catch (_) {
+            return null;
+        }
+
+        var barrier = browseFunctionalResetBarrier;
+        if (barrier) {
+            var ownership = browseFunctionalResetOwnership;
+            var ownedRequestId = ownership && ownership.barrier === barrier
+                ? ownership.resultsRequestId
+                : null;
+            if (ownedRequestId != null) {
+                try {
+                    if (global.__isBrowseResultsRequestCurrent(ownedRequestId)) {
+                        // The retry's own canonical render must retain its barrier.
+                        return null;
+                    }
+                } catch (_) {
+                    // An ownership token that cannot be classified is not proven stale.
+                    return null;
+                }
+            }
+            if (!cancelBrowseFunctionalResetBarrier(barrier, false)) {
+                return null;
+            }
+        }
+
+        var recovery = captureBrowseFunctionalResetRecovery();
+        if (!recovery
+            || !updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId)) {
+            if (recovery && activeBrowseFunctionalResetRecovery === recovery) {
+                activeBrowseFunctionalResetRecovery = null;
+            }
+            return null;
+        }
+        return {
+            recovery: recovery,
+            functionalResetGeneration: recovery.functionalResetGeneration
+        };
+    }
+
     function completeBrowseFunctionalResetRecovery(recovery, succeeded) {
         if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
             return false;
@@ -2042,9 +2103,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             || browseFunctionalResetState.generation !== recovery.functionalResetGeneration
             || appNavigationIntentGeneration !== recovery.navigationGeneration
             || browseResetIntentGeneration !== recovery.resetGeneration
-            || (recovery.resultsRequestId != null
-                && typeof global.__isBrowseResultsRequestCurrent === 'function'
-                && !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId))
+            || recovery.resultsRequestId == null
+            || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+            || !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId)
             || getActiveViewName() !== 'browse') {
             return false;
         }
@@ -2053,6 +2114,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             status: 'succeeded',
             outcome: true
         };
+        browseFunctionalResetFailureDebt = null;
         completedBrowseFunctionalResetBarrier = null;
         return true;
     }
@@ -2077,6 +2139,18 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var initialization;
         var initializationRequestId = null;
         var retainedInitializationRequestId = null;
+        var pendingFilterOutcome = canApplyPendingFilter ? 'retryable-failure' : 'not-applicable';
+        function pendingFilterWasSuperseded() {
+            if (!pendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
+                return true;
+            }
+            if (getActiveViewName() !== 'browse') {
+                return true;
+            }
+            return initializationRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(initializationRequestId);
+        }
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
@@ -2107,7 +2181,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 if (!canApplyPendingFilter) {
                     return true;
                 }
-                if (global.__pendingBrowseFilter !== pendingFilter) {
+                if (pendingFilterWasSuperseded()) {
+                    pendingFilterOutcome = 'superseded';
                     return false;
                 }
                 var filterArgs = [
@@ -2121,16 +2196,32 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 }
                 return Promise.resolve(global.applyBrowseFilter.apply(global, filterArgs))
                     .then(function normalizePendingFilterResult(result) {
-                        return result !== false;
+                        // Legacy filter implementations resolve without a value
+                        // after applying successfully; only explicit null/false
+                        // are retryable non-application outcomes.
+                        if (result !== false && result !== null) {
+                            pendingFilterOutcome = 'applied';
+                            return true;
+                        }
+                        if (pendingFilterWasSuperseded()) {
+                            pendingFilterOutcome = 'superseded';
+                        }
+                        return false;
                     });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
+                if (pendingFilterOutcome !== 'applied' && pendingFilterWasSuperseded()) {
+                    pendingFilterOutcome = 'superseded';
+                }
+                if (pendingFilter
+                    && global.__pendingBrowseFilter === pendingFilter
+                    && (pendingFilterOutcome === 'applied'
+                        || pendingFilterOutcome === 'superseded')) {
+                    delete global.__pendingBrowseFilter;
+                }
                 if (retainedInitializationRequestId != null
                     && typeof global.__endBrowseUserResultsRequest === 'function') {
                     global.__endBrowseUserResultsRequest(retainedInitializationRequestId);
-                }
-                if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
-                    delete global.__pendingBrowseFilter;
                 }
             });
     }
@@ -3097,6 +3188,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         captureBrowseFunctionalResetRecovery: captureBrowseFunctionalResetRecovery,
         updateBrowseFunctionalResetRecoveryResultsRequest:
             updateBrowseFunctionalResetRecoveryResultsRequest,
+        prepareBrowseFunctionalResetRecoveryForForeground:
+            prepareBrowseFunctionalResetRecoveryForForeground,
         completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1818,6 +1818,20 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             && left.pendingFilterIntentGeneration === right.pendingFilterIntentGeneration;
     }
 
+    function retireCompletedBrowseGroupLeaseBarrier(lease, barrier) {
+        if (!lease
+            || !barrier
+            || browseGroupLease !== lease
+            || lease.functionalResetBarrier !== barrier
+            || browseFunctionalResetBarrier !== null
+            || completedBrowseFunctionalResetBarrier !== barrier
+            || browseFunctionalResetState.status !== 'succeeded') {
+            return false;
+        }
+        lease.functionalResetBarrier = null;
+        return true;
+    }
+
     function isBrowseGroupLeaseCurrent(lease) {
         if (!lease
             || lease.navigationGeneration !== appNavigationIntentGeneration
@@ -2397,7 +2411,14 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     completeBrowseFunctionalResetBarrier(resetBarrier, false);
                     return false;
                 }
-                return completeBrowseFunctionalResetBarrier(resetBarrier, true);
+                var completed = completeBrowseFunctionalResetBarrier(resetBarrier, true);
+                if (completed) {
+                    retireCompletedBrowseGroupLeaseBarrier(
+                        synchronizationLease,
+                        resetBarrier
+                    );
+                }
+                return completed;
             }, function (error) {
                 completeBrowseFunctionalResetBarrier(resetBarrier, false);
                 throw error;

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1717,7 +1717,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     var browseRuntimePromise = null;
+    var browseRuntimePrepared = false;
     var browseGroupPromise = null;
+    var browseGroupLease = null;
     var browseResetIntentGeneration = 0;
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
@@ -1731,6 +1733,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
     var browseFunctionalResetFailureDebt = null;
+    var browsePendingFilterIntentGeneration = 0;
+    var browsePendingFilterConsumerGeneration = 0;
+    var activeBrowsePendingFilterConsumer = null;
+    var browsePendingFilterIntentMetadata = new WeakMap();
     var browseFunctionalResetState = {
         generation: 0,
         status: 'idle',
@@ -1739,6 +1745,111 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
+
+    function getOrCreateBrowsePendingFilterIntent(pendingFilter, navigationGeneration) {
+        if (!pendingFilter || typeof pendingFilter !== 'object') {
+            return null;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(pendingFilter);
+        if (!intent) {
+            intent = {
+                generation: ++browsePendingFilterIntentGeneration,
+                navigationGeneration: navigationGeneration
+            };
+            browsePendingFilterIntentMetadata.set(pendingFilter, intent);
+        }
+        return intent;
+    }
+
+    function beginBrowsePendingFilterConsumer(pendingFilter, navigationGeneration) {
+        var effectiveNavigationGeneration = navigationGeneration == null
+            ? appNavigationIntentGeneration
+            : navigationGeneration;
+        var intent = getOrCreateBrowsePendingFilterIntent(
+            pendingFilter,
+            effectiveNavigationGeneration
+        );
+        if (!intent) {
+            return null;
+        }
+        var consumer = {
+            generation: ++browsePendingFilterConsumerGeneration,
+            pendingFilter: pendingFilter,
+            intentGeneration: intent.generation,
+            navigationGeneration: intent.navigationGeneration
+        };
+        activeBrowsePendingFilterConsumer = consumer;
+        return consumer;
+    }
+
+    function isBrowsePendingFilterConsumerCurrent(consumer) {
+        return !!consumer
+            && activeBrowsePendingFilterConsumer === consumer
+            && global.__pendingBrowseFilter === consumer.pendingFilter;
+    }
+
+    function isBrowsePendingFilterIntentCurrent(consumer) {
+        return isBrowsePendingFilterConsumerCurrent(consumer)
+            && consumer.navigationGeneration === appNavigationIntentGeneration
+            && getActiveViewName() === 'browse';
+    }
+
+    function captureBrowseGroupLease() {
+        var pendingFilter = global.__pendingBrowseFilter || null;
+        var intent = getOrCreateBrowsePendingFilterIntent(
+            pendingFilter,
+            appNavigationIntentGeneration
+        );
+        return {
+            navigationGeneration: appNavigationIntentGeneration,
+            activeView: getActiveViewName(),
+            functionalResetBarrier: browseFunctionalResetBarrier,
+            pendingFilter: pendingFilter,
+            pendingFilterIntentGeneration: intent ? intent.generation : null
+        };
+    }
+
+    function areBrowseGroupLeasesEquivalent(left, right) {
+        return !!left
+            && !!right
+            && left.navigationGeneration === right.navigationGeneration
+            && left.functionalResetBarrier === right.functionalResetBarrier
+            && left.pendingFilter === right.pendingFilter
+            && left.pendingFilterIntentGeneration === right.pendingFilterIntentGeneration;
+    }
+
+    function isBrowseGroupLeaseCurrent(lease) {
+        if (!lease
+            || lease.navigationGeneration !== appNavigationIntentGeneration
+            || getActiveViewName() !== lease.activeView
+            || (global.__pendingBrowseFilter || null) !== lease.pendingFilter) {
+            return false;
+        }
+        if (!lease.pendingFilter) {
+            return true;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(lease.pendingFilter);
+        return !!intent
+            && intent.generation === lease.pendingFilterIntentGeneration
+            && intent.navigationGeneration === lease.navigationGeneration;
+    }
+
+    function discardSupersededBrowseGroupPendingFilter(lease) {
+        if (!lease
+            || !lease.pendingFilter
+            || lease.navigationGeneration === appNavigationIntentGeneration
+            || global.__pendingBrowseFilter !== lease.pendingFilter) {
+            return false;
+        }
+        var intent = browsePendingFilterIntentMetadata.get(lease.pendingFilter);
+        if (!intent
+            || intent.generation !== lease.pendingFilterIntentGeneration
+            || intent.navigationGeneration !== lease.navigationGeneration) {
+            return false;
+        }
+        delete global.__pendingBrowseFilter;
+        return true;
+    }
 
     function reapplyAppMixins() {
         if (global.ExamSystemAppMixins && typeof global.ExamSystemAppMixins.__applyToApp === 'function') {
@@ -1882,6 +1993,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             return false;
         });
         browseFunctionalResetBarrier = barrier;
+        // A Browse handoff may already be waiting for the raw runtime. Bind a
+        // reset registered during that wait to the same synchronization lease
+        // so its eventual failure cannot be skipped after the barrier pointer
+        // is retired.
+        if (browseGroupLease && browseGroupPromise) {
+            browseGroupLease.functionalResetBarrier = barrier;
+        }
         var resultsRequestId = null;
         if (typeof global.__beginBrowseResultsRequest === 'function') {
             resultsRequestId = global.__beginBrowseResultsRequest();
@@ -2129,22 +2247,42 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 
     global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
-    function synchronizeActiveBrowseViewNow(functionalResetBarrier) {
-        if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
-            return Promise.resolve();
+    function synchronizeActiveBrowseViewNow(functionalResetBarrier, synchronizationLease) {
+        if (!isBrowseGroupLeaseCurrent(synchronizationLease)) {
+            return Promise.resolve(false);
+        }
+        if (synchronizationLease.activeView !== 'browse') {
+            return Promise.resolve(true);
+        }
+        if (typeof global.initializeBrowseView !== 'function') {
+            return Promise.resolve(false);
         }
 
-        var pendingFilter = global.__pendingBrowseFilter || null;
+        var pendingFilter = synchronizationLease.pendingFilter || null;
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
+        var pendingFilterConsumer = canApplyPendingFilter
+            ? beginBrowsePendingFilterConsumer(
+                pendingFilter,
+                synchronizationLease.navigationGeneration
+            )
+            : null;
         var initialization;
         var initializationRequestId = null;
         var retainedInitializationRequestId = null;
         var pendingFilterOutcome = canApplyPendingFilter ? 'retryable-failure' : 'not-applicable';
-        function pendingFilterWasSuperseded() {
-            if (!pendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
-                return true;
+        function pendingFilterAttemptIsCurrent() {
+            return !canApplyPendingFilter
+                || (isBrowsePendingFilterIntentCurrent(pendingFilterConsumer)
+                    && (initializationRequestId == null
+                        || typeof global.__isBrowseResultsRequestCurrent !== 'function'
+                        || global.__isBrowseResultsRequestCurrent(initializationRequestId)));
+        }
+        function currentConsumerWasSuperseded() {
+            if (!canApplyPendingFilter
+                || !isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer)) {
+                return false;
             }
-            if (getActiveViewName() !== 'browse') {
+            if (!isBrowsePendingFilterIntentCurrent(pendingFilterConsumer)) {
                 return true;
             }
             return initializationRequestId != null
@@ -2154,6 +2292,11 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
+            if (!isBrowseGroupLeaseCurrent(synchronizationLease)
+                || (canApplyPendingFilter
+                    && !isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer))) {
+                return Promise.resolve(false);
+            }
             initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
@@ -2181,8 +2324,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 if (!canApplyPendingFilter) {
                     return true;
                 }
-                if (pendingFilterWasSuperseded()) {
-                    pendingFilterOutcome = 'superseded';
+                if (!pendingFilterAttemptIsCurrent()) {
+                    if (currentConsumerWasSuperseded()) {
+                        pendingFilterOutcome = 'superseded';
+                    }
                     return false;
                 }
                 var filterArgs = [
@@ -2203,17 +2348,22 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                             pendingFilterOutcome = 'applied';
                             return true;
                         }
-                        if (pendingFilterWasSuperseded()) {
+                        if (currentConsumerWasSuperseded()) {
                             pendingFilterOutcome = 'superseded';
                         }
                         return false;
                     });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
-                if (pendingFilterOutcome !== 'applied' && pendingFilterWasSuperseded()) {
+                var ownsCurrentConsumer = !canApplyPendingFilter
+                    || isBrowsePendingFilterConsumerCurrent(pendingFilterConsumer);
+                if (ownsCurrentConsumer
+                    && pendingFilterOutcome !== 'applied'
+                    && currentConsumerWasSuperseded()) {
                     pendingFilterOutcome = 'superseded';
                 }
-                if (pendingFilter
+                if (ownsCurrentConsumer
+                    && pendingFilter
                     && global.__pendingBrowseFilter === pendingFilter
                     && (pendingFilterOutcome === 'applied'
                         || pendingFilterOutcome === 'superseded')) {
@@ -2226,10 +2376,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             });
     }
 
-    function synchronizeActiveBrowseViewAfterLoad() {
-        var resetBarrier = browseFunctionalResetBarrier;
+    function synchronizeActiveBrowseViewAfterLoad(synchronizationLease) {
+        var resetBarrier = synchronizationLease
+            ? synchronizationLease.functionalResetBarrier
+            : browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow().then(function (synchronized) {
+            return synchronizeActiveBrowseViewNow(null, synchronizationLease).then(function (synchronized) {
                 return synchronized !== false;
             });
         }
@@ -2240,7 +2392,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
                 return false;
             }
-            return synchronizeActiveBrowseViewNow(resetBarrier).then(function (synchronized) {
+            return synchronizeActiveBrowseViewNow(resetBarrier, synchronizationLease).then(function (synchronized) {
                 if (synchronized === false) {
                     completeBrowseFunctionalResetBarrier(resetBarrier, false);
                     return false;
@@ -2263,35 +2415,76 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         return browseRuntimePromise;
     }
 
+    function prepareLoadedBrowseRuntime() {
+        reapplyAppMixins();
+        initializeNavigationShell();
+        ensureBrowseStateManager();
+        if (typeof global.setupBrowsePreferenceUI === 'function') {
+            try {
+                global.setupBrowsePreferenceUI();
+            } catch (error) {
+                console.warn('[MainEntry] 初始化题库偏好 UI 失败:', error);
+            }
+        }
+        browseRuntimePrepared = true;
+        return true;
+    }
+
+    function prepareBrowseRuntimeAfterLoad() {
+        return ensureBrowseRuntimeGroup().then(prepareLoadedBrowseRuntime);
+    }
+
+    function prepareBrowseRuntimeForBackgroundRefresh() {
+        var activeSynchronization = browseGroupPromise;
+        if (!activeSynchronization && !browseRuntimePrepared) {
+            return ensureBrowseGroup();
+        }
+        var runtimeReady = prepareBrowseRuntimeAfterLoad();
+        if (!activeSynchronization) {
+            return runtimeReady;
+        }
+        return Promise.all([runtimeReady, activeSynchronization]).then(function afterExistingSync(values) {
+            return values[1] === false ? false : true;
+        });
+    }
+
     function ensureBrowseGroup() {
-        if (!browseGroupPromise) {
-            browseGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
-                reapplyAppMixins();
-                initializeNavigationShell();
-                ensureBrowseStateManager();
-                if (typeof global.setupBrowsePreferenceUI === 'function') {
-                    try {
-                        global.setupBrowsePreferenceUI();
-                    } catch (error) {
-                        console.warn('[MainEntry] 初始化题库偏好 UI 失败:', error);
+        var requestedLease = captureBrowseGroupLease();
+        if (!browseGroupPromise || !areBrowseGroupLeasesEquivalent(browseGroupLease, requestedLease)) {
+            browseGroupLease = requestedLease;
+            var requestedGroupPromise = ensureBrowseRuntimeGroup().then(function onBrowseLoaded() {
+                prepareLoadedBrowseRuntime();
+                if (!isBrowseGroupLeaseCurrent(requestedLease)) {
+                    discardSupersededBrowseGroupPendingFilter(requestedLease);
+                    if (browseGroupPromise === requestedGroupPromise) {
+                        browseGroupPromise = null;
+                        browseGroupLease = null;
                     }
+                    return false;
                 }
-                return synchronizeActiveBrowseViewAfterLoad()
+                return synchronizeActiveBrowseViewAfterLoad(requestedLease)
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
                         return false;
                     })
                     .then(function browseViewSynchronized(synchronized) {
                         if (synchronized === false) {
-                            browseGroupPromise = null;
+                            if (browseGroupPromise === requestedGroupPromise) {
+                                browseGroupPromise = null;
+                                browseGroupLease = null;
+                            }
                             return false;
                         }
                         return true;
                     });
             }).catch(function onBrowseLoadError(error) {
-                browseGroupPromise = null;
+                if (browseGroupPromise === requestedGroupPromise) {
+                    browseGroupPromise = null;
+                    browseGroupLease = null;
+                }
                 throw error;
             });
+            browseGroupPromise = requestedGroupPromise;
         }
         return browseGroupPromise;
     }
@@ -2978,7 +3171,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 }
                 return;
             }
-            var browseReady = ensureBrowseGroup();
+            // Index publication is background work. It needs the loaded
+            // runtime, but must not start or consume a foreground activation
+            // synchronization lease.
+            var browseReady = prepareBrowseRuntimeForBackgroundRefresh();
             var resultsRequestId = hasReplayRequest ? replayRequestId : null;
             var resultsRequestCaptured = hasReplayRequest;
             if (!hasReplayRequest && typeof global.__getBrowseResultsRequestId === 'function') {
@@ -3191,12 +3387,15 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         prepareBrowseFunctionalResetRecoveryForForeground:
             prepareBrowseFunctionalResetRecoveryForForeground,
         completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
+        beginBrowsePendingFilterConsumer: beginBrowsePendingFilterConsumer,
+        isBrowsePendingFilterConsumerCurrent: isBrowsePendingFilterConsumerCurrent,
+        isBrowsePendingFilterIntentCurrent: isBrowsePendingFilterIntentCurrent,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,
         ensureStateCoreGroup: ensureStateCoreGroup,
         ensureSessionSuiteReady: ensureSessionSuiteReady,
-        browseReady: function () { return browseGroupPromise || ensureBrowseGroup(); },
+        browseReady: function () { return ensureBrowseGroup(); },
         examDataReady: ensureExamData
     });
 })(typeof window !== 'undefined' ? window : this);

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -893,7 +893,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             syncOnNavigate: true,
             onNavigate: function onNavigate(viewName) {
                 if (typeof global.showView === 'function') {
-                    global.showView(viewName);
+                    global.showView(viewName, false);
                     return;
                 }
                 if (global.app && typeof global.app.navigateToView === 'function') {
@@ -1731,6 +1731,21 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
     }
 
+    function ensureBrowseStateManager() {
+        if (global.browseStateManager) {
+            return global.browseStateManager;
+        }
+        if (typeof global.BrowseStateManager !== 'function') {
+            return null;
+        }
+        try {
+            return new global.BrowseStateManager();
+        } catch (error) {
+            console.warn('[MainEntry] 初始化浏览状态管理器失败:', error);
+            return null;
+        }
+    }
+
     function synchronizeActiveBrowseViewAfterLoad() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
@@ -1743,7 +1758,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             })
             .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter) {
+                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
                     return undefined;
                 }
                 return global.applyBrowseFilter(
@@ -1764,6 +1779,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         if (!browseGroupPromise) {
             browseGroupPromise = ensureLazyGroup(BROWSE_GROUP).then(function onBrowseLoaded() {
                 reapplyAppMixins();
+                initializeNavigationShell();
+                ensureBrowseStateManager();
                 if (typeof global.setupBrowsePreferenceUI === 'function') {
                     try {
                         global.setupBrowsePreferenceUI();
@@ -1841,12 +1858,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     function initializeNavigationShell() {
+        var controller = null;
         try {
             if (global.NavigationController && typeof global.NavigationController.ensure === 'function') {
-                global.NavigationController.ensure({
+                controller = global.NavigationController.ensure({
                     containerSelector: '.main-nav',
                     activeClass: 'active',
-                    initialView: 'overview',
+                    initialView: getActiveViewName() || 'overview',
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
@@ -1855,7 +1873,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     },
                     onNavigate: function onNavigate(viewName) {
                         if (typeof global.showView === 'function') {
-                            global.showView(viewName);
+                            global.showView(viewName, false);
                             return;
                         }
                         if (global.app && typeof global.app.navigateToView === 'function') {
@@ -1867,6 +1885,19 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         } catch (error) {
             console.warn('[MainEntry] 初始化导航失败:', error);
         }
+        if (controller && typeof document !== 'undefined') {
+            var navRoot = document.querySelector('.main-nav');
+            var fallbackHandler = navRoot && navRoot._legacyNavHandler;
+            if (typeof fallbackHandler === 'function' && typeof navRoot.removeEventListener === 'function') {
+                navRoot.removeEventListener('click', fallbackHandler);
+                try {
+                    delete navRoot._legacyNavHandler;
+                } catch (_) {
+                    navRoot._legacyNavHandler = null;
+                }
+            }
+        }
+        return controller;
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {
@@ -1928,7 +1959,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
-            return ensureLazyGroup(group).then(function () {
+            var groupReady = group === BROWSE_GROUP
+                ? ensureBrowseGroup()
+                : ensureLazyGroup(group);
+            return groupReady.then(function () {
                 var fn = global[name];
                 if (typeof fn === 'function' && fn !== proxy) {
                     return fn.apply(global, args);

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1721,6 +1721,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var browseResetIntentGeneration = 0;
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
+    var appNavigationIntentGeneration = 0;
+    var examIndexRefreshGeneration = 0;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -1884,6 +1886,21 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         return ensureLazyGroup(SETTINGS_GROUP);
     }
 
+    function markAppNavigationIntent(event) {
+        if (event && event.__appEntryNavigationIntentTracked === true) {
+            return appNavigationIntentGeneration;
+        }
+        appNavigationIntentGeneration += 1;
+        if (event) {
+            try {
+                event.__appEntryNavigationIntentTracked = true;
+            } catch (_) { }
+        }
+        return appNavigationIntentGeneration;
+    }
+
+    global.__markAppNavigationIntent = markAppNavigationIntent;
+
     function initializeNavigationShell() {
         var controller = null;
         try {
@@ -1895,10 +1912,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     syncOnNavigate: true,
                     onRepeatNavigate: function onRepeatNavigate(viewName) {
                         if (viewName === 'browse' && typeof global.resetBrowseViewToAll === 'function') {
-                            global.resetBrowseViewToAll();
+                            return global.resetBrowseViewToAll();
                         }
+                        return false;
                     },
-                    onNavigate: function onNavigate(viewName) {
+                    onNavigate: function onNavigate(viewName, event) {
+                        markAppNavigationIntent(event);
                         if (typeof global.showView === 'function') {
                             global.showView(viewName, false);
                             return;
@@ -2174,6 +2193,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
         var proxy = function lazyProxy() {
             var args = Array.prototype.slice.call(arguments);
+            var activeViewAtRequest = name === 'browseCategory'
+                ? getActiveViewName()
+                : null;
+            var navigationIntentAtRequest = name === 'browseCategory'
+                ? appNavigationIntentGeneration
+                : null;
             var tracksBrowseResults = group === BROWSE_GROUP && (
                 name === 'filterByType'
                 || name === 'filterByFrequency'
@@ -2212,6 +2237,11 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                         || !isBrowseResultsSnapshotCurrent(
                             resultsRequestCaptured ? resultsRequestId : getCurrentBrowseResultsRequest()
                         ))) {
+                    return false;
+                }
+                if (name === 'browseCategory'
+                    && (getActiveViewName() !== activeViewAtRequest
+                        || navigationIntentAtRequest !== appNavigationIntentGeneration)) {
                     return false;
                 }
                 var fn = global[name];
@@ -2385,6 +2415,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var activeView = getActiveViewName();
 
         if (activeView === 'browse') {
+            var refreshGeneration = ++examIndexRefreshGeneration;
+            var resultsProxyGenerationAtReceipt = browseResultsProxyGeneration;
             var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
                 && global.__isBrowseResetIntentInFlight();
             if (resetInFlight) {
@@ -2417,6 +2449,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 });
             }
             browseReady.then(function afterBrowseReady() {
+                if (refreshGeneration !== examIndexRefreshGeneration
+                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration) {
+                    return;
+                }
                 var effectiveRequestId = resultsRequestCaptured
                     ? resultsRequestId
                     : getCurrentBrowseResultsRequest();
@@ -2427,6 +2463,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     }
                     return;
                 }
+                var refreshRequestId = typeof global.__beginBrowseResultsRequest === 'function'
+                    ? global.__beginBrowseResultsRequest()
+                    : effectiveRequestId;
                 var searchInput = document.getElementById('exam-search-input')
                     || document.querySelector('.search-input');
                 var searchQuery = searchInput && typeof searchInput.value === 'string'
@@ -2436,14 +2475,14 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     try {
                         global.searchExams(
                             searchQuery,
-                            effectiveRequestId
+                            refreshRequestId
                         );
                     } catch (_) { }
                 } else if (typeof global.loadExamList === 'function') {
                     try {
                         global.loadExamList(
                             snapshot,
-                            effectiveRequestId
+                            refreshRequestId
                         );
                     } catch (_) { }
                 }

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1812,10 +1812,17 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     function synchronizeActiveBrowseViewAfterLoad() {
         var resetBarrier = browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow();
+            return synchronizeActiveBrowseViewNow().then(function () {
+                return true;
+            });
         }
         return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
-            return resetSucceeded ? synchronizeActiveBrowseViewNow() : undefined;
+            if (!resetSucceeded) {
+                return false;
+            }
+            return synchronizeActiveBrowseViewNow().then(function () {
+                return true;
+            });
         });
     }
 
@@ -1845,8 +1852,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return synchronizeActiveBrowseViewAfterLoad()
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
+                        return true;
                     })
-                    .then(function browseViewSynchronized() {
+                    .then(function browseViewSynchronized(synchronized) {
+                        if (synchronized === false) {
+                            browseGroupPromise = null;
+                            return false;
+                        }
                         return true;
                     });
             }).catch(function onBrowseLoadError(error) {
@@ -1925,6 +1937,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     global.__markAppNavigationIntent = markAppNavigationIntent;
+    global.__getAppNavigationIntentGeneration = function getAppNavigationIntentGeneration() {
+        return appNavigationIntentGeneration;
+    };
 
     function initializeNavigationShell() {
         var controller = null;
@@ -2173,7 +2188,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     resultsRequestCaptured = true;
                 });
             }
-            return groupReady.then(function invoke() {
+            return groupReady.then(function invoke(groupSucceeded) {
+                if (groupName === BROWSE_GROUP && groupSucceeded === false) {
+                    return false;
+                }
                 if (groupName === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
                     return false;
                 }
@@ -2298,7 +2316,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     resultsRequestCaptured = true;
                 });
             }
-            return groupReady.then(function () {
+            return groupReady.then(function (groupSucceeded) {
+                if (group === BROWSE_GROUP && groupSucceeded === false) {
+                    return false;
+                }
                 if (group === BROWSE_GROUP && resetGeneration !== browseResetIntentGeneration) {
                     return false;
                 }
@@ -2525,7 +2546,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     resultsRequestCaptured = true;
                 });
             }
-            browseReady.then(function afterBrowseReady() {
+            browseReady.then(function afterBrowseReady(groupSucceeded) {
+                if (groupSucceeded === false) {
+                    return;
+                }
                 if (refreshGeneration !== examIndexRefreshGeneration
                     || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration
                     || navigationGenerationAtReceipt !== appNavigationIntentGeneration

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1726,6 +1726,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
+    var completedBrowseFunctionalResetBarrier = null;
+    var browseFunctionalResetGeneration = 0;
+    var browseFunctionalResetState = {
+        generation: 0,
+        status: 'idle',
+        outcome: null
+    };
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -1756,17 +1763,69 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     function registerBrowseFunctionalResetBarrier(resetPromise) {
-        var barrier = Promise.resolve(resetPromise).catch(function () {
+        var generation = ++browseFunctionalResetGeneration;
+        completedBrowseFunctionalResetBarrier = null;
+        browseFunctionalResetState = {
+            generation: generation,
+            status: 'pending',
+            outcome: null
+        };
+        var barrier = Promise.resolve(resetPromise).then(function normalizeResetOutcome(succeeded) {
+            return succeeded === true;
+        }, function normalizeResetFailure() {
             return false;
         });
         browseFunctionalResetBarrier = barrier;
-        barrier.finally(function clearBrowseFunctionalResetBarrier() {
+        if (typeof global.__beginBrowseResultsRequest === 'function') {
+            global.__beginBrowseResultsRequest();
+        }
+        barrier.then(function settleBrowseFunctionalResetState(succeeded) {
             if (browseFunctionalResetBarrier === barrier) {
-                browseFunctionalResetBarrier = null;
+                browseFunctionalResetState = {
+                    generation: generation,
+                    status: succeeded ? 'pending' : 'failed',
+                    outcome: succeeded
+                };
+                if (!succeeded) {
+                    browseFunctionalResetBarrier = null;
+                }
             }
         });
         return barrier;
     }
+
+    function completeBrowseFunctionalResetBarrier(barrier, succeeded) {
+        if (!barrier) {
+            return false;
+        }
+        if (browseFunctionalResetBarrier !== barrier) {
+            return succeeded === true
+                && completedBrowseFunctionalResetBarrier === barrier
+                && browseFunctionalResetState.status === 'succeeded';
+        }
+        browseFunctionalResetState = {
+            generation: browseFunctionalResetGeneration,
+            status: succeeded === true ? 'succeeded' : 'failed',
+            outcome: succeeded === true
+        };
+        browseFunctionalResetBarrier = null;
+        completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
+        return succeeded === true;
+    }
+
+    function isBrowseFunctionalResetBarrierCurrent(barrier) {
+        return !!barrier && browseFunctionalResetBarrier === barrier;
+    }
+
+    function getBrowseFunctionalResetState() {
+        return {
+            generation: browseFunctionalResetState.generation,
+            status: browseFunctionalResetState.status,
+            outcome: browseFunctionalResetState.outcome
+        };
+    }
+
+    global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
     function synchronizeActiveBrowseViewNow() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
@@ -1832,8 +1891,15 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             if (!resetSucceeded) {
                 return false;
             }
+            if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
+                return false;
+            }
             return synchronizeActiveBrowseViewNow().then(function () {
+                completeBrowseFunctionalResetBarrier(resetBarrier, true);
                 return true;
+            }, function (error) {
+                completeBrowseFunctionalResetBarrier(resetBarrier, false);
+                throw error;
             });
         });
     }
@@ -1864,7 +1930,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return synchronizeActiveBrowseViewAfterLoad()
                     .catch(function onBrowseViewSyncError(error) {
                         console.warn('[MainEntry] 恢复题库视图状态失败:', error);
-                        return true;
+                        return false;
                     })
                     .then(function browseViewSynchronized(synchronized) {
                         if (synchronized === false) {
@@ -2749,6 +2815,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         ensureBrowseRuntimeGroup: ensureBrowseRuntimeGroup,
         ensureBrowseRuntime: ensureBrowseGroup,
         registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
+        completeBrowseFunctionalResetBarrier: completeBrowseFunctionalResetBarrier,
+        isBrowseFunctionalResetBarrierCurrent: isBrowseFunctionalResetBarrierCurrent,
+        getBrowseFunctionalResetState: getBrowseFunctionalResetState,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1776,12 +1776,19 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         var canApplyPendingFilter = !!pendingFilter && typeof global.applyBrowseFilter === 'function';
         var initialization;
         var initializationRequestId = null;
+        var retainedInitializationRequestId = null;
         try {
             // Start synchronization in this reaction so a queued repeat reset can
             // acquire the next latest-wins token immediately after it.
             initialization = global.initializeBrowseView({ skipLoad: canApplyPendingFilter });
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
+            }
+            if (initializationRequestId != null
+                && typeof global.__retainBrowseUserResultsRequest === 'function') {
+                retainedInitializationRequestId = global.__retainBrowseUserResultsRequest(
+                    initializationRequestId
+                );
             }
         } catch (error) {
             return Promise.reject(error);
@@ -1803,6 +1810,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 return global.applyBrowseFilter.apply(global, filterArgs);
             })
             .finally(function clearConsumedPendingBrowseFilter() {
+                if (retainedInitializationRequestId != null
+                    && typeof global.__endBrowseUserResultsRequest === 'function') {
+                    global.__endBrowseUserResultsRequest(retainedInitializationRequestId);
+                }
                 if (pendingFilter && global.__pendingBrowseFilter === pendingFilter) {
                     delete global.__pendingBrowseFilter;
                 }

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1722,6 +1722,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var activeBrowseResetIntent = null;
     var browseResultsProxyGeneration = 0;
     var appNavigationIntentGeneration = 0;
+    var activeLibraryGeneration = 0;
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
@@ -1951,6 +1952,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     global.__getAppNavigationIntentGeneration = function getAppNavigationIntentGeneration() {
         return appNavigationIntentGeneration;
     };
+    global.__getActiveLibraryGeneration = function getActiveLibraryGeneration() {
+        return activeLibraryGeneration;
+    };
 
     function initializeNavigationShell() {
         var controller = null;
@@ -2103,6 +2107,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     global.__closeBrowseResetIntent = closeBrowseResetIntent;
     global.__endBrowseResetIntent = endBrowseResetIntent;
     global.__isBrowseResetIntentInFlight = isBrowseResetIntentInFlight;
+    global.__getBrowseResetIntentGeneration = function getBrowseResetIntentGeneration() {
+        return browseResetIntentGeneration;
+    };
 
     function beginBrowseResultsProxyIntent() {
         browseResultsProxyGeneration += 1;
@@ -2661,6 +2668,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     }
 
     global.addEventListener('examIndexLoaded', function onExamIndexLoaded(event) {
+        activeLibraryGeneration += 1;
         handleExamIndexLoaded(event && event.detail ? event.detail.index : []);
     });
 

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1723,6 +1723,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var browseResultsProxyGeneration = 0;
     var appNavigationIntentGeneration = 0;
     var examIndexRefreshGeneration = 0;
+    var deferredBrowseIndexRefresh = null;
+    var browseFunctionalResetBarrier = null;
     var stateCorePromise = null;
     var sessionSuitePromise = null;
     var coreBootstrapStarted = false;
@@ -1752,7 +1754,20 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
     }
 
-    function synchronizeActiveBrowseViewAfterLoad() {
+    function registerBrowseFunctionalResetBarrier(resetPromise) {
+        var barrier = Promise.resolve(resetPromise).catch(function () {
+            return false;
+        });
+        browseFunctionalResetBarrier = barrier;
+        barrier.finally(function clearBrowseFunctionalResetBarrier() {
+            if (browseFunctionalResetBarrier === barrier) {
+                browseFunctionalResetBarrier = null;
+            }
+        });
+        return barrier;
+    }
+
+    function synchronizeActiveBrowseViewNow() {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
         }
@@ -1792,6 +1807,16 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                     delete global.__pendingBrowseFilter;
                 }
             });
+    }
+
+    function synchronizeActiveBrowseViewAfterLoad() {
+        var resetBarrier = browseFunctionalResetBarrier;
+        if (!resetBarrier) {
+            return synchronizeActiveBrowseViewNow();
+        }
+        return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
+            return resetSucceeded ? synchronizeActiveBrowseViewNow() : undefined;
+        });
     }
 
     function ensureBrowseRuntimeGroup() {
@@ -2076,6 +2101,51 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         return requestId == null
             || typeof global.__isBrowseResultsRequestCurrent !== 'function'
             || global.__isBrowseResultsRequestCurrent(requestId);
+    }
+
+    function isBrowseUserResultsRequestInFlight(requestId) {
+        return requestId != null
+            && typeof global.__isBrowseUserResultsRequestInFlight === 'function'
+            && global.__isBrowseUserResultsRequestInFlight(requestId);
+    }
+
+    function isBrowseUserResultsRequest(requestId) {
+        return requestId != null
+            && typeof global.__isBrowseUserResultsRequest === 'function'
+            && global.__isBrowseUserResultsRequest(requestId);
+    }
+
+    function deferBrowseIndexRefresh(snapshot, refreshGeneration, proxyGeneration, navigationGeneration) {
+        deferredBrowseIndexRefresh = {
+            snapshot: Array.isArray(snapshot) ? snapshot.slice() : [],
+            refreshGeneration: refreshGeneration,
+            proxyGeneration: proxyGeneration,
+            navigationGeneration: navigationGeneration
+        };
+    }
+
+    function replayDeferredBrowseIndexRefresh(settledRequestId) {
+        var deferred = deferredBrowseIndexRefresh;
+        if (!deferred) {
+            return;
+        }
+        if (deferred.refreshGeneration !== examIndexRefreshGeneration
+            || deferred.proxyGeneration !== browseResultsProxyGeneration
+            || deferred.navigationGeneration !== appNavigationIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            deferredBrowseIndexRefresh = null;
+            return;
+        }
+        var currentRequestId = getCurrentBrowseResultsRequest();
+        if (isBrowseUserResultsRequestInFlight(currentRequestId)) {
+            return;
+        }
+        if (currentRequestId !== settledRequestId) {
+            deferredBrowseIndexRefresh = null;
+            return;
+        }
+        deferredBrowseIndexRefresh = null;
+        handleExamIndexLoaded(deferred.snapshot, currentRequestId);
     }
 
     function proxyAfterGroup(groupName, getter, fallback) {
@@ -2417,6 +2487,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         if (activeView === 'browse') {
             var refreshGeneration = ++examIndexRefreshGeneration;
             var resultsProxyGenerationAtReceipt = browseResultsProxyGeneration;
+            var navigationGenerationAtReceipt = appNavigationIntentGeneration;
             var resetInFlight = typeof global.__isBrowseResetIntentInFlight === 'function'
                 && global.__isBrowseResetIntentInFlight();
             if (resetInFlight) {
@@ -2456,13 +2527,32 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             }
             browseReady.then(function afterBrowseReady() {
                 if (refreshGeneration !== examIndexRefreshGeneration
-                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration) {
+                    || resultsProxyGenerationAtReceipt !== browseResultsProxyGeneration
+                    || navigationGenerationAtReceipt !== appNavigationIntentGeneration
+                    || getActiveViewName() !== 'browse') {
                     return;
                 }
                 var effectiveRequestId = resultsRequestCaptured
                     ? resultsRequestId
                     : getCurrentBrowseResultsRequest();
                 if (!isBrowseResultsSnapshotCurrent(effectiveRequestId)) {
+                    var currentRequestId = getCurrentBrowseResultsRequest();
+                    if (isBrowseUserResultsRequestInFlight(currentRequestId)) {
+                        deferBrowseIndexRefresh(
+                            snapshot,
+                            refreshGeneration,
+                            resultsProxyGenerationAtReceipt,
+                            navigationGenerationAtReceipt
+                        );
+                    } else if (isBrowseUserResultsRequest(currentRequestId)) {
+                        deferBrowseIndexRefresh(
+                            snapshot,
+                            refreshGeneration,
+                            resultsProxyGenerationAtReceipt,
+                            navigationGenerationAtReceipt
+                        );
+                        replayDeferredBrowseIndexRefresh(currentRequestId);
+                    }
                     var staleLoading = document.querySelector('#browse-view .loading');
                     if (staleLoading) {
                         staleLoading.style.display = 'none';
@@ -2471,6 +2561,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 }
                 if (typeof global.__isBrowseUserResultsRequestInFlight === 'function'
                     && global.__isBrowseUserResultsRequestInFlight(effectiveRequestId)) {
+                    deferBrowseIndexRefresh(
+                        snapshot,
+                        refreshGeneration,
+                        resultsProxyGenerationAtReceipt,
+                        navigationGenerationAtReceipt
+                    );
                     var deferredLoading = document.querySelector('#browse-view .loading');
                     if (deferredLoading) {
                         deferredLoading.style.display = 'none';
@@ -2480,12 +2576,20 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 var refreshRequestId = typeof global.__beginBrowseResultsRequest === 'function'
                     ? global.__beginBrowseResultsRequest()
                     : effectiveRequestId;
+                if (deferredBrowseIndexRefresh
+                    && deferredBrowseIndexRefresh.refreshGeneration <= refreshGeneration) {
+                    deferredBrowseIndexRefresh = null;
+                }
                 var searchInput = document.getElementById('exam-search-input')
                     || document.querySelector('.search-input');
                 var searchQuery = searchInput && typeof searchInput.value === 'string'
                     ? searchInput.value.trim()
                     : '';
-                if (searchQuery && typeof global.searchExams === 'function') {
+                if (typeof global.__renderBrowseResultsForState === 'function') {
+                    try {
+                        global.__renderBrowseResultsForState(snapshot, refreshRequestId);
+                    } catch (_) { }
+                } else if (searchQuery && typeof global.searchExams === 'function') {
                     try {
                         global.searchExams(
                             searchQuery,
@@ -2523,6 +2627,11 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 
     global.addEventListener('examIndexLoaded', function onExamIndexLoaded(event) {
         handleExamIndexLoaded(event && event.detail ? event.detail.index : []);
+    });
+
+    global.addEventListener('browseUserResultsRequestSettled', function onBrowseUserResultsRequestSettled(event) {
+        var requestId = event && event.detail ? event.detail.requestId : null;
+        replayDeferredBrowseIndexRefresh(requestId);
     });
 
     global.addEventListener('appCoreReady', function onAppCoreReady() {
@@ -2594,7 +2703,9 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     global.AppEntry = Object.assign({}, global.AppEntry || {}, {
         STRICT_ON_DEMAND: STRICT_ON_DEMAND,
         ensureBrowseGroup: ensureBrowseGroup,
+        ensureBrowseRuntimeGroup: ensureBrowseRuntimeGroup,
         ensureBrowseRuntime: ensureBrowseGroup,
+        registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -1726,6 +1726,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     var examIndexRefreshGeneration = 0;
     var deferredBrowseIndexRefresh = null;
     var browseFunctionalResetBarrier = null;
+    var browseFunctionalResetOwnership = null;
+    var activeBrowseFunctionalResetRecovery = null;
     var completedBrowseFunctionalResetBarrier = null;
     var browseFunctionalResetGeneration = 0;
     var browseFunctionalResetState = {
@@ -1762,7 +1764,110 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         }
     }
 
+    function invalidateBrowseResultsForSupersedingIntent() {
+        if (typeof global.__beginBrowseResultsRequest !== 'function') {
+            return;
+        }
+        try {
+            global.__beginBrowseResultsRequest();
+        } catch (_) { }
+    }
+
+    function isBrowseFunctionalResetOwnershipCurrent(barrier, includeResultsRequest) {
+        var ownership = browseFunctionalResetOwnership;
+        if (!barrier
+            || browseFunctionalResetBarrier !== barrier
+            || !ownership
+            || ownership.barrier !== barrier
+            || ownership.navigationGeneration !== appNavigationIntentGeneration
+            || ownership.resetGeneration !== browseResetIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        if (includeResultsRequest && typeof global.__isBrowseResultsRequestCurrent === 'function') {
+            // Once the runtime exposes token arbitration, an unbound cold lease
+            // must fail closed instead of adopting whichever request is current.
+            if (ownership.resultsRequestId == null
+                || !global.__isBrowseResultsRequestCurrent(ownership.resultsRequestId)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function claimBrowseFunctionalResetResultsRequest(barrier) {
+        var ownership = browseFunctionalResetOwnership;
+        if (!barrier
+            || browseFunctionalResetBarrier !== barrier
+            || !ownership
+            || ownership.barrier !== barrier
+            || ownership.navigationGeneration !== appNavigationIntentGeneration
+            || ownership.resetGeneration !== browseResetIntentGeneration
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        if (ownership.resultsRequestId != null) {
+            return true;
+        }
+        if (typeof global.__beginBrowseResultsRequest !== 'function') {
+            return false;
+        }
+        if (typeof global.__getBrowseResultsRequestId === 'function') {
+            try {
+                if (global.__getBrowseResultsRequestId() !== 0) {
+                    return false;
+                }
+            } catch (_) {
+                return false;
+            }
+        }
+        try {
+            var resultsRequestId = global.__beginBrowseResultsRequest();
+            if (resultsRequestId == null) {
+                return false;
+            }
+            ownership.resultsRequestId = resultsRequestId;
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function cancelBrowseFunctionalResetBarrier(barrier, invalidateResults) {
+        if (!barrier || browseFunctionalResetBarrier !== barrier) {
+            return false;
+        }
+        if (invalidateResults === true) {
+            invalidateBrowseResultsForSupersedingIntent();
+        }
+        browseFunctionalResetBarrier = null;
+        browseFunctionalResetOwnership = null;
+        completedBrowseFunctionalResetBarrier = null;
+        browseFunctionalResetState = {
+            generation: ++browseFunctionalResetGeneration,
+            status: 'idle',
+            outcome: null
+        };
+        return true;
+    }
+
+    function cancelCurrentBrowseFunctionalResetForSupersedingIntent() {
+        var shouldInvalidateResults = false;
+        if (browseFunctionalResetBarrier) {
+            cancelBrowseFunctionalResetBarrier(browseFunctionalResetBarrier, false);
+            shouldInvalidateResults = true;
+        }
+        if (activeBrowseFunctionalResetRecovery) {
+            activeBrowseFunctionalResetRecovery = null;
+            shouldInvalidateResults = true;
+        }
+        if (shouldInvalidateResults) {
+            invalidateBrowseResultsForSupersedingIntent();
+        }
+    }
+
     function registerBrowseFunctionalResetBarrier(resetPromise) {
+        activeBrowseFunctionalResetRecovery = null;
         var generation = ++browseFunctionalResetGeneration;
         completedBrowseFunctionalResetBarrier = null;
         browseFunctionalResetState = {
@@ -1776,11 +1881,39 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             return false;
         });
         browseFunctionalResetBarrier = barrier;
+        var resultsRequestId = null;
         if (typeof global.__beginBrowseResultsRequest === 'function') {
-            global.__beginBrowseResultsRequest();
+            resultsRequestId = global.__beginBrowseResultsRequest();
+        }
+        browseFunctionalResetOwnership = {
+            barrier: barrier,
+            generation: generation,
+            navigationGeneration: appNavigationIntentGeneration,
+            resetGeneration: browseResetIntentGeneration,
+            resultsRequestId: resultsRequestId,
+            deferredExamIndexSnapshot: null
+        };
+        if (resultsRequestId == null) {
+            // This continuation is registered before the deferred reset body can
+            // attach its lazy-owner continuation, so a cold barrier claims R1
+            // before any later filter or background refresh can own the runtime.
+            ensureBrowseRuntimeGroup().then(function bindColdFunctionalResetResultsRequest() {
+                if (browseFunctionalResetBarrier !== barrier) {
+                    return;
+                }
+                if (!claimBrowseFunctionalResetResultsRequest(barrier)
+                    && browseFunctionalResetBarrier === barrier
+                    && typeof global.__isBrowseResultsRequestCurrent === 'function') {
+                    cancelBrowseFunctionalResetBarrier(barrier, false);
+                }
+            }).catch(function ignoreColdFunctionalResetBindingFailure() { });
         }
         barrier.then(function settleBrowseFunctionalResetState(succeeded) {
             if (browseFunctionalResetBarrier === barrier) {
+                if (!isBrowseFunctionalResetOwnershipCurrent(barrier, false)) {
+                    cancelBrowseFunctionalResetBarrier(barrier, false);
+                    return;
+                }
                 browseFunctionalResetState = {
                     generation: generation,
                     status: succeeded ? 'pending' : 'failed',
@@ -1788,6 +1921,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 };
                 if (!succeeded) {
                     browseFunctionalResetBarrier = null;
+                    browseFunctionalResetOwnership = null;
                 }
             }
         });
@@ -1803,18 +1937,124 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 && completedBrowseFunctionalResetBarrier === barrier
                 && browseFunctionalResetState.status === 'succeeded';
         }
+        if (!isBrowseFunctionalResetOwnershipCurrent(barrier, true)) {
+            cancelBrowseFunctionalResetBarrier(barrier, false);
+            return false;
+        }
+        var completedOwnership = browseFunctionalResetOwnership;
+        var deferredExamIndexSnapshot = succeeded === true
+            && completedOwnership
+            && Array.isArray(completedOwnership.deferredExamIndexSnapshot)
+            ? completedOwnership.deferredExamIndexSnapshot.slice()
+            : null;
+        var completedGeneration = browseFunctionalResetGeneration;
+        var completedNavigationGeneration = appNavigationIntentGeneration;
+        var completedResetGeneration = browseResetIntentGeneration;
         browseFunctionalResetState = {
-            generation: browseFunctionalResetGeneration,
+            generation: completedGeneration,
             status: succeeded === true ? 'succeeded' : 'failed',
             outcome: succeeded === true
         };
         browseFunctionalResetBarrier = null;
+        browseFunctionalResetOwnership = null;
         completedBrowseFunctionalResetBarrier = succeeded === true ? barrier : null;
+        if (deferredExamIndexSnapshot) {
+            Promise.resolve().then(function replayFunctionalResetIndexSnapshot() {
+                if (browseFunctionalResetGeneration !== completedGeneration
+                    || browseFunctionalResetState.status !== 'succeeded'
+                    || appNavigationIntentGeneration !== completedNavigationGeneration
+                    || browseResetIntentGeneration !== completedResetGeneration
+                    || getActiveViewName() !== 'browse') {
+                    return;
+                }
+                handleExamIndexLoaded(deferredExamIndexSnapshot);
+            });
+        }
         return succeeded === true;
     }
 
     function isBrowseFunctionalResetBarrierCurrent(barrier) {
-        return !!barrier && browseFunctionalResetBarrier === barrier;
+        if (isBrowseFunctionalResetOwnershipCurrent(barrier, true)) {
+            return true;
+        }
+        if (barrier && browseFunctionalResetBarrier === barrier) {
+            cancelBrowseFunctionalResetBarrier(barrier, false);
+        }
+        return false;
+    }
+
+    function updateBrowseFunctionalResetResultsRequest(barrier, requestId) {
+        if (!isBrowseFunctionalResetOwnershipCurrent(barrier, false)) {
+            return false;
+        }
+        var nextRequestId = requestId;
+        if (nextRequestId == null && typeof global.__getBrowseResultsRequestId === 'function') {
+            nextRequestId = global.__getBrowseResultsRequestId();
+        }
+        if (nextRequestId == null) {
+            return false;
+        }
+        browseFunctionalResetOwnership.resultsRequestId = nextRequestId;
+        return true;
+    }
+
+    function captureBrowseFunctionalResetRecovery() {
+        if (browseFunctionalResetBarrier
+            || browseFunctionalResetState.status !== 'failed'
+            || getActiveViewName() !== 'browse') {
+            return null;
+        }
+        var recovery = {
+            functionalResetGeneration: browseFunctionalResetState.generation,
+            navigationGeneration: appNavigationIntentGeneration,
+            resetGeneration: browseResetIntentGeneration,
+            resultsRequestId: typeof global.__getBrowseResultsRequestId === 'function'
+                ? global.__getBrowseResultsRequestId()
+                : null
+        };
+        activeBrowseFunctionalResetRecovery = recovery;
+        return recovery;
+    }
+
+    function updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId) {
+        if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
+            return false;
+        }
+        var nextRequestId = requestId;
+        if (nextRequestId == null && typeof global.__getBrowseResultsRequestId === 'function') {
+            nextRequestId = global.__getBrowseResultsRequestId();
+        }
+        if (nextRequestId == null) {
+            return false;
+        }
+        recovery.resultsRequestId = nextRequestId;
+        return true;
+    }
+
+    function completeBrowseFunctionalResetRecovery(recovery, succeeded) {
+        if (!recovery || activeBrowseFunctionalResetRecovery !== recovery) {
+            return false;
+        }
+        activeBrowseFunctionalResetRecovery = null;
+        if (succeeded !== true
+            || browseFunctionalResetBarrier
+            || browseFunctionalResetState.status !== 'failed'
+            || browseFunctionalResetState.generation !== recovery.functionalResetGeneration
+            || appNavigationIntentGeneration !== recovery.navigationGeneration
+            || browseResetIntentGeneration !== recovery.resetGeneration
+            || (recovery.resultsRequestId != null
+                && typeof global.__isBrowseResultsRequestCurrent === 'function'
+                && !global.__isBrowseResultsRequestCurrent(recovery.resultsRequestId))
+            || getActiveViewName() !== 'browse') {
+            return false;
+        }
+        browseFunctionalResetState = {
+            generation: ++browseFunctionalResetGeneration,
+            status: 'succeeded',
+            outcome: true
+        };
+        completedBrowseFunctionalResetBarrier = null;
+        return true;
     }
 
     function getBrowseFunctionalResetState() {
@@ -1827,7 +2067,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
 
     global.__getBrowseFunctionalResetState = getBrowseFunctionalResetState;
 
-    function synchronizeActiveBrowseViewNow() {
+    function synchronizeActiveBrowseViewNow(functionalResetBarrier) {
         if (getActiveViewName() !== 'browse' || typeof global.initializeBrowseView !== 'function') {
             return Promise.resolve();
         }
@@ -1844,6 +2084,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             if (typeof global.__getBrowseResultsRequestId === 'function') {
                 initializationRequestId = global.__getBrowseResultsRequestId();
             }
+            if (functionalResetBarrier) {
+                updateBrowseFunctionalResetResultsRequest(
+                    functionalResetBarrier,
+                    initializationRequestId
+                );
+            }
             if (initializationRequestId != null
                 && typeof global.__retainBrowseUserResultsRequest === 'function') {
                 retainedInitializationRequestId = global.__retainBrowseUserResultsRequest(
@@ -1854,9 +2100,15 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             return Promise.reject(error);
         }
         return Promise.resolve(initialization)
-            .then(function applyPendingBrowseFilter() {
-                if (!canApplyPendingFilter || global.__pendingBrowseFilter !== pendingFilter) {
-                    return undefined;
+            .then(function applyPendingBrowseFilter(initializationResult) {
+                if (initializationResult === null || initializationResult === false) {
+                    return false;
+                }
+                if (!canApplyPendingFilter) {
+                    return true;
+                }
+                if (global.__pendingBrowseFilter !== pendingFilter) {
+                    return false;
                 }
                 var filterArgs = [
                     pendingFilter.category,
@@ -1867,7 +2119,10 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 if (initializationRequestId != null) {
                     filterArgs.push(initializationRequestId);
                 }
-                return global.applyBrowseFilter.apply(global, filterArgs);
+                return Promise.resolve(global.applyBrowseFilter.apply(global, filterArgs))
+                    .then(function normalizePendingFilterResult(result) {
+                        return result !== false;
+                    });
             })
             .finally(function clearConsumedPendingBrowseFilter() {
                 if (retainedInitializationRequestId != null
@@ -1883,8 +2138,8 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     function synchronizeActiveBrowseViewAfterLoad() {
         var resetBarrier = browseFunctionalResetBarrier;
         if (!resetBarrier) {
-            return synchronizeActiveBrowseViewNow().then(function () {
-                return true;
+            return synchronizeActiveBrowseViewNow().then(function (synchronized) {
+                return synchronized !== false;
             });
         }
         return Promise.resolve(resetBarrier).then(function afterFunctionalReset(resetSucceeded) {
@@ -1894,9 +2149,12 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             if (!isBrowseFunctionalResetBarrierCurrent(resetBarrier)) {
                 return false;
             }
-            return synchronizeActiveBrowseViewNow().then(function () {
-                completeBrowseFunctionalResetBarrier(resetBarrier, true);
-                return true;
+            return synchronizeActiveBrowseViewNow(resetBarrier).then(function (synchronized) {
+                if (synchronized === false) {
+                    completeBrowseFunctionalResetBarrier(resetBarrier, false);
+                    return false;
+                }
+                return completeBrowseFunctionalResetBarrier(resetBarrier, true);
             }, function (error) {
                 completeBrowseFunctionalResetBarrier(resetBarrier, false);
                 throw error;
@@ -2006,6 +2264,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
             return appNavigationIntentGeneration;
         }
         appNavigationIntentGeneration += 1;
+        cancelCurrentBrowseFunctionalResetForSupersedingIntent();
         if (event) {
             try {
                 event.__appEntryNavigationIntentTracked = true;
@@ -2070,6 +2329,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
     function beginBrowseResetIntent() {
         browseResetIntentGeneration += 1;
         browseResultsProxyGeneration += 1;
+        cancelCurrentBrowseFunctionalResetForSupersedingIntent();
         activeBrowseResetIntent = {
             __browseResetIntent: true,
             generation: browseResetIntentGeneration,
@@ -2605,6 +2865,20 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 }
                 return;
             }
+            var functionalResetBarrier = browseFunctionalResetBarrier;
+            if (functionalResetBarrier
+                && isBrowseFunctionalResetOwnershipCurrent(functionalResetBarrier, true)) {
+                browseFunctionalResetOwnership.deferredExamIndexSnapshot = snapshot.slice();
+                var functionalResetLoading = document.querySelector('#browse-view .loading');
+                if (functionalResetLoading) {
+                    functionalResetLoading.style.display = 'none';
+                }
+                return;
+            }
+            if (functionalResetBarrier
+                && browseFunctionalResetBarrier === functionalResetBarrier) {
+                isBrowseFunctionalResetBarrierCurrent(functionalResetBarrier);
+            }
             var hasReplayRequest = arguments.length > 1 && replayRequestId != null;
             if (hasReplayRequest && !isBrowseResultsSnapshotCurrent(replayRequestId)) {
                 var staleReplayLoading = document.querySelector('#browse-view .loading');
@@ -2817,7 +3091,13 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
         registerBrowseFunctionalResetBarrier: registerBrowseFunctionalResetBarrier,
         completeBrowseFunctionalResetBarrier: completeBrowseFunctionalResetBarrier,
         isBrowseFunctionalResetBarrierCurrent: isBrowseFunctionalResetBarrierCurrent,
+        cancelBrowseFunctionalResetBarrier: cancelBrowseFunctionalResetBarrier,
+        updateBrowseFunctionalResetResultsRequest: updateBrowseFunctionalResetResultsRequest,
         getBrowseFunctionalResetState: getBrowseFunctionalResetState,
+        captureBrowseFunctionalResetRecovery: captureBrowseFunctionalResetRecovery,
+        updateBrowseFunctionalResetRecoveryResultsRequest:
+            updateBrowseFunctionalResetRecoveryResultsRequest,
+        completeBrowseFunctionalResetRecovery: completeBrowseFunctionalResetRecovery,
         ensureMoreToolsGroup: ensureMoreToolsGroup,
         ensureSettingsToolsGroup: ensureSettingsToolsGroup,
         ensurePracticeSuiteGroup: ensurePracticeSuiteGroup,

--- a/js/components/BrowseStateManager.js
+++ b/js/components/BrowseStateManager.js
@@ -86,19 +86,16 @@ class BrowseStateManager {
      * 处理浏览导航
      */
     handleBrowseNavigation() {
-        console.log('[BrowseStateManager] 处理浏览导航，重置为显示所有考试');
+        console.log('[BrowseStateManager] 记录题库浏览导航');
 
-        if (typeof window.clearPendingBrowseAutoScroll === 'function') {
-            try { window.clearPendingBrowseAutoScroll(); } catch (_) {}
-        }
-
-        // 重置到全部考试视图
-        this.resetToAllExams();
+        // 导航控制器单独区分“进入 Browse”和“重复点击 Browse”。
+        // 普通进入时保留待处理的分类与持久化偏好；重复导航才由
+        // ExamActions.resetBrowseViewToAll 执行原子重置。
 
         // 记录导航历史
         this.addToHistory({
             action: 'navigate_to_browse',
-            filter: 'all',
+            filter: this.currentFilter,
             timestamp: Date.now()
         });
     }
@@ -308,6 +305,11 @@ class BrowseStateManager {
         this.setState({
             currentCategory: null,
             currentFrequency: null,
+            filters: {
+                frequency: 'all',
+                status: 'all',
+                difficulty: 'all'
+            },
             searchQuery: '',
             pagination: {
                 page: 1,
@@ -357,9 +359,14 @@ class BrowseStateManager {
      * 清除搜索状态
      */
     clearSearchState() {
-        const searchInput = document.querySelector('.search-input');
+        const searchInput = document.getElementById('exam-search-input')
+            || document.querySelector('.search-input');
         if (searchInput) {
             searchInput.value = '';
+        }
+        const clearButton = document.getElementById('search-clear-btn');
+        if (clearButton) {
+            clearButton.hidden = true;
         }
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -2128,8 +2128,10 @@ function refreshBrowseProgressFromRecords(
             return false;
         }
         // Both derived states are built without mutation. Validate the
-        // completion candidate before accepting the anchor queue; the later
-        // completion commit is then one non-throwing assignment.
+        // completion candidate before publishing the generation-fenced live
+        // anchor snapshot; durable anchor persistence remains downstream of
+        // that accepted projection. The completion commit is then one
+        // non-throwing assignment.
         const preparedCompletionIndex = prepareBrowseCompletionIndex(recordSnapshot);
         if (!isPreparedBrowseCompletionIndex(preparedCompletionIndex)) {
             return false;
@@ -2138,7 +2140,13 @@ function refreshBrowseProgressFromRecords(
             recordSnapshot,
             indexSnapshot
         );
-        if (commitBrowseAnchorUpdates(preparedAnchorUpdates) !== true) {
+        const anchorPublication = candidatePracticeProjectionGeneration != null
+            ? { practiceProjectionGeneration: candidatePracticeProjectionGeneration }
+            : null;
+        if (commitBrowseAnchorUpdates(
+            preparedAnchorUpdates,
+            anchorPublication
+        ) !== true) {
             return false;
         }
         commitBrowseCompletionIndex(preparedCompletionIndex);

--- a/js/main.js
+++ b/js/main.js
@@ -1844,6 +1844,45 @@ function clearPracticeHistorySearch() {
     searchPracticeHistory('');
 }
 
+let pendingBrowseProgressRefreshIndex = null;
+let browseProgressRefreshRetryTimer = null;
+
+function retryPendingBrowseProgressRefresh() {
+    if (browseProgressRefreshRetryTimer != null) {
+        return;
+    }
+    browseProgressRefreshRetryTimer = setTimeout(() => {
+        browseProgressRefreshRetryTimer = null;
+        flushPendingBrowseProgressRefresh();
+    }, 50);
+}
+
+function flushPendingBrowseProgressRefresh() {
+    if (!Array.isArray(pendingBrowseProgressRefreshIndex)) {
+        return;
+    }
+    const browseView = document.getElementById('browse-view');
+    const isBrowseActive = browseView && browseView.classList.contains('active');
+    if (!isBrowseActive) {
+        pendingBrowseProgressRefreshIndex = null;
+        return;
+    }
+    const resetInFlight = typeof window.__isBrowseResetIntentInFlight === 'function'
+        && window.__isBrowseResetIntentInFlight();
+    if (resetInFlight) {
+        retryPendingBrowseProgressRefresh();
+        return;
+    }
+    if (isBrowseUserResultsRequestInFlight(browseResultsRequestId)) {
+        return;
+    }
+    const indexSnapshot = pendingBrowseProgressRefreshIndex;
+    pendingBrowseProgressRefreshIndex = null;
+    Promise.resolve(renderBrowseResultsForState(indexSnapshot)).catch((error) => {
+        console.warn('[Browse] 刷新浏览进度列表失败:', error);
+    });
+}
+
 function refreshBrowseProgressFromRecords(records, examIndex) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
@@ -1856,8 +1895,9 @@ function refreshBrowseProgressFromRecords(records, examIndex) {
         }
         const browseView = document.getElementById('browse-view');
         const isBrowseActive = browseView && browseView.classList.contains('active');
-        if (isBrowseActive && typeof loadExamList === 'function') {
-            loadExamList(indexSnapshot);
+        if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
+            pendingBrowseProgressRefreshIndex = indexSnapshot;
+            flushPendingBrowseProgressRefresh();
         }
     } catch (error) {
         console.warn('[Browse] 刷新浏览进度失败:', error);
@@ -2071,6 +2111,9 @@ function endBrowseUserResultsRequest(requestId) {
                 }));
             } catch (_) { }
         }
+        if (retainCount === 1) {
+            flushPendingBrowseProgressRefresh();
+        }
         return;
     }
     browseUserResultsRequestRetains.set(requestId, retainCount - 1);
@@ -2096,7 +2139,6 @@ window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
-    browseInitialFilterHydrationConsumed = true;
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
@@ -2128,6 +2170,7 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         }
 
         // 重置筛选器状态
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState('all', type);
         setBrowseTitle(formatBrowseTitle('all', type));
 
@@ -2181,7 +2224,6 @@ async function applyBrowseFilter(
     renderRequestId = null,
     navigationIntentGeneration = null
 ) {
-    browseInitialFilterHydrationConsumed = true;
     const getActiveViewId = () => {
         const activeView = typeof document.querySelector === 'function'
             ? document.querySelector('.view.active')
@@ -2288,6 +2330,7 @@ async function applyBrowseFilter(
         }
 
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState(normalizedCategory, effectiveType);
 
 
@@ -2309,6 +2352,7 @@ async function applyBrowseFilter(
             return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
+        browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState('all', 'all');
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
             window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
@@ -2327,61 +2371,80 @@ async function applyBrowseFilter(
 
 // Initialize browse view when it's activated
 async function initializeBrowseView(options = {}) {
+    const userRequestId = options.renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(options.renderRequestId);
     const activeRequestId = options.renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? userRequestId
         : options.renderRequestId;
-    console.log('[System] Initializing browse view...');
-    const [examIndex] = await Promise.all([
-        resolveActiveExamIndex(),
-        typeof window.whenBrowseViewPreferencesReady === 'function'
-            ? window.whenBrowseViewPreferencesReady()
-            : Promise.resolve()
-    ]);
+    try {
+        console.log('[System] Initializing browse view...');
+        const [examIndex] = await Promise.all([
+            resolveActiveExamIndex(),
+            typeof window.whenBrowseViewPreferencesReady === 'function'
+                ? window.whenBrowseViewPreferencesReady()
+                : Promise.resolve()
+        ]);
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return null;
-    }
-
-    // 初始化 browseController
-    if (window.browseController && !window.browseController.buttonContainer) {
-        window.browseController.initialize('type-filter-buttons', examIndex);
-    }
-    if (typeof window.refreshListeningAvailabilityUI === 'function') {
-        window.refreshListeningAvailabilityUI(examIndex);
-    }
-
-    if (!browseInitialFilterHydrationConsumed) {
-        const persisted = getPersistedBrowseFilter();
-        if (persisted) {
-            setBrowseFilterState(persisted.category, persisted.type);
-            setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
-        } else {
-            setBrowseFilterState('all', 'all');
-            setBrowseTitle(formatBrowseTitle('all', 'all'));
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return null;
         }
-        browseInitialFilterHydrationConsumed = true;
-    }
 
-    setupBrowseSortControl();
-    setupBrowseFrequencyFilterControl();
-    if (!options.skipLoad) {
-        await renderBrowseResultsForState(examIndex, activeRequestId);
+        // 初始化 browseController
+        if (window.browseController && !window.browseController.buttonContainer) {
+            window.browseController.initialize('type-filter-buttons', examIndex);
+        }
+        if (typeof window.refreshListeningAvailabilityUI === 'function') {
+            window.refreshListeningAvailabilityUI(examIndex);
+        }
+
+        const browseFilterMutationRevision = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : 0;
+        if (!browseInitialFilterHydrationConsumed && browseFilterMutationRevision > 0) {
+            browseInitialFilterHydrationConsumed = true;
+        } else if (!browseInitialFilterHydrationConsumed) {
+            const persisted = getPersistedBrowseFilter();
+            browseInitialFilterHydrationConsumed = true;
+            if (persisted) {
+                setBrowseFilterState(persisted.category, persisted.type);
+                setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
+            } else {
+                setBrowseFilterState('all', 'all');
+                setBrowseTitle(formatBrowseTitle('all', 'all'));
+            }
+        }
+
+        setupBrowseSortControl();
+        setupBrowseFrequencyFilterControl();
+        if (!options.skipLoad) {
+            await renderBrowseResultsForState(examIndex, activeRequestId);
+        }
+        return examIndex;
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
-    return examIndex;
 }
 
 async function activateBrowseView(options = {}) {
+    const userRequestId = options.renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(options.renderRequestId);
     const activeRequestId = options.renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? userRequestId
         : options.renderRequestId;
-    const examIndex = await initializeBrowseView({
-        skipLoad: true,
-        renderRequestId: activeRequestId
-    });
-    if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
-        return false;
+    try {
+        const examIndex = await initializeBrowseView({
+            skipLoad: true,
+            renderRequestId: activeRequestId
+        });
+        if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        return renderBrowseResultsForState(examIndex, activeRequestId);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
-    return renderBrowseResultsForState(examIndex, activeRequestId);
 }
 
 window.activateBrowseView = activateBrowseView;

--- a/js/main.js
+++ b/js/main.js
@@ -303,11 +303,46 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
+let practiceRecordsSyncInvocationGeneration = 0;
+let practiceRecordsDataGeneration = 0;
+let practiceRecordsCommitSubscriptionAttached = false;
+const PRACTICE_RECORD_ENTITY_STORES = new Set([
+    'practiceSummaries',
+    'practiceDetails',
+    'practiceAnnotations'
+]);
+
+function ensurePracticeRecordsCommitSubscription() {
+    if (practiceRecordsCommitSubscriptionAttached) {
+        return;
+    }
+    const backups = window.AppData && window.AppData.backups;
+    if (!backups || typeof backups.onDataCommitted !== 'function') {
+        return;
+    }
+    backups.onDataCommitted((event) => {
+        const targets = event && Array.isArray(event.targets) ? event.targets : [];
+        const touchesPracticeRecords = targets.some((target) => {
+            const store = typeof target === 'string'
+                ? target
+                : target && (target.store || target.logicalKey);
+            return PRACTICE_RECORD_ENTITY_STORES.has(store);
+        });
+        if (touchesPracticeRecords) {
+            practiceRecordsDataGeneration += 1;
+        }
+    });
+    practiceRecordsCommitSubscriptionAttached = true;
+}
+
 async function syncPracticeRecords(options = {}) {
+    ensurePracticeRecordsCommitSubscription();
+    const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -367,6 +402,16 @@ async function syncPracticeRecords(options = {}) {
         });
     } catch (e) { console.warn('[System] normalize durations failed:', e); }
 
+    const sourceLibraryIsCurrent = isBrowseProgressRefreshEpochCurrent({
+        activeLibraryGeneration: browseProgressSourceEpoch.activeLibraryGeneration
+    });
+    if (invocationGeneration !== practiceRecordsSyncInvocationGeneration
+        || !sourceLibraryIsCurrent
+        || browseProgressSourceEpoch.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+        console.log('[System] 丢弃已过期的练习记录同步投影');
+        return records;
+    }
+
     // Avoid resetting the list when the authoritative light projection is unchanged.
     try {
         const renderer = window.PracticeHistoryRenderer;
@@ -391,18 +436,90 @@ async function syncPracticeRecords(options = {}) {
 
 let practiceRecordsLoadPromise = null;
 let pendingPracticeRecordsSyncRequest = null;
+let activePracticeRecordsSyncRequest = null;
 
-function queuePendingPracticeRecordsSync(trigger, options = {}) {
+function normalizePracticeRecordsSyncOptions(options = {}) {
+    const normalized = Object.assign({}, options || {});
+    normalized.forceRender = !!normalized.forceRender;
+    normalized.mode = normalized.mode === 'full' ? 'full' : 'summary';
+    return normalized;
+}
+
+function capturePracticeRecordsSyncRequest(trigger, options = {}) {
+    return {
+        trigger,
+        options: normalizePracticeRecordsSyncOptions(options),
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration
+    };
+}
+
+function practiceRecordsSyncGenerationCovers(existing, incoming, key) {
+    if (incoming[key] == null) {
+        return true;
+    }
+    return existing[key] != null && existing[key] >= incoming[key];
+}
+
+function practiceRecordsSyncRequestCovers(existing, incoming) {
+    if (!existing || !incoming) {
+        return false;
+    }
+    const existingOptions = existing.options || {};
+    const incomingOptions = incoming.options || {};
+    return practiceRecordsSyncGenerationCovers(existing, incoming, 'activeLibraryGeneration')
+        && practiceRecordsSyncGenerationCovers(existing, incoming, 'practiceRecordsDataGeneration')
+        && (existingOptions.forceRender || !incomingOptions.forceRender)
+        && (existingOptions.mode === 'full' || incomingOptions.mode !== 'full');
+}
+
+function activePracticeRecordsSyncRequestCovers(incoming) {
+    return !!activePracticeRecordsSyncRequest
+        && activePracticeRecordsSyncRequest.invocationGeneration
+            === practiceRecordsSyncInvocationGeneration
+        && practiceRecordsSyncRequestCovers(activePracticeRecordsSyncRequest, incoming);
+}
+
+function mergePracticeRecordsSyncGeneration(previousValue, nextValue) {
+    if (previousValue == null) {
+        return nextValue;
+    }
+    if (nextValue == null) {
+        return previousValue;
+    }
+    return Math.max(previousValue, nextValue);
+}
+
+function queuePendingPracticeRecordsSync(incoming) {
     const previous = pendingPracticeRecordsSyncRequest;
+    const activeOptions = activePracticeRecordsSyncRequest
+        && activePracticeRecordsSyncRequest.options
+        ? activePracticeRecordsSyncRequest.options
+        : {};
     const previousOptions = previous && previous.options ? previous.options : {};
-    const nextOptions = Object.assign({}, previousOptions, options || {});
-    nextOptions.forceRender = !!(previousOptions.forceRender || (options && options.forceRender));
-    nextOptions.mode = previousOptions.mode === 'full' || (options && options.mode === 'full')
+    const incomingOptions = incoming && incoming.options ? incoming.options : {};
+    const nextOptions = Object.assign({}, activeOptions, previousOptions, incomingOptions);
+    nextOptions.forceRender = !!(
+        activeOptions.forceRender
+        || previousOptions.forceRender
+        || incomingOptions.forceRender
+    );
+    nextOptions.mode = activeOptions.mode === 'full'
+        || previousOptions.mode === 'full'
+        || incomingOptions.mode === 'full'
         ? 'full'
         : 'summary';
     pendingPracticeRecordsSyncRequest = {
-        trigger,
-        options: nextOptions
+        trigger: incoming.trigger,
+        options: nextOptions,
+        activeLibraryGeneration: mergePracticeRecordsSyncGeneration(
+            previous && previous.activeLibraryGeneration,
+            incoming.activeLibraryGeneration
+        ),
+        practiceRecordsDataGeneration: mergePracticeRecordsSyncGeneration(
+            previous && previous.practiceRecordsDataGeneration,
+            incoming.practiceRecordsDataGeneration
+        )
     };
 }
 
@@ -411,12 +528,19 @@ async function drainPracticeRecordsSyncQueue(initialRequest) {
     let result = null;
     try {
         while (request) {
+            activePracticeRecordsSyncRequest = request;
             let syncError = null;
             try {
-                result = await syncPracticeRecords(Object.assign(
+                request.activeLibraryGeneration = readBrowseProgressGeneration(
+                    '__getActiveLibraryGeneration'
+                );
+                request.practiceRecordsDataGeneration = practiceRecordsDataGeneration;
+                request.invocationGeneration = practiceRecordsSyncInvocationGeneration + 1;
+                const syncPromise = syncPracticeRecords(Object.assign(
                     { mode: 'summary' },
                     request.options || {}
                 ));
+                result = await syncPromise;
             } catch (error) {
                 syncError = error;
             }
@@ -435,20 +559,22 @@ async function drainPracticeRecordsSyncQueue(initialRequest) {
         }
         return result;
     } finally {
+        activePracticeRecordsSyncRequest = null;
         practiceRecordsLoadPromise = null;
     }
 }
 
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
+    ensurePracticeRecordsCommitSubscription();
+    const incomingRequest = capturePracticeRecordsSyncRequest(trigger, options);
     if (practiceRecordsLoadPromise) {
-        queuePendingPracticeRecordsSync(trigger, options);
+        if (!activePracticeRecordsSyncRequestCovers(incomingRequest)
+            && !practiceRecordsSyncRequestCovers(pendingPracticeRecordsSyncRequest, incomingRequest)) {
+            queuePendingPracticeRecordsSync(incomingRequest);
+        }
         return practiceRecordsLoadPromise;
     }
-    const initialRequest = {
-        trigger,
-        options: Object.assign({}, options || {})
-    };
-    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(initialRequest);
+    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(incomingRequest);
     return practiceRecordsLoadPromise;
 }
 
@@ -1914,18 +2040,41 @@ function readBrowseProgressGeneration(getterName) {
     }
 }
 
+function readBrowseFunctionalResetState() {
+    const getter = window && typeof window.__getBrowseFunctionalResetState === 'function'
+        ? window.__getBrowseFunctionalResetState
+        : null;
+    if (!getter) {
+        return { generation: null, status: 'idle', outcome: null };
+    }
+    try {
+        const state = getter();
+        const generation = Number(state && state.generation);
+        return {
+            generation: Number.isFinite(generation) ? generation : null,
+            status: state && typeof state.status === 'string' ? state.status : 'idle',
+            outcome: state && typeof state.outcome === 'boolean' ? state.outcome : null
+        };
+    } catch (_) {
+        return { generation: null, status: 'idle', outcome: null };
+    }
+}
+
 function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
     const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
     const hasSourceLibraryGeneration = Object.prototype.hasOwnProperty.call(
         source,
         'activeLibraryGeneration'
     );
+    const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration')
+        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
+        functionalResetGeneration: functionalResetState.generation,
+        functionalResetWasPending: functionalResetState.status === 'pending'
     };
 }
 
@@ -1936,12 +2085,16 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
         activeLibraryGeneration: '__getActiveLibraryGeneration',
         resetGeneration: '__getBrowseResetIntentGeneration'
     };
-    return Object.keys(generationGetters).every((key) => {
+    const ordinaryGenerationsAreCurrent = Object.keys(generationGetters).every((key) => {
         if (captured[key] == null) {
             return true;
         }
         return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
     });
+    if (!ordinaryGenerationsAreCurrent || captured.functionalResetGeneration == null) {
+        return ordinaryGenerationsAreCurrent;
+    }
+    return readBrowseFunctionalResetState().generation === captured.functionalResetGeneration;
 }
 
 function clearPendingBrowseProgressRefresh() {
@@ -1971,6 +2124,21 @@ function flushPendingBrowseProgressRefresh() {
         clearPendingBrowseProgressRefresh();
         return;
     }
+    const functionalResetState = readBrowseFunctionalResetState();
+    if (functionalResetState.status === 'failed') {
+        clearPendingBrowseProgressRefresh();
+        return;
+    }
+    if (functionalResetState.status === 'pending') {
+        retryPendingBrowseProgressRefresh();
+        return;
+    }
+    if (pending.epoch && pending.epoch.functionalResetWasPending) {
+        // The post-reset activation owns the canonical render. A progress
+        // snapshot observed during the barrier must never replay afterward.
+        clearPendingBrowseProgressRefresh();
+        return;
+    }
     const browseView = document.getElementById('browse-view');
     const isBrowseActive = browseView && browseView.classList.contains('active');
     if (!isBrowseActive) {
@@ -1997,14 +2165,14 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
-        if (typeof rebuildBrowseCompletionIndex === 'function') {
-            rebuildBrowseCompletionIndex(recordSnapshot);
-        }
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
         if (!isBrowseProgressRefreshEpochCurrent({
             activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
         })) {
             return;
+        }
+        if (typeof rebuildBrowseCompletionIndex === 'function') {
+            rebuildBrowseCompletionIndex(recordSnapshot);
         }
         if (typeof updateBrowseAnchorsFromRecords === 'function') {
             updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);

--- a/js/main.js
+++ b/js/main.js
@@ -2028,6 +2028,7 @@ function browseCategory(category, type = 'reading', filterMode = null, path = nu
 }
 
 let browseResultsRequestId = 0;
+const browseUserResultsRequestRetains = new Map();
 
 function beginBrowseResultsRequest() {
     browseResultsRequestId += 1;
@@ -2038,88 +2039,127 @@ function isBrowseResultsRequestCurrent(requestId) {
     return requestId == null || requestId === browseResultsRequestId;
 }
 
+function retainBrowseUserResultsRequest(requestId) {
+    if (requestId == null || !isBrowseResultsRequestCurrent(requestId)) {
+        return null;
+    }
+    const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
+    browseUserResultsRequestRetains.set(requestId, retainCount + 1);
+    return requestId;
+}
+
+function beginBrowseUserResultsRequest() {
+    return retainBrowseUserResultsRequest(beginBrowseResultsRequest());
+}
+
+function endBrowseUserResultsRequest(requestId) {
+    if (requestId == null) {
+        return;
+    }
+    const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
+    if (retainCount <= 1) {
+        browseUserResultsRequestRetains.delete(requestId);
+        return;
+    }
+    browseUserResultsRequestRetains.set(requestId, retainCount - 1);
+}
+
+function isBrowseUserResultsRequestInFlight(requestId) {
+    return requestId != null && (browseUserResultsRequestRetains.get(requestId) || 0) > 0;
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
     return browseResultsRequestId;
 };
+window.__beginBrowseUserResultsRequest = beginBrowseUserResultsRequest;
+window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
+window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
+window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
-    const requestedType = type;
-    let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(renderRequestId);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
-        if (!Array.isArray(examIndexOverride)) {
-            examIndex = await resolveActiveExamIndex();
-        }
-        const listeningAvailable = typeof window.hasActiveListeningLibrary === 'function'
-            ? window.hasActiveListeningLibrary(examIndex)
-            : examIndex.some((exam) => exam && exam.type === 'listening');
-        if (requestedType === 'listening' && !listeningAvailable) {
-            type = 'all';
-            if (typeof window.showMessage === 'function') {
-                window.showMessage('听力题库尚未加载', 'warning');
+        const requestedType = type;
+        let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
+        try {
+            if (!Array.isArray(examIndexOverride)) {
+                examIndex = await resolveActiveExamIndex();
+            }
+            const listeningAvailable = typeof window.hasActiveListeningLibrary === 'function'
+                ? window.hasActiveListeningLibrary(examIndex)
+                : examIndex.some((exam) => exam && exam.type === 'listening');
+            if (requestedType === 'listening' && !listeningAvailable) {
+                type = 'all';
+                if (typeof window.showMessage === 'function') {
+                    window.showMessage('听力题库尚未加载', 'warning');
+                }
+            }
+        } catch (_) {
+            if (requestedType === 'listening') {
+                type = 'all';
             }
         }
-    } catch (_) {
-        if (requestedType === 'listening') {
-            type = 'all';
+
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return;
         }
-    }
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
-    }
+        // 重置筛选器状态
+        setBrowseFilterState('all', type);
+        setBrowseTitle(formatBrowseTitle('all', type));
 
-    // 重置筛选器状态
-    setBrowseFilterState('all', type);
-    setBrowseTitle(formatBrowseTitle('all', type));
+        // 重置浏览模式和路径（清除频率模式残留）
+        window.__browseFilterMode = 'default';
+        window.__browsePath = null;
 
-    // 重置浏览模式和路径（清除频率模式残留）
-    window.__browseFilterMode = 'default';
-    window.__browsePath = null;
+        // 重置 browseController 到默认模式
+        // 关键修复：仅在当前不是默认模式时才调用 resetToDefault，防止死循环
+        // (resetToDefault -> setMode -> applyFilter -> filterByType -> global.filterByType)
+        if (window.browseController &&
+            window.browseController.currentMode !== 'default' &&
+            typeof window.browseController.resetToDefault === 'function') {
+            window.browseController.resetToDefault(examIndex, activeRequestId, { skipApply: true });
+        }
 
-    // 重置 browseController 到默认模式
-    // 关键修复：仅在当前不是默认模式时才调用 resetToDefault，防止死循环
-    // (resetToDefault -> setMode -> applyFilter -> filterByType -> global.filterByType)
-    if (window.browseController &&
-        window.browseController.currentMode !== 'default' &&
-        typeof window.browseController.resetToDefault === 'function') {
-        window.browseController.resetToDefault(examIndex, activeRequestId);
-    }
-
-    // 更新题库浏览筛选按钮的 active 状态
-    var container = document.getElementById('type-filter-buttons');
-    if (container) {
-        var buttons = container.querySelectorAll('.shui-segmented-btn');
-        for (var i = 0; i < buttons.length; i++) {
-            var btn = buttons[i];
-            if (btn.dataset.filterType === type || btn.dataset.filterId === type) {
-                btn.classList.add('active');
-                btn.setAttribute('aria-pressed', 'true');
-            } else {
-                btn.classList.remove('active');
-                btn.setAttribute('aria-pressed', 'false');
+        // 更新题库浏览筛选按钮的 active 状态
+        var container = document.getElementById('type-filter-buttons');
+        if (container) {
+            var buttons = container.querySelectorAll('.shui-segmented-btn');
+            for (var i = 0; i < buttons.length; i++) {
+                var btn = buttons[i];
+                if (btn.dataset.filterType === type || btn.dataset.filterId === type) {
+                    btn.classList.add('active');
+                    btn.setAttribute('aria-pressed', 'true');
+                } else {
+                    btn.classList.remove('active');
+                    btn.setAttribute('aria-pressed', 'false');
+                }
             }
         }
-    }
 
-    // 触发滑块指示器同步
-    if (typeof window.updateSegmentedIndicators === 'function') {
-        setTimeout(window.updateSegmentedIndicators, 10);
-    }
+        // 触发滑块指示器同步
+        if (typeof window.updateSegmentedIndicators === 'function') {
+            setTimeout(window.updateSegmentedIndicators, 10);
+        }
 
-    // 刷新题库列表
-    await loadExamList(examIndex, activeRequestId);
+        // 保留活动搜索与新类型筛选的交集。
+        await renderBrowseResultsForState(examIndex, activeRequestId);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
+    }
 }
 
 // 应用分类筛选（供 App/总览调用）
 async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : retainBrowseUserResultsRequest(renderRequestId);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
@@ -2173,7 +2213,12 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
                     if (!window.browseController.buttonContainer) {
                         window.browseController.initialize('type-filter-buttons', indexSnapshot);
                     }
-                    window.browseController.setMode(effectiveFilterMode, indexSnapshot, activeRequestId);
+                    window.browseController.setMode(
+                        effectiveFilterMode,
+                        indexSnapshot,
+                        activeRequestId,
+                        { skipApply: true }
+                    );
                 } catch (error) {
                     console.warn('[Browse] 切换浏览模式失败:', error);
                 }
@@ -2185,7 +2230,11 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             if (window.browseController &&
                 window.browseController.currentMode !== 'default' &&
                 typeof window.browseController.resetToDefault === 'function') {
-                window.browseController.resetToDefault(indexSnapshot, activeRequestId);
+                window.browseController.resetToDefault(
+                    indexSnapshot,
+                    activeRequestId,
+                    { skipApply: true }
+                );
             }
         }
 
@@ -2199,12 +2248,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
 
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
 
-        // 3. 刷新题库列表
-        // 如果是频率模式，setMode 已经处理了刷新，不需要再次调用 loadExamList
-        // 只有在默认模式下才显式调用
-        if (!effectiveFilterMode) {
-            await loadExamList(indexSnapshot, activeRequestId);
-        }
+        // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
+        await renderBrowseResultsForState(indexSnapshot, activeRequestId);
 
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
             return;
@@ -2221,15 +2266,17 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
         setBrowseFilterState('all', 'all');
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
-            window.browseController.resetToDefault(null, activeRequestId);
+            window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
         }
         // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
         setTimeout(() => {
             if (!isBrowseResultsRequestCurrent(activeRequestId)) {
                 return;
             }
-            try { loadExamList(null, activeRequestId); } catch (_) { }
+            try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
         }, 0);
+    } finally {
+        endBrowseUserResultsRequest(userRequestId);
     }
 }
 
@@ -2270,7 +2317,7 @@ async function initializeBrowseView(options = {}) {
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
     if (!options.skipLoad) {
-        await loadExamList(examIndex, activeRequestId);
+        await renderBrowseResultsForState(examIndex, activeRequestId);
     }
 }
 
@@ -2284,13 +2331,21 @@ function getBrowseSearchQuery() {
     return input && typeof input.value === 'string' ? input.value.trim() : '';
 }
 
-function refreshBrowseResults() {
-    const activeRequestId = beginBrowseResultsRequest();
+function renderBrowseResultsForState(examIndexOverride = null, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
     const query = getBrowseSearchQuery();
     if (query) {
-        return performSearch(query, activeRequestId);
+        return performSearch(query, activeRequestId, examIndexOverride);
     }
-    return loadExamList(null, activeRequestId);
+    return loadExamList(examIndexOverride, activeRequestId);
+}
+
+window.__renderBrowseResultsForState = renderBrowseResultsForState;
+
+function refreshBrowseResults() {
+    return renderBrowseResultsForState();
 }
 
 let browseControlsSeeded = false;
@@ -2303,7 +2358,9 @@ async function setupBrowseControls() {
                     const browse = await window.AppData.preferences.getBrowse();
                     if (browse) {
                         window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                        updateBrowseFrequencyButtons(
+                            browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
+                        );
                     }
                 } catch (_) { /* defaults remain active */ }
                 browseControlsSeeded = true;
@@ -2348,19 +2405,25 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
-    window.__browseFrequencyFilter = activeFilter;
+    if (window.ExamActions && typeof window.ExamActions.setBrowseFrequencyFilter === 'function') {
+        return window.ExamActions.setBrowseFrequencyFilter(activeFilter);
+    }
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
-        return;
+        return activeFilter;
     }
     container.querySelectorAll('[data-frequency-filter]').forEach((button) => {
         const isActive = button.dataset.frequencyFilter === activeFilter;
         button.classList.toggle('active', isActive);
         button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
+    return activeFilter;
 }
 
 function resetBrowseFilterStateToAll() {
+    if (window.ExamActions && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
+        return window.ExamActions.resetBrowseFilterStateToAll();
+    }
     window.__browseFilterMode = 'default';
     window.__browsePath = null;
     updateBrowseFrequencyButtons('all');
@@ -2380,7 +2443,6 @@ function setupBrowseFrequencyFilterControl() {
         return;
     }
     let savedFilter = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
-    window.__browseFrequencyFilter = savedFilter;
     updateBrowseFrequencyButtons(savedFilter);
 }
 
@@ -2388,7 +2450,6 @@ function filterByFrequency(filter) {
     const requested = normalizeBrowseFrequencyFilter(filter);
     const current = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
     const next = requested !== 'all' && requested === current ? 'all' : requested;
-    window.__browseFrequencyFilter = next;
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
     refreshBrowseResults();
@@ -3123,18 +3184,20 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
     return list;
 }
 
-async function performSearch(query, renderRequestId = null) {
+async function performSearch(query, renderRequestId = null, examIndexOverride = null) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
     const normalizedQuery = String(query || '').toLowerCase().trim();
     if (!normalizedQuery) {
-        return loadExamList(null, activeRequestId);
+        return loadExamList(examIndexOverride, activeRequestId);
     }
 
     // 调试日志
     console.log('[Search] 执行搜索，查询词:', normalizedQuery);
-    const examIndexSnapshot = await resolveActiveExamIndex();
+    const examIndexSnapshot = Array.isArray(examIndexOverride)
+        ? examIndexOverride
+        : await resolveActiveExamIndex();
     if (!isBrowseResultsRequestCurrent(activeRequestId)) {
         return;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -235,7 +235,7 @@ function ensureLegacyNavigation(options) {
         },
         onNavigate: function onNavigate(viewName) {
             if (typeof window.showView === 'function') {
-                window.showView(viewName);
+                window.showView(viewName, false);
                 return;
             }
             if (window.app && typeof window.app.navigateToView === 'function') {
@@ -262,7 +262,11 @@ async function initializeLegacyComponents() {
     try { showMessage('系统准备就绪', 'success'); } catch (_) { }
 
     try {
-        ensureLegacyNavigation({ initialView: 'overview' });
+        const activeView = document.querySelector('.view.active');
+        const activeViewName = activeView && activeView.id
+            ? activeView.id.replace(/-view$/, '')
+            : 'overview';
+        ensureLegacyNavigation({ initialView: activeViewName });
     } catch (error) {
         console.warn('[Navigation] 初始化导航控制器失败:', error);
     }
@@ -275,8 +279,8 @@ async function initializeLegacyComponents() {
         console.log('[System] PDF处理器已初始化');
     }
     if (window.BrowseStateManager) {
-        browseStateManager = new BrowseStateManager();
-        console.log('[System] 浏览状态管理器已初始化');
+        browseStateManager = window.browseStateManager || new window.BrowseStateManager();
+        console.log('[System] 浏览状态管理器已就绪');
     }
     // 性能优化器已拆到 diagnostics-tools；浏览页保留无依赖降级路径。
     if (window.PerformanceOptimizer) {
@@ -2285,22 +2289,33 @@ function refreshBrowseResults() {
 }
 
 let browseControlsSeeded = false;
+let browseControlsSeedPromise = null;
 async function setupBrowseControls() {
     if (!browseControlsSeeded) {
-        try {
-            const browse = await window.AppData.preferences.getBrowse();
-            if (browse) {
-                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
-            }
-        } catch (_) { /* defaults remain active */ }
-        browseControlsSeeded = true;
+        if (!browseControlsSeedPromise) {
+            browseControlsSeedPromise = (async () => {
+                try {
+                    const browse = await window.AppData.preferences.getBrowse();
+                    if (browse) {
+                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                        window.__browseFrequencyFilter = browse.frequencyFilter || window.__browseFrequencyFilter;
+                    }
+                } catch (_) { /* defaults remain active */ }
+                browseControlsSeeded = true;
+            })();
+        }
+        await browseControlsSeedPromise;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
 }
 
 async function persistBrowsePreference(patch) {
+    if (window.AppData && window.AppData.preferences
+        && typeof window.AppData.preferences.patchBrowse === 'function') {
+        await window.AppData.preferences.patchBrowse(patch);
+        return;
+    }
     const current = await window.AppData.preferences.getBrowse() || {};
     await window.AppData.preferences.setBrowse(Object.assign({}, current, patch));
 }
@@ -2328,6 +2343,7 @@ function setupBrowseSortControl() {
 
 function updateBrowseFrequencyButtons(filter) {
     const activeFilter = normalizeBrowseFrequencyFilter(filter || window.__browseFrequencyFilter || 'all');
+    window.__browseFrequencyFilter = activeFilter;
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return;

--- a/js/main.js
+++ b/js/main.js
@@ -2039,6 +2039,9 @@ function isBrowseResultsRequestCurrent(requestId) {
 
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
+window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
+    return browseResultsRequestId;
+};
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
     const activeRequestId = renderRequestId == null
@@ -2112,8 +2115,10 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
 }
 
 // 应用分类筛选（供 App/总览调用）
-async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null) {
-    const activeRequestId = beginBrowseResultsRequest();
+async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId)) {
@@ -3023,8 +3028,13 @@ async function setActiveLibraryConfiguration(key) {
 
 let debouncedExamSearch = null;
 
-function searchExams(query) {
-    const activeRequestId = beginBrowseResultsRequest();
+function searchExams(query, renderRequestId = null) {
+    const activeRequestId = renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : renderRequestId;
+    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+        return false;
+    }
     toggleSearchClearButton(query);
     if (window.performanceOptimizer && typeof window.performanceOptimizer.debounce === 'function') {
         // 跨 input 事件复用同一个 debounce 闭包，避免每个字符都排队一次搜索。

--- a/js/main.js
+++ b/js/main.js
@@ -306,10 +306,10 @@ let lastPracticeRecordsSignature = null;
 let practiceRecordsSyncInvocationGeneration = 0;
 let practiceRecordsDataGeneration = 0;
 let practiceRecordsCommitSubscriptionAttached = false;
+const activePracticeRecordsSyncInvocations = new Map();
 const PRACTICE_RECORD_ENTITY_STORES = new Set([
     'practiceSummaries',
-    'practiceDetails',
-    'practiceAnnotations'
+    'practiceDetails'
 ]);
 
 function ensurePracticeRecordsCommitSubscription() {
@@ -330,6 +330,17 @@ function ensurePracticeRecordsCommitSubscription() {
         });
         if (touchesPracticeRecords) {
             practiceRecordsDataGeneration += 1;
+            if (activePracticeRecordsSyncInvocations.size > 0) {
+                const replacementMode = Array.from(
+                    activePracticeRecordsSyncInvocations.values()
+                ).some((activeOptions) => activeOptions && activeOptions.mode === 'full')
+                    ? 'full'
+                    : 'summary';
+                startPracticeRecordsSyncInBackground('practice-data-committed', {
+                    forceRender: true,
+                    mode: replacementMode
+                });
+            }
         }
     });
     practiceRecordsCommitSubscriptionAttached = true;
@@ -338,6 +349,16 @@ function ensurePracticeRecordsCommitSubscription() {
 async function syncPracticeRecords(options = {}) {
     ensurePracticeRecordsCommitSubscription();
     const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
+    const normalizedOptions = normalizePracticeRecordsSyncOptions(options);
+    activePracticeRecordsSyncInvocations.set(invocationGeneration, normalizedOptions);
+    try {
+        return await executePracticeRecordsSync(normalizedOptions, invocationGeneration);
+    } finally {
+        activePracticeRecordsSyncInvocations.delete(invocationGeneration);
+    }
+}
+
+async function executePracticeRecordsSync(options, invocationGeneration) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
@@ -2066,12 +2087,19 @@ function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
         source,
         'activeLibraryGeneration'
     );
+    const hasSourcePracticeRecordsDataGeneration = Object.prototype.hasOwnProperty.call(
+        source,
+        'practiceRecordsDataGeneration'
+    );
     const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        practiceRecordsDataGeneration: hasSourcePracticeRecordsDataGeneration
+            ? source.practiceRecordsDataGeneration
+            : practiceRecordsDataGeneration,
         resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
         functionalResetGeneration: functionalResetState.generation,
         functionalResetWasPending: functionalResetState.status === 'pending'
@@ -2091,8 +2119,15 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
         }
         return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
     });
-    if (!ordinaryGenerationsAreCurrent || captured.functionalResetGeneration == null) {
-        return ordinaryGenerationsAreCurrent;
+    if (!ordinaryGenerationsAreCurrent) {
+        return false;
+    }
+    if (captured.practiceRecordsDataGeneration != null
+        && captured.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+        return false;
+    }
+    if (captured.functionalResetGeneration == null) {
+        return true;
     }
     return readBrowseFunctionalResetState().generation === captured.functionalResetGeneration;
 }
@@ -2534,6 +2569,11 @@ async function applyBrowseFilter(
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    const functionalResetRecovery = window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
         if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
@@ -2634,6 +2674,8 @@ async function applyBrowseFilter(
         if (typeof window.showView === 'function' && !document.getElementById('browse-view')?.classList.contains('active')) {
             window.showView('browse', false);
         }
+        functionalResetRecoverySucceeded = true;
+        return true;
     } catch (e) {
         if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
             return false;
@@ -2651,7 +2693,16 @@ async function applyBrowseFilter(
             }
             try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
         }, 0);
+        return false;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -2735,6 +2786,12 @@ async function initializeBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
+    const functionalResetRecovery = !options.skipLoad
+        && window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         console.log('[System] Initializing browse view...');
         const [examIndex] = await Promise.all([
@@ -2783,10 +2840,22 @@ async function initializeBrowseView(options = {}) {
         setupBrowseSortControl();
         setupBrowseFrequencyFilterControl();
         if (!options.skipLoad) {
-            await renderBrowseResultsForState(examIndex, activeRequestId);
+            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId);
+            if (renderResult === false || !isBrowseResultsRequestCurrent(activeRequestId)) {
+                return null;
+            }
+            functionalResetRecoverySucceeded = true;
         }
         return examIndex;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -2798,6 +2867,11 @@ async function activateBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
+    const functionalResetRecovery = window.AppEntry
+        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
+        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
+        : null;
+    let functionalResetRecoverySucceeded = false;
     try {
         const examIndex = await initializeBrowseView({
             skipLoad: true,
@@ -2806,8 +2880,19 @@ async function activateBrowseView(options = {}) {
         if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
             return false;
         }
-        return renderBrowseResultsForState(examIndex, activeRequestId);
+        const result = await renderBrowseResultsForState(examIndex, activeRequestId);
+        functionalResetRecoverySucceeded = result !== false
+            && isBrowseResultsRequestCurrent(activeRequestId);
+        return result;
     } finally {
+        if (functionalResetRecovery
+            && window.AppEntry
+            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
+            window.AppEntry.completeBrowseFunctionalResetRecovery(
+                functionalResetRecovery,
+                functionalResetRecoverySucceeded
+            );
+        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -303,16 +303,20 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
-// Browse progress is a derived projection. This generation orders only that
-// projection; it never changes syncPracticeRecords' public return value or the
-// Practice-history single-flight contract below.
+// Browse progress is a derived projection. Invocation order and the accepted
+// projection watermark are intentionally separate: a newer sync that merely
+// starts must not invalidate an already successful projection if it later
+// fails. Neither counter changes syncPracticeRecords' public return value or
+// the Practice-history single-flight contract below.
+let browsePracticeProjectionInvocationSequence = 0;
 let browsePracticeProjectionGeneration = 0;
 async function syncPracticeRecords(options = {}) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
+    const practiceProjectionInvocation = ++browsePracticeProjectionInvocationSequence;
     const browseProgressSourceEpoch = {
         activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceProjectionGeneration: ++browsePracticeProjectionGeneration
+        practiceProjectionGeneration: null
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -385,7 +389,15 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+    // Publish Browse ownership only after this invocation has produced a
+    // complete snapshot. A failed newer invocation therefore cannot strand a
+    // successful repaint queued behind a foreground request. Conversely, an
+    // older success that settles after a newer success remains stale.
+    if (practiceProjectionInvocation > browsePracticeProjectionGeneration) {
+        browsePracticeProjectionGeneration = practiceProjectionInvocation;
+        browseProgressSourceEpoch.practiceProjectionGeneration = practiceProjectionInvocation;
+        refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+    }
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
@@ -2404,6 +2416,56 @@ function completeCurrentForegroundBrowseRecovery(recovery, succeeded) {
     return appEntry.completeBrowseFunctionalResetRecovery(recovery, succeeded === true);
 }
 
+const browseRenderCommitReceiptMarker = {};
+
+function createBrowseRenderCommitReceipt(requestId, foregroundEpoch) {
+    return {
+        marker: browseRenderCommitReceiptMarker,
+        requestId,
+        foregroundEpoch,
+        committed: false
+    };
+}
+
+function markBrowseRenderCommitReceipt(receipt) {
+    if (!receipt || receipt.marker !== browseRenderCommitReceiptMarker) {
+        return false;
+    }
+    receipt.committed = true;
+    return true;
+}
+
+function commitForegroundBrowseResults(
+    renderRequestId,
+    sourceEpoch,
+    commit
+) {
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch(sourceEpoch);
+    if (!isBrowseResultsRequestCurrent(renderRequestId)
+        || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)
+        || typeof commit !== 'function') {
+        return false;
+    }
+    const foregroundRecovery = captureCurrentForegroundBrowseRecovery(renderRequestId, false);
+    const preparedFunctionalResetState = readBrowseFunctionalResetState();
+    foregroundEpoch.functionalResetGeneration = preparedFunctionalResetState.generation;
+    const receipt = createBrowseRenderCommitReceipt(renderRequestId, foregroundEpoch);
+    let committed = false;
+    try {
+        if (!isBrowseResultsRequestCurrent(renderRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        const result = commit(receipt);
+        committed = receipt.committed === true
+            && isBrowseResultsRequestCurrent(renderRequestId)
+            && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        return committed ? result : false;
+    } finally {
+        completeCurrentForegroundBrowseRecovery(foregroundRecovery, committed);
+    }
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
@@ -2414,13 +2476,16 @@ window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
 window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
 window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
+window.__captureBrowseForegroundRenderEpoch = captureBrowseForegroundRenderEpoch;
+window.__markBrowseRenderCommitReceipt = markBrowseRenderCommitReceipt;
+window.__commitForegroundBrowseResults = commitForegroundBrowseResults;
 
-async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
+async function filterByType(type, examIndexOverride = null, renderRequestId = null, options = {}) {
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
-    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch(options.foregroundEpoch);
     try {
         const requestedType = type;
         let listeningUnavailable = false;
@@ -2436,10 +2501,9 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
                 type = 'all';
                 listeningUnavailable = true;
             }
-        } catch (_) {
-            if (requestedType === 'listening') {
-                type = 'all';
-            }
+        } catch (error) {
+            console.warn('[Browse] 读取活动题库失败，已取消类型筛选提交:', error);
+            return false;
         }
 
         if (!isBrowseResultsRequestCurrent(activeRequestId)
@@ -2887,6 +2951,7 @@ async function renderBrowseResultsForState(
         : null;
     let foregroundRecovery = null;
     let renderSucceeded = false;
+    let commitReceipt = null;
     try {
         if (!isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
@@ -2905,14 +2970,21 @@ async function renderBrowseResultsForState(
         }
         const isRenderCurrent = () => isBrowseResultsRequestCurrent(activeRequestId)
             && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        commitReceipt = createBrowseRenderCommitReceipt(activeRequestId, foregroundEpoch);
         const result = query
             ? await performSearch(query, activeRequestId, examIndexOverride, {
-                isCurrent: isRenderCurrent
+                isCurrent: isRenderCurrent,
+                commitReceipt,
+                foregroundEpoch
             })
             : await loadExamList(examIndexOverride, activeRequestId, {
-                isCurrent: isRenderCurrent
+                isCurrent: isRenderCurrent,
+                commitReceipt,
+                foregroundEpoch
             });
         if (result === false
+            || !commitReceipt
+            || commitReceipt.committed !== true
             || !isBrowseResultsRequestCurrent(activeRequestId)
             || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
@@ -2934,7 +3006,6 @@ function refreshBrowseResults(options = {}) {
 let browseControlsSeeded = false;
 let browseControlsSeedPromise = null;
 let browseControlsSeedReadRevision = null;
-let browseControlsSeedReadEpoch = null;
 let browseControlsMutationRevision = 0;
 
 function isBrowseControlsSetupCurrent(options = {}) {
@@ -2955,7 +3026,6 @@ async function setupBrowseControls(options = {}) {
     if (!browseControlsSeeded) {
         if (!browseControlsSeedPromise) {
             browseControlsSeedReadRevision = browseControlsMutationRevision;
-            browseControlsSeedReadEpoch = captureBrowseForegroundRenderEpoch();
             browseControlsSeedPromise = (async () => {
                 try {
                     return await window.AppData.preferences.getBrowse();
@@ -2966,20 +3036,12 @@ async function setupBrowseControls(options = {}) {
         const seedPromise = browseControlsSeedPromise;
         const browse = await seedPromise;
         if (!isBrowseControlsSetupCurrent(options)) {
-            if (!browseControlsSeeded && browseControlsSeedPromise === seedPromise) {
-                browseControlsSeedPromise = null;
-                browseControlsSeedReadRevision = null;
-                browseControlsSeedReadEpoch = null;
-            }
+            // Caller cancellation is local. The promise and its immutable
+            // mutation fence belong to the shared hydration transaction; a
+            // stale waiter must not force a current waiter to reread storage.
             return false;
         }
         if (browseControlsSeedPromise !== seedPromise) {
-            return setupBrowseControls(options);
-        }
-        if (!isBrowseForegroundRenderEpochCurrent(browseControlsSeedReadEpoch)) {
-            browseControlsSeedPromise = null;
-            browseControlsSeedReadRevision = null;
-            browseControlsSeedReadEpoch = null;
             return setupBrowseControls(options);
         }
         if (!browseControlsSeeded) {
@@ -2993,6 +3055,8 @@ async function setupBrowseControls(options = {}) {
                 );
             }
             browseControlsSeeded = true;
+            browseControlsSeedPromise = null;
+            browseControlsSeedReadRevision = null;
         }
     }
     if (!isBrowseControlsSetupCurrent(options)) {
@@ -3162,7 +3226,12 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null, op
     }
 
     if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-        return window.ExamActions.loadExamList(examIndex);
+        return window.ExamActions.loadExamList(examIndex, {
+            commitReceipt: options.commitReceipt,
+            renderRequestId: activeRequestId,
+            foregroundEpoch: options.foregroundEpoch,
+            recoveryManaged: true
+        });
     }
     console.warn('[main.js] ExamActions.loadExamList 未就绪，尝试加载 browse-view 组');
     if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
@@ -3175,21 +3244,26 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null, op
                 return false;
             }
             if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-                return window.ExamActions.loadExamList(examIndex);
+                return window.ExamActions.loadExamList(examIndex, {
+                    commitReceipt: options.commitReceipt,
+                    renderRequestId: activeRequestId,
+                    foregroundEpoch: options.foregroundEpoch,
+                    recoveryManaged: true
+                });
             } else {
                 // 最终降级：直接 DOM 渲染
-                return loadExamListFallback(examIndex);
+                return loadExamListFallback(examIndex, options);
             }
         }).catch(function (err) {
             if (!isCurrent()) {
                 return false;
             }
             console.error('[main.js] browse-view 组加载失败:', err);
-            return loadExamListFallback(examIndex);
+            return loadExamListFallback(examIndex, options);
         });
     } else {
         // 无懒加载器，直接降级
-        return loadExamListFallback(examIndex);
+        return loadExamListFallback(examIndex, options);
     }
 }
 
@@ -3339,12 +3413,12 @@ function createFallbackExamCard(exam, options = {}) {
     return item;
 }
 
-function loadExamListFallback(examIndexSnapshot = []) {
+function loadExamListFallback(examIndexSnapshot = [], options = {}) {
     console.warn('[main.js] 使用降级渲染逻辑');
     try {
         let examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
         const container = document.getElementById('exam-list-container');
-        if (!container) return;
+        if (!container) return false;
 
         // 清除 loading 指示器
         const loadingEl = document.querySelector('#browse-view .loading');
@@ -3356,7 +3430,8 @@ function loadExamListFallback(examIndexSnapshot = []) {
 
         if (examIndex.length === 0) {
             container.innerHTML = '<div class="exam-list-empty"><p>暂无题目</p></div>';
-            return;
+            markBrowseRenderCommitReceipt(options.commitReceipt);
+            return [];
         }
 
         // 应用当前筛选状态（修复 P2 bug）
@@ -3424,7 +3499,8 @@ function loadExamListFallback(examIndexSnapshot = []) {
 
         if (filtered.length === 0) {
             container.innerHTML = '<div class="exam-list-empty"><p>未找到匹配的题目</p></div>';
-            return;
+            markBrowseRenderCommitReceipt(options.commitReceipt);
+            return filtered;
         }
         
         const list = document.createElement('div');
@@ -3438,8 +3514,11 @@ function loadExamListFallback(examIndexSnapshot = []) {
         });
         container.innerHTML = '';
         container.appendChild(list);
+        markBrowseRenderCommitReceipt(options.commitReceipt);
+        return filtered;
     } catch (err) {
         console.error('[main.js] 降级渲染失败:', err);
+        return false;
     }
 }
 
@@ -3958,11 +4037,17 @@ async function performSearch(
     if (!isCurrent()) {
         return false;
     }
+    let committed = false;
     if (window.ExamActions && typeof window.ExamActions.displayExams === 'function') {
-        window.ExamActions.displayExams(searchResults);
+        committed = window.ExamActions.displayExams(searchResults, {
+            commitReceipt: options.commitReceipt
+        }) === true;
     } else if (typeof window.displayExams === 'function') {
-        window.displayExams(searchResults);
+        committed = window.displayExams(searchResults, {
+            commitReceipt: options.commitReceipt
+        }) === true;
     }
+    return committed ? searchResults : false;
 }
 
 async function toggleBulkDelete() {

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ let practiceListScroller = null;
 let app = null;
 let pdfHandler = null;
 let browseStateManager = null;
+let browseInitialFilterHydrationConsumed = false;
 
 function normalizeRecordId(id) {
     if (id == null) {
@@ -2095,6 +2096,7 @@ window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight
 window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
+    browseInitialFilterHydrationConsumed = true;
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
@@ -2171,15 +2173,42 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
 }
 
 // 应用分类筛选（供 App/总览调用）
-async function applyBrowseFilter(category = 'all', type = null, filterMode = null, path = null, renderRequestId = null) {
+async function applyBrowseFilter(
+    category = 'all',
+    type = null,
+    filterMode = null,
+    path = null,
+    renderRequestId = null,
+    navigationIntentGeneration = null
+) {
+    browseInitialFilterHydrationConsumed = true;
+    const getActiveViewId = () => {
+        const activeView = typeof document.querySelector === 'function'
+            ? document.querySelector('.view.active')
+            : null;
+        return activeView ? activeView.id : null;
+    };
+    const activeViewIdAtRequest = getActiveViewId();
+    const capturedNavigationIntentGeneration = navigationIntentGeneration == null
+        && typeof window.__getAppNavigationIntentGeneration === 'function'
+        ? window.__getAppNavigationIntentGeneration()
+        : navigationIntentGeneration;
+    const isNavigationIntentCurrent = () => {
+        if (capturedNavigationIntentGeneration != null
+            && typeof window.__getAppNavigationIntentGeneration === 'function'
+            && window.__getAppNavigationIntentGeneration() !== capturedNavigationIntentGeneration) {
+            return false;
+        }
+        return getActiveViewId() === activeViewIdAtRequest;
+    };
     const userRequestId = renderRequestId == null
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
     try {
         const indexSnapshot = await resolveActiveExamIndex();
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
         const memorizeSelectionActive = isReadingMemorizeBrowseMode();
         if (memorizeSelectionActive) {
@@ -2254,8 +2283,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
 
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
@@ -2267,8 +2296,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
         await renderBrowseResultsForState(indexSnapshot, activeRequestId);
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
 
         // 若未在浏览视图，则尽力切换
@@ -2276,8 +2305,8 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
             window.showView('browse', false);
         }
     } catch (e) {
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+            return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
         setBrowseFilterState('all', 'all');
@@ -2286,7 +2315,7 @@ async function applyBrowseFilter(category = 'all', type = null, filterMode = nul
         }
         // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
         setTimeout(() => {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
                 return;
             }
             try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
@@ -2321,13 +2350,16 @@ async function initializeBrowseView(options = {}) {
         window.refreshListeningAvailabilityUI(examIndex);
     }
 
-    const persisted = getPersistedBrowseFilter();
-    if (persisted) {
-        setBrowseFilterState(persisted.category, persisted.type);
-        setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
-    } else {
-        setBrowseFilterState('all', 'all');
-        setBrowseTitle(formatBrowseTitle('all', 'all'));
+    if (!browseInitialFilterHydrationConsumed) {
+        const persisted = getPersistedBrowseFilter();
+        if (persisted) {
+            setBrowseFilterState(persisted.category, persisted.type);
+            setBrowseTitle(formatBrowseTitle(persisted.category, persisted.type));
+        } else {
+            setBrowseFilterState('all', 'all');
+            setBrowseTitle(formatBrowseTitle('all', 'all'));
+        }
+        browseInitialFilterHydrationConsumed = true;
     }
 
     setupBrowseSortControl();
@@ -3180,6 +3212,7 @@ function clearSearch() {
 
 function getBrowseFilteredExamBase(examIndexSnapshot = []) {
     const examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
+    const folderScopedExamIndex = applyActiveBrowseFolderFilter(examIndex);
     const activeCategory = typeof getCurrentCategory === 'function' ? getCurrentCategory() : 'all';
     const activeExamType = typeof getCurrentExamType === 'function' ? getCurrentExamType() : 'all';
     const isFrequencyMode = window.__browseFilterMode && window.__browseFilterMode !== 'default';
@@ -3188,7 +3221,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         : null;
 
     if (window.ExamFilterService && typeof window.ExamFilterService.filterExams === 'function') {
-        const filtered = window.ExamFilterService.filterExams(examIndex, {
+        return window.ExamFilterService.filterExams(folderScopedExamIndex, {
             activeCategory,
             activeExamType,
             browseFilterMode: window.__browseFilterMode,
@@ -3197,10 +3230,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             sortMode: window.__browseSortMode,
             frequencyFilter: window.__browseFrequencyFilter
         });
-        return applyActiveBrowseFolderFilter(filtered);
     }
 
-    let list = Array.isArray(examIndex) ? examIndex.slice() : [];
+    let list = folderScopedExamIndex.slice();
     if (activeExamType !== 'all') {
         list = list.filter((exam) => exam && exam.type === activeExamType);
     }
@@ -3217,7 +3249,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             window.__browseFrequencyFilter
         );
     }
-    return applyActiveBrowseFolderFilter(list);
+    return list;
 }
 
 function applyActiveBrowseFolderFilter(exams) {

--- a/js/main.js
+++ b/js/main.js
@@ -303,67 +303,16 @@ async function initializeLegacyComponents() {
 // Practice history is read from AppData for each refresh. Only its signature is
 // retained as runtime UI state; record arrays never become a second authority.
 let lastPracticeRecordsSignature = null;
-let practiceRecordsSyncInvocationGeneration = 0;
-let practiceRecordsDataGeneration = 0;
-let practiceRecordsCommitSubscriptionAttached = false;
-const activePracticeRecordsSyncInvocations = new Map();
-const PRACTICE_RECORD_ENTITY_STORES = new Set([
-    'practiceSummaries',
-    'practiceDetails'
-]);
-
-function ensurePracticeRecordsCommitSubscription() {
-    if (practiceRecordsCommitSubscriptionAttached) {
-        return;
-    }
-    const backups = window.AppData && window.AppData.backups;
-    if (!backups || typeof backups.onDataCommitted !== 'function') {
-        return;
-    }
-    backups.onDataCommitted((event) => {
-        const targets = event && Array.isArray(event.targets) ? event.targets : [];
-        const touchesPracticeRecords = targets.some((target) => {
-            const store = typeof target === 'string'
-                ? target
-                : target && (target.store || target.logicalKey);
-            return PRACTICE_RECORD_ENTITY_STORES.has(store);
-        });
-        if (touchesPracticeRecords) {
-            practiceRecordsDataGeneration += 1;
-            if (activePracticeRecordsSyncInvocations.size > 0) {
-                const replacementMode = Array.from(
-                    activePracticeRecordsSyncInvocations.values()
-                ).some((activeOptions) => activeOptions && activeOptions.mode === 'full')
-                    ? 'full'
-                    : 'summary';
-                startPracticeRecordsSyncInBackground('practice-data-committed', {
-                    forceRender: true,
-                    mode: replacementMode
-                });
-            }
-        }
-    });
-    practiceRecordsCommitSubscriptionAttached = true;
-}
-
+// Browse progress is a derived projection. This generation orders only that
+// projection; it never changes syncPracticeRecords' public return value or the
+// Practice-history single-flight contract below.
+let browsePracticeProjectionGeneration = 0;
 async function syncPracticeRecords(options = {}) {
-    ensurePracticeRecordsCommitSubscription();
-    const invocationGeneration = ++practiceRecordsSyncInvocationGeneration;
-    const normalizedOptions = normalizePracticeRecordsSyncOptions(options);
-    activePracticeRecordsSyncInvocations.set(invocationGeneration, normalizedOptions);
-    try {
-        return await executePracticeRecordsSync(normalizedOptions, invocationGeneration);
-    } finally {
-        activePracticeRecordsSyncInvocations.delete(invocationGeneration);
-    }
-}
-
-async function executePracticeRecordsSync(options, invocationGeneration) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const browseProgressSourceEpoch = {
         activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration
+        practiceProjectionGeneration: ++browsePracticeProjectionGeneration
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -423,16 +372,6 @@ async function executePracticeRecordsSync(options, invocationGeneration) {
         });
     } catch (e) { console.warn('[System] normalize durations failed:', e); }
 
-    const sourceLibraryIsCurrent = isBrowseProgressRefreshEpochCurrent({
-        activeLibraryGeneration: browseProgressSourceEpoch.activeLibraryGeneration
-    });
-    if (invocationGeneration !== practiceRecordsSyncInvocationGeneration
-        || !sourceLibraryIsCurrent
-        || browseProgressSourceEpoch.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
-        console.log('[System] 丢弃已过期的练习记录同步投影');
-        return records;
-    }
-
     // Avoid resetting the list when the authoritative light projection is unchanged.
     try {
         const renderer = window.PracticeHistoryRenderer;
@@ -456,146 +395,85 @@ async function executePracticeRecordsSync(options, invocationGeneration) {
 }
 
 let practiceRecordsLoadPromise = null;
-let pendingPracticeRecordsSyncRequest = null;
-let activePracticeRecordsSyncRequest = null;
+let activeBrowseProgressSyncLibraryGeneration = null;
+let pendingBrowseProgressLibrarySync = null;
 
-function normalizePracticeRecordsSyncOptions(options = {}) {
-    const normalized = Object.assign({}, options || {});
-    normalized.forceRender = !!normalized.forceRender;
-    normalized.mode = normalized.mode === 'full' ? 'full' : 'summary';
-    return normalized;
-}
-
-function capturePracticeRecordsSyncRequest(trigger, options = {}) {
-    return {
-        trigger,
-        options: normalizePracticeRecordsSyncOptions(options),
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration
-    };
-}
-
-function practiceRecordsSyncGenerationCovers(existing, incoming, key) {
-    if (incoming[key] == null) {
-        return true;
-    }
-    return existing[key] != null && existing[key] >= incoming[key];
-}
-
-function practiceRecordsSyncRequestCovers(existing, incoming) {
-    if (!existing || !incoming) {
-        return false;
-    }
-    const existingOptions = existing.options || {};
-    const incomingOptions = incoming.options || {};
-    return practiceRecordsSyncGenerationCovers(existing, incoming, 'activeLibraryGeneration')
-        && practiceRecordsSyncGenerationCovers(existing, incoming, 'practiceRecordsDataGeneration')
-        && (existingOptions.forceRender || !incomingOptions.forceRender)
-        && (existingOptions.mode === 'full' || incomingOptions.mode !== 'full');
-}
-
-function activePracticeRecordsSyncRequestCovers(incoming) {
-    return !!activePracticeRecordsSyncRequest
-        && activePracticeRecordsSyncRequest.invocationGeneration
-            === practiceRecordsSyncInvocationGeneration
-        && practiceRecordsSyncRequestCovers(activePracticeRecordsSyncRequest, incoming);
-}
-
-function mergePracticeRecordsSyncGeneration(previousValue, nextValue) {
-    if (previousValue == null) {
-        return nextValue;
-    }
-    if (nextValue == null) {
-        return previousValue;
-    }
-    return Math.max(previousValue, nextValue);
-}
-
-function queuePendingPracticeRecordsSync(incoming) {
-    const previous = pendingPracticeRecordsSyncRequest;
-    const activeOptions = activePracticeRecordsSyncRequest
-        && activePracticeRecordsSyncRequest.options
-        ? activePracticeRecordsSyncRequest.options
-        : {};
+function mergeBrowseProgressLibrarySyncRequest(trigger, options, libraryGeneration) {
+    const previous = pendingBrowseProgressLibrarySync;
     const previousOptions = previous && previous.options ? previous.options : {};
-    const incomingOptions = incoming && incoming.options ? incoming.options : {};
-    const nextOptions = Object.assign({}, activeOptions, previousOptions, incomingOptions);
-    nextOptions.forceRender = !!(
-        activeOptions.forceRender
-        || previousOptions.forceRender
-        || incomingOptions.forceRender
-    );
-    nextOptions.mode = activeOptions.mode === 'full'
-        || previousOptions.mode === 'full'
-        || incomingOptions.mode === 'full'
-        ? 'full'
-        : 'summary';
-    pendingPracticeRecordsSyncRequest = {
-        trigger: incoming.trigger,
-        options: nextOptions,
-        activeLibraryGeneration: mergePracticeRecordsSyncGeneration(
-            previous && previous.activeLibraryGeneration,
-            incoming.activeLibraryGeneration
-        ),
-        practiceRecordsDataGeneration: mergePracticeRecordsSyncGeneration(
-            previous && previous.practiceRecordsDataGeneration,
-            incoming.practiceRecordsDataGeneration
-        )
+    const incomingOptions = options || {};
+    pendingBrowseProgressLibrarySync = {
+        trigger,
+        libraryGeneration,
+        options: {
+            forceRender: !!(previousOptions.forceRender || incomingOptions.forceRender),
+            mode: previousOptions.mode === 'full' || incomingOptions.mode === 'full'
+                ? 'full'
+                : 'summary'
+        }
     };
 }
 
-async function drainPracticeRecordsSyncQueue(initialRequest) {
+async function drainBrowseProgressLibrarySync(initialRequest) {
     let request = initialRequest;
     let result = null;
     try {
         while (request) {
-            activePracticeRecordsSyncRequest = request;
+            activeBrowseProgressSyncLibraryGeneration = readBrowseProgressGeneration(
+                '__getActiveLibraryGeneration'
+            );
             let syncError = null;
             try {
-                request.activeLibraryGeneration = readBrowseProgressGeneration(
-                    '__getActiveLibraryGeneration'
-                );
-                request.practiceRecordsDataGeneration = practiceRecordsDataGeneration;
-                request.invocationGeneration = practiceRecordsSyncInvocationGeneration + 1;
-                const syncPromise = syncPracticeRecords(Object.assign(
+                result = await syncPracticeRecords(Object.assign(
                     { mode: 'summary' },
                     request.options || {}
                 ));
-                result = await syncPromise;
             } catch (error) {
                 syncError = error;
             }
-            const nextRequest = pendingPracticeRecordsSyncRequest;
-            pendingPracticeRecordsSyncRequest = null;
-            if (syncError && !nextRequest) {
+            request = pendingBrowseProgressLibrarySync;
+            pendingBrowseProgressLibrarySync = null;
+            if (syncError && !request) {
                 throw syncError;
             }
             if (syncError) {
                 console.warn(
-                    `[System] 练习记录同步失败(${request.trigger})，继续处理已排队的最新请求:`,
+                    `[System] 练习记录同步失败(${initialRequest.trigger})，继续刷新最新题库进度:`,
                     syncError
                 );
             }
-            request = nextRequest;
         }
         return result;
     } finally {
-        activePracticeRecordsSyncRequest = null;
+        activeBrowseProgressSyncLibraryGeneration = null;
+        pendingBrowseProgressLibrarySync = null;
         practiceRecordsLoadPromise = null;
     }
 }
 
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
-    ensurePracticeRecordsCommitSubscription();
-    const incomingRequest = capturePracticeRecordsSyncRequest(trigger, options);
+    const requestedLibraryGeneration = readBrowseProgressGeneration(
+        '__getActiveLibraryGeneration'
+    );
     if (practiceRecordsLoadPromise) {
-        if (!activePracticeRecordsSyncRequestCovers(incomingRequest)
-            && !practiceRecordsSyncRequestCovers(pendingPracticeRecordsSyncRequest, incomingRequest)) {
-            queuePendingPracticeRecordsSync(incomingRequest);
+        // Keep the baseline single-flight contract for same-library calls. Only
+        // a newer active library earns one coalesced Browse-progress tail; this
+        // is not a generic Practice-data replacement scheduler.
+        if (requestedLibraryGeneration != null
+            && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration) {
+            mergeBrowseProgressLibrarySyncRequest(
+                trigger,
+                options,
+                requestedLibraryGeneration
+            );
         }
         return practiceRecordsLoadPromise;
     }
-    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(incomingRequest);
+    practiceRecordsLoadPromise = drainBrowseProgressLibrarySync({
+        trigger,
+        options: Object.assign({}, options || {}),
+        libraryGeneration: requestedLibraryGeneration
+    });
     return practiceRecordsLoadPromise;
 }
 
@@ -2087,19 +1965,15 @@ function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
         source,
         'activeLibraryGeneration'
     );
-    const hasSourcePracticeRecordsDataGeneration = Object.prototype.hasOwnProperty.call(
-        source,
-        'practiceRecordsDataGeneration'
-    );
     const functionalResetState = readBrowseFunctionalResetState();
     return {
         navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
         activeLibraryGeneration: hasSourceLibraryGeneration
             ? source.activeLibraryGeneration
             : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceRecordsDataGeneration: hasSourcePracticeRecordsDataGeneration
-            ? source.practiceRecordsDataGeneration
-            : practiceRecordsDataGeneration,
+        practiceProjectionGeneration: Number.isFinite(Number(source.practiceProjectionGeneration))
+            ? Number(source.practiceProjectionGeneration)
+            : browsePracticeProjectionGeneration,
         resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration'),
         functionalResetGeneration: functionalResetState.generation,
         functionalResetWasPending: functionalResetState.status === 'pending'
@@ -2122,8 +1996,8 @@ function isBrowseProgressRefreshEpochCurrent(epoch) {
     if (!ordinaryGenerationsAreCurrent) {
         return false;
     }
-    if (captured.practiceRecordsDataGeneration != null
-        && captured.practiceRecordsDataGeneration !== practiceRecordsDataGeneration) {
+    if (captured.practiceProjectionGeneration != null
+        && captured.practiceProjectionGeneration !== browsePracticeProjectionGeneration) {
         return false;
     }
     if (captured.functionalResetGeneration == null) {
@@ -2201,9 +2075,7 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
-        if (!isBrowseProgressRefreshEpochCurrent({
-            activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
-        })) {
+        if (!isBrowseProgressRefreshEpochCurrent(pendingEpoch)) {
             return;
         }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
@@ -2449,6 +2321,89 @@ function isBrowseUserResultsRequest(requestId) {
     return requestId != null && requestId === lastBrowseUserResultsRequestId;
 }
 
+function captureBrowseForegroundRenderEpoch(sourceEpoch = null) {
+    const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
+    const functionalResetState = readBrowseFunctionalResetState();
+    const readSourceOrGeneration = (key, getterName) => Object.prototype.hasOwnProperty.call(source, key)
+        ? source[key]
+        : readBrowseProgressGeneration(getterName);
+    return {
+        navigationGeneration: readSourceOrGeneration(
+            'navigationGeneration',
+            '__getAppNavigationIntentGeneration'
+        ),
+        activeLibraryGeneration: readSourceOrGeneration(
+            'activeLibraryGeneration',
+            '__getActiveLibraryGeneration'
+        ),
+        resetGeneration: readSourceOrGeneration(
+            'resetGeneration',
+            '__getBrowseResetIntentGeneration'
+        ),
+        functionalResetGeneration: Object.prototype.hasOwnProperty.call(
+            source,
+            'functionalResetGeneration'
+        )
+            ? source.functionalResetGeneration
+            : functionalResetState.generation
+    };
+}
+
+function isBrowseForegroundRenderEpochCurrent(epoch) {
+    if (!epoch || typeof epoch !== 'object') {
+        return true;
+    }
+    const generations = {
+        navigationGeneration: '__getAppNavigationIntentGeneration',
+        activeLibraryGeneration: '__getActiveLibraryGeneration',
+        resetGeneration: '__getBrowseResetIntentGeneration'
+    };
+    const ordinaryGenerationsAreCurrent = Object.keys(generations).every((key) => {
+        if (epoch[key] == null) {
+            return true;
+        }
+        return readBrowseProgressGeneration(generations[key]) === epoch[key];
+    });
+    if (!ordinaryGenerationsAreCurrent || epoch.functionalResetGeneration == null) {
+        return ordinaryGenerationsAreCurrent;
+    }
+    return readBrowseFunctionalResetState().generation === epoch.functionalResetGeneration;
+}
+
+function captureCurrentForegroundBrowseRecovery(requestId, explicitlyForeground = false) {
+    const isForeground = explicitlyForeground
+        || isBrowseUserResultsRequestInFlight(requestId);
+    if (!isForeground || !isBrowseResultsRequestCurrent(requestId)) {
+        return null;
+    }
+    const appEntry = window.AppEntry;
+    if (appEntry
+        && typeof appEntry.prepareBrowseFunctionalResetRecoveryForForeground === 'function') {
+        const prepared = appEntry.prepareBrowseFunctionalResetRecoveryForForeground(requestId);
+        return prepared && prepared.recovery ? prepared.recovery : prepared;
+    }
+    if (!appEntry
+        || typeof appEntry.captureBrowseFunctionalResetRecovery !== 'function') {
+        return null;
+    }
+    const recovery = appEntry.captureBrowseFunctionalResetRecovery();
+    if (recovery
+        && typeof appEntry.updateBrowseFunctionalResetRecoveryResultsRequest === 'function') {
+        appEntry.updateBrowseFunctionalResetRecoveryResultsRequest(recovery, requestId);
+    }
+    return recovery;
+}
+
+function completeCurrentForegroundBrowseRecovery(recovery, succeeded) {
+    const appEntry = window.AppEntry;
+    if (!recovery
+        || !appEntry
+        || typeof appEntry.completeBrowseFunctionalResetRecovery !== 'function') {
+        return false;
+    }
+    return appEntry.completeBrowseFunctionalResetRecovery(recovery, succeeded === true);
+}
+
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
 window.__isBrowseResultsRequestCurrent = isBrowseResultsRequestCurrent;
 window.__getBrowseResultsRequestId = function getBrowseResultsRequestId() {
@@ -2465,8 +2420,10 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     try {
         const requestedType = type;
+        let listeningUnavailable = false;
         let examIndex = Array.isArray(examIndexOverride) ? examIndexOverride : [];
         try {
             if (!Array.isArray(examIndexOverride)) {
@@ -2477,9 +2434,7 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
                 : examIndex.some((exam) => exam && exam.type === 'listening');
             if (requestedType === 'listening' && !listeningAvailable) {
                 type = 'all';
-                if (typeof window.showMessage === 'function') {
-                    window.showMessage('听力题库尚未加载', 'warning');
-                }
+                listeningUnavailable = true;
             }
         } catch (_) {
             if (requestedType === 'listening') {
@@ -2487,8 +2442,12 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-            return;
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        if (listeningUnavailable && typeof window.showMessage === 'function') {
+            window.showMessage('听力题库尚未加载', 'warning');
         }
 
         // 重置筛选器状态
@@ -2531,7 +2490,9 @@ async function filterByType(type, examIndexOverride = null, renderRequestId = nu
         }
 
         // 保留活动搜索与新类型筛选的交集。
-        await renderBrowseResultsForState(examIndex, activeRequestId);
+        return await renderBrowseResultsForState(examIndex, activeRequestId, {
+            foregroundEpoch
+        });
     } finally {
         endBrowseUserResultsRequest(userRequestId);
     }
@@ -2569,14 +2530,12 @@ async function applyBrowseFilter(
         ? beginBrowseUserResultsRequest()
         : retainBrowseUserResultsRequest(renderRequestId);
     const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
-    const functionalResetRecovery = window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     try {
         const indexSnapshot = await resolveActiveExamIndex();
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
         const memorizeSelectionActive = isReadingMemorizeBrowseMode();
@@ -2652,7 +2611,9 @@ async function applyBrowseFilter(
             }
         }
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
 
@@ -2664,9 +2625,13 @@ async function applyBrowseFilter(
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
 
         // 3. 统一刷新，确保活动搜索继续约束分类/路径结果。
-        await renderBrowseResultsForState(indexSnapshot, activeRequestId);
+        const renderResult = await renderBrowseResultsForState(indexSnapshot, activeRequestId, {
+            foregroundEpoch
+        });
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (renderResult === false
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()) {
             return false;
         }
 
@@ -2674,10 +2639,11 @@ async function applyBrowseFilter(
         if (typeof window.showView === 'function' && !document.getElementById('browse-view')?.classList.contains('active')) {
             window.showView('browse', false);
         }
-        functionalResetRecoverySucceeded = true;
         return true;
     } catch (e) {
-        if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
         console.warn('[Browse] 应用筛选失败，回退到默认列表:', e);
@@ -2686,23 +2652,19 @@ async function applyBrowseFilter(
         if (window.browseController && typeof window.browseController.resetToDefault === 'function') {
             window.browseController.resetToDefault(null, activeRequestId, { skipApply: true });
         }
-        // 避免在错误处理中再次同步调用可能导致错误的 loadExamList，使用 setTimeout 打断调用栈
-        setTimeout(() => {
-            if (!isBrowseResultsRequestCurrent(activeRequestId) || !isNavigationIntentCurrent()) {
-                return;
-            }
-            try { renderBrowseResultsForState(null, activeRequestId); } catch (_) { }
-        }, 0);
+        // Break the failing call stack while retaining this foreground lease.
+        // The original epoch must still be current before the fallback may write.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isNavigationIntentCurrent()
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        try {
+            await renderBrowseResultsForState(null, activeRequestId, { foregroundEpoch });
+        } catch (_) { }
         return false;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -2786,12 +2748,9 @@ async function initializeBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
-    const functionalResetRecovery = !options.skipLoad
-        && window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = options.foregroundEpoch
+        ? captureBrowseForegroundRenderEpoch(options.foregroundEpoch)
+        : captureBrowseForegroundRenderEpoch();
     try {
         console.log('[System] Initializing browse view...');
         const [examIndex] = await Promise.all([
@@ -2801,7 +2760,8 @@ async function initializeBrowseView(options = {}) {
                 : Promise.resolve()
         ]);
 
-        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return null;
         }
 
@@ -2820,7 +2780,9 @@ async function initializeBrowseView(options = {}) {
             const persistedAuthoritativeFilter = await persistAuthoritativeBrowseFilterBeforeHydration(
                 activeRequestId
             );
-            if (!persistedAuthoritativeFilter || !isBrowseResultsRequestCurrent(activeRequestId)) {
+            if (!persistedAuthoritativeFilter
+                || !isBrowseResultsRequestCurrent(activeRequestId)
+                || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
                 console.warn('[Browse] 权威筛选尚未持久化，已推迟首次 hydration');
                 return null;
             }
@@ -2839,23 +2801,20 @@ async function initializeBrowseView(options = {}) {
 
         setupBrowseSortControl();
         setupBrowseFrequencyFilterControl();
+        if (!isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return null;
+        }
         if (!options.skipLoad) {
-            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId);
+            const renderResult = await renderBrowseResultsForState(examIndex, activeRequestId, {
+                foregroundEpoch
+            });
             if (renderResult === false || !isBrowseResultsRequestCurrent(activeRequestId)) {
                 return null;
             }
-            functionalResetRecoverySucceeded = true;
         }
         return examIndex;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -2867,32 +2826,25 @@ async function activateBrowseView(options = {}) {
     const activeRequestId = options.renderRequestId == null
         ? userRequestId
         : options.renderRequestId;
-    const functionalResetRecovery = window.AppEntry
-        && typeof window.AppEntry.captureBrowseFunctionalResetRecovery === 'function'
-        ? window.AppEntry.captureBrowseFunctionalResetRecovery()
-        : null;
-    let functionalResetRecoverySucceeded = false;
+    const foregroundEpoch = options.foregroundEpoch
+        ? captureBrowseForegroundRenderEpoch(options.foregroundEpoch)
+        : captureBrowseForegroundRenderEpoch();
     try {
         const examIndex = await initializeBrowseView({
             skipLoad: true,
-            renderRequestId: activeRequestId
+            renderRequestId: activeRequestId,
+            foregroundEpoch
         });
-        if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+        if (!Array.isArray(examIndex)
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
             return false;
         }
-        const result = await renderBrowseResultsForState(examIndex, activeRequestId);
-        functionalResetRecoverySucceeded = result !== false
-            && isBrowseResultsRequestCurrent(activeRequestId);
+        const result = await renderBrowseResultsForState(examIndex, activeRequestId, {
+            foregroundEpoch
+        });
         return result;
     } finally {
-        if (functionalResetRecovery
-            && window.AppEntry
-            && typeof window.AppEntry.completeBrowseFunctionalResetRecovery === 'function') {
-            window.AppEntry.completeBrowseFunctionalResetRecovery(
-                functionalResetRecovery,
-                functionalResetRecoverySucceeded
-            );
-        }
         endBrowseUserResultsRequest(userRequestId);
     }
 }
@@ -2909,45 +2861,146 @@ function getBrowseSearchQuery() {
     return input && typeof input.value === 'string' ? input.value.trim() : '';
 }
 
-function renderBrowseResultsForState(examIndexOverride = null, renderRequestId = null) {
+async function renderBrowseResultsForState(
+    examIndexOverride = null,
+    renderRequestId = null,
+    options = {}
+) {
+    const hasQueryOverride = Object.prototype.hasOwnProperty.call(options || {}, 'query');
+    const query = hasQueryOverride ? String(options.query || '').trim() : getBrowseSearchQuery();
+    const explicitlyForeground = options && options.foreground === true;
+    const foregroundRetainId = explicitlyForeground
+        ? (renderRequestId == null
+            ? beginBrowseUserResultsRequest()
+            : retainBrowseUserResultsRequest(renderRequestId))
+        : null;
     const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
+        ? (explicitlyForeground ? foregroundRetainId : beginBrowseResultsRequest())
         : renderRequestId;
-    const query = getBrowseSearchQuery();
-    if (query) {
-        return performSearch(query, activeRequestId, examIndexOverride);
+    if (explicitlyForeground && foregroundRetainId == null) {
+        return false;
     }
-    return loadExamList(examIndexOverride, activeRequestId);
+    const isForeground = explicitlyForeground
+        || isBrowseUserResultsRequestInFlight(activeRequestId);
+    const foregroundEpoch = isForeground
+        ? captureBrowseForegroundRenderEpoch(options && options.foregroundEpoch)
+        : null;
+    let foregroundRecovery = null;
+    let renderSucceeded = false;
+    try {
+        if (!isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        foregroundRecovery = captureCurrentForegroundBrowseRecovery(
+            activeRequestId,
+            explicitlyForeground
+        );
+        if (foregroundEpoch) {
+            // Atomic preparation may neutrally cancel a stale retry barrier and
+            // restore its durable failure debt (or idle state). Adopt only that
+            // synchronous internal generation; navigation/library/reset
+            // ownership remains the foreground intent captured by the caller.
+            const preparedFunctionalResetState = readBrowseFunctionalResetState();
+            foregroundEpoch.functionalResetGeneration = preparedFunctionalResetState.generation;
+        }
+        const isRenderCurrent = () => isBrowseResultsRequestCurrent(activeRequestId)
+            && isBrowseForegroundRenderEpochCurrent(foregroundEpoch);
+        const result = query
+            ? await performSearch(query, activeRequestId, examIndexOverride, {
+                isCurrent: isRenderCurrent
+            })
+            : await loadExamList(examIndexOverride, activeRequestId, {
+                isCurrent: isRenderCurrent
+            });
+        if (result === false
+            || !isBrowseResultsRequestCurrent(activeRequestId)
+            || !isBrowseForegroundRenderEpochCurrent(foregroundEpoch)) {
+            return false;
+        }
+        renderSucceeded = true;
+        return result;
+    } finally {
+        completeCurrentForegroundBrowseRecovery(foregroundRecovery, renderSucceeded);
+        endBrowseUserResultsRequest(foregroundRetainId);
+    }
 }
 
 window.__renderBrowseResultsForState = renderBrowseResultsForState;
 
-function refreshBrowseResults() {
-    return renderBrowseResultsForState();
+function refreshBrowseResults(options = {}) {
+    return renderBrowseResultsForState(null, null, options);
 }
 
 let browseControlsSeeded = false;
 let browseControlsSeedPromise = null;
-async function setupBrowseControls() {
+let browseControlsSeedReadRevision = null;
+let browseControlsSeedReadEpoch = null;
+let browseControlsMutationRevision = 0;
+
+function isBrowseControlsSetupCurrent(options = {}) {
+    if (!options || typeof options.isCurrent !== 'function') {
+        return true;
+    }
+    try {
+        return options.isCurrent() !== false;
+    } catch (_) {
+        return false;
+    }
+}
+
+async function setupBrowseControls(options = {}) {
+    if (!isBrowseControlsSetupCurrent(options)) {
+        return false;
+    }
     if (!browseControlsSeeded) {
         if (!browseControlsSeedPromise) {
+            browseControlsSeedReadRevision = browseControlsMutationRevision;
+            browseControlsSeedReadEpoch = captureBrowseForegroundRenderEpoch();
             browseControlsSeedPromise = (async () => {
                 try {
-                    const browse = await window.AppData.preferences.getBrowse();
-                    if (browse) {
-                        window.__browseSortMode = browse.sortMode || window.__browseSortMode;
-                        updateBrowseFrequencyButtons(
-                            browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
-                        );
-                    }
+                    return await window.AppData.preferences.getBrowse();
                 } catch (_) { /* defaults remain active */ }
-                browseControlsSeeded = true;
+                return null;
             })();
         }
-        await browseControlsSeedPromise;
+        const seedPromise = browseControlsSeedPromise;
+        const browse = await seedPromise;
+        if (!isBrowseControlsSetupCurrent(options)) {
+            if (!browseControlsSeeded && browseControlsSeedPromise === seedPromise) {
+                browseControlsSeedPromise = null;
+                browseControlsSeedReadRevision = null;
+                browseControlsSeedReadEpoch = null;
+            }
+            return false;
+        }
+        if (browseControlsSeedPromise !== seedPromise) {
+            return setupBrowseControls(options);
+        }
+        if (!isBrowseForegroundRenderEpochCurrent(browseControlsSeedReadEpoch)) {
+            browseControlsSeedPromise = null;
+            browseControlsSeedReadRevision = null;
+            browseControlsSeedReadEpoch = null;
+            return setupBrowseControls(options);
+        }
+        if (!browseControlsSeeded) {
+            // A user frequency/sort intent that happened while storage was being
+            // read owns the controls. The older preference snapshot must not
+            // overwrite it when the await settles.
+            if (browseControlsSeedReadRevision === browseControlsMutationRevision && browse) {
+                window.__browseSortMode = browse.sortMode || window.__browseSortMode;
+                updateBrowseFrequencyButtons(
+                    browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
+                );
+            }
+            browseControlsSeeded = true;
+        }
+    }
+    if (!isBrowseControlsSetupCurrent(options)) {
+        return false;
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
+    return true;
 }
 
 async function persistBrowsePreference(patch) {
@@ -2974,9 +3027,10 @@ function setupBrowseSortControl() {
     sortSelect.value = normalizeSortMode(savedMode);
     window.__browseSortMode = sortSelect.value;
     sortSelect.addEventListener('change', () => {
+        browseControlsMutationRevision += 1;
         window.__browseSortMode = normalizeSortMode(sortSelect.value);
         persistBrowsePreference({ sortMode: window.__browseSortMode }).catch(console.warn);
-        refreshBrowseResults();
+        refreshBrowseResults({ foreground: true });
     });
     sortSelect.dataset.bound = 'true';
 }
@@ -3026,9 +3080,12 @@ function filterByFrequency(filter) {
     const requested = normalizeBrowseFrequencyFilter(filter);
     const current = normalizeBrowseFrequencyFilter(window.__browseFrequencyFilter || 'all');
     const next = requested !== 'all' && requested === current ? 'all' : requested;
+    browseControlsMutationRevision += 1;
+    // Record the live intent before any async preference write or lazy owner
+    // delegation so an older control-seed read cannot become authoritative.
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
-    refreshBrowseResults();
+    refreshBrowseResults({ foreground: true });
 }
 
 // 全局桥接：HTML 按钮 onclick="browseCategory('P1','reading')"
@@ -3075,20 +3132,33 @@ function filterRecordsByType(type) {
 }
 
 
-async function loadExamList(examIndexOverride = null, renderRequestId = null) {
+async function loadExamList(examIndexOverride = null, renderRequestId = null, options = {}) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
-    await setupBrowseControls();
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    const isCurrent = () => {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        if (!options || typeof options.isCurrent !== 'function') {
+            return true;
+        }
+        try {
+            return options.isCurrent() !== false;
+        } catch (_) {
+            return false;
+        }
+    };
+    const controlsReady = await setupBrowseControls({ isCurrent });
+    if (controlsReady === false || !isCurrent()) {
+        return false;
     }
     const examIndex = Array.isArray(examIndexOverride)
         ? examIndexOverride
         : await resolveActiveExamIndex();
 
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
 
     if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
@@ -3096,27 +3166,30 @@ async function loadExamList(examIndexOverride = null, renderRequestId = null) {
     }
     console.warn('[main.js] ExamActions.loadExamList 未就绪，尝试加载 browse-view 组');
     if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
-        return window.AppLazyLoader.ensureGroup('browse-view').then(function () {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-                return;
+        return window.AppLazyLoader.ensureGroup('browse-view').then(async function () {
+            if (!isCurrent()) {
+                return false;
             }
-            setupBrowseControls();
+            const lazyControlsReady = await setupBrowseControls({ isCurrent });
+            if (lazyControlsReady === false || !isCurrent()) {
+                return false;
+            }
             if (window.ExamActions && typeof window.ExamActions.loadExamList === 'function') {
-                window.ExamActions.loadExamList(examIndex);
+                return window.ExamActions.loadExamList(examIndex);
             } else {
                 // 最终降级：直接 DOM 渲染
-                loadExamListFallback(examIndex);
+                return loadExamListFallback(examIndex);
             }
         }).catch(function (err) {
-            if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-                return;
+            if (!isCurrent()) {
+                return false;
             }
             console.error('[main.js] browse-view 组加载失败:', err);
-            loadExamListFallback(examIndex);
+            return loadExamListFallback(examIndex);
         });
     } else {
         // 无懒加载器，直接降级
-        loadExamListFallback(examIndex);
+        return loadExamListFallback(examIndex);
     }
 }
 
@@ -3678,25 +3751,76 @@ async function setActiveLibraryConfiguration(key) {
 
 
 let debouncedExamSearch = null;
+let pendingDebouncedExamSearchRequestId = null;
 
 function searchExams(query, renderRequestId = null) {
-    const activeRequestId = renderRequestId == null
-        ? beginBrowseResultsRequest()
-        : renderRequestId;
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+    const explicitRequestIsForeground = renderRequestId != null
+        && isBrowseUserResultsRequestInFlight(renderRequestId);
+    const isForegroundIntent = renderRequestId == null || explicitRequestIsForeground;
+    const userRequestId = renderRequestId == null
+        ? beginBrowseUserResultsRequest()
+        : (explicitRequestIsForeground
+            ? retainBrowseUserResultsRequest(renderRequestId)
+            : null);
+    const activeRequestId = renderRequestId == null ? userRequestId : renderRequestId;
+    if (activeRequestId == null
+        || !isBrowseResultsRequestCurrent(activeRequestId)
+        || (isForegroundIntent && userRequestId == null)) {
+        endBrowseUserResultsRequest(userRequestId);
         return false;
     }
+    // Capture navigation/reset/library ownership at input time, before the
+    // debounce delay. A later callback must not adopt an intervening intent.
+    const foregroundEpoch = captureBrowseForegroundRenderEpoch();
     toggleSearchClearButton(query);
     if (window.performanceOptimizer && typeof window.performanceOptimizer.debounce === 'function') {
         // 跨 input 事件复用同一个 debounce 闭包，避免每个字符都排队一次搜索。
         if (!debouncedExamSearch) {
-            debouncedExamSearch = window.performanceOptimizer.debounce(performSearch, 300, 'exam_search');
+            debouncedExamSearch = window.performanceOptimizer.debounce((
+                nextQuery,
+                nextRequestId,
+                retainedRequestId,
+                intentEpoch,
+                foregroundIntent
+            ) => {
+                if (pendingDebouncedExamSearchRequestId === retainedRequestId) {
+                    pendingDebouncedExamSearchRequestId = null;
+                }
+                Promise.resolve(renderBrowseResultsForState(null, nextRequestId, {
+                    foreground: foregroundIntent,
+                    foregroundEpoch: intentEpoch,
+                    query: nextQuery
+                })).catch((error) => {
+                    console.warn('[Search] 搜索结果刷新失败:', error);
+                }).finally(() => {
+                    endBrowseUserResultsRequest(retainedRequestId);
+                });
+            }, 300, 'exam_search');
         }
-        debouncedExamSearch(query, activeRequestId);
+        if (pendingDebouncedExamSearchRequestId != null) {
+            endBrowseUserResultsRequest(pendingDebouncedExamSearchRequestId);
+        }
+        pendingDebouncedExamSearchRequestId = userRequestId;
+        debouncedExamSearch(
+            query,
+            activeRequestId,
+            userRequestId,
+            foregroundEpoch,
+            isForegroundIntent
+        );
     } else {
         // Fallback: direct call if optimizer not available
-        performSearch(query, activeRequestId);
+        Promise.resolve(renderBrowseResultsForState(null, activeRequestId, {
+            foreground: isForegroundIntent,
+            foregroundEpoch,
+            query
+        })).catch((error) => {
+            console.warn('[Search] 搜索结果刷新失败:', error);
+        }).finally(() => {
+            endBrowseUserResultsRequest(userRequestId);
+        });
     }
+    return true;
 }
 
 function toggleSearchClearButton(query) {
@@ -3784,13 +3908,31 @@ function applyActiveBrowseFolderFilter(exams) {
     return Array.isArray(folderFiltered) ? folderFiltered : list;
 }
 
-async function performSearch(query, renderRequestId = null, examIndexOverride = null) {
+async function performSearch(
+    query,
+    renderRequestId = null,
+    examIndexOverride = null,
+    options = {}
+) {
     const activeRequestId = renderRequestId == null
         ? beginBrowseResultsRequest()
         : renderRequestId;
+    const isCurrent = () => {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        if (!options || typeof options.isCurrent !== 'function') {
+            return true;
+        }
+        try {
+            return options.isCurrent() !== false;
+        } catch (_) {
+            return false;
+        }
+    };
     const normalizedQuery = String(query || '').toLowerCase().trim();
     if (!normalizedQuery) {
-        return loadExamList(examIndexOverride, activeRequestId);
+        return loadExamList(examIndexOverride, activeRequestId, { isCurrent });
     }
 
     // 调试日志
@@ -3798,8 +3940,8 @@ async function performSearch(query, renderRequestId = null, examIndexOverride = 
     const examIndexSnapshot = Array.isArray(examIndexOverride)
         ? examIndexOverride
         : await resolveActiveExamIndex();
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
     const searchBase = getBrowseFilteredExamBase(examIndexSnapshot);
     console.log('[Search] 当前筛选后索引数量:', searchBase.length);
@@ -3813,8 +3955,8 @@ async function performSearch(query, renderRequestId = null, examIndexOverride = 
     });
 
     console.log('[Search] 搜索结果数量:', searchResults.length);
-    if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+    if (!isCurrent()) {
+        return false;
     }
     if (window.ExamActions && typeof window.ExamActions.displayExams === 'function') {
         window.ExamActions.displayExams(searchResults);

--- a/js/main.js
+++ b/js/main.js
@@ -2029,6 +2029,7 @@ function browseCategory(category, type = 'reading', filterMode = null, path = nu
 
 let browseResultsRequestId = 0;
 const browseUserResultsRequestRetains = new Map();
+let lastBrowseUserResultsRequestId = null;
 
 function beginBrowseResultsRequest() {
     browseResultsRequestId += 1;
@@ -2045,6 +2046,7 @@ function retainBrowseUserResultsRequest(requestId) {
     }
     const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
     browseUserResultsRequestRetains.set(requestId, retainCount + 1);
+    lastBrowseUserResultsRequestId = requestId;
     return requestId;
 }
 
@@ -2059,6 +2061,15 @@ function endBrowseUserResultsRequest(requestId) {
     const retainCount = browseUserResultsRequestRetains.get(requestId) || 0;
     if (retainCount <= 1) {
         browseUserResultsRequestRetains.delete(requestId);
+        if (retainCount === 1
+            && typeof window.dispatchEvent === 'function'
+            && typeof window.CustomEvent === 'function') {
+            try {
+                window.dispatchEvent(new window.CustomEvent('browseUserResultsRequestSettled', {
+                    detail: { requestId }
+                }));
+            } catch (_) { }
+        }
         return;
     }
     browseUserResultsRequestRetains.set(requestId, retainCount - 1);
@@ -2066,6 +2077,10 @@ function endBrowseUserResultsRequest(requestId) {
 
 function isBrowseUserResultsRequestInFlight(requestId) {
     return requestId != null && (browseUserResultsRequestRetains.get(requestId) || 0) > 0;
+}
+
+function isBrowseUserResultsRequest(requestId) {
+    return requestId != null && requestId === lastBrowseUserResultsRequestId;
 }
 
 window.__beginBrowseResultsRequest = beginBrowseResultsRequest;
@@ -2077,6 +2092,7 @@ window.__beginBrowseUserResultsRequest = beginBrowseUserResultsRequest;
 window.__retainBrowseUserResultsRequest = retainBrowseUserResultsRequest;
 window.__endBrowseUserResultsRequest = endBrowseUserResultsRequest;
 window.__isBrowseUserResultsRequestInFlight = isBrowseUserResultsRequestInFlight;
+window.__isBrowseUserResultsRequest = isBrowseUserResultsRequest;
 
 async function filterByType(type, examIndexOverride = null, renderRequestId = null) {
     const userRequestId = renderRequestId == null
@@ -2294,7 +2310,7 @@ async function initializeBrowseView(options = {}) {
     ]);
 
     if (!isBrowseResultsRequestCurrent(activeRequestId)) {
-        return;
+        return null;
     }
 
     // 初始化 browseController
@@ -2319,7 +2335,24 @@ async function initializeBrowseView(options = {}) {
     if (!options.skipLoad) {
         await renderBrowseResultsForState(examIndex, activeRequestId);
     }
+    return examIndex;
 }
+
+async function activateBrowseView(options = {}) {
+    const activeRequestId = options.renderRequestId == null
+        ? beginBrowseResultsRequest()
+        : options.renderRequestId;
+    const examIndex = await initializeBrowseView({
+        skipLoad: true,
+        renderRequestId: activeRequestId
+    });
+    if (!Array.isArray(examIndex) || !isBrowseResultsRequestCurrent(activeRequestId)) {
+        return false;
+    }
+    return renderBrowseResultsForState(examIndex, activeRequestId);
+}
+
+window.activateBrowseView = activateBrowseView;
 
 function normalizeBrowseFrequencyFilter(value) {
     const raw = String(value || '').trim().toLowerCase();
@@ -2408,6 +2441,10 @@ function updateBrowseFrequencyButtons(filter) {
     if (window.ExamActions && typeof window.ExamActions.setBrowseFrequencyFilter === 'function') {
         return window.ExamActions.setBrowseFrequencyFilter(activeFilter);
     }
+    const stateOwner = window.ExamActions && window.ExamActions.browseFilterStateOwner;
+    if (stateOwner && typeof stateOwner.setFrequencyFilter === 'function') {
+        return stateOwner.setFrequencyFilter(activeFilter);
+    }
     const container = document.getElementById('browse-frequency-filter-buttons');
     if (!container) {
         return activeFilter;
@@ -2424,17 +2461,11 @@ function resetBrowseFilterStateToAll() {
     if (window.ExamActions && typeof window.ExamActions.resetBrowseFilterStateToAll === 'function') {
         return window.ExamActions.resetBrowseFilterStateToAll();
     }
-    window.__browseFilterMode = 'default';
-    window.__browsePath = null;
-    updateBrowseFrequencyButtons('all');
-
-    if (window.browseController) {
-        window.browseController.currentMode = 'default';
-        window.browseController.activeFilter = 'all';
+    const stateOwner = window.ExamActions && window.ExamActions.browseFilterStateOwner;
+    if (stateOwner && typeof stateOwner.resetToAll === 'function') {
+        return stateOwner.resetToAll();
     }
-    if (typeof setBrowseFilterState === 'function') {
-        setBrowseFilterState('all', 'all');
-    }
+    return false;
 }
 
 function setupBrowseFrequencyFilterControl() {
@@ -3157,7 +3188,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         : null;
 
     if (window.ExamFilterService && typeof window.ExamFilterService.filterExams === 'function') {
-        return window.ExamFilterService.filterExams(examIndex, {
+        const filtered = window.ExamFilterService.filterExams(examIndex, {
             activeCategory,
             activeExamType,
             browseFilterMode: window.__browseFilterMode,
@@ -3166,6 +3197,7 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             sortMode: window.__browseSortMode,
             frequencyFilter: window.__browseFrequencyFilter
         });
+        return applyActiveBrowseFolderFilter(filtered);
     }
 
     let list = Array.isArray(examIndex) ? examIndex.slice() : [];
@@ -3179,9 +3211,32 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         list = list.filter((exam) => typeof exam?.path === 'string' && exam.path.includes(basePathFilter));
     }
     if (window.ExamActions && typeof window.ExamActions.applyBrowsePostFilters === 'function') {
-        return window.ExamActions.applyBrowsePostFilters(list, window.__browseSortMode, window.__browseFrequencyFilter);
+        list = window.ExamActions.applyBrowsePostFilters(
+            list,
+            window.__browseSortMode,
+            window.__browseFrequencyFilter
+        );
     }
-    return list;
+    return applyActiveBrowseFolderFilter(list);
+}
+
+function applyActiveBrowseFolderFilter(exams) {
+    const list = Array.isArray(exams) ? exams : [];
+    const controller = window.browseController;
+    if (!controller
+        || typeof controller.getCurrentModeConfig !== 'function'
+        || typeof controller.filterExamsByFolder !== 'function') {
+        return list;
+    }
+    const config = controller.getCurrentModeConfig();
+    if (!config || config.filterLogic !== 'folder-based') {
+        return list;
+    }
+    const folderFiltered = controller.filterExamsByFolder(
+        list,
+        controller.activeFilter || 'all'
+    );
+    return Array.isArray(folderFiltered) ? folderFiltered : list;
 }
 
 async function performSearch(query, renderRequestId = null, examIndexOverride = null) {

--- a/js/main.js
+++ b/js/main.js
@@ -306,6 +306,9 @@ let lastPracticeRecordsSignature = null;
 async function syncPracticeRecords(options = {}) {
     const { forceRender = false, mode = 'summary' } = options || {};
     const loadMode = mode === 'full' ? 'full' : 'summary';
+    const browseProgressSourceEpoch = {
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
+    };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
     let [records, insightRecords, examIndex] = await Promise.all([
@@ -377,7 +380,7 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    refreshBrowseProgressFromRecords(records, examIndex);
+    refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
@@ -387,16 +390,65 @@ async function syncPracticeRecords(options = {}) {
 }
 
 let practiceRecordsLoadPromise = null;
+let pendingPracticeRecordsSyncRequest = null;
+
+function queuePendingPracticeRecordsSync(trigger, options = {}) {
+    const previous = pendingPracticeRecordsSyncRequest;
+    const previousOptions = previous && previous.options ? previous.options : {};
+    const nextOptions = Object.assign({}, previousOptions, options || {});
+    nextOptions.forceRender = !!(previousOptions.forceRender || (options && options.forceRender));
+    nextOptions.mode = previousOptions.mode === 'full' || (options && options.mode === 'full')
+        ? 'full'
+        : 'summary';
+    pendingPracticeRecordsSyncRequest = {
+        trigger,
+        options: nextOptions
+    };
+}
+
+async function drainPracticeRecordsSyncQueue(initialRequest) {
+    let request = initialRequest;
+    let result = null;
+    try {
+        while (request) {
+            let syncError = null;
+            try {
+                result = await syncPracticeRecords(Object.assign(
+                    { mode: 'summary' },
+                    request.options || {}
+                ));
+            } catch (error) {
+                syncError = error;
+            }
+            const nextRequest = pendingPracticeRecordsSyncRequest;
+            pendingPracticeRecordsSyncRequest = null;
+            if (syncError && !nextRequest) {
+                throw syncError;
+            }
+            if (syncError) {
+                console.warn(
+                    `[System] 练习记录同步失败(${request.trigger})，继续处理已排队的最新请求:`,
+                    syncError
+                );
+            }
+            request = nextRequest;
+        }
+        return result;
+    } finally {
+        practiceRecordsLoadPromise = null;
+    }
+}
+
 function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
     if (practiceRecordsLoadPromise) {
+        queuePendingPracticeRecordsSync(trigger, options);
         return practiceRecordsLoadPromise;
     }
-    const loadTask = (async () => {
-        return syncPracticeRecords(Object.assign({ mode: 'summary' }, options || {}));
-    })();
-    practiceRecordsLoadPromise = loadTask.finally(() => {
-        practiceRecordsLoadPromise = null;
-    });
+    const initialRequest = {
+        trigger,
+        options: Object.assign({}, options || {})
+    };
+    practiceRecordsLoadPromise = drainPracticeRecordsSyncQueue(initialRequest);
     return practiceRecordsLoadPromise;
 }
 
@@ -1844,8 +1896,61 @@ function clearPracticeHistorySearch() {
     searchPracticeHistory('');
 }
 
-let pendingBrowseProgressRefreshIndex = null;
+let pendingBrowseProgressRefresh = null;
 let browseProgressRefreshRetryTimer = null;
+
+function readBrowseProgressGeneration(getterName) {
+    const getter = window && typeof window[getterName] === 'function'
+        ? window[getterName]
+        : null;
+    if (!getter) {
+        return null;
+    }
+    try {
+        const value = Number(getter());
+        return Number.isFinite(value) ? value : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function captureBrowseProgressRefreshEpoch(sourceEpoch = null) {
+    const source = sourceEpoch && typeof sourceEpoch === 'object' ? sourceEpoch : {};
+    const hasSourceLibraryGeneration = Object.prototype.hasOwnProperty.call(
+        source,
+        'activeLibraryGeneration'
+    );
+    return {
+        navigationGeneration: readBrowseProgressGeneration('__getAppNavigationIntentGeneration'),
+        activeLibraryGeneration: hasSourceLibraryGeneration
+            ? source.activeLibraryGeneration
+            : readBrowseProgressGeneration('__getActiveLibraryGeneration'),
+        resetGeneration: readBrowseProgressGeneration('__getBrowseResetIntentGeneration')
+    };
+}
+
+function isBrowseProgressRefreshEpochCurrent(epoch) {
+    const captured = epoch && typeof epoch === 'object' ? epoch : {};
+    const generationGetters = {
+        navigationGeneration: '__getAppNavigationIntentGeneration',
+        activeLibraryGeneration: '__getActiveLibraryGeneration',
+        resetGeneration: '__getBrowseResetIntentGeneration'
+    };
+    return Object.keys(generationGetters).every((key) => {
+        if (captured[key] == null) {
+            return true;
+        }
+        return readBrowseProgressGeneration(generationGetters[key]) === captured[key];
+    });
+}
+
+function clearPendingBrowseProgressRefresh() {
+    pendingBrowseProgressRefresh = null;
+    if (browseProgressRefreshRetryTimer != null) {
+        clearTimeout(browseProgressRefreshRetryTimer);
+        browseProgressRefreshRetryTimer = null;
+    }
+}
 
 function retryPendingBrowseProgressRefresh() {
     if (browseProgressRefreshRetryTimer != null) {
@@ -1858,13 +1963,18 @@ function retryPendingBrowseProgressRefresh() {
 }
 
 function flushPendingBrowseProgressRefresh() {
-    if (!Array.isArray(pendingBrowseProgressRefreshIndex)) {
+    const pending = pendingBrowseProgressRefresh;
+    if (!pending || !Array.isArray(pending.index)) {
+        return;
+    }
+    if (!isBrowseProgressRefreshEpochCurrent(pending.epoch)) {
+        clearPendingBrowseProgressRefresh();
         return;
     }
     const browseView = document.getElementById('browse-view');
     const isBrowseActive = browseView && browseView.classList.contains('active');
     if (!isBrowseActive) {
-        pendingBrowseProgressRefreshIndex = null;
+        clearPendingBrowseProgressRefresh();
         return;
     }
     const resetInFlight = typeof window.__isBrowseResetIntentInFlight === 'function'
@@ -1876,27 +1986,36 @@ function flushPendingBrowseProgressRefresh() {
     if (isBrowseUserResultsRequestInFlight(browseResultsRequestId)) {
         return;
     }
-    const indexSnapshot = pendingBrowseProgressRefreshIndex;
-    pendingBrowseProgressRefreshIndex = null;
+    const indexSnapshot = pending.index;
+    clearPendingBrowseProgressRefresh();
     Promise.resolve(renderBrowseResultsForState(indexSnapshot)).catch((error) => {
         console.warn('[Browse] 刷新浏览进度列表失败:', error);
     });
 }
 
-function refreshBrowseProgressFromRecords(records, examIndex) {
+function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = null) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
-        if (typeof updateBrowseAnchorsFromRecords === 'function') {
-            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
-        }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
             rebuildBrowseCompletionIndex(recordSnapshot);
+        }
+        const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
+        if (!isBrowseProgressRefreshEpochCurrent({
+            activeLibraryGeneration: pendingEpoch.activeLibraryGeneration
+        })) {
+            return;
+        }
+        if (typeof updateBrowseAnchorsFromRecords === 'function') {
+            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
         }
         const browseView = document.getElementById('browse-view');
         const isBrowseActive = browseView && browseView.classList.contains('active');
         if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
-            pendingBrowseProgressRefreshIndex = indexSnapshot;
+            pendingBrowseProgressRefresh = {
+                index: indexSnapshot,
+                epoch: pendingEpoch
+            };
             flushPendingBrowseProgressRefresh();
         }
     } catch (error) {
@@ -2369,6 +2488,77 @@ async function applyBrowseFilter(
     }
 }
 
+function getLiveBrowseFilterSnapshot() {
+    let filter = null;
+    if (typeof window.getBrowseFilterState === 'function') {
+        try {
+            filter = window.getBrowseFilterState();
+        } catch (_) { }
+    }
+    const rawCategory = filter && typeof filter.category === 'string'
+        ? filter.category
+        : (typeof window.getCurrentCategory === 'function' ? window.getCurrentCategory() : 'all');
+    const rawType = filter && typeof filter.type === 'string'
+        ? filter.type
+        : (typeof window.getCurrentExamType === 'function' ? window.getCurrentExamType() : 'all');
+    const category = typeof window.normalizeCategoryKey === 'function'
+        ? window.normalizeCategoryKey(rawCategory)
+        : (typeof rawCategory === 'string' && rawCategory.trim() ? rawCategory.trim() : 'all');
+    const type = typeof window.normalizeExamType === 'function'
+        ? window.normalizeExamType(rawType)
+        : (rawType === 'reading' || rawType === 'listening' ? rawType : 'all');
+    return { category, type };
+}
+
+function browseFiltersMatch(left, right) {
+    return !!left && !!right
+        && left.category === right.category
+        && left.type === right.type;
+}
+
+async function persistAuthoritativeBrowseFilterBeforeHydration(activeRequestId) {
+    if (typeof window.persistBrowseFilter !== 'function'
+        || typeof window.flushBrowsePreferenceWrites !== 'function'
+        || !window.AppData
+        || !window.AppData.preferences
+        || typeof window.AppData.preferences.getBrowse !== 'function') {
+        return false;
+    }
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        const revisionBefore = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : 0;
+        const filterSnapshot = getLiveBrowseFilterSnapshot();
+        let durablePreferences;
+        try {
+            window.persistBrowseFilter(filterSnapshot.category, filterSnapshot.type);
+            await window.flushBrowsePreferenceWrites();
+            durablePreferences = await window.AppData.preferences.getBrowse();
+        } catch (error) {
+            console.warn('[Browse] 持久化权威筛选失败:', error);
+            return false;
+        }
+        if (!isBrowseResultsRequestCurrent(activeRequestId)) {
+            return false;
+        }
+        const revisionAfter = typeof window.getBrowseFilterMutationRevision === 'function'
+            ? Number(window.getBrowseFilterMutationRevision()) || 0
+            : revisionBefore;
+        const currentFilter = getLiveBrowseFilterSnapshot();
+        if (revisionAfter !== revisionBefore || !browseFiltersMatch(currentFilter, filterSnapshot)) {
+            continue;
+        }
+        return browseFiltersMatch(
+            durablePreferences && durablePreferences.lastFilter,
+            filterSnapshot
+        );
+    }
+    return false;
+}
+
 // Initialize browse view when it's activated
 async function initializeBrowseView(options = {}) {
     const userRequestId = options.renderRequestId == null
@@ -2402,6 +2592,13 @@ async function initializeBrowseView(options = {}) {
             ? Number(window.getBrowseFilterMutationRevision()) || 0
             : 0;
         if (!browseInitialFilterHydrationConsumed && browseFilterMutationRevision > 0) {
+            const persistedAuthoritativeFilter = await persistAuthoritativeBrowseFilterBeforeHydration(
+                activeRequestId
+            );
+            if (!persistedAuthoritativeFilter || !isBrowseResultsRequestCurrent(activeRequestId)) {
+                console.warn('[Browse] 权威筛选尚未持久化，已推迟首次 hydration');
+                return null;
+            }
             browseInitialFilterHydrationConsumed = true;
         } else if (!browseInitialFilterHydrationConsumed) {
             const persisted = getPersistedBrowseFilter();

--- a/js/main.js
+++ b/js/main.js
@@ -315,8 +315,7 @@ async function syncPracticeRecords(options = {}) {
     const loadMode = mode === 'full' ? 'full' : 'summary';
     const practiceProjectionInvocation = ++browsePracticeProjectionInvocationSequence;
     const browseProgressSourceEpoch = {
-        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration'),
-        practiceProjectionGeneration: null
+        activeLibraryGeneration: readBrowseProgressGeneration('__getActiveLibraryGeneration')
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
@@ -389,14 +388,25 @@ async function syncPracticeRecords(options = {}) {
         }
     } catch (_) { /* 保底不中断同步流程 */ }
 
-    // Publish Browse ownership only after this invocation has produced a
-    // complete snapshot. A failed newer invocation therefore cannot strand a
-    // successful repaint queued behind a foreground request. Conversely, an
-    // older success that settles after a newer success remains stale.
+    // Publish Browse ownership only after the derived completion state,
+    // anchors, and any active-view repaint have accepted this snapshot. A
+    // newer invocation that reads successfully but fails publication must not
+    // invalidate an older repaint already queued behind a foreground request.
     if (practiceProjectionInvocation > browsePracticeProjectionGeneration) {
-        browsePracticeProjectionGeneration = practiceProjectionInvocation;
-        browseProgressSourceEpoch.practiceProjectionGeneration = practiceProjectionInvocation;
-        refreshBrowseProgressFromRecords(records, examIndex, browseProgressSourceEpoch);
+        const projectionAccepted = refreshBrowseProgressFromRecords(
+            records,
+            examIndex,
+            browseProgressSourceEpoch,
+            { practiceProjectionGeneration: practiceProjectionInvocation }
+        );
+        if (projectionAccepted) {
+            browsePracticeProjectionGeneration = practiceProjectionInvocation;
+            Promise.resolve().then(() => {
+                flushPendingBrowseProgressRefresh();
+            }).catch((error) => {
+                console.warn('[Browse] 刷新浏览进度列表失败:', error);
+            });
+        }
     }
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
@@ -2082,13 +2092,32 @@ function flushPendingBrowseProgressRefresh() {
     });
 }
 
-function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = null) {
+function refreshBrowseProgressFromRecords(
+    records,
+    examIndex,
+    refreshEpoch = null,
+    publication = null
+) {
     try {
         const recordSnapshot = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
+        const candidateValue = publication && publication.practiceProjectionGeneration;
+        const candidatePracticeProjectionGeneration = candidateValue != null
+            && Number.isFinite(Number(candidateValue))
+            ? Number(candidateValue)
+            : null;
+        if (candidatePracticeProjectionGeneration != null
+            && candidatePracticeProjectionGeneration <= browsePracticeProjectionGeneration) {
+            return false;
+        }
         const pendingEpoch = captureBrowseProgressRefreshEpoch(refreshEpoch);
         if (!isBrowseProgressRefreshEpochCurrent(pendingEpoch)) {
-            return;
+            return false;
+        }
+        const browseView = document.getElementById('browse-view');
+        const isBrowseActive = browseView && browseView.classList.contains('active');
+        if (isBrowseActive && typeof renderBrowseResultsForState !== 'function') {
+            return false;
         }
         if (typeof rebuildBrowseCompletionIndex === 'function') {
             rebuildBrowseCompletionIndex(recordSnapshot);
@@ -2096,17 +2125,25 @@ function refreshBrowseProgressFromRecords(records, examIndex, refreshEpoch = nul
         if (typeof updateBrowseAnchorsFromRecords === 'function') {
             updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
         }
-        const browseView = document.getElementById('browse-view');
-        const isBrowseActive = browseView && browseView.classList.contains('active');
-        if (isBrowseActive && typeof renderBrowseResultsForState === 'function') {
+        if (isBrowseActive) {
+            if (candidatePracticeProjectionGeneration != null) {
+                pendingEpoch.practiceProjectionGeneration =
+                    candidatePracticeProjectionGeneration;
+            }
             pendingBrowseProgressRefresh = {
                 index: indexSnapshot,
                 epoch: pendingEpoch
             };
-            flushPendingBrowseProgressRefresh();
+            // Candidate projections are flushed by syncPracticeRecords only
+            // after their accepted generation becomes the public watermark.
+            if (candidatePracticeProjectionGeneration == null) {
+                flushPendingBrowseProgressRefresh();
+            }
         }
+        return true;
     } catch (error) {
         console.warn('[Browse] 刷新浏览进度失败:', error);
+        return false;
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -227,11 +227,12 @@ function ensureLegacyNavigation(options) {
         onRepeatNavigate: function onRepeatNavigate(viewName) {
             if (viewName === 'browse') {
                 if (window.ExamActions && typeof window.ExamActions.resetBrowseViewToAll === 'function') {
-                    window.ExamActions.resetBrowseViewToAll();
+                    return window.ExamActions.resetBrowseViewToAll();
                 } else if (typeof window.resetBrowseViewToAll === 'function') {
-                    window.resetBrowseViewToAll();
+                    return window.resetBrowseViewToAll();
                 }
             }
+            return false;
         },
         onNavigate: function onNavigate(viewName) {
             if (typeof window.showView === 'function') {
@@ -2287,10 +2288,9 @@ function refreshBrowseResults() {
     const activeRequestId = beginBrowseResultsRequest();
     const query = getBrowseSearchQuery();
     if (query) {
-        performSearch(query, activeRequestId);
-        return;
+        return performSearch(query, activeRequestId);
     }
-    loadExamList(null, activeRequestId);
+    return loadExamList(null, activeRequestId);
 }
 
 let browseControlsSeeded = false;
@@ -2358,6 +2358,20 @@ function updateBrowseFrequencyButtons(filter) {
         button.classList.toggle('active', isActive);
         button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
+}
+
+function resetBrowseFilterStateToAll() {
+    window.__browseFilterMode = 'default';
+    window.__browsePath = null;
+    updateBrowseFrequencyButtons('all');
+
+    if (window.browseController) {
+        window.browseController.currentMode = 'default';
+        window.browseController.activeFilter = 'all';
+    }
+    if (typeof setBrowseFilterState === 'function') {
+        setBrowseFilterState('all', 'all');
+    }
 }
 
 function setupBrowseFrequencyFilterControl() {

--- a/js/main.js
+++ b/js/main.js
@@ -2119,12 +2119,29 @@ function refreshBrowseProgressFromRecords(
         if (isBrowseActive && typeof renderBrowseResultsForState !== 'function') {
             return false;
         }
-        if (typeof rebuildBrowseCompletionIndex === 'function') {
-            rebuildBrowseCompletionIndex(recordSnapshot);
+        const canStageProjection = typeof prepareBrowseCompletionIndex === 'function'
+            && typeof isPreparedBrowseCompletionIndex === 'function'
+            && typeof commitBrowseCompletionIndex === 'function'
+            && typeof prepareBrowseAnchorUpdates === 'function'
+            && typeof commitBrowseAnchorUpdates === 'function';
+        if (!canStageProjection) {
+            return false;
         }
-        if (typeof updateBrowseAnchorsFromRecords === 'function') {
-            updateBrowseAnchorsFromRecords(recordSnapshot, indexSnapshot);
+        // Both derived states are built without mutation. Validate the
+        // completion candidate before accepting the anchor queue; the later
+        // completion commit is then one non-throwing assignment.
+        const preparedCompletionIndex = prepareBrowseCompletionIndex(recordSnapshot);
+        if (!isPreparedBrowseCompletionIndex(preparedCompletionIndex)) {
+            return false;
         }
+        const preparedAnchorUpdates = prepareBrowseAnchorUpdates(
+            recordSnapshot,
+            indexSnapshot
+        );
+        if (commitBrowseAnchorUpdates(preparedAnchorUpdates) !== true) {
+            return false;
+        }
+        commitBrowseCompletionIndex(preparedCompletionIndex);
         if (isBrowseActive) {
             if (candidatePracticeProjectionGeneration != null) {
                 pendingEpoch.practiceProjectionGeneration =
@@ -2137,7 +2154,11 @@ function refreshBrowseProgressFromRecords(
             // Candidate projections are flushed by syncPracticeRecords only
             // after their accepted generation becomes the public watermark.
             if (candidatePracticeProjectionGeneration == null) {
-                flushPendingBrowseProgressRefresh();
+                Promise.resolve().then(() => {
+                    flushPendingBrowseProgressRefresh();
+                }).catch((error) => {
+                    console.warn('[Browse] 刷新浏览进度列表失败:', error);
+                });
             }
         }
         return true;

--- a/js/presentation/app-actions.js
+++ b/js/presentation/app-actions.js
@@ -3,7 +3,7 @@
 
     var prefetchTriggered = false;
     var attachedPrefetchHandlers = false;
-    var browsePrefetchTriggered = false;
+    var browsePrefetchPromise = null;
     var morePrefetchTriggered = false;
 
     function ensurePracticeSuite() {
@@ -52,15 +52,20 @@
     }
 
     function triggerBrowsePrefetch() {
-        if (browsePrefetchTriggered) {
-            return;
+        if (browsePrefetchPromise) {
+            return browsePrefetchPromise;
         }
-        browsePrefetchTriggered = true;
-        if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
-            global.AppLazyLoader.ensureGroup('browse-runtime').catch(function swallow(error) {
-                console.warn('[AppActions] 浏览模块预加载失败:', error);
-            });
+        if (typeof global.ensureBrowseGroup === 'function') {
+            browsePrefetchPromise = Promise.resolve(global.ensureBrowseGroup());
+        } else if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+            browsePrefetchPromise = Promise.resolve(global.AppLazyLoader.ensureGroup('browse-runtime'));
+        } else {
+            browsePrefetchPromise = Promise.resolve();
         }
+        browsePrefetchPromise = browsePrefetchPromise.catch(function swallow(error) {
+            console.warn('[AppActions] 浏览模块预加载失败:', error);
+        });
+        return browsePrefetchPromise;
     }
 
     function triggerMorePrefetch() {
@@ -500,6 +505,10 @@
         var tasks = [];
         if (loader) {
             tasks.push(loader.ensureGroup('exam-data'));
+        }
+        if (typeof global.ensureBrowseGroup === 'function') {
+            tasks.push(global.ensureBrowseGroup().catch(function () { return undefined; }));
+        } else if (loader) {
             tasks.push(loader.ensureGroup('browse-runtime').catch(function () { return undefined; }));
         }
         return Promise.all(tasks).then(function () {

--- a/js/presentation/navigation-controller.js
+++ b/js/presentation/navigation-controller.js
@@ -12,7 +12,7 @@
             syncOnNavigate: true,
             onNavigate: function onNavigate(viewName) {
                 if (typeof global.showView === 'function') {
-                    global.showView(viewName);
+                    global.showView(viewName, false);
                     return;
                 }
                 if (global.app && typeof global.app.navigateToView === 'function') {

--- a/js/services/libraryManager.js
+++ b/js/services/libraryManager.js
@@ -278,12 +278,12 @@
             }
             try { global.updateOverview && global.updateOverview(index); } catch (_) { }
             refreshListeningAvailabilityUI(index);
-            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
-                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
-            }
             try {
                 global.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { index: cloneArray(index) } }));
             } catch (_) { }
+            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
+                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
+            }
             return loadTime;
         }
 
@@ -751,6 +751,9 @@
                 global.dispatchEvent(new CustomEvent('examIndexLoaded', { detail: { key, index: cloneArray(exams) } }));
             } catch (error) {
                 console.warn('[LibraryManager] 题库切换事件派发失败', error);
+            }
+            if (typeof global.startPracticeRecordsSyncInBackground === 'function') {
+                global.startPracticeRecordsSyncInBackground('library-loaded', { forceRender: true });
             }
 
             if (!options.skipConfigRefresh && typeof global.renderLibraryConfigList === 'function') {

--- a/js/utils/BrowsePreferencesUtils.js
+++ b/js/utils/BrowsePreferencesUtils.js
@@ -8,6 +8,9 @@
     let browsePreferencesReady = null;
     let browsePreferenceWriteQueue = Promise.resolve();
     const pendingBrowsePreferenceWrites = [];
+    let browseAnchorProjection = null;
+    let browseAnchorProjectionRevision = 0;
+    let browseAnchorPersistenceDebt = null;
     let currentBrowseScrollElement = null;
     let removeBrowseScrollListener = null;
     let pendingBrowseAutoScroll = null;
@@ -169,7 +172,16 @@
         if (!browsePreferencesCache) {
             browsePreferencesCache = loadBrowsePreferencesFromStorage();
         }
-        return browsePreferencesCache;
+        if (!browseAnchorProjection) {
+            return browsePreferencesCache;
+        }
+        return Object.assign({}, browsePreferencesCache, {
+            // Anchors are a derived live projection. Keep the accepted
+            // generation visible while its durable write is still pending or
+            // has failed; user-authored preferences remain committed-cache
+            // values until their existing write contract completes.
+            listAnchors: mergeBrowseAnchors({}, browseAnchorProjection.anchors)
+        });
     }
 
     async function whenBrowseViewPreferencesReady() {
@@ -180,10 +192,13 @@
         return getBrowseViewPreferences();
     }
 
-    function mergeBrowsePreferences(current, partial = {}) {
+    function mergeBrowsePreferences(current, partial = {}, options = {}) {
+        const replaceListAnchors = options.replaceListAnchors === true;
         return {
             scrollPositions: Object.assign({}, current.scrollPositions, partial.scrollPositions || {}),
-            listAnchors: mergeBrowseAnchors(current.listAnchors, partial.listAnchors),
+            listAnchors: replaceListAnchors
+                ? mergeBrowseAnchors({}, partial.listAnchors)
+                : mergeBrowseAnchors(current.listAnchors, partial.listAnchors),
             autoScrollEnabled: Object.prototype.hasOwnProperty.call(partial, 'autoScrollEnabled')
                 ? !!partial.autoScrollEnabled
                 : current.autoScrollEnabled,
@@ -193,33 +208,75 @@
         };
     }
 
-    function saveBrowseViewPreferences(partial = {}) {
-        const request = { partial: Object.assign({}, partial) };
+    function removePendingBrowsePreferenceWrite(request) {
+        const index = pendingBrowsePreferenceWrites.indexOf(request);
+        if (index >= 0) {
+            pendingBrowsePreferenceWrites.splice(index, 1);
+        }
+    }
+
+    function enqueueBrowsePreferenceWrite(partial = {}, options = {}) {
+        const request = {
+            partial: Object.assign({}, partial),
+            replaceListAnchors: options.replaceListAnchors === true,
+            anchorRevision: Number.isFinite(Number(options.anchorRevision))
+                ? Number(options.anchorRevision)
+                : null
+        };
         pendingBrowsePreferenceWrites.push(request);
         const preview = pendingBrowsePreferenceWrites.reduce(
-            (current, pending) => mergeBrowsePreferences(current, pending.partial),
+            (current, pending) => mergeBrowsePreferences(
+                current,
+                pending.partial,
+                pending
+            ),
             getBrowseViewPreferences()
         );
 
         if (!global.AppData || !global.AppData.preferences) {
-            pendingBrowsePreferenceWrites.splice(pendingBrowsePreferenceWrites.indexOf(request), 1);
+            removePendingBrowsePreferenceWrite(request);
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
             console.warn('[BrowsePreferences] AppData.preferences 不可用，偏好未保存');
-            return preview;
+            return { preview, outcome: Promise.resolve(false) };
         }
 
-        browsePreferenceWriteQueue = browsePreferenceWriteQueue.then(async () => {
+        const outcome = browsePreferenceWriteQueue.then(async () => {
             await global.AppData.ready;
             if (browsePreferencesReady) await browsePreferencesReady;
-            const next = mergeBrowsePreferences(getBrowseViewPreferences(), request.partial);
+            const next = mergeBrowsePreferences(
+                getBrowseViewPreferences(),
+                request.partial,
+                request
+            );
             await global.AppData.preferences.patchBrowse(next);
             browsePreferencesCache = next;
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt = null;
+            }
+            return true;
         }).catch((error) => {
+            if (request.anchorRevision != null
+                && browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === request.anchorRevision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
             console.warn('[BrowsePreferences] 保存浏览偏好失败，保留上次已提交值', error);
+            return false;
         }).finally(() => {
-            const index = pendingBrowsePreferenceWrites.indexOf(request);
-            if (index >= 0) pendingBrowsePreferenceWrites.splice(index, 1);
+            removePendingBrowsePreferenceWrite(request);
         });
-        return preview;
+        browsePreferenceWriteQueue = outcome.then(() => undefined);
+        return { preview, outcome };
+    }
+
+    function saveBrowseViewPreferences(partial = {}) {
+        return enqueueBrowsePreferenceWrite(partial).preview;
     }
 
     function flushBrowsePreferenceWrites() {
@@ -762,7 +819,6 @@
         const list = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const updates = {};
-        const seenKeys = new Set();
 
         list.forEach((record) => {
             const info = resolveRecordExamInfo(record, indexSnapshot);
@@ -783,32 +839,95 @@
             if (!existing || timestamp > existing.timestamp) {
                 updates[key] = anchor;
             }
-            seenKeys.add(key);
         });
 
-        const currentAnchors = getBrowseViewPreferences().listAnchors || {};
-        Object.keys(currentAnchors || {}).forEach((key) => {
-            if (!seenKeys.has(key)) {
-                updates[key] = null;
-            }
-        });
-
-        return updates;
+        // The Practice record list is authoritative, so stage a complete
+        // immutable projection instead of a delta against possibly stale
+        // durable preferences. A newer snapshot therefore replaces every
+        // anchor omitted from it without relying on deletion tombstones.
+        return mergeBrowseAnchors({}, updates);
     }
 
-    function commitBrowseAnchorUpdates(updates) {
+    function readBrowseAnchorPublicationGeneration(publication) {
+        const raw = publication && typeof publication === 'object'
+            ? publication.practiceProjectionGeneration
+            : publication;
+        if (raw == null) {
+            return null;
+        }
+        const generation = Number(raw);
+        return Number.isFinite(generation) ? generation : null;
+    }
+
+    function getBrowseAnchorProjectionState() {
+        if (!browseAnchorProjection) {
+            return { revision: 0, generation: null, persistence: 'idle' };
+        }
+        const debt = browseAnchorPersistenceDebt
+            && browseAnchorPersistenceDebt.revision === browseAnchorProjection.revision
+            ? browseAnchorPersistenceDebt
+            : null;
+        return {
+            revision: browseAnchorProjection.revision,
+            generation: browseAnchorProjection.generation,
+            persistence: debt ? debt.status : 'persisted'
+        };
+    }
+
+    function commitBrowseAnchorUpdates(updates, publication = null) {
         if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
             return false;
         }
-        if (Object.keys(updates).length > 0) {
-            saveBrowseViewPreferences({ listAnchors: updates });
+        let anchors;
+        try {
+            anchors = mergeBrowseAnchors({}, updates);
+        } catch (_) {
+            return false;
+        }
+        const generation = readBrowseAnchorPublicationGeneration(publication);
+        if (generation != null
+            && browseAnchorProjection
+            && browseAnchorProjection.generation != null
+            && generation <= browseAnchorProjection.generation) {
+            return false;
+        }
+
+        const revision = browseAnchorProjectionRevision + 1;
+        const acceptedProjection = {
+            anchors,
+            generation: generation != null
+                ? generation
+                : (browseAnchorProjection ? browseAnchorProjection.generation : null),
+            revision
+        };
+        // This is the anchor publication point: one synchronous assignment
+        // makes the newest full snapshot visible to consumers and subsequent
+        // preparation before any durable write can settle.
+        browseAnchorProjectionRevision = revision;
+        browseAnchorProjection = acceptedProjection;
+        // Keep only the current projection debt. A later accepted full
+        // snapshot supersedes it and retries through the same preference
+        // queue; no independent retry scheduler is introduced here.
+        browseAnchorPersistenceDebt = { revision, status: 'pending' };
+
+        try {
+            enqueueBrowsePreferenceWrite(
+                { listAnchors: anchors },
+                { replaceListAnchors: true, anchorRevision: revision }
+            );
+        } catch (error) {
+            if (browseAnchorPersistenceDebt
+                && browseAnchorPersistenceDebt.revision === revision) {
+                browseAnchorPersistenceDebt.status = 'failed';
+            }
+            console.warn('[BrowsePreferences] 浏览锚点持久化排队失败', error);
         }
         return true;
     }
 
-    function updateBrowseAnchorsFromRecords(records, examIndex) {
+    function updateBrowseAnchorsFromRecords(records, examIndex, publication = null) {
         const updates = prepareBrowseAnchorUpdates(records, examIndex);
-        commitBrowseAnchorUpdates(updates);
+        commitBrowseAnchorUpdates(updates, publication);
         return updates;
     }
 
@@ -840,6 +959,7 @@
     global.getPersistedBrowseFilter = getPersistedBrowseFilter;
     global.prepareBrowseAnchorUpdates = prepareBrowseAnchorUpdates;
     global.commitBrowseAnchorUpdates = commitBrowseAnchorUpdates;
+    global.getBrowseAnchorProjectionState = getBrowseAnchorProjectionState;
     global.updateBrowseAnchorsFromRecords = updateBrowseAnchorsFromRecords;
 
     global.setBrowseTitle = setBrowseTitle;

--- a/js/utils/BrowsePreferencesUtils.js
+++ b/js/utils/BrowsePreferencesUtils.js
@@ -758,7 +758,7 @@
         }
     }
 
-    function updateBrowseAnchorsFromRecords(records, examIndex) {
+    function prepareBrowseAnchorUpdates(records, examIndex) {
         const list = Array.isArray(records) ? records : [];
         const indexSnapshot = Array.isArray(examIndex) ? examIndex : [];
         const updates = {};
@@ -793,11 +793,23 @@
             }
         });
 
-        if (Object.keys(updates).length === 0) {
-            return;
-        }
+        return updates;
+    }
 
-        saveBrowseViewPreferences({ listAnchors: updates });
+    function commitBrowseAnchorUpdates(updates) {
+        if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+            return false;
+        }
+        if (Object.keys(updates).length > 0) {
+            saveBrowseViewPreferences({ listAnchors: updates });
+        }
+        return true;
+    }
+
+    function updateBrowseAnchorsFromRecords(records, examIndex) {
+        const updates = prepareBrowseAnchorUpdates(records, examIndex);
+        commitBrowseAnchorUpdates(updates);
+        return updates;
     }
 
     // --- Global Event Listeners ---
@@ -826,6 +838,8 @@
     global.flushBrowsePreferenceWrites = flushBrowsePreferenceWrites;
     global.persistBrowseFilter = persistBrowseFilter;
     global.getPersistedBrowseFilter = getPersistedBrowseFilter;
+    global.prepareBrowseAnchorUpdates = prepareBrowseAnchorUpdates;
+    global.commitBrowseAnchorUpdates = commitBrowseAnchorUpdates;
     global.updateBrowseAnchorsFromRecords = updateBrowseAnchorsFromRecords;
 
     global.setBrowseTitle = setBrowseTitle;

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -2657,7 +2657,7 @@
         options = options || {};
         var container = this._getContainer();
         if (!container) {
-            return;
+            return false;
         }
 
         var loadingSelector = options.loadingSelector || this.loadingSelector;
@@ -2667,7 +2667,7 @@
         if (normalizedExams.length === 0) {
             this._renderEmptyState(container, options.emptyState);
             this._hideLoading(loadingIndicator);
-            return;
+            return true;
         }
 
         var examList = this._createExamList();
@@ -2686,6 +2686,7 @@
 
         this._replaceContent(container, [examList]);
         this._hideLoading(loadingIndicator);
+        return true;
     };
 
     LegacyExamListView.prototype._createExamList = function _createExamList() {

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -3483,7 +3483,7 @@
         }
 
         if (typeof window.showView === 'function') {
-            window.showView(viewName);
+            window.showView(viewName, false);
             return;
         }
 

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -3547,14 +3547,28 @@
         }
 
         event.preventDefault();
-        this.navigate(viewName, event);
         if (alreadyActive && typeof this.options.onRepeatNavigate === 'function') {
+            var repeatHandled = true;
             try {
-                this.options.onRepeatNavigate(viewName, event);
+                var repeatResult = this.options.onRepeatNavigate(viewName, event);
+                if (repeatResult === false) {
+                    repeatHandled = false;
+                } else if (repeatResult && typeof repeatResult.then === 'function') {
+                    Promise.resolve(repeatResult).catch(function handleRepeatFailure(repeatError) {
+                        console.warn('[LegacyNavigationController] onRepeatNavigate 执行失败', repeatError);
+                    });
+                }
             } catch (repeatError) {
                 console.warn('[LegacyNavigationController] onRepeatNavigate 执行失败', repeatError);
             }
+            if (repeatHandled) {
+                if (this.options.syncOnNavigate !== false) {
+                    this.syncActive(viewName);
+                }
+                return;
+            }
         }
+        this.navigate(viewName, event);
         if (this.options.syncOnNavigate !== false) {
             this.syncActive(viewName);
         }

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -3289,7 +3289,7 @@
         return Array.isArray(record.suiteEntries) ? record.suiteEntries : [];
     }
 
-    function rebuildBrowseCompletionIndex(records) {
+    function prepareBrowseCompletionIndex(records) {
         var byExamId = new Map();
         var byTitle = new Map();
         var recordSnapshot = ensureArray(records).slice();
@@ -3323,13 +3323,37 @@
                 }
             });
         });
-        browseCompletionIndex = {
+        return {
             byExamId: byExamId,
             byTitle: byTitle,
             records: recordSnapshot,
             ready: true
         };
-        return browseCompletionIndex;
+    }
+
+    function isPreparedBrowseCompletionIndex(preparedIndex) {
+        return !!preparedIndex
+            && preparedIndex.byExamId instanceof Map
+            && preparedIndex.byTitle instanceof Map
+            && Array.isArray(preparedIndex.records)
+            && preparedIndex.ready === true;
+    }
+
+    function commitBrowseCompletionIndex(preparedIndex) {
+        if (!isPreparedBrowseCompletionIndex(preparedIndex)) {
+            return false;
+        }
+        // Preparation performs every operation that can fail. Publication is
+        // deliberately one assignment so later stages cannot observe a
+        // partially rebuilt completion map.
+        browseCompletionIndex = preparedIndex;
+        return true;
+    }
+
+    function rebuildBrowseCompletionIndex(records) {
+        var preparedIndex = prepareBrowseCompletionIndex(records);
+        commitBrowseCompletionIndex(preparedIndex);
+        return preparedIndex;
     }
 
     function ensureBrowseCompletionIndex() {
@@ -3399,6 +3423,9 @@
         };
     };
 
+    global.prepareBrowseCompletionIndex = prepareBrowseCompletionIndex;
+    global.isPreparedBrowseCompletionIndex = isPreparedBrowseCompletionIndex;
+    global.commitBrowseCompletionIndex = commitBrowseCompletionIndex;
     global.rebuildBrowseCompletionIndex = rebuildBrowseCompletionIndex;
 
     // --- Legacy navigation controller ---

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -3547,6 +3547,11 @@
         }
 
         event.preventDefault();
+        if (viewName === 'browse') {
+            try {
+                event.__browseNavigationHandled = true;
+            } catch (_) { }
+        }
         if (alreadyActive && typeof this.options.onRepeatNavigate === 'function') {
             var repeatHandled = true;
             try {

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -191,6 +191,7 @@ const KNOWN_SYMBOL_CONFLICTS = {
     'js/bundles/browse.bundle.js': {
         __browseFilterMode: ['js/app/examActions.js', 'js/app/browseController.js', 'js/main.js'],
         __browsePath: ['js/app/examActions.js', 'js/app/browseController.js', 'js/main.js'],
+        __browseFrequencyFilter: ['js/app/examActions.js', 'js/main.js'],
         __readingMemorizeBrowseMode: ['js/app/examActions.js', 'js/main.js'],
         __browseMemorizeFilterMode: ['js/app/examActions.js', 'js/main.js'],
         clearPendingBrowseAutoScroll: ['js/utils/BrowsePreferencesUtils.js', 'js/main.js'],

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -191,7 +191,6 @@ const KNOWN_SYMBOL_CONFLICTS = {
     'js/bundles/browse.bundle.js': {
         __browseFilterMode: ['js/app/examActions.js', 'js/app/browseController.js', 'js/main.js'],
         __browsePath: ['js/app/examActions.js', 'js/app/browseController.js', 'js/main.js'],
-        __browseFrequencyFilter: ['js/app/examActions.js', 'js/main.js'],
         __readingMemorizeBrowseMode: ['js/app/examActions.js', 'js/main.js'],
         __browseMemorizeFilterMode: ['js/app/examActions.js', 'js/main.js'],
         clearPendingBrowseAutoScroll: ['js/utils/BrowsePreferencesUtils.js', 'js/main.js'],


### PR DESCRIPTION
## Summary

- reset repeated Question Bank navigation against the active library index through the shared latest-wins loader
- clear category, type, frequency, path, and search state only for repeated navigation while preserving normal and explicit category navigation
- carry reset intent safely across lazy Browse startup and prevent stale reset/filter work from overwriting newer interactions
- keep generated bundles synchronized and add focused regression coverage

## Root cause

`ExamActions.resetBrowseViewToAll()` called its module-local `loadExamList()` without an index. That loader treats a missing index as `[]`, so repeated Question Bank navigation could render an empty list. Independent lazy-navigation and pending-filter paths could also restore stale scope after a reset.

## Validation

- `node --test --test-concurrency=1 "tests/js/**/*.test.js"` from `developer` (82/82)
- `python -m unittest discover -s developer/tests/py -p "test_*.py"` (20/20)
- `python developer/tests/ci/run_static_suite.py`
- `python developer/tests/ci/check_reading_data_integrity.py`
- `python developer/tests/e2e/e2e_runner.py` (8/8)
- `node scripts/build-bundles.mjs --check` (14 outputs current)

Fixes #114
