### PR TITLE
fix(backup): preserve unrecognized latest backups

### DIFF
--- a/developer/tests/js/externalBackupServiceV2.test.js
+++ b/developer/tests/js/externalBackupServiceV2.test.js
@@ -992,6 +992,65 @@ async function testBindingExistingBackupRequiresRestoreBeforeAnyWrite() {
     assert.equal(directory.files.get('ielts-atlas-backup-latest.json'), originalText);
 }
 
+async function testBindingUnrecognizedLatestPreservesBytesAcrossWritesAndReload() {
+    const latestFilename = 'ielts-atlas-backup-latest.json';
+    const unrecognizedBackups = [
+        '  {\r\n  "backup": "未完成",\r\n',
+        JSON.stringify({
+            ...makeSnapshot('fnv1a-future-schema', 'future'),
+            schemaVersion: 3
+        }, null, 2) + '\n'
+    ];
+
+    for (const originalText of unrecognizedBackups) {
+        for (const writeNow of [true, false]) {
+            const directory = createDirectory();
+            directory.files.set(latestFilename, originalText);
+            const originalFiles = new Map(directory.files);
+            const harness = createHarness({ directory });
+            await harness.ready();
+
+            const bound = await harness.service.bindDirectory({ writeNow });
+            assert.equal(bound.existingBackupFound, true,
+                'an unrecognized latest file is still an existing backup');
+            assert.equal(bound.writeResult, null);
+            assert.equal(harness.service.getStatus().awaitingRestore, true);
+            assert.equal(harness.indexedDB.values.get('metadata').awaitingRestore, true);
+            assert.deepEqual(directory.files, originalFiles,
+                'binding must preserve every byte and must not create a fallback generation');
+
+            await assert.rejects(
+                () => harness.service.restoreFromLatest({ confirmed: true }),
+                /未找到有效的 v2 本地备份文件/
+            );
+            assert.equal(harness.calls.commit.length, 0);
+            assert.equal(harness.service.getStatus().awaitingRestore, true,
+                'a failed restore must not clear the overwrite guard');
+
+            for (const reload of [false, true]) {
+                const active = reload
+                    ? createHarness({ indexedDB: harness.indexedDB, directory })
+                    : harness;
+                await active.ready();
+                assert.equal(active.service.getStatus().awaitingRestore, true);
+                active.setSnapshot(makeSnapshot('fnv1a-later-commit', 'later'));
+                active.emitCommitted();
+                await active.flushTimers();
+
+                const automaticWrite = await active.service.flushSilentlyIfPermitted();
+                assert.equal(automaticWrite.success, false);
+                assert.equal(automaticWrite.reason, 'restore_required');
+                const manualWrite = await active.service.writeNow();
+                assert.equal(manualWrite.success, false);
+                assert.equal(manualWrite.reason, 'restore_required');
+                assert.equal(active.service.getStatus().dirty, true);
+                assert.deepEqual(directory.files, originalFiles,
+                    'later writes and reloads must preserve the unrecognized backup byte for byte');
+            }
+        }
+    }
+}
+
 async function testFullResetWorksWhenAppDataReadyRejects() {
     const harness = createHarness({
         appDataReady: Promise.reject(new Error('corrupt AppData initialization'))
@@ -1319,6 +1378,7 @@ async function main() {
     await testFullResetSuspendsWritesAndPreservesDiskFiles();
     await testFullResetPublicLockAndRollbackContract();
     await testBindingExistingBackupRequiresRestoreBeforeAnyWrite();
+    await testBindingUnrecognizedLatestPreservesBytesAcrossWritesAndReload();
     await testFullResetWorksWhenAppDataReadyRejects();
     await testFullResetAllowsDirtyStateWhenNoDirectoryIsBound();
     await testFullResetWriteFailurePreservesBindingState();

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -5974,9 +5974,11 @@
                 throw new Error('本地备份服务刚刚开始重置，请重新选择文件夹');
             }
             if (state.suspended || state.resetPreparing) throw new Error('本地备份服务正在重置');
-            var existingLatest = await readValidatedV2File(handle, LATEST_FILENAME, V2_SCHEMA_VERSION);
-            var existingGeneration = existingLatest ? null : await findLatestDatedGeneration(handle);
-            existingBackupFound = Boolean(existingLatest || existingGeneration);
+            // An unreadable or unsupported latest file must remain protected even
+            // when this version cannot restore it and no valid generation exists.
+            var existingLatestFound = await fileExists(handle, LATEST_FILENAME);
+            var existingGeneration = existingLatestFound ? null : await findLatestDatedGeneration(handle);
+            existingBackupFound = existingLatestFound || Boolean(existingGeneration);
             meta = cloneMeta({
                 directoryName: handle.name || 'backup',
                 lastWriteAt: null,

--- a/js/core/externalBackupService.js
+++ b/js/core/externalBackupService.js
@@ -625,9 +625,11 @@
                 throw new Error('本地备份服务刚刚开始重置，请重新选择文件夹');
             }
             if (state.suspended || state.resetPreparing) throw new Error('本地备份服务正在重置');
-            var existingLatest = await readValidatedV2File(handle, LATEST_FILENAME, V2_SCHEMA_VERSION);
-            var existingGeneration = existingLatest ? null : await findLatestDatedGeneration(handle);
-            existingBackupFound = Boolean(existingLatest || existingGeneration);
+            // An unreadable or unsupported latest file must remain protected even
+            // when this version cannot restore it and no valid generation exists.
+            var existingLatestFound = await fileExists(handle, LATEST_FILENAME);
+            var existingGeneration = existingLatestFound ? null : await findLatestDatedGeneration(handle);
+            existingBackupFound = existingLatestFound || Boolean(existingGeneration);
             meta = cloneMeta({
                 directoryName: handle.name || 'backup',
                 lastWriteAt: null,


### PR DESCRIPTION
Binding a directory containing an invalid or unsupported `ielts-atlas-backup-latest.json` could overwrite its only backup with the current browser snapshot. Check file existence independently of snapshot validation and persist the existing restore guard so those bytes remain protected until the backup is explicitly resolved.

Regression coverage checks malformed JSON and a future schema with both `writeNow` modes, failed restores, later automatic and manual writes, and reloads. Existing empty-directory initialization and valid latest/dated-generation restore behavior remain covered. Regenerate the affected core foundation bundle.

Closes #133.

## Validation

- `node developer/tests/js/externalBackupServiceV2.test.js`
- `node --test --test-concurrency=1 --test-reporter=dot "developer/tests/js/**/*.test.js"`
- `node scripts/build-bundles.mjs --check` — all 14 outputs are current.
- `git diff --check`
