### PR TITLE
build(vocabulary): sync progress export runtime bundle

### DIFF
--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -406,11 +406,17 @@
 
     async function exportProgress(words) {
         if (!window.AppData || !window.AppData.vocab) throw new Error('AppData.vocab 未加载');
-        if (!Array.isArray(words)) throw new Error('当前词表尚未加载');
         await window.AppData.ready;
         const config = await window.AppData.vocab.getConfig();
         const listId = config.activeListId || 'default';
-        const entries = words.map(cloneProgressEntry);
+        let entries;
+        if (Array.isArray(words)) {
+            entries = words.map(cloneProgressEntry);
+        } else {
+            const list = await window.AppData.vocab.readList(listId);
+            const listWords = Array.isArray(list) ? list : (list && Array.isArray(list.words) ? list.words : []);
+            entries = listWords.map(cloneProgressEntry);
+        }
         if (entries.some((entry) => !entry)) {
             throw new Error('当前词表包含无效词汇数据');
         }


### PR DESCRIPTION
## Summary

- Refresh `js/bundles/more.bundle.js` from the existing `js/utils/vocabDataIO.js` source.
- Align the shipped `exportProgress` fallback with the active vocabulary-list behavior already present on `opensource`.
- Isolate the generated runtime reconciliation requested during the review of #125.

## Verification

- `node scripts/build-bundles.mjs --check`
- `node developer/tests/js/vocabDataIO.test.js`
- `node developer/tests/js/integration/vocabSessionView.test.js`

## Relationship to #125

This narrow PR should be merged before #125 is rebased, allowing #125 to drop the unrelated generated bundle change. It ships source behavior that already exists on `opensource` by reconciling the tracked runtime artifact.