### PR TITLE
fix(browse): preserve scope after returning from practice

### DIFF
--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -474,6 +474,8 @@ const integrationBrowseState = { category: 'all', type: 'all' };
 const integrationIndexResolvers = [];
 const integrationPracticeRecordResolvers = [];
 let integrationIndexResolutionCount = 0;
+let integrationPracticeListCount = 0;
+let integrationCanonicalPracticeRecords = [];
 const IntegrationCustomEvent = class CustomEvent {
     constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
 };
@@ -596,8 +598,11 @@ const integrationSandbox = {
         },
         practice: {
             async list() {
+                integrationPracticeListCount += 1;
                 const next = integrationPracticeRecordResolvers.shift();
-                return next ? next.promise : [];
+                return next
+                    ? next.promise
+                    : integrationCanonicalPracticeRecords.map((record) => ({ ...record }));
             },
             async listInsights() { return []; },
             async getStats() { return {}; }
@@ -949,6 +954,126 @@ assert.strictEqual(
     redundantTailPoison,
     'a head success must not be overturned by an invented failing tail'
 );
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+integrationBrowseState.category = 'P4';
+integrationBrowseState.type = 'listening';
+integrationSearchInput.value = '';
+integrationSandbox.__browseFilterMode = 'frequency-p4';
+integrationSandbox.__browsePath = 'ListeningPractice/100 P4/P4 高频(52)';
+integrationSandbox.__browseFrequencyFilter = 'high';
+integrationSandbox.__browseSortMode = 'frequency-desc';
+integrationSandbox.browseController.currentMode = 'frequency-p4';
+integrationSandbox.browseController.currentCategory = 'P4';
+integrationSandbox.browseController.currentExamType = 'listening';
+const completionResumeScope = {
+    filter: { ...integrationBrowseState },
+    query: integrationSearchInput.value,
+    mode: integrationSandbox.__browseFilterMode,
+    path: integrationSandbox.__browsePath,
+    frequency: integrationSandbox.__browseFrequencyFilter,
+    sort: integrationSandbox.__browseSortMode,
+    controllerMode: integrationSandbox.browseController.currentMode,
+    controllerCategory: integrationSandbox.browseController.currentCategory,
+    controllerType: integrationSandbox.browseController.currentExamType
+};
+const visibilityResumeIndex = deferred();
+const postCommitIndex = deferred();
+const visibilityIndexSnapshot = [{
+    id: 'p4-high-current',
+    title: 'Current P4 listening exam',
+    category: 'P4',
+    type: 'listening',
+    path: 'ListeningPractice/100 P4/P4 高频(52)',
+    frequency: 'high'
+}];
+integrationIndexResolvers.push(visibilityResumeIndex, postCommitIndex);
+integrationCanonicalPracticeRecords = [{ id: 'before-completion' }];
+const completionResumeReadCountBefore = integrationPracticeListCount;
+const visibilityResumeCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'visibility-resume',
+    { forceRender: true }
+);
+await waitForCondition(
+    () => integrationPracticeListCount === completionResumeReadCountBefore + 1,
+    'visibility resume must read the pre-commit Practice snapshot'
+);
+await Promise.resolve();
+integrationCanonicalPracticeRecords = [
+    { id: 'before-completion' },
+    { id: 'saved-completion' }
+];
+const completionSavedJoin = integrationSandbox.ensurePracticeRecordsSync(
+    'completion-saved',
+    { forceRender: true, requirePostCommitRead: true }
+);
+assert.strictEqual(
+    completionSavedJoin,
+    visibilityResumeCycle,
+    'completion-saved must remain part of the active managed cycle'
+);
+visibilityResumeIndex.resolve(visibilityIndexSnapshot);
+await waitForCondition(
+    () => integrationPracticeListCount === completionResumeReadCountBefore + 2,
+    'completion-saved must start one authoritative read after the visibility cycle'
+);
+postCommitIndex.resolve(visibilityIndexSnapshot);
+assert.deepStrictEqual(
+    Array.from(await completionSavedJoin, (record) => record.id),
+    ['before-completion', 'saved-completion'],
+    'the managed cycle must resolve with the post-commit Practice snapshot'
+);
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.strictEqual(
+    integrationPracticeListCount,
+    completionResumeReadCountBefore + 2,
+    'the save/resume ordering must perform exactly one head and one trailing read'
+);
+assert.deepStrictEqual(
+    integrationCompletionRefreshes,
+    [
+        ['before-completion'],
+        ['before-completion', 'saved-completion']
+    ],
+    'the production projection path must publish the authoritative completion state'
+);
+assert.deepStrictEqual(
+    integrationPracticeUpdates,
+    [
+        { records: ['before-completion'], index: ['p4-high-current'] },
+        { records: ['before-completion', 'saved-completion'], index: ['p4-high-current'] }
+    ],
+    'the post-commit read must reach the production Practice projection'
+);
+assert.deepStrictEqual(
+    {
+        filter: { ...integrationBrowseState },
+        query: integrationSearchInput.value,
+        mode: integrationSandbox.__browseFilterMode,
+        path: integrationSandbox.__browsePath,
+        frequency: integrationSandbox.__browseFrequencyFilter,
+        sort: integrationSandbox.__browseSortMode,
+        controllerMode: integrationSandbox.browseController.currentMode,
+        controllerCategory: integrationSandbox.browseController.currentCategory,
+        controllerType: integrationSandbox.browseController.currentExamType
+    },
+    completionResumeScope,
+    'the post-commit tail must not rehydrate or replace the live Browse scope'
+);
+integrationCanonicalPracticeRecords = [];
+integrationBrowseState.category = 'all';
+integrationBrowseState.type = 'all';
+integrationSearchInput.value = '';
+integrationSandbox.__browseFilterMode = 'default';
+integrationSandbox.__browsePath = null;
+integrationSandbox.__browseFrequencyFilter = 'all';
+integrationSandbox.__browseSortMode = 'default';
+integrationSandbox.browseController.currentMode = 'default';
+integrationSandbox.browseController.currentCategory = 'all';
+integrationSandbox.browseController.currentExamType = 'all';
 
 integrationRenders.length = 0;
 integrationAnchorIndexes.length = 0;

--- a/developer/tests/js/browseLatestWins.test.js
+++ b/developer/tests/js/browseLatestWins.test.js
@@ -994,8 +994,7 @@ integrationIndexResolvers.push(visibilityResumeIndex, postCommitIndex);
 integrationCanonicalPracticeRecords = [{ id: 'before-completion' }];
 const completionResumeReadCountBefore = integrationPracticeListCount;
 const visibilityResumeCycle = integrationSandbox.ensurePracticeRecordsSync(
-    'visibility-resume',
-    { forceRender: true }
+    'visibility-resume'
 );
 await waitForCondition(
     () => integrationPracticeListCount === completionResumeReadCountBefore + 1,
@@ -1078,6 +1077,57 @@ integrationSandbox.browseController.currentExamType = 'all';
 integrationRenders.length = 0;
 integrationAnchorIndexes.length = 0;
 integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
+const unchangedVisibilityFirstIndex = deferred();
+const unchangedVisibilitySecondIndex = deferred();
+const unchangedVisibilityIndexSnapshot = [{ id: 'visibility-unchanged-index' }];
+integrationIndexResolvers.push(
+    unchangedVisibilityFirstIndex,
+    unchangedVisibilitySecondIndex
+);
+integrationCanonicalPracticeRecords = [{ id: 'visibility-unchanged-record' }];
+const firstUnchangedVisibilityCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'visibility-resume'
+);
+unchangedVisibilityFirstIndex.resolve(unchangedVisibilityIndexSnapshot);
+await firstUnchangedVisibilityCycle;
+await new Promise((resolve) => setTimeout(resolve, 0));
+const secondUnchangedVisibilityCycle = integrationSandbox.ensurePracticeRecordsSync(
+    'visibility-resume'
+);
+unchangedVisibilitySecondIndex.resolve(unchangedVisibilityIndexSnapshot);
+await secondUnchangedVisibilityCycle;
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.deepStrictEqual(
+    integrationCompletionRefreshes,
+    [
+        ['visibility-unchanged-record'],
+        ['visibility-unchanged-record']
+    ],
+    'unchanged visibility records must still refresh the production Browse projection'
+);
+assert.deepStrictEqual(
+    integrationAnchorIndexes,
+    [
+        ['visibility-unchanged-index'],
+        ['visibility-unchanged-index']
+    ],
+    'unchanged visibility records must still refresh production Browse anchors'
+);
+assert.deepStrictEqual(
+    integrationPracticeUpdates,
+    [{
+        records: ['visibility-unchanged-record'],
+        index: ['visibility-unchanged-index']
+    }],
+    'the repeated visibility refresh must not rebuild the hidden Practice UI'
+);
+integrationCanonicalPracticeRecords = [];
+
+integrationRenders.length = 0;
+integrationAnchorIndexes.length = 0;
+integrationCompletionRefreshes.length = 0;
+integrationPracticeUpdates.length = 0;
 const libraryARecords = deferred();
 const libraryBRecords = deferred();
 const libraryAIndex = deferred();

--- a/developer/tests/js/browseVisibilityResume.test.js
+++ b/developer/tests/js/browseVisibilityResume.test.js
@@ -276,8 +276,13 @@ async function createHarness() {
     sandbox.setBrowseFilterState('P1', 'reading');
     await sandbox.flushBrowsePreferenceWrites();
 
-    sandbox.ensurePracticeRecordsSync = async (trigger, options) => {
-        progressSyncCalls.push({ trigger, options: { ...options } });
+    sandbox.ensurePracticeRecordsSync = async (...syncArgs) => {
+        const [trigger, options] = syncArgs;
+        progressSyncCalls.push({
+            trigger,
+            options: { ...(options || {}) },
+            argumentCount: syncArgs.length
+        });
         const activeFilter = sandbox.getBrowseFilterState();
         const query = searchInput.value.trim().toLowerCase();
         const pathFilter = sandbox.__browsePath;
@@ -401,7 +406,8 @@ test('visibility resume refreshes progress without rehydrating or reactivating B
     assert.deepEqual(harness.durableBrowse.filter, { category: 'all', type: 'all' });
     assert.deepEqual(harness.progressSyncCalls, [{
         trigger: 'visibility-resume',
-        options: { forceRender: true }
+        options: {},
+        argumentCount: 1
     }]);
     assert.deepEqual(harness.renderedIds, [['selected-ocean']]);
 });
@@ -426,12 +432,33 @@ test('visibility resume preserves an explicit empty Browse query', async () => {
     );
     assert.deepEqual(harness.progressSyncCalls, [{
         trigger: 'visibility-resume',
-        options: { forceRender: true }
+        options: {},
+        argumentCount: 1
     }]);
     assert.deepEqual(
         harness.renderedIds,
         [['selected-ocean', 'wrong-query']],
         'an empty query must retain every result in the selected path and frequency scope'
+    );
+});
+
+test('visibility resume fallback sync omits hidden-Practice force-render options', async () => {
+    const harness = await createHarness();
+    const fallbackSyncCalls = [];
+    delete harness.sandbox.ensurePracticeRecordsSync;
+    harness.sandbox.syncPracticeRecords = async (...syncArgs) => {
+        fallbackSyncCalls.push(syncArgs);
+        return [];
+    };
+
+    const refresh = harness.app.refreshData();
+    harness.statsGate.resolve();
+    await refresh;
+
+    assert.deepEqual(
+        fallbackSyncCalls,
+        [[]],
+        'the fallback visibility refresh must not force the hidden Practice UI to render'
     );
 });
 

--- a/developer/tests/js/browseVisibilityResume.test.js
+++ b/developer/tests/js/browseVisibilityResume.test.js
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function loadScript(relativePath, context) {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    vm.runInContext(source, context, { filename: relativePath });
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(value) { values.add(value); },
+        remove(value) { values.delete(value); },
+        toggle(value, enabled) {
+            if (enabled) values.add(value);
+            else values.delete(value);
+        },
+        contains(value) { return values.has(value); }
+    };
+}
+
+function createButton(dataset, active = false) {
+    return {
+        dataset: { ...dataset },
+        classList: createClassList(active ? ['active'] : []),
+        ariaPressed: active ? 'true' : 'false',
+        setAttribute(name, value) {
+            if (name === 'aria-pressed') this.ariaPressed = value;
+        }
+    };
+}
+
+async function createHarness() {
+    const statsGate = deferred();
+    const stalePreferenceRead = deferred();
+    const preferencePatches = [];
+    const renderedIds = [];
+    const progressSyncCalls = [];
+    let resumePreferenceReads = 0;
+    let useDelayedResumePreference = false;
+    let browseInitializations = 0;
+
+    const durableBrowse = {
+        lastFilter: { category: 'P1', type: 'reading' },
+        filter: { category: 'all', type: 'all' },
+        frequencyFilter: 'medium',
+        sortMode: 'frequency-desc'
+    };
+    const examIndex = [
+        {
+            id: 'selected-ocean',
+            title: 'Ocean currents',
+            category: 'P2',
+            type: 'reading',
+            path: 'ReadingPractice/100 P2/Ocean',
+            frequency: 'high'
+        },
+        {
+            id: 'wrong-frequency',
+            title: 'Ocean climate',
+            category: 'P2',
+            type: 'reading',
+            path: 'ReadingPractice/100 P2/Ocean',
+            frequency: 'low'
+        },
+        {
+            id: 'wrong-query',
+            title: 'Desert winds',
+            category: 'P2',
+            type: 'reading',
+            path: 'ReadingPractice/100 P2/Ocean',
+            frequency: 'high'
+        },
+        {
+            id: 'wrong-category',
+            title: 'Ocean habitats',
+            category: 'P3',
+            type: 'reading',
+            path: 'ReadingPractice/100 P3/Ocean',
+            frequency: 'high'
+        }
+    ];
+    const practiceRecords = [{
+        examId: 'selected-ocean',
+        accuracy: 1,
+        startTime: '2026-08-30T00:00:00.000Z'
+    }];
+    const searchInput = { value: 'ocean' };
+    const typeButtons = [
+        createButton({ filterType: 'all' }),
+        createButton({ filterType: 'reading' }, true),
+        createButton({ filterType: 'listening' })
+    ];
+    const frequencyButtons = [
+        createButton({ frequencyFilter: 'high' }, true),
+        createButton({ frequencyFilter: 'medium' }),
+        createButton({ frequencyFilter: 'low' })
+    ];
+    const browseView = { id: 'browse-view', classList: createClassList(['active']) };
+    const documentListeners = new Map();
+    const documentStub = {
+        hidden: false,
+        readyState: 'loading',
+        body: { classList: createClassList(), appendChild() {} },
+        documentElement: { classList: createClassList() },
+        addEventListener(type, handler) {
+            if (!documentListeners.has(type)) documentListeners.set(type, []);
+            documentListeners.get(type).push(handler);
+        },
+        removeEventListener() {},
+        querySelector(selector) {
+            if (selector === '.search-input') return searchInput;
+            if (selector === '.view.active') return browseView;
+            return null;
+        },
+        querySelectorAll() { return []; },
+        getElementById(id) {
+            if (id === 'browse-view') return browseView;
+            if (id === 'exam-search-input') return searchInput;
+            if (id === 'type-filter-buttons') {
+                return { querySelectorAll() { return typeButtons; } };
+            }
+            if (id === 'browse-frequency-filter-buttons') {
+                return { querySelectorAll() { return frequencyButtons; } };
+            }
+            return null;
+        },
+        createElement() {
+            return {
+                classList: createClassList(),
+                dataset: {},
+                style: {},
+                appendChild() {},
+                setAttribute() {}
+            };
+        }
+    };
+
+    const quietConsole = { log() {}, info() {}, warn() {}, error() {} };
+    const sandbox = {
+        console: quietConsole,
+        document: documentStub,
+        location: {
+            href: 'https://example.test/index.html?view=browse',
+            search: '?view=browse',
+            origin: 'https://example.test',
+            protocol: 'https:'
+        },
+        history: { replaceState() {} },
+        navigator: {},
+        URL,
+        URLSearchParams,
+        Promise,
+        Set,
+        Map,
+        Date,
+        Math,
+        JSON,
+        CustomEvent: class CustomEvent {
+            constructor(type, init = {}) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        },
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+        cancelAnimationFrame: clearTimeout,
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent() {},
+        confirm() { return false; },
+        alert() {},
+        __browseFilterMode: 'frequency-p1',
+        __browsePath: 'ReadingPractice/100 P1',
+        __browseFrequencyFilter: 'medium',
+        __browseSortMode: 'frequency-desc',
+        browseController: {
+            currentMode: 'frequency-p1',
+            activeFilter: 'medium',
+            currentCategory: 'P1',
+            currentExamType: 'reading'
+        },
+        browseStateManager: {
+            currentFilter: 'P1',
+            state: {
+                currentCategory: 'P1',
+                currentFrequency: 'medium',
+                filters: { frequency: 'medium', status: 'all', difficulty: 'all' },
+                searchQuery: 'ocean'
+            }
+        },
+        async resolveActiveLibraryIndex() {
+            return examIndex;
+        },
+        initializeBrowseView() {
+            browseInitializations += 1;
+            return Promise.resolve(examIndex);
+        },
+        AppData: {
+            ready: Promise.resolve(),
+            preferences: {
+                async getBrowse() {
+                    if (useDelayedResumePreference) {
+                        resumePreferenceReads += 1;
+                        return stalePreferenceRead.promise;
+                    }
+                    return clone(durableBrowse);
+                },
+                async patchBrowse(value) {
+                    const patch = clone(value || {});
+                    preferencePatches.push(patch);
+                    Object.assign(durableBrowse, patch);
+                    return clone(durableBrowse);
+                },
+                async setBrowse(value) {
+                    Object.assign(durableBrowse, clone(value || {}));
+                    return clone(durableBrowse);
+                }
+            },
+            practice: {
+                async getStats() {
+                    await statsGate.promise;
+                    return { totalPractices: practiceRecords.length };
+                },
+                async list() {
+                    return clone(practiceRecords);
+                }
+            }
+        }
+    };
+    sandbox.window = sandbox;
+    sandbox.globalThis = sandbox;
+    sandbox.self = sandbox;
+    const context = vm.createContext(sandbox);
+
+    loadScript('js/app/state-service.js', context);
+    loadScript('js/utils/BrowsePreferencesUtils.js', context);
+    await sandbox.whenBrowseViewPreferencesReady();
+    loadScript('js/app.js', context);
+    const app = vm.runInContext('new ExamSystemApp()', context);
+    app.initializeGlobalCompatibility();
+    app.currentView = 'browse';
+
+    sandbox.setBrowseFilterState('P1', 'reading');
+    await sandbox.flushBrowsePreferenceWrites();
+
+    sandbox.ensurePracticeRecordsSync = async (trigger, options) => {
+        progressSyncCalls.push({ trigger, options: { ...options } });
+        const activeFilter = sandbox.getBrowseFilterState();
+        const query = searchInput.value.trim().toLowerCase();
+        const pathFilter = sandbox.__browsePath;
+        const frequencyFilter = sandbox.__browseFrequencyFilter;
+        const ids = examIndex
+            .filter((exam) => activeFilter.category === 'all'
+                || exam.category === activeFilter.category)
+            .filter((exam) => activeFilter.type === 'all'
+                || exam.type === activeFilter.type)
+            .filter((exam) => !pathFilter || exam.path.includes(pathFilter))
+            .filter((exam) => frequencyFilter === 'all'
+                || exam.frequency === frequencyFilter)
+            .filter((exam) => !query || exam.title.toLowerCase().includes(query))
+            .map((exam) => exam.id);
+        renderedIds.push(ids);
+        return clone(practiceRecords);
+    };
+
+    return {
+        app,
+        sandbox,
+        durableBrowse,
+        documentListeners,
+        examIndex,
+        frequencyButtons,
+        preferencePatches,
+        progressSyncCalls,
+        renderedIds,
+        searchInput,
+        stalePreferenceRead,
+        statsGate,
+        typeButtons,
+        getBrowseInitializations: () => browseInitializations,
+        getResumePreferenceReads: () => resumePreferenceReads,
+        beginDelayedResumePreferenceRead() {
+            useDelayedResumePreference = true;
+        }
+    };
+}
+
+function applyLatestBrowseIntent(harness) {
+    const { app, sandbox, searchInput, typeButtons, frequencyButtons } = harness;
+    sandbox.setBrowseFilterState('P2', 'reading');
+    sandbox.__browseFilterMode = 'frequency-p2';
+    sandbox.__browsePath = 'ReadingPractice/100 P2/Ocean';
+    sandbox.__browseFrequencyFilter = 'high';
+    sandbox.__browseSortMode = 'frequency-desc';
+    sandbox.browseController.currentMode = 'frequency-p2';
+    sandbox.browseController.activeFilter = 'high';
+    sandbox.browseController.currentCategory = 'P2';
+    sandbox.browseController.currentExamType = 'reading';
+    sandbox.browseStateManager.currentFilter = 'P2';
+    sandbox.browseStateManager.state.currentCategory = 'P2';
+    sandbox.browseStateManager.state.currentFrequency = 'high';
+    sandbox.browseStateManager.state.filters.frequency = 'high';
+    sandbox.browseStateManager.state.searchQuery = 'ocean';
+    searchInput.value = 'ocean';
+    typeButtons.forEach((button) => {
+        const active = button.dataset.filterType === 'reading';
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    frequencyButtons.forEach((button) => {
+        const active = button.dataset.frequencyFilter === 'high';
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    assert.deepEqual(clone(app.state.ui.browseFilter), { category: 'P2', type: 'reading' });
+}
+
+test('visibility resume refreshes progress without rehydrating or reactivating Browse scope', async () => {
+    const harness = await createHarness();
+    harness.beginDelayedResumePreferenceRead();
+
+    const refresh = harness.app.refreshData();
+    await flushMicrotasks();
+    applyLatestBrowseIntent(harness);
+    await harness.sandbox.flushBrowsePreferenceWrites();
+
+    harness.stalePreferenceRead.resolve({
+        lastFilter: { category: 'P1', type: 'reading' },
+        filter: { category: 'all', type: 'all' },
+        frequencyFilter: 'medium',
+        sortMode: 'frequency-desc'
+    });
+    harness.statsGate.resolve();
+    await refresh;
+    await harness.sandbox.flushBrowsePreferenceWrites();
+
+    assert.equal(
+        harness.getResumePreferenceReads(),
+        0,
+        'visibility resume must not start a persisted Browse-intent read'
+    );
+    assert.equal(
+        harness.getBrowseInitializations(),
+        0,
+        'visibility resume must not run the cold Browse initializer'
+    );
+    assert.deepEqual(
+        clone(harness.sandbox.getBrowseFilterState()),
+        { category: 'P2', type: 'reading' }
+    );
+    assert.deepEqual(
+        clone(harness.app.state.ui.browseFilter),
+        { category: 'P2', type: 'reading' }
+    );
+    assert.equal(harness.sandbox.getBrowseFilterMutationRevision(), 2);
+    assert.equal(harness.sandbox.__browseFilterMode, 'frequency-p2');
+    assert.equal(harness.sandbox.__browsePath, 'ReadingPractice/100 P2/Ocean');
+    assert.equal(harness.sandbox.__browseFrequencyFilter, 'high');
+    assert.equal(harness.sandbox.__browseSortMode, 'frequency-desc');
+    assert.equal(harness.sandbox.browseController.currentMode, 'frequency-p2');
+    assert.equal(harness.sandbox.browseController.activeFilter, 'high');
+    assert.equal(harness.sandbox.browseStateManager.currentFilter, 'P2');
+    assert.equal(harness.sandbox.browseStateManager.state.currentFrequency, 'high');
+    assert.equal(harness.searchInput.value, 'ocean');
+    assert.equal(harness.typeButtons[1].ariaPressed, 'true');
+    assert.equal(harness.frequencyButtons[0].ariaPressed, 'true');
+    assert.deepEqual(harness.durableBrowse.lastFilter, { category: 'P2', type: 'reading' });
+    assert.deepEqual(harness.durableBrowse.filter, { category: 'all', type: 'all' });
+    assert.deepEqual(harness.progressSyncCalls, [{
+        trigger: 'visibility-resume',
+        options: { forceRender: true }
+    }]);
+    assert.deepEqual(harness.renderedIds, [['selected-ocean']]);
+});
+
+test('visibilitychange uses the state-neutral refresh path after initialization', async () => {
+    const harness = await createHarness();
+    applyLatestBrowseIntent(harness);
+    await harness.sandbox.flushBrowsePreferenceWrites();
+    harness.app.isInitialized = true;
+    harness.app.setupEventListeners();
+    harness.statsGate.resolve();
+
+    const handlers = harness.documentListeners.get('visibilitychange') || [];
+    assert.equal(handlers.length, 2);
+    handlers.at(-1)();
+    await flushMicrotasks(16);
+
+    assert.equal(harness.getResumePreferenceReads(), 0);
+    assert.equal(harness.getBrowseInitializations(), 0);
+    assert.deepEqual(harness.renderedIds, [['selected-ocean']]);
+    assert.deepEqual(
+        clone(harness.sandbox.getBrowseFilterState()),
+        { category: 'P2', type: 'reading' }
+    );
+});

--- a/developer/tests/js/browseVisibilityResume.test.js
+++ b/developer/tests/js/browseVisibilityResume.test.js
@@ -70,7 +70,7 @@ async function createHarness() {
     let browseInitializations = 0;
 
     const durableBrowse = {
-        lastFilter: { category: 'P1', type: 'reading' },
+        lastFilter: { category: 'P1', type: 'listening' },
         filter: { category: 'all', type: 'all' },
         frequencyFilter: 'medium',
         sortMode: 'frequency-desc'
@@ -79,33 +79,33 @@ async function createHarness() {
         {
             id: 'selected-ocean',
             title: 'Ocean currents',
-            category: 'P2',
-            type: 'reading',
-            path: 'ReadingPractice/100 P2/Ocean',
+            category: 'P4',
+            type: 'listening',
+            path: 'ListeningPractice/100 P4/P4 高频(52)/Ocean',
             frequency: 'high'
         },
         {
             id: 'wrong-frequency',
             title: 'Ocean climate',
-            category: 'P2',
-            type: 'reading',
-            path: 'ReadingPractice/100 P2/Ocean',
+            category: 'P4',
+            type: 'listening',
+            path: 'ListeningPractice/100 P4/P4 高频(52)/Ocean',
             frequency: 'low'
         },
         {
             id: 'wrong-query',
             title: 'Desert winds',
-            category: 'P2',
-            type: 'reading',
-            path: 'ReadingPractice/100 P2/Ocean',
+            category: 'P4',
+            type: 'listening',
+            path: 'ListeningPractice/100 P4/P4 高频(52)/Ocean',
             frequency: 'high'
         },
         {
             id: 'wrong-category',
             title: 'Ocean habitats',
-            category: 'P3',
-            type: 'reading',
-            path: 'ReadingPractice/100 P3/Ocean',
+            category: 'P1',
+            type: 'listening',
+            path: 'ListeningPractice/100 P1/P1 高频（35）/Ocean',
             frequency: 'high'
         }
     ];
@@ -203,14 +203,14 @@ async function createHarness() {
         confirm() { return false; },
         alert() {},
         __browseFilterMode: 'frequency-p1',
-        __browsePath: 'ReadingPractice/100 P1',
+        __browsePath: 'ListeningPractice/100 P1',
         __browseFrequencyFilter: 'medium',
         __browseSortMode: 'frequency-desc',
         browseController: {
             currentMode: 'frequency-p1',
             activeFilter: 'medium',
             currentCategory: 'P1',
-            currentExamType: 'reading'
+            currentExamType: 'listening'
         },
         browseStateManager: {
             currentFilter: 'P1',
@@ -318,25 +318,25 @@ async function createHarness() {
     };
 }
 
-function applyLatestBrowseIntent(harness) {
+function applyLatestBrowseIntent(harness, searchQuery = 'ocean') {
     const { app, sandbox, searchInput, typeButtons, frequencyButtons } = harness;
-    sandbox.setBrowseFilterState('P2', 'reading');
-    sandbox.__browseFilterMode = 'frequency-p2';
-    sandbox.__browsePath = 'ReadingPractice/100 P2/Ocean';
+    sandbox.setBrowseFilterState('P4', 'listening');
+    sandbox.__browseFilterMode = 'frequency-p4';
+    sandbox.__browsePath = 'ListeningPractice/100 P4/P4 高频(52)/Ocean';
     sandbox.__browseFrequencyFilter = 'high';
     sandbox.__browseSortMode = 'frequency-desc';
-    sandbox.browseController.currentMode = 'frequency-p2';
+    sandbox.browseController.currentMode = 'frequency-p4';
     sandbox.browseController.activeFilter = 'high';
-    sandbox.browseController.currentCategory = 'P2';
-    sandbox.browseController.currentExamType = 'reading';
-    sandbox.browseStateManager.currentFilter = 'P2';
-    sandbox.browseStateManager.state.currentCategory = 'P2';
+    sandbox.browseController.currentCategory = 'P4';
+    sandbox.browseController.currentExamType = 'listening';
+    sandbox.browseStateManager.currentFilter = 'P4';
+    sandbox.browseStateManager.state.currentCategory = 'P4';
     sandbox.browseStateManager.state.currentFrequency = 'high';
     sandbox.browseStateManager.state.filters.frequency = 'high';
-    sandbox.browseStateManager.state.searchQuery = 'ocean';
-    searchInput.value = 'ocean';
+    sandbox.browseStateManager.state.searchQuery = searchQuery;
+    searchInput.value = searchQuery;
     typeButtons.forEach((button) => {
-        const active = button.dataset.filterType === 'reading';
+        const active = button.dataset.filterType === 'listening';
         button.classList.toggle('active', active);
         button.setAttribute('aria-pressed', active ? 'true' : 'false');
     });
@@ -345,7 +345,7 @@ function applyLatestBrowseIntent(harness) {
         button.classList.toggle('active', active);
         button.setAttribute('aria-pressed', active ? 'true' : 'false');
     });
-    assert.deepEqual(clone(app.state.ui.browseFilter), { category: 'P2', type: 'reading' });
+    assert.deepEqual(clone(app.state.ui.browseFilter), { category: 'P4', type: 'listening' });
 }
 
 test('visibility resume refreshes progress without rehydrating or reactivating Browse scope', async () => {
@@ -358,7 +358,7 @@ test('visibility resume refreshes progress without rehydrating or reactivating B
     await harness.sandbox.flushBrowsePreferenceWrites();
 
     harness.stalePreferenceRead.resolve({
-        lastFilter: { category: 'P1', type: 'reading' },
+        lastFilter: { category: 'P1', type: 'listening' },
         filter: { category: 'all', type: 'all' },
         frequencyFilter: 'medium',
         sortMode: 'frequency-desc'
@@ -379,31 +379,60 @@ test('visibility resume refreshes progress without rehydrating or reactivating B
     );
     assert.deepEqual(
         clone(harness.sandbox.getBrowseFilterState()),
-        { category: 'P2', type: 'reading' }
+        { category: 'P4', type: 'listening' }
     );
     assert.deepEqual(
         clone(harness.app.state.ui.browseFilter),
-        { category: 'P2', type: 'reading' }
+        { category: 'P4', type: 'listening' }
     );
     assert.equal(harness.sandbox.getBrowseFilterMutationRevision(), 2);
-    assert.equal(harness.sandbox.__browseFilterMode, 'frequency-p2');
-    assert.equal(harness.sandbox.__browsePath, 'ReadingPractice/100 P2/Ocean');
+    assert.equal(harness.sandbox.__browseFilterMode, 'frequency-p4');
+    assert.equal(harness.sandbox.__browsePath, 'ListeningPractice/100 P4/P4 高频(52)/Ocean');
     assert.equal(harness.sandbox.__browseFrequencyFilter, 'high');
     assert.equal(harness.sandbox.__browseSortMode, 'frequency-desc');
-    assert.equal(harness.sandbox.browseController.currentMode, 'frequency-p2');
+    assert.equal(harness.sandbox.browseController.currentMode, 'frequency-p4');
     assert.equal(harness.sandbox.browseController.activeFilter, 'high');
-    assert.equal(harness.sandbox.browseStateManager.currentFilter, 'P2');
+    assert.equal(harness.sandbox.browseStateManager.currentFilter, 'P4');
     assert.equal(harness.sandbox.browseStateManager.state.currentFrequency, 'high');
     assert.equal(harness.searchInput.value, 'ocean');
-    assert.equal(harness.typeButtons[1].ariaPressed, 'true');
+    assert.equal(harness.typeButtons[2].ariaPressed, 'true');
     assert.equal(harness.frequencyButtons[0].ariaPressed, 'true');
-    assert.deepEqual(harness.durableBrowse.lastFilter, { category: 'P2', type: 'reading' });
+    assert.deepEqual(harness.durableBrowse.lastFilter, { category: 'P4', type: 'listening' });
     assert.deepEqual(harness.durableBrowse.filter, { category: 'all', type: 'all' });
     assert.deepEqual(harness.progressSyncCalls, [{
         trigger: 'visibility-resume',
         options: { forceRender: true }
     }]);
     assert.deepEqual(harness.renderedIds, [['selected-ocean']]);
+});
+
+test('visibility resume preserves an explicit empty Browse query', async () => {
+    const harness = await createHarness();
+    applyLatestBrowseIntent(harness, '');
+    await harness.sandbox.flushBrowsePreferenceWrites();
+
+    const refresh = harness.app.refreshData();
+    harness.statsGate.resolve();
+    await refresh;
+
+    assert.equal(harness.searchInput.value, '');
+    assert.equal(harness.sandbox.browseStateManager.state.searchQuery, '');
+    assert.equal(harness.sandbox.__browseFilterMode, 'frequency-p4');
+    assert.equal(harness.sandbox.__browsePath, 'ListeningPractice/100 P4/P4 高频(52)/Ocean');
+    assert.equal(harness.sandbox.__browseFrequencyFilter, 'high');
+    assert.deepEqual(
+        clone(harness.sandbox.getBrowseFilterState()),
+        { category: 'P4', type: 'listening' }
+    );
+    assert.deepEqual(harness.progressSyncCalls, [{
+        trigger: 'visibility-resume',
+        options: { forceRender: true }
+    }]);
+    assert.deepEqual(
+        harness.renderedIds,
+        [['selected-ocean', 'wrong-query']],
+        'an empty query must retain every result in the selected path and frequency scope'
+    );
 });
 
 test('visibilitychange uses the state-neutral refresh path after initialization', async () => {
@@ -424,6 +453,6 @@ test('visibilitychange uses the state-neutral refresh path after initialization'
     assert.deepEqual(harness.renderedIds, [['selected-ocean']]);
     assert.deepEqual(
         clone(harness.sandbox.getBrowseFilterState()),
-        { category: 'P2', type: 'reading' }
+        { category: 'P4', type: 'listening' }
     );
 });

--- a/js/app.js
+++ b/js/app.js
@@ -1110,11 +1110,9 @@ class ExamSystemApp {
         },
         async loadInitialData() {
             try {
-                const browsePreference = await window.AppData.preferences.getBrowse();
-                const browseFilter = browsePreference && browsePreference.filter
-                    ? browsePreference.filter
-                    : { category: 'all', type: 'all' };
-                this.setState('ui.browseFilter', browseFilter);
+                // Browse intent is hydrated once by initializeBrowseView from
+                // the canonical lastFilter preference. Data refreshes must not
+                // replay an older durable scope into the live state service.
                 await this.loadUserStats();
                 await this.updateOverviewStats();
             } catch (error) {
@@ -1301,6 +1299,20 @@ class ExamSystemApp {
         async refreshData() {
             try {
                 await this.loadInitialData();
+                if (this.currentView === 'browse') {
+                    // A visibility resume only needs fresh derived progress.
+                    // Re-running Browse activation would rehydrate and
+                    // normalize the user's live category/mode/path scope.
+                    if (typeof window.ensurePracticeRecordsSync === 'function') {
+                        await window.ensurePracticeRecordsSync(
+                            'visibility-resume',
+                            { forceRender: true }
+                        );
+                    } else if (typeof window.syncPracticeRecords === 'function') {
+                        await window.syncPracticeRecords({ forceRender: true });
+                    }
+                    return;
+                }
                 this.onViewActivated(this.currentView);
             } catch (error) {
                 console.error('Failed to refresh data:', error);

--- a/js/app.js
+++ b/js/app.js
@@ -1304,12 +1304,9 @@ class ExamSystemApp {
                     // Re-running Browse activation would rehydrate and
                     // normalize the user's live category/mode/path scope.
                     if (typeof window.ensurePracticeRecordsSync === 'function') {
-                        await window.ensurePracticeRecordsSync(
-                            'visibility-resume',
-                            { forceRender: true }
-                        );
+                        await window.ensurePracticeRecordsSync('visibility-resume');
                     } else if (typeof window.syncPracticeRecords === 'function') {
-                        await window.syncPracticeRecords({ forceRender: true });
+                        await window.syncPracticeRecords();
                     }
                     return;
                 }

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -18203,12 +18203,15 @@ function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
     const requestedLibraryGeneration = readBrowseProgressGeneration(
         '__getActiveLibraryGeneration'
     );
+    const requiresPostCommitRead = !!(options && options.requirePostCommitRead);
     if (practiceRecordsLoadPromise) {
         // Keep the baseline single-flight contract for same-library calls. Only
-        // a newer active library earns one coalesced Browse-progress tail; this
-        // is not a generic Practice-data replacement scheduler.
-        if (requestedLibraryGeneration != null
-            && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration) {
+        // a newer active library or an explicitly committed Practice mutation
+        // earns one coalesced Browse-progress tail; this is not a generic
+        // Practice-data replacement scheduler.
+        if (requiresPostCommitRead
+            || (requestedLibraryGeneration != null
+                && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration)) {
             mergeBrowseProgressLibrarySyncRequest(
                 trigger,
                 options,
@@ -18686,7 +18689,10 @@ function setupMessageListener() {
                     showMessage('练习已完成，正在更新记录...', 'success');
                     showCompletionSummary(payload);
                 }
-                setTimeout(() => ensurePracticeRecordsSync('completion-saved'), 300);
+                setTimeout(() => ensurePracticeRecordsSync('completion-saved', {
+                    forceRender: true,
+                    requirePostCommitRead: true
+                }), 300);
             };
             const onCompletionSaveFailed = (saveError) => {
                 sendFallbackSubmitOutcome(rec, payload, false, 'save_failed');

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -3007,11 +3007,9 @@ class ExamSystemApp {
         },
         async loadInitialData() {
             try {
-                const browsePreference = await window.AppData.preferences.getBrowse();
-                const browseFilter = browsePreference && browsePreference.filter
-                    ? browsePreference.filter
-                    : { category: 'all', type: 'all' };
-                this.setState('ui.browseFilter', browseFilter);
+                // Browse intent is hydrated once by initializeBrowseView from
+                // the canonical lastFilter preference. Data refreshes must not
+                // replay an older durable scope into the live state service.
                 await this.loadUserStats();
                 await this.updateOverviewStats();
             } catch (error) {
@@ -3198,6 +3196,20 @@ class ExamSystemApp {
         async refreshData() {
             try {
                 await this.loadInitialData();
+                if (this.currentView === 'browse') {
+                    // A visibility resume only needs fresh derived progress.
+                    // Re-running Browse activation would rehydrate and
+                    // normalize the user's live category/mode/path scope.
+                    if (typeof window.ensurePracticeRecordsSync === 'function') {
+                        await window.ensurePracticeRecordsSync(
+                            'visibility-resume',
+                            { forceRender: true }
+                        );
+                    } else if (typeof window.syncPracticeRecords === 'function') {
+                        await window.syncPracticeRecords({ forceRender: true });
+                    }
+                    return;
+                }
                 this.onViewActivated(this.currentView);
             } catch (error) {
                 console.error('Failed to refresh data:', error);

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -3201,12 +3201,9 @@ class ExamSystemApp {
                     // Re-running Browse activation would rehydrate and
                     // normalize the user's live category/mode/path scope.
                     if (typeof window.ensurePracticeRecordsSync === 'function') {
-                        await window.ensurePracticeRecordsSync(
-                            'visibility-resume',
-                            { forceRender: true }
-                        );
+                        await window.ensurePracticeRecordsSync('visibility-resume');
                     } else if (typeof window.syncPracticeRecords === 'function') {
-                        await window.syncPracticeRecords({ forceRender: true });
+                        await window.syncPracticeRecords();
                     }
                     return;
                 }

--- a/js/main.js
+++ b/js/main.js
@@ -477,12 +477,15 @@ function ensurePracticeRecordsSync(trigger = 'default', options = {}) {
     const requestedLibraryGeneration = readBrowseProgressGeneration(
         '__getActiveLibraryGeneration'
     );
+    const requiresPostCommitRead = !!(options && options.requirePostCommitRead);
     if (practiceRecordsLoadPromise) {
         // Keep the baseline single-flight contract for same-library calls. Only
-        // a newer active library earns one coalesced Browse-progress tail; this
-        // is not a generic Practice-data replacement scheduler.
-        if (requestedLibraryGeneration != null
-            && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration) {
+        // a newer active library or an explicitly committed Practice mutation
+        // earns one coalesced Browse-progress tail; this is not a generic
+        // Practice-data replacement scheduler.
+        if (requiresPostCommitRead
+            || (requestedLibraryGeneration != null
+                && requestedLibraryGeneration !== activeBrowseProgressSyncLibraryGeneration)) {
             mergeBrowseProgressLibrarySyncRequest(
                 trigger,
                 options,
@@ -960,7 +963,10 @@ function setupMessageListener() {
                     showMessage('练习已完成，正在更新记录...', 'success');
                     showCompletionSummary(payload);
                 }
-                setTimeout(() => ensurePracticeRecordsSync('completion-saved'), 300);
+                setTimeout(() => ensurePracticeRecordsSync('completion-saved', {
+                    forceRender: true,
+                    requirePostCommitRead: true
+                }), 300);
             };
             const onCompletionSaveFailed = (saveError) => {
                 sendFallbackSubmitOutcome(rec, payload, false, 'save_failed');


### PR DESCRIPTION
## Summary

- Keep persisted Browse-filter hydration in the one-time Browse initializer, which reads the canonical `lastFilter` value.
- Make parent-page visibility resume refresh statistics and derived practice progress without reactivating or normalizing the live Browse scope.
- Add lifecycle regression coverage for delayed stale preference reads, category/type, mode/subfilter, path, frequency, sort, query, persisted state, and rendered IDs.
- Regenerate runtime bundles; the full bundle build also synchronizes the existing vocabulary bundle with its current source.

## Root cause

`refreshData()` called `loadInitialData()` on every visibility resume. That method replayed the legacy `browsePreference.filter` value through `ui.browseFilter`, which also persisted the stale value through `AppStateService`. The subsequent full Browse activation could then normalize mode and path against the refreshed index while leaving the search input untouched.

## Verification

- `node --test --test-concurrency=1 developer/tests/js/browseLatestWins.test.js developer/tests/js/browseNavigationReset.test.js developer/tests/js/browseVisibilityResume.test.js` (27 passed)
- `node --test --test-concurrency=1 "developer/tests/js/**/*.test.js"` (102 passed)
- `node scripts/build-bundles.mjs --check`
- `python -m unittest discover -s developer/tests/py -p "test_*.py"` (20 passed)
- `python developer/tests/ci/check_reading_data_integrity.py` (passed; only the allowlisted duplicate warning remains)

Closes #124