### PR TITLE
fix(practice): preserve restarted sessions after interrupted saves

### DIFF
--- a/developer/tests/js/practiceRecorder.test.js
+++ b/developer/tests/js/practiceRecorder.test.js
@@ -13,6 +13,12 @@ function clone(value) {
     return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
+function deferred() {
+    let resolve;
+    const promise = new Promise((complete) => { resolve = complete; });
+    return { promise, resolve };
+}
+
 function loadScript(relativePath, context) {
     vm.runInContext(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'), context, { filename: relativePath });
 }
@@ -30,6 +36,11 @@ function createHarness() {
         }],
         commands: [],
         backupCalls: [],
+        activeCheckpoints: new Map(),
+        interruptedRecords: [],
+        discardedSessionIds: [],
+        intervals: new Set(),
+        events: [],
         failCompleteAttempts: 0
     };
     const quietConsole = { log() {}, warn() {}, error() {}, info() {}, debug() {} };
@@ -61,6 +72,22 @@ function createHarness() {
             }
         },
         recovery: {
+            async saveActiveSession(session) {
+                state.activeCheckpoints.set(session.id, clone(session));
+                return { committed: true };
+            },
+            async discardActiveSession(id) {
+                state.discardedSessionIds.push(id);
+                state.activeCheckpoints.delete(id);
+                return { committed: true };
+            },
+            async saveInterrupted(record) {
+                state.interruptedRecords.push(clone(record));
+                return { committed: true };
+            },
+            async listInterrupted() {
+                return clone(state.interruptedRecords);
+            },
             async listDrafts() {
                 return clone(state.drafts);
             },
@@ -146,8 +173,27 @@ function createHarness() {
         console: quietConsole,
         setTimeout,
         clearTimeout,
-        setInterval,
-        clearInterval,
+        setInterval() {
+            const timer = Symbol('session listener');
+            state.intervals.add(timer);
+            return timer;
+        },
+        clearInterval(timer) {
+            state.intervals.delete(timer);
+        },
+        navigator: { userAgent: 'PracticeRecorder test' },
+        screen: { width: 1280, height: 720 },
+        CustomEvent: class {
+            constructor(type, options) {
+                this.type = type;
+                this.detail = options.detail;
+            }
+        },
+        document: {
+            dispatchEvent(event) {
+                state.events.push({ type: event.type, detail: clone(event.detail) });
+            }
+        },
         Date,
         Math,
         JSON
@@ -157,6 +203,8 @@ function createHarness() {
     loadScript('js/core/practiceCore.js', context);
     loadScript('js/core/practiceRecorder.js', context);
     const recorder = Object.create(windowStub.PracticeRecorder.prototype);
+    recorder.activeSessions = new Map();
+    recorder.sessionListeners = new Map();
     recorder.wait = async () => {};
     return { recorder, state, windowStub };
 }
@@ -343,33 +391,151 @@ async function main() {
             assert.deepStrictEqual(state.backupCalls.map((call) => call.method), ['previewImport']);
         });
 
-        await record('failed interrupted save keeps the active checkpoint', async () => {
-            const { recorder, windowStub } = createHarness();
-            const session = {
-                id: 'active-session:session-interrupted',
-                sessionId: 'session-interrupted',
-                examId: 'reading-p1',
-                startTime: '2026-07-26T00:00:00.000Z',
-                status: 'active',
-                progress: { currentQuestion: 4 },
-                answers: { q1: 'A' },
-                metadata: {}
-            };
-            recorder.activeSessions = new Map([['reading-p1', session]]);
-            recorder.cleanupSessionListener = () => {};
-            recorder.dispatchSessionEvent = () => {};
-            recorder.saveInterruptedRecord = async () => {
+        for (const mode of ['replacement', 'identity rebind', 'same-id replacement']) {
+            await record(`delayed interrupted save preserves the session after ${mode}`, async () => {
+                const { recorder, state, windowStub } = createHarness();
+                const examId = 'reading-p1';
+                const original = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+                recorder.handleSessionProgress({
+                    examId,
+                    progress: { currentQuestion: 4 },
+                    answers: { q1: 'A' }
+                });
+                await recorder.saveActiveSessions();
+
+                const saveGate = deferred();
+                const saveInterrupted = windowStub.AppData.recovery.saveInterrupted;
+                windowStub.AppData.recovery.saveInterrupted = async (value) => {
+                    await saveGate.promise;
+                    return saveInterrupted(value);
+                };
+                const ending = recorder.endPracticeSession(examId, 'timeout');
+                assert.strictEqual(state.interruptedRecords.length, 0);
+
+                const sessionId = mode === 'same-id replacement' ? 'session-A' : 'session-B';
+                if (mode === 'identity rebind') {
+                    recorder.handleSessionStarted({ examId, sessionId });
+                    assert.strictEqual(recorder.activeSessions.get(examId), original);
+                } else {
+                    recorder.startPracticeSession(examId, { sessionId });
+                    assert.notStrictEqual(recorder.activeSessions.get(examId), original);
+                }
+                const replacement = recorder.activeSessions.get(examId);
+                const listener = recorder.sessionListeners.get(examId);
+                recorder.handleSessionProgress({
+                    examId,
+                    progress: { currentQuestion: 5 },
+                    answers: { q1: 'B' }
+                });
+                await recorder.saveActiveSessions();
+                const checkpoint = clone(state.activeCheckpoints.get(replacement.id));
+                assert.strictEqual(checkpoint.sessionId, sessionId);
+
+                saveGate.resolve();
+                assert.strictEqual(await ending, true);
+
+                assert.strictEqual(state.interruptedRecords.length, 1);
+                assert.strictEqual(state.interruptedRecords[0].sessionId, 'session-A');
+                assert.strictEqual(state.interruptedRecords[0].reason, 'timeout');
+                assert.strictEqual(state.interruptedRecords[0].progress.currentQuestion, 4);
+                assert.deepStrictEqual(state.interruptedRecords[0].answers, { q1: 'A' });
+                assert.strictEqual(recorder.activeSessions.get(examId), replacement,
+                    'the superseded end call must preserve the current session');
+                assert.strictEqual(recorder.sessionListeners.get(examId), listener);
+                assert(state.intervals.has(listener), 'the current listener must remain scheduled');
+                assert.deepStrictEqual(state.activeCheckpoints.get(replacement.id), checkpoint);
+                assert.strictEqual(state.events.filter((event) => event.type === 'practicesessionEnded').length, 0);
+
+                recorder.handleSessionProgress({
+                    examId,
+                    progress: { currentQuestion: 6 },
+                    answers: { q1: 'C' }
+                });
+                await recorder.saveActiveSessions();
+                assert.strictEqual(replacement.progress.currentQuestion, 6);
+                assert.deepStrictEqual(clone(replacement.answers), { q1: 'C' });
+                assert.strictEqual(state.activeCheckpoints.get(replacement.id).progress.currentQuestion, 6);
+                assert.deepStrictEqual(state.activeCheckpoints.get(replacement.id).answers, { q1: 'C' });
+            });
+        }
+
+        for (const reason of ['completed', 'timeout']) {
+            await record(`normal ${reason} cleanup removes the session and emits one end event`, async () => {
+                const { recorder, state } = createHarness();
+                const examId = 'reading-p1';
+                const session = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+                const listener = recorder.sessionListeners.get(examId);
+                await recorder.saveActiveSessions();
+
+                assert.strictEqual(await recorder.endPracticeSession(examId, reason), true);
+                assert.strictEqual(recorder.activeSessions.has(examId), false);
+                assert.strictEqual(recorder.sessionListeners.has(examId), false);
+                assert.strictEqual(state.intervals.has(listener), false);
+                assert.strictEqual(state.activeCheckpoints.has(session.id), false);
+                assert.deepStrictEqual(state.discardedSessionIds, [session.id]);
+                assert.strictEqual(state.interruptedRecords.length, reason === 'timeout' ? 1 : 0);
+                assert.deepStrictEqual(
+                    state.events.filter((event) => event.type === 'practicesessionEnded'),
+                    [{ type: 'practicesessionEnded', detail: { examId, reason } }]
+                );
+                assert.strictEqual(await recorder.endPracticeSession(examId, reason), false);
+            });
+
+            await record(`delayed ${reason} checkpoint cleanup does not announce a replacement as ended`, async () => {
+                const { recorder, state, windowStub } = createHarness();
+                const examId = 'reading-p1';
+                const original = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+                await recorder.saveActiveSessions();
+
+                const discardStarted = deferred();
+                const discardGate = deferred();
+                const discardActiveSession = windowStub.AppData.recovery.discardActiveSession;
+                windowStub.AppData.recovery.discardActiveSession = async (id) => {
+                    assert.strictEqual(id, original.id);
+                    discardStarted.resolve();
+                    await discardGate.promise;
+                    return discardActiveSession(id);
+                };
+                const ending = recorder.endPracticeSession(examId, reason);
+                await discardStarted.promise;
+                const replacement = recorder.startPracticeSession(examId, { sessionId: 'session-B' });
+                const listener = recorder.sessionListeners.get(examId);
+                await recorder.saveActiveSessions();
+
+                discardGate.resolve();
+                assert.strictEqual(await ending, true);
+                assert.strictEqual(recorder.activeSessions.get(examId), replacement);
+                assert.strictEqual(recorder.sessionListeners.get(examId), listener);
+                assert(state.intervals.has(listener));
+                assert.strictEqual(state.activeCheckpoints.has(original.id), false);
+                assert.strictEqual(state.activeCheckpoints.get(replacement.id).sessionId, 'session-B');
+                assert.strictEqual(state.events.filter((event) => event.type === 'practicesessionEnded').length, 0);
+            });
+        }
+
+        await record('failed interrupted save keeps the active checkpoint and listener', async () => {
+            const { recorder, state, windowStub } = createHarness();
+            const examId = 'reading-p1';
+            const session = recorder.startPracticeSession(examId, { sessionId: 'session-interrupted' });
+            const listener = recorder.sessionListeners.get(examId);
+            await recorder.saveActiveSessions();
+            const checkpoint = clone(state.activeCheckpoints.get(session.id));
+            windowStub.AppData.recovery.saveInterrupted = async () => {
                 const error = new Error('quota exceeded');
                 error.code = 'QUOTA_EXCEEDED';
                 throw error;
             };
-            let discardCalls = 0;
-            windowStub.AppData.recovery.discardActiveSession = async () => { discardCalls += 1; };
 
-            const ended = await recorder.endPracticeSession('reading-p1', 'timeout');
+            const ended = await recorder.endPracticeSession(examId, 'timeout');
             assert.strictEqual(ended, false);
-            assert.strictEqual(recorder.activeSessions.get('reading-p1'), session);
-            assert.strictEqual(discardCalls, 0, 'the only durable checkpoint must not be discarded after save failure');
+            assert.strictEqual(recorder.activeSessions.get(examId), session);
+            assert.strictEqual(recorder.sessionListeners.get(examId), listener);
+            assert(state.intervals.has(listener));
+            assert.deepStrictEqual(state.activeCheckpoints.get(session.id), checkpoint);
+            assert.strictEqual(state.discardedSessionIds.length, 0,
+                'the only durable checkpoint must not be discarded after save failure');
+            assert.strictEqual(state.interruptedRecords.length, 0);
+            assert.strictEqual(state.events.filter((event) => event.type === 'practicesessionEnded').length, 0);
         });
 
         await record('backup create and restore delegate to the backups domain', async () => {

--- a/developer/tests/js/practiceRecorder.test.js
+++ b/developer/tests/js/practiceRecorder.test.js
@@ -23,7 +23,7 @@ function loadScript(relativePath, context) {
     vm.runInContext(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'), context, { filename: relativePath });
 }
 
-function createHarness() {
+function createHarness({ now = null } = {}) {
     const state = {
         records: [],
         drafts: [{
@@ -194,7 +194,12 @@ function createHarness() {
                 state.events.push({ type: event.type, detail: clone(event.detail) });
             }
         },
-        Date,
+        Date: now === null ? Date : class extends Date {
+            constructor(...args) {
+                super(...(args.length ? args : [now]));
+            }
+            static now() { return now; }
+        },
         Math,
         JSON
     };
@@ -205,6 +210,7 @@ function createHarness() {
     const recorder = Object.create(windowStub.PracticeRecorder.prototype);
     recorder.activeSessions = new Map();
     recorder.sessionListeners = new Map();
+    recorder.sessionStartGenerations = new WeakMap();
     recorder.wait = async () => {};
     return { recorder, state, windowStub };
 }
@@ -391,17 +397,20 @@ async function main() {
             assert.deepStrictEqual(state.backupCalls.map((call) => call.method), ['previewImport']);
         });
 
-        for (const mode of ['replacement', 'identity rebind', 'same-id replacement']) {
+        for (const mode of ['replacement', 'identity rebind', 'same-id replacement', 'same-id identity rebind']) {
             await record(`delayed interrupted save preserves the session after ${mode}`, async () => {
-                const { recorder, state, windowStub } = createHarness();
+                const { recorder, state, windowStub } = createHarness({ now: Date.parse('2026-09-05T00:00:00.000Z') });
                 const examId = 'reading-p1';
                 const original = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+                recorder.handleSessionStarted({ examId, sessionId: 'session-A' });
                 recorder.handleSessionProgress({
                     examId,
                     progress: { currentQuestion: 4 },
                     answers: { q1: 'A' }
                 });
                 await recorder.saveActiveSessions();
+                const originalStatus = original.status;
+                const originalActivity = original.lastActivity;
 
                 const saveGate = deferred();
                 const saveInterrupted = windowStub.AppData.recovery.saveInterrupted;
@@ -412,8 +421,8 @@ async function main() {
                 const ending = recorder.endPracticeSession(examId, 'timeout');
                 assert.strictEqual(state.interruptedRecords.length, 0);
 
-                const sessionId = mode === 'same-id replacement' ? 'session-A' : 'session-B';
-                if (mode === 'identity rebind') {
+                const sessionId = mode.startsWith('same-id') ? 'session-A' : 'session-B';
+                if (mode.endsWith('identity rebind')) {
                     recorder.handleSessionStarted({ examId, sessionId });
                     assert.strictEqual(recorder.activeSessions.get(examId), original);
                 } else {
@@ -422,11 +431,18 @@ async function main() {
                 }
                 const replacement = recorder.activeSessions.get(examId);
                 const listener = recorder.sessionListeners.get(examId);
-                recorder.handleSessionProgress({
-                    examId,
-                    progress: { currentQuestion: 5 },
-                    answers: { q1: 'B' }
-                });
+                if (mode === 'same-id identity rebind') {
+                    assert.strictEqual(replacement.sessionId, 'session-A');
+                    assert.strictEqual(replacement.status, originalStatus);
+                    assert.strictEqual(replacement.lastActivity, originalActivity,
+                        'a restart must supersede cleanup even within the same clock tick');
+                } else {
+                    recorder.handleSessionProgress({
+                        examId,
+                        progress: { currentQuestion: 5 },
+                        answers: { q1: 'B' }
+                    });
+                }
                 await recorder.saveActiveSessions();
                 const checkpoint = clone(state.activeCheckpoints.get(replacement.id));
                 assert.strictEqual(checkpoint.sessionId, sessionId);
@@ -459,11 +475,48 @@ async function main() {
             });
         }
 
+        await record('a host start for another exam does not supersede the ending session', async () => {
+            const { recorder, state, windowStub } = createHarness();
+            const examId = 'reading-p1';
+            const original = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+            recorder.handleSessionStarted({ examId, sessionId: 'session-A' });
+            await recorder.saveActiveSessions();
+
+            const saveGate = deferred();
+            const saveInterrupted = windowStub.AppData.recovery.saveInterrupted;
+            windowStub.AppData.recovery.saveInterrupted = async (value) => {
+                await saveGate.promise;
+                return saveInterrupted(value);
+            };
+            const ending = recorder.endPracticeSession(examId, 'timeout');
+            recorder.handleSessionStarted({ examId: 'reading-p2', sessionId: 'session-B' });
+            recorder.handleSessionStarted({ examId: 'reading-p2', sessionId: 'session-B' });
+            const otherSession = recorder.activeSessions.get('reading-p2');
+            const otherListener = recorder.sessionListeners.get('reading-p2');
+            await recorder.saveActiveSessions();
+
+            saveGate.resolve();
+            assert.strictEqual(await ending, true);
+            assert.strictEqual(recorder.activeSessions.has(examId), false);
+            assert.strictEqual(recorder.sessionListeners.has(examId), false);
+            assert.strictEqual(state.activeCheckpoints.has(original.id), false);
+            assert.strictEqual(state.interruptedRecords[0].sessionId, 'session-A');
+            assert.strictEqual(recorder.activeSessions.get('reading-p2'), otherSession);
+            assert.strictEqual(recorder.sessionListeners.get('reading-p2'), otherListener);
+            assert(state.intervals.has(otherListener));
+            assert.strictEqual(state.activeCheckpoints.get(otherSession.id).sessionId, 'session-B');
+            assert.deepStrictEqual(
+                state.events.filter((event) => event.type === 'practicesessionEnded'),
+                [{ type: 'practicesessionEnded', detail: { examId, reason: 'timeout' } }]
+            );
+        });
+
         for (const reason of ['completed', 'timeout']) {
             await record(`normal ${reason} cleanup removes the session and emits one end event`, async () => {
                 const { recorder, state } = createHarness();
                 const examId = 'reading-p1';
                 const session = recorder.startPracticeSession(examId, { sessionId: 'session-A' });
+                recorder.handleSessionStarted({ examId, sessionId: 'session-A' });
                 const listener = recorder.sessionListeners.get(examId);
                 await recorder.saveActiveSessions();
 

--- a/js/bundles/practice.bundle.js
+++ b/js/bundles/practice.bundle.js
@@ -5132,7 +5132,7 @@ class PracticeRecorder {
     async endPracticeSession(examId, reason = 'completed') {
         if (!this.activeSessions.has(examId)) return false;
 
-        let session = this.activeSessions.get(examId);
+        const session = this.activeSessions.get(examId);
         let sessionEntityId;
         try {
             sessionEntityId = this.activeSessionEntityId(session);
@@ -5174,6 +5174,13 @@ class PracticeRecorder {
             }
         }
 
+        // The interrupted save may outlive a replacement or an in-place host
+        // rebind. Only the original object and identity still own this cleanup.
+        if (this.activeSessions.get(examId) !== session
+            || this.activeSessionEntityId(session) !== sessionEntityId) {
+            return true;
+        }
+
         // 清理会话
         this.activeSessions.delete(examId);
         this.cleanupSessionListener(examId);
@@ -5181,6 +5188,11 @@ class PracticeRecorder {
             await window.AppData.recovery.discardActiveSession(sessionEntityId);
         } catch (error) {
             console.error('[PracticeRecorder] 清理活动会话失败:', error);
+        }
+
+        // A new session can also start while the old checkpoint is discarded.
+        if (this.activeSessions.has(examId)) {
+            return true;
         }
 
         console.log(`Practice session ended: ${examId} (${reason})`);

--- a/js/bundles/practice.bundle.js
+++ b/js/bundles/practice.bundle.js
@@ -3920,6 +3920,7 @@ class PracticeRecorder {
     constructor() {
         this.activeSessions = new Map();
         this.sessionListeners = new Map();
+        this.sessionStartGenerations = new WeakMap();
         this.autoSaveInterval = 30000; // 30秒自动保存
         this.autoSaveTimer = null;
 
@@ -4733,6 +4734,9 @@ class PracticeRecorder {
 
         let session = this.activeSessions.get(examId);
         const previousEntityId = this.activeSessionEntityId(session);
+        // A host start supersedes pending cleanup even if its ID, status, and
+        // timestamp are unchanged. Keep this generation out of stored sessions.
+        this.sessionStartGenerations.set(session, (this.sessionStartGenerations.get(session) || 0) + 1);
         session.sessionId = sessionId;
         session.id = this.activeSessionEntityId(sessionId);
         session.status = 'active';
@@ -5133,6 +5137,7 @@ class PracticeRecorder {
         if (!this.activeSessions.has(examId)) return false;
 
         const session = this.activeSessions.get(examId);
+        const sessionStartGeneration = this.sessionStartGenerations.get(session) || 0;
         let sessionEntityId;
         try {
             sessionEntityId = this.activeSessionEntityId(session);
@@ -5175,9 +5180,10 @@ class PracticeRecorder {
         }
 
         // The interrupted save may outlive a replacement or an in-place host
-        // rebind. Only the original object and identity still own this cleanup.
+        // rebind. Only the original object, identity, and start generation own cleanup.
         if (this.activeSessions.get(examId) !== session
-            || this.activeSessionEntityId(session) !== sessionEntityId) {
+            || this.activeSessionEntityId(session) !== sessionEntityId
+            || (this.sessionStartGenerations.get(session) || 0) !== sessionStartGeneration) {
             return true;
         }
 

--- a/js/core/practiceRecorder.js
+++ b/js/core/practiceRecorder.js
@@ -1218,7 +1218,7 @@ class PracticeRecorder {
     async endPracticeSession(examId, reason = 'completed') {
         if (!this.activeSessions.has(examId)) return false;
 
-        let session = this.activeSessions.get(examId);
+        const session = this.activeSessions.get(examId);
         let sessionEntityId;
         try {
             sessionEntityId = this.activeSessionEntityId(session);
@@ -1260,6 +1260,13 @@ class PracticeRecorder {
             }
         }
 
+        // The interrupted save may outlive a replacement or an in-place host
+        // rebind. Only the original object and identity still own this cleanup.
+        if (this.activeSessions.get(examId) !== session
+            || this.activeSessionEntityId(session) !== sessionEntityId) {
+            return true;
+        }
+
         // 清理会话
         this.activeSessions.delete(examId);
         this.cleanupSessionListener(examId);
@@ -1267,6 +1274,11 @@ class PracticeRecorder {
             await window.AppData.recovery.discardActiveSession(sessionEntityId);
         } catch (error) {
             console.error('[PracticeRecorder] 清理活动会话失败:', error);
+        }
+
+        // A new session can also start while the old checkpoint is discarded.
+        if (this.activeSessions.has(examId)) {
+            return true;
         }
 
         console.log(`Practice session ended: ${examId} (${reason})`);

--- a/js/core/practiceRecorder.js
+++ b/js/core/practiceRecorder.js
@@ -6,6 +6,7 @@ class PracticeRecorder {
     constructor() {
         this.activeSessions = new Map();
         this.sessionListeners = new Map();
+        this.sessionStartGenerations = new WeakMap();
         this.autoSaveInterval = 30000; // 30秒自动保存
         this.autoSaveTimer = null;
 
@@ -819,6 +820,9 @@ class PracticeRecorder {
 
         let session = this.activeSessions.get(examId);
         const previousEntityId = this.activeSessionEntityId(session);
+        // A host start supersedes pending cleanup even if its ID, status, and
+        // timestamp are unchanged. Keep this generation out of stored sessions.
+        this.sessionStartGenerations.set(session, (this.sessionStartGenerations.get(session) || 0) + 1);
         session.sessionId = sessionId;
         session.id = this.activeSessionEntityId(sessionId);
         session.status = 'active';
@@ -1219,6 +1223,7 @@ class PracticeRecorder {
         if (!this.activeSessions.has(examId)) return false;
 
         const session = this.activeSessions.get(examId);
+        const sessionStartGeneration = this.sessionStartGenerations.get(session) || 0;
         let sessionEntityId;
         try {
             sessionEntityId = this.activeSessionEntityId(session);
@@ -1261,9 +1266,10 @@ class PracticeRecorder {
         }
 
         // The interrupted save may outlive a replacement or an in-place host
-        // rebind. Only the original object and identity still own this cleanup.
+        // rebind. Only the original object, identity, and start generation own cleanup.
         if (this.activeSessions.get(examId) !== session
-            || this.activeSessionEntityId(session) !== sessionEntityId) {
+            || this.activeSessionEntityId(session) !== sessionEntityId
+            || (this.sessionStartGenerations.get(session) || 0) !== sessionStartGeneration) {
             return true;
         }
 


### PR DESCRIPTION
## Summary

A delayed interruption save could remove a restarted exam's live session and listener. An in-place restart that reused the same session ID could also lose its checkpoint. Cleanup now revalidates the captured session object, stable identity, and per-session start generation. Each in-place host start advances the generation even when its ID, status, and timestamp are unchanged; the generation stays in memory outside stored checkpoints.

Preserve the restarted session's checkpoint and subsequent progress while still recording the original interruption. Suppress exam-scoped end events when a new session starts during checkpoint cleanup, retain normal completion and failed-save behavior, and regenerate the practice bundle. Deferred-save regressions cover object replacement, different-ID and same-ID in-place restarts with frozen time, and independent starts for other exams.

Fixes #134.
Fixes #139.

## Validation

- Confirmed the same-ID in-place restart regression fails against the previously reviewed commit.
- `node developer/tests/js/practiceRecorder.test.js` — 19 checks passed.
- `node --test --test-concurrency=1 "developer/tests/js/**/*.test.js"` — 111 tests passed.
- `python -m unittest discover -s developer/tests/py -p "test_*.py"` — 26 tests passed.
- `node scripts/build-bundles.mjs --check` — all 14 bundles are current.
- `python developer/tests/ci/run_static_suite.py` — 138 checks passed.
- `python developer/tests/e2e/full_reset_flow.py` — passed.
- `python developer/tests/e2e/suite_practice_flow.py` — passed.
