### PR TITLE
feat: add practice insights and learning-state filters

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8329,4 +8329,172 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
         grid-template-columns: minmax(0, 1fr);
     }
 }
+/* Learning-state browse filters and performance breakdowns */
+.browse-learning-filters {
+    display: grid;
+    gap: 10px;
+    margin: 0 0 var(--space-md);
+    padding: 12px 14px;
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--border-radius-lg);
+    background: color-mix(in srgb, var(--color-white) 88%, transparent);
+}
 
+.browse-filter-group {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.browse-filter-group__label {
+    min-width: 38px;
+    color: var(--color-gray-500);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+}
+
+.browse-state-chip {
+    border: 1px solid var(--color-gray-300);
+    border-radius: 999px;
+    padding: 6px 12px;
+    background: var(--color-white);
+    color: var(--color-gray-700);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--font-size-sm);
+    transition: border-color var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+}
+
+.browse-state-chip:hover { border-color: var(--color-brand-primary); }
+
+.browse-state-chip.active,
+.browse-state-chip[aria-pressed="true"] {
+    border-color: var(--color-brand-primary);
+    background: var(--color-brand-primary);
+    color: var(--color-white);
+}
+
+.exam-favorite-btn {
+    min-width: 40px;
+    padding-inline: 10px;
+    color: var(--color-gray-500);
+}
+
+.exam-favorite-btn[aria-pressed="true"] {
+    border-color: #d49a00;
+    background: #fff6d8;
+    color: #9a6800;
+}
+
+.practice-performance-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+    gap: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+}
+
+.practice-performance-panel {
+    min-width: 0;
+    padding: var(--space-xl);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--border-radius-xl);
+    background: var(--color-white);
+    box-shadow: var(--shadow-sm);
+}
+
+.practice-performance-panel__header h3 {
+    margin: 2px 0 var(--space-lg);
+    font-size: var(--font-size-lg);
+}
+
+.practice-performance-panel__eyebrow {
+    margin: 0;
+    color: var(--color-brand-primary);
+    font-size: 11px;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: .12em;
+    text-transform: uppercase;
+}
+
+.question-type-performance-list {
+    display: grid;
+    gap: 8px;
+    max-height: 340px;
+    overflow: auto;
+}
+
+.performance-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) auto;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 12px;
+    border-radius: var(--border-radius-md);
+    background: var(--color-gray-50);
+}
+
+.performance-row__heading { display: grid; gap: 2px; }
+
+.performance-row__heading span,
+.practice-performance-panel__note,
+.category-performance-card p {
+    color: var(--color-gray-500);
+    font-size: var(--font-size-xs);
+}
+
+.performance-row__metrics { display: flex; gap: 16px; }
+
+.performance-row__metrics > span {
+    display: grid;
+    min-width: 68px;
+    text-align: right;
+}
+
+.performance-row__metrics strong { color: var(--color-gray-900); }
+.performance-row__metrics small { color: var(--color-gray-500); }
+
+.practice-performance-panel__note {
+    margin: 12px 0 0;
+    line-height: 1.55;
+}
+
+.category-performance-list { display: grid; gap: 10px; }
+
+.category-performance-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 14px;
+    padding: 14px;
+    border-left: 4px solid var(--color-brand-primary);
+    border-radius: var(--border-radius-md);
+    background: var(--color-gray-50);
+}
+
+.category-performance-card h4,
+.category-performance-card p { margin: 0; }
+
+.category-performance-card__accuracy {
+    justify-self: end;
+    color: var(--color-brand-primary);
+}
+
+.category-performance-card p { grid-column: 1 / -1; }
+
+.category-performance-card.is-empty {
+    border-left-color: var(--color-gray-300);
+    opacity: .72;
+}
+
+.performance-empty {
+    margin: 0;
+    padding: 24px 12px;
+    color: var(--color-gray-500);
+    text-align: center;
+}
+
+@media (max-width: 768px) {
+    .practice-performance-grid { grid-template-columns: 1fr; }
+    .performance-row { grid-template-columns: 1fr; }
+    .performance-row__metrics > span { text-align: left; }
+}

--- a/developer/tests/js/appDataV2.test.js
+++ b/developer/tests/js/appDataV2.test.js
@@ -1461,8 +1461,12 @@ async function run() {
         suiteEntries: [{
             examId: 'reading-child',
             title: 'Child',
+            category: 'P2',
             correctAnswers: { q1: 'A', q2: 'B' },
             scoreInfo: { correct: 1, total: 2 },
+            questionTypePerformance: {
+                matching_headings: { total: 2, correct: 1, timeSpent: 90 }
+            },
             answers: { 1: 'A' },
             notes: { 1: 'private' },
             replay: { html: '<secret>' }
@@ -1473,6 +1477,10 @@ async function run() {
     assert.strictEqual(suiteLight.suiteEntrySummaries[0].totalQuestions, 2);
     assert.strictEqual(suiteLight.suiteEntrySummaries[0].accuracy, 0.5);
     assert.strictEqual(suiteLight.suiteEntrySummaries[0].type, 'reading');
+    assert.strictEqual(suiteLight.suiteEntrySummaries[0].category, 'P2');
+    assert.deepStrictEqual(suiteLight.suiteEntrySummaries[0].questionTypePerformance, {
+        matching_headings: { total: 2, correct: 1, accuracy: 0.5, timeSpent: 90 }
+    });
     assert(!JSON.stringify(suiteLight.suiteEntrySummaries).includes('answers'));
     assert(!JSON.stringify(suiteLight.suiteEntrySummaries).includes('private'));
     const insightRecord = app.practice.projectLight({
@@ -1488,6 +1496,10 @@ async function run() {
         { true_false_not_given: 2, short_answer: 1 },
         'light projection must retain compact error counts without answer content'
     );
+    assert.deepStrictEqual(insightRecord.questionTypePerformance, {
+        true_false_not_given: { total: 3, correct: 1, accuracy: 1 / 3 },
+        short_answer: { total: 2, correct: 1, accuracy: 0.5 }
+    }, 'light projection must retain compact accuracy metrics for the performance dashboard');
     const insightSuite = app.practice.projectLight({
         id: 'suite-insight',
         type: 'suite',

--- a/developer/tests/js/examFilterService.test.js
+++ b/developer/tests/js/examFilterService.test.js
@@ -195,9 +195,20 @@ function testLearningStateFiltersAndRecommendations(service) {
     const recommended = service.filterExams(exams, {
         activeExamType: 'reading',
         sortMode: 'recommended',
+        favoriteExamIds: new Set(['p2']),
         completionResolver
     });
     assert.strictEqual(recommended[0].id, 'r1-other', '智能推荐应优先安排正确率较低的已做错题');
+
+    const favoriteRecommended = service.filterExams([
+        { id: 'plain', title: 'A', category: 'P1', type: 'reading', frequency: 'low' },
+        { id: 'saved', title: 'B', category: 'P1', type: 'reading', frequency: 'low' }
+    ], {
+        activeExamType: 'reading',
+        sortMode: 'recommended',
+        favoriteExamIds: new Set(['saved'])
+    });
+    assert.strictEqual(favoriteRecommended[0].id, 'saved', '智能推荐应复用预计算的 Set 收藏索引');
 }
 
 function testLoadExamListBindsBrowseControls() {

--- a/developer/tests/js/examFilterService.test.js
+++ b/developer/tests/js/examFilterService.test.js
@@ -161,6 +161,45 @@ function testDifficultySort(service) {
     assert.strictEqual(result[result.length - 1].id, 'freq-b', '缺少 difficultyScore 的题目应排在最后');
 }
 
+function testLearningStateFiltersAndRecommendations(service) {
+    const exams = createExams();
+    const statuses = {
+        'p1-09': { percentage: 100 },
+        'r1-other': { percentage: 55 },
+        p2: { percentage: 80 }
+    };
+    const completionResolver = (exam) => statuses[exam.id] || null;
+
+    const unattempted = service.filterExams(exams, {
+        activeExamType: 'reading',
+        progressFilter: 'unattempted',
+        completionResolver
+    });
+    assert(unattempted.every((exam) => !statuses[exam.id]), '未做筛选只能保留没有练习记录的题目');
+
+    const wrong = service.filterExams(exams, {
+        activeExamType: 'reading',
+        progressFilter: 'wrong',
+        completionResolver
+    });
+    assert.deepStrictEqual(Array.from(wrong, (exam) => exam.id).sort(), ['p2', 'r1-other'], '做错筛选应保留最近正确率低于 100% 的题目');
+
+    const favorite = service.filterExams(exams, {
+        activeExamType: 'reading',
+        progressFilter: 'favorite',
+        favoriteExamIds: ['p2'],
+        completionResolver
+    });
+    assert.deepStrictEqual(Array.from(favorite, (exam) => exam.id), ['p2'], '收藏筛选应按持久化题目 id 过滤');
+
+    const recommended = service.filterExams(exams, {
+        activeExamType: 'reading',
+        sortMode: 'recommended',
+        completionResolver
+    });
+    assert.strictEqual(recommended[0].id, 'r1-other', '智能推荐应优先安排正确率较低的已做错题');
+}
+
 function testLoadExamListBindsBrowseControls() {
     const harness = createExamActionsHarness();
     assert(harness.window.ExamActions, 'ExamActions 应该挂到 window');
@@ -197,6 +236,7 @@ function main() {
     testFallbackCategoryInFrequencyMode(service);
     testFrequencySort(service);
     testDifficultySort(service);
+    testLearningStateFiltersAndRecommendations(service);
     testLoadExamListBindsBrowseControls();
     testInvalidInput(service);
     testExamFilterHostIsNotForwardOnlyStub();

--- a/developer/tests/js/practicePerformanceBreakdown.test.js
+++ b/developer/tests/js/practicePerformanceBreakdown.test.js
@@ -46,6 +46,17 @@ const records = [
                 }
             }
         ]
+    },
+    {
+        examId: 'listening-p1',
+        type: 'listening',
+        metadata: { category: 'P1' },
+        duration: 600,
+        totalQuestions: 10,
+        correctAnswers: 10,
+        questionTypePerformance: {
+            general: { total: 10, correct: 10, timeSpent: 600 }
+        }
     }
 ];
 
@@ -56,6 +67,7 @@ assert.strictEqual(result.categories[0].averageDuration, 120);
 assert.strictEqual(result.categories[1].attempts, 1, '套题子项应归入自己的 P2 分项');
 assert.strictEqual(result.categories[1].accuracy, 1 / 3);
 assert.strictEqual(result.categories[2].attempts, 0);
+assert.strictEqual(result.questionTypes.some((row) => row.type === 'other'), false, '听力题型不能混入阅读表现面板');
 
 const tfng = result.questionTypes.find((row) => row.type === 'true-false-not-given');
 const shortAnswer = result.questionTypes.find((row) => row.type === 'short-answer');

--- a/developer/tests/js/practicePerformanceBreakdown.test.js
+++ b/developer/tests/js/practicePerformanceBreakdown.test.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), '..', '..', '..');
+const source = fs.readFileSync(path.join(repoRoot, 'js/views/legacyViewBundle.js'), 'utf8');
+const windowStub = {};
+const sandbox = {
+    window: windowStub,
+    console: { log() {}, warn() {}, error() {}, info() {} },
+    setTimeout() {},
+    clearTimeout() {}
+};
+vm.runInContext(source, vm.createContext(sandbox), { filename: 'js/views/legacyViewBundle.js' });
+
+const records = [
+    {
+        examId: 'p1-a',
+        type: 'reading',
+        metadata: { category: 'P1' },
+        duration: 120,
+        totalQuestions: 4,
+        correctAnswers: 3,
+        questionTypePerformance: {
+            true_false_not_given: { total: 2, correct: 2, timeSpent: 40 },
+            short_answer: { total: 2, correct: 1 }
+        }
+    },
+    {
+        type: 'reading-suite',
+        duration: 999,
+        suiteEntrySummaries: [
+            {
+                examId: 'p2-a',
+                type: 'reading',
+                category: 'P2',
+                duration: 180,
+                totalQuestions: 3,
+                correctAnswers: 1,
+                questionTypePerformance: {
+                    short_answer: { total: 3, correct: 1 }
+                }
+            }
+        ]
+    }
+];
+
+const result = windowStub.PracticeStats.calculatePerformanceBreakdown(records, []);
+assert.strictEqual(result.categories[0].attempts, 1);
+assert.strictEqual(result.categories[0].accuracy, 0.75);
+assert.strictEqual(result.categories[0].averageDuration, 120);
+assert.strictEqual(result.categories[1].attempts, 1, '套题子项应归入自己的 P2 分项');
+assert.strictEqual(result.categories[1].accuracy, 1 / 3);
+assert.strictEqual(result.categories[2].attempts, 0);
+
+const tfng = result.questionTypes.find((row) => row.type === 'true-false-not-given');
+const shortAnswer = result.questionTypes.find((row) => row.type === 'short-answer');
+assert(tfng && shortAnswer, '题型别名应归一化后参与汇总');
+assert.strictEqual(tfng.accuracy, 1);
+assert.strictEqual(tfng.averageTime, 20, '显式题型计时应优先使用');
+assert.strictEqual(shortAnswer.correct, 2);
+assert.strictEqual(shortAnswer.total, 5);
+assert.strictEqual(shortAnswer.duration, 260, '缺少逐题计时时应按剩余整场耗时折算');
+assert.strictEqual(shortAnswer.estimatedTime, true);
+
+console.log(JSON.stringify({
+    status: 'pass',
+    detail: 'practice performance breakdown tests passed'
+}, null, 2));

--- a/developer/tests/js/practicePerformanceBreakdown.test.js
+++ b/developer/tests/js/practicePerformanceBreakdown.test.js
@@ -57,6 +57,19 @@ const records = [
         questionTypePerformance: {
             general: { total: 10, correct: 10, timeSpent: 600 }
         }
+    },
+    {
+        type: 'listening-suite',
+        suiteEntrySummaries: [
+            {
+                examId: 'legacy-listening-child',
+                category: 'P2',
+                duration: 300,
+                questionTypePerformance: {
+                    general: { total: 5, correct: 5, timeSpent: 300 }
+                }
+            }
+        ]
     }
 ];
 

--- a/developer/tests/js/unifiedReadingCoreRegression.test.js
+++ b/developer/tests/js/unifiedReadingCoreRegression.test.js
@@ -687,6 +687,31 @@ function testQuestionTypePerformanceIncludesActiveTiming() {
     assert.strictEqual(results.answerComparison.q3.timeSpent, 15);
 }
 
+function testDropzoneTimingTargetsDroppedQuestion() {
+    const { hooks } = loadHooks();
+    hooks.setTestState({
+        dataset: { questionOrder: ['q1', 'q2'] },
+        currentActiveQuestionId: 'q1',
+        questionTimingStartedAtMs: 1000,
+        questionTimeSpentMs: {},
+        readOnly: false,
+        reviewMode: false,
+        submitted: false
+    });
+    assert.strictEqual(hooks.checkpointActiveQuestionTiming(2000, false), 1000);
+    hooks.setTestInteraction({
+        timerRunning: true,
+        questionDragStartedAtMs: 2000,
+        questionDragOriginId: 'q1',
+        questionDragCommitted: false
+    });
+
+    const target = { dataset: { question: 'q2' } };
+    assert.strictEqual(hooks.resolveDropzoneQuestionId(target), 'q2');
+    assert.strictEqual(hooks.activateQuestionTimingForDropzone(target), true);
+    assert.strictEqual(hooks.checkpointActiveQuestionTiming(5000, false), 3000, '拖拽耗时应归入目标题');
+}
+
 async function main() {
     testClimateLogbookProductionAnswers();
     testWaterFilterProductionAnswersRemainSlotSpecific();
@@ -721,6 +746,7 @@ async function main() {
     testJudgementChoicesRemainAvailableForHighlighting();
     testSuiteTimerIgnoresEmptyLimitValues();
     testQuestionTypePerformanceIncludesActiveTiming();
+    testDropzoneTimingTargetsDroppedQuestion();
     process.stdout.write(JSON.stringify({
         status: 'pass',
         detail: 'unified reading submit/timer/scoring regressions covered'

--- a/developer/tests/js/unifiedReadingCoreRegression.test.js
+++ b/developer/tests/js/unifiedReadingCoreRegression.test.js
@@ -659,6 +659,34 @@ function testSuiteTimerIgnoresEmptyLimitValues() {
     assert.strictEqual(timer.textContent, '60 minutes remaining', 'empty suite timer limit should fall back instead of rendering 0 minutes remaining');
 }
 
+function testQuestionTypePerformanceIncludesActiveTiming() {
+    const { hooks } = loadHooks();
+    hooks.setTestState({
+        currentActiveQuestionId: 'q1',
+        questionTimingStartedAtMs: 1000,
+        questionTimeSpentMs: {}
+    });
+    assert.strictEqual(hooks.checkpointActiveQuestionTiming(6000, false), 5000, 'active question timing should checkpoint elapsed milliseconds');
+    const dataset = {
+        questionOrder: ['q1', 'q2', 'q3'],
+        answerKey: { q1: 'A', q2: 'B', q3: 'C' },
+        questionGroups: [
+            { kind: 'true_false_not_given', questionIds: ['q1', 'q2'] },
+            { kind: 'short_answer', questionIds: ['q3'] }
+        ]
+    };
+    const results = hooks.buildResultsFromAnswers(
+        dataset,
+        { q1: 'A', q2: 'X', q3: 'C' },
+        { q1: 12000, q2: 8000, q3: 15000 }
+    );
+
+    assert.strictEqual(results.questionTypePerformance['true-false-not-given'].timeSpent, 20);
+    assert.strictEqual(results.questionTypePerformance['true-false-not-given'].averageTime, 10);
+    assert.strictEqual(results.questionTypePerformance['short-answer'].timeSpent, 15);
+    assert.strictEqual(results.answerComparison.q3.timeSpent, 15);
+}
+
 async function main() {
     testClimateLogbookProductionAnswers();
     testWaterFilterProductionAnswersRemainSlotSpecific();
@@ -692,6 +720,7 @@ async function main() {
     testPersistedChoiceStringSplitsForHighlighting();
     testJudgementChoicesRemainAvailableForHighlighting();
     testSuiteTimerIgnoresEmptyLimitValues();
+    testQuestionTypePerformanceIncludesActiveTiming();
     process.stdout.write(JSON.stringify({
         status: 'pass',
         detail: 'unified reading submit/timer/scoring regressions covered'

--- a/developer/tests/js/unifiedReadingCoreRegression.test.js
+++ b/developer/tests/js/unifiedReadingCoreRegression.test.js
@@ -712,6 +712,28 @@ function testDropzoneTimingTargetsDroppedQuestion() {
     assert.strictEqual(hooks.checkpointActiveQuestionTiming(5000, false), 3000, '拖拽耗时应归入目标题');
 }
 
+function testGroupedCheckboxFocusTargetsQuestionTiming() {
+    const { hooks } = loadHooks();
+    hooks.setTestState({
+        dataset: {
+            questionOrder: ['q9', 'q10', 'q11'],
+            answerKey: { q9: 'A', q10: 'B', q11: 'C' },
+            questionGroups: [{ kind: 'multi_choice', questionIds: ['q10', 'q11'] }]
+        },
+        currentActiveQuestionId: 'q9',
+        questionTimingStartedAtMs: 1000,
+        questionTimeSpentMs: {},
+        readOnly: false,
+        reviewMode: false,
+        submitted: false
+    });
+    hooks.setTestInteraction({ timerRunning: true });
+
+    assert.strictEqual(hooks.resolveNamedControlQuestionId('q10_11'), 'q10');
+    assert.strictEqual(hooks.activateQuestionTimingForNamedControl('q10_11', 3000), true);
+    assert.strictEqual(hooks.checkpointActiveQuestionTiming(5000, false), 2000, '组合多选计时应切换到题组内题目');
+}
+
 async function main() {
     testClimateLogbookProductionAnswers();
     testWaterFilterProductionAnswersRemainSlotSpecific();
@@ -747,6 +769,7 @@ async function main() {
     testSuiteTimerIgnoresEmptyLimitValues();
     testQuestionTypePerformanceIncludesActiveTiming();
     testDropzoneTimingTargetsDroppedQuestion();
+    testGroupedCheckboxFocusTargetsQuestionTiming();
     process.stdout.write(JSON.stringify({
         status: 'pass',
         detail: 'unified reading submit/timer/scoring regressions covered'

--- a/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
+++ b/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
@@ -281,6 +281,49 @@ async function testInlinePartTimingAccumulatesMillisecondsAndFreezesSubmissionRo
     assert.strictEqual(slot.durationMs, pausedDurationMs, 'paused time must not accrue into the active part');
 }
 
+async function testInlineSubmissionCheckpointsActiveQuestionTiming() {
+    const { hooks } = loadHooks();
+    const dataset = {
+        meta: { title: 'Timed Submission Part' },
+        questionOrder: ['q1'],
+        answerKey: { q1: 'A' },
+        questionGroups: [{ kind: 'short_answer', questionIds: ['q1'] }]
+    };
+    const slot = {
+        examId: 'timed-submit-part',
+        title: 'Timed Submission Part',
+        category: 'P1',
+        dataset,
+        draft: { answers: { q1: 'A' }, updatedAt: Date.now() - 5000 },
+        questionTimeSpentMs: {},
+        durationMs: 0,
+        durationSeconds: 0,
+        navStatus: new Map()
+    };
+    hooks.setTestState({
+        dataset,
+        currentActiveQuestionId: 'q1',
+        questionTimingStartedAtMs: Date.now() - 5000,
+        readOnly: false,
+        reviewMode: false,
+        submitted: false,
+        suite: {
+            inline: true,
+            activeExamId: 'timed-submit-part',
+            activeStartedAtMs: Date.now() - 5000,
+            sequence: [{ examId: 'timed-submit-part', title: 'Timed Submission Part', category: 'P1' }],
+            slotsByExamId: new Map([['timed-submit-part', slot]])
+        }
+    });
+    hooks.setTestInteraction({ timerRunning: true });
+
+    const snapshot = hooks.buildInlineSuiteSubmissionSnapshot();
+    const performance = snapshot.suiteEntries[0].questionTypePerformance['short-answer'];
+    assert(performance, 'inline suite submission should include active question type performance');
+    assert(performance.timeSpent >= 4.5, 'running active-question time must be checkpointed before suite scoring');
+    assert(snapshot.results.questionTypePerformance['short-answer'].timeSpent >= 4.5);
+}
+
 async function testInlineEnvelopeGuard() {
     const { hooks } = loadHooks();
 
@@ -915,6 +958,7 @@ async function main() {
     await testDraftArbitration();
     await testSuiteTimerModePrecedence();
     await testInlinePartTimingAccumulatesMillisecondsAndFreezesSubmissionRows();
+    await testInlineSubmissionCheckpointsActiveQuestionTiming();
     await testInlineEnvelopeGuard();
     await testInlineReinitSnapshot();
     await testWindowSessionMessageGuard();

--- a/index.html
+++ b/index.html
@@ -219,6 +219,32 @@
                     </div>
                 </div>
 
+                <div class="browse-learning-filters" aria-label="学习状态筛选">
+                    <div
+                        id="browse-category-filter-buttons"
+                        class="browse-filter-group"
+                        aria-label="阅读分项"
+                    >
+                        <span class="browse-filter-group__label">分项</span>
+                        <button class="browse-state-chip active" type="button" aria-pressed="true" data-category-filter="all">全部</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-category-filter="P1">P1</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-category-filter="P2">P2</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-category-filter="P3">P3</button>
+                    </div>
+                    <div
+                        id="browse-progress-filter-buttons"
+                        class="browse-filter-group"
+                        aria-label="练习状态"
+                    >
+                        <span class="browse-filter-group__label">状态</span>
+                        <button class="browse-state-chip active" type="button" aria-pressed="true" data-progress-filter="all">全部</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-progress-filter="unattempted">未做</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-progress-filter="completed">已做</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-progress-filter="wrong">做错</button>
+                        <button class="browse-state-chip" type="button" aria-pressed="false" data-progress-filter="favorite">收藏</button>
+                    </div>
+                </div>
+
                 <div class="search-box">
                     <div class="search-row">
                         <div class="search-input-wrap">
@@ -296,6 +322,7 @@
                                 aria-label="题库排序"
                             >
                                 <option value="default">默认排序</option>
+                                <option value="recommended">智能推荐</option>
                                 <option value="frequency-desc">
                                     频率高→低
                                 </option>
@@ -374,6 +401,28 @@
                             <div class="hero-card__value" id="streak-days">0</div>
                             <div class="hero-card__meta">坚持天数</div>
                         </div>
+                    </div>
+
+                    <div class="practice-performance-grid">
+                        <section class="practice-performance-panel" aria-labelledby="question-type-performance-title">
+                            <div class="practice-performance-panel__header">
+                                <div>
+                                    <p class="practice-performance-panel__eyebrow">Question types</p>
+                                    <h3 id="question-type-performance-title">各题型正确率与平均耗时</h3>
+                                </div>
+                            </div>
+                            <div id="question-type-performance-list" class="question-type-performance-list"></div>
+                            <p id="question-type-time-note" class="practice-performance-panel__note"></p>
+                        </section>
+                        <section class="practice-performance-panel" aria-labelledby="category-performance-title">
+                            <div class="practice-performance-panel__header">
+                                <div>
+                                    <p class="practice-performance-panel__eyebrow">Passage parts</p>
+                                    <h3 id="category-performance-title">P1 / P2 / P3 分项表现</h3>
+                                </div>
+                            </div>
+                            <div id="category-performance-list" class="category-performance-list"></div>
+                        </section>
                     </div>
 
                     <div class="practice-insights-grid">

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -122,6 +122,9 @@
     }
 
     function resolveFavoriteExamIds(value) {
+        if (value && typeof value.has === 'function' && Object.prototype.toString.call(value) === '[object Set]') {
+            return value;
+        }
         return new Set((Array.isArray(value) ? value : (global.__browseFavoriteExamIds || []))
             .map((id) => String(id || '').trim())
             .filter(Boolean));
@@ -177,9 +180,10 @@
         const list = Array.isArray(exams) ? exams.slice() : [];
         const mode = String(sortMode || global.__browseSortMode || 'default').trim().toLowerCase();
         if (mode === 'recommended') {
+            const favorites = resolveFavoriteExamIds(favoriteExamIds);
             return list.sort((a, b) => {
-                const scoreDiff = recommendationScore(b, favoriteExamIds, completionResolver)
-                    - recommendationScore(a, favoriteExamIds, completionResolver);
+                const scoreDiff = recommendationScore(b, favorites, completionResolver)
+                    - recommendationScore(a, favorites, completionResolver);
                 return scoreDiff || compareByCategoryThenTitle(a, b);
             });
         }
@@ -264,7 +268,7 @@
         const progressFilter = normalizeBrowseProgressFilter(
             safeState.progressFilter || safeState.browseProgressFilter || global.__browseProgressFilter || 'all'
         );
-        const favoriteExamIds = Array.isArray(safeState.favoriteExamIds)
+        const favoriteExamIds = safeState.favoriteExamIds !== undefined
             ? safeState.favoriteExamIds
             : global.__browseFavoriteExamIds;
         const completionResolver = typeof safeState.completionResolver === 'function'

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -116,9 +116,73 @@
         return list.filter((exam) => normalizeFrequencyBucket(exam) === filter);
     }
 
-    function applyExamSort(exams, sortMode) {
+    function normalizeBrowseProgressFilter(value) {
+        const raw = String(value || '').trim().toLowerCase();
+        return ['unattempted', 'completed', 'wrong', 'favorite'].includes(raw) ? raw : 'all';
+    }
+
+    function resolveFavoriteExamIds(value) {
+        return new Set((Array.isArray(value) ? value : (global.__browseFavoriteExamIds || []))
+            .map((id) => String(id || '').trim())
+            .filter(Boolean));
+    }
+
+    function isFavoriteExam(exam, favoriteExamIds) {
+        return Boolean(exam && exam.id && resolveFavoriteExamIds(favoriteExamIds).has(String(exam.id)));
+    }
+
+    function resolveExamCompletionStatus(exam, resolver) {
+        const getStatus = typeof resolver === 'function'
+            ? resolver
+            : (typeof global.getBrowseCompletionStatus === 'function' ? global.getBrowseCompletionStatus : null);
+        if (!getStatus) return null;
+        try {
+            return getStatus(exam) || null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function applyBrowseProgressFilter(exams, progressFilter, favoriteExamIds, completionResolver) {
+        const list = Array.isArray(exams) ? exams.slice() : [];
+        const filter = normalizeBrowseProgressFilter(progressFilter || global.__browseProgressFilter || 'all');
+        if (filter === 'all') return list;
+        const favorites = resolveFavoriteExamIds(favoriteExamIds);
+        if (filter === 'favorite') {
+            return list.filter((exam) => exam && exam.id && favorites.has(String(exam.id)));
+        }
+        return list.filter((exam) => {
+            const status = resolveExamCompletionStatus(exam, completionResolver);
+            if (filter === 'unattempted') return !status;
+            if (filter === 'completed') return Boolean(status);
+            return Boolean(status && Number(status.percentage) < 100);
+        });
+    }
+
+    function recommendationScore(exam, favoriteExamIds, completionResolver) {
+        const status = resolveExamCompletionStatus(exam, completionResolver);
+        let score = resolveFrequencyRank(exam) * 8;
+        if (!status) {
+            score += 120;
+        } else if (Number(status.percentage) < 100) {
+            score += 200 + Math.max(0, 100 - Number(status.percentage || 0));
+        }
+        if (isFavoriteExam(exam, favoriteExamIds)) score += 6;
+        const difficulty = resolveDifficultyScore(exam);
+        if (Number.isFinite(difficulty)) score += difficulty;
+        return score;
+    }
+
+    function applyExamSort(exams, sortMode, favoriteExamIds, completionResolver) {
         const list = Array.isArray(exams) ? exams.slice() : [];
         const mode = String(sortMode || global.__browseSortMode || 'default').trim().toLowerCase();
+        if (mode === 'recommended') {
+            return list.sort((a, b) => {
+                const scoreDiff = recommendationScore(b, favoriteExamIds, completionResolver)
+                    - recommendationScore(a, favoriteExamIds, completionResolver);
+                return scoreDiff || compareByCategoryThenTitle(a, b);
+            });
+        }
         if (mode === 'difficulty-desc') {
             return list.sort((a, b) => {
                 const difficultyA = resolveDifficultyScore(a);
@@ -141,10 +205,16 @@
         });
     }
 
-    function applyBrowsePostFilters(exams, sortMode, frequencyFilter) {
+    function applyBrowsePostFilters(exams, sortMode, frequencyFilter, progressFilter, favoriteExamIds, completionResolver) {
         const deduplicated = deduplicateExams(exams);
         const frequencyFiltered = applyBrowseFrequencyFilter(deduplicated, frequencyFilter);
-        return applyExamSort(frequencyFiltered, sortMode);
+        const progressFiltered = applyBrowseProgressFilter(
+            frequencyFiltered,
+            progressFilter,
+            favoriteExamIds,
+            completionResolver
+        );
+        return applyExamSort(progressFiltered, sortMode, favoriteExamIds, completionResolver);
     }
 
     function hasListeningEntries(exams) {
@@ -191,6 +261,15 @@
         const frequencyFilter = normalizeBrowseFrequencyFilter(
             safeState.frequencyFilter || safeState.browseFrequencyFilter || global.__browseFrequencyFilter || 'all'
         );
+        const progressFilter = normalizeBrowseProgressFilter(
+            safeState.progressFilter || safeState.browseProgressFilter || global.__browseProgressFilter || 'all'
+        );
+        const favoriteExamIds = Array.isArray(safeState.favoriteExamIds)
+            ? safeState.favoriteExamIds
+            : global.__browseFavoriteExamIds;
+        const completionResolver = typeof safeState.completionResolver === 'function'
+            ? safeState.completionResolver
+            : null;
         const isFrequencyMode = filterMode !== 'default';
         const basePathFilter = isFrequencyMode
             && typeof safeState.basePathFilter === 'string'
@@ -236,7 +315,14 @@
             }
         }
 
-        return applyBrowsePostFilters(list, sortMode, frequencyFilter);
+        return applyBrowsePostFilters(
+            list,
+            sortMode,
+            frequencyFilter,
+            progressFilter,
+            favoriteExamIds,
+            completionResolver
+        );
     }
 
     function formatFrequencyLabel(frequency) {
@@ -1009,6 +1095,9 @@
         try {
             global.__browseFilterMode = 'default';
             global.__browsePath = null;
+            if (typeof global.updateBrowseProgressButtons === 'function') {
+                global.updateBrowseProgressButtons('all');
+            }
             setBrowseFrequencyFilter('all');
         } catch (error) {
             console.warn('[ExamActions] 重置题库功能状态失败:', error);
@@ -1071,6 +1160,20 @@
                 }
             });
         }
+        ['browse-category-filter-buttons', 'browse-progress-filter-buttons'].forEach((containerId) => {
+            const container = document.getElementById(containerId);
+            if (!container || typeof container.querySelectorAll !== 'function') return;
+            container.querySelectorAll('button').forEach((button) => {
+                const value = button.dataset && (button.dataset.categoryFilter || button.dataset.progressFilter);
+                const active = value === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        });
         return true;
     }
 
@@ -1114,6 +1217,7 @@
         try {
             await preferences.patchBrowse({
                 frequencyFilter: 'all',
+                progressFilter: 'all',
                 filter: { category: 'all', type: 'all' }
             });
             return true;
@@ -1143,7 +1247,8 @@
     function isPersistedBrowseReset(browse, requireStateManager) {
         if (!browse || !isAllBrowseFilter(browse.lastFilter)
             || !isAllBrowseFilter(browse.filter)
-            || browse.frequencyFilter !== 'all') {
+            || browse.frequencyFilter !== 'all'
+            || (browse.progressFilter && browse.progressFilter !== 'all')) {
             return false;
         }
         if (!requireStateManager) {
@@ -1715,6 +1820,20 @@
             return item;
         }
 
+        if (!isSelecting) {
+            const favoriteBtn = document.createElement('button');
+            const favorite = isFavoriteExam(exam);
+            favoriteBtn.className = 'btn btn-outline exam-item-action-btn exam-favorite-btn';
+            favoriteBtn.type = 'button';
+            favoriteBtn.dataset.action = 'favorite';
+            if (exam.id) favoriteBtn.dataset.examId = exam.id;
+            favoriteBtn.textContent = favorite ? '★' : '☆';
+            favoriteBtn.title = favorite ? '取消收藏' : '收藏题目';
+            favoriteBtn.setAttribute('aria-label', (favorite ? '取消收藏 ' : '收藏 ') + (exam.title || ''));
+            favoriteBtn.setAttribute('aria-pressed', favorite ? 'true' : 'false');
+            actions.appendChild(favoriteBtn);
+        }
+
         const startBtn = document.createElement('button');
         startBtn.className = 'btn exam-item-action-btn';
         startBtn.type = 'button';
@@ -1794,6 +1913,13 @@
                 return;
             }
 
+            if (action === 'favorite') {
+                if (typeof global.toggleBrowseFavorite === 'function') {
+                    global.toggleBrowseFavorite(examId);
+                }
+                return;
+            }
+
             if (action === 'reading-memorize-select') {
                 launchReadingMemorizeExam(examId);
                 return;
@@ -1839,6 +1965,9 @@
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="generate"]', function (event) {
+                invoke(this, event);
+            });
+            global.DOM.delegate('click', '[data-action="favorite"]', function (event) {
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="suite-custom-select"]', function (event) {
@@ -1995,7 +2124,10 @@
         applyExamSort,
         applyBrowsePostFilters,
         applyBrowseFrequencyFilter,
+        applyBrowseProgressFilter,
         normalizeBrowseFrequencyFilter,
+        normalizeBrowseProgressFilter,
+        isFavoriteExam,
         setBrowseFrequencyFilter,
         browseFilterStateOwner,
         resetBrowseFilterStateToAll,

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -260,10 +260,170 @@
         });
     }
 
+    function firstPerformanceNumber() {
+        for (var i = 0; i < arguments.length; i += 1) {
+            if (arguments[i] === undefined || arguments[i] === null || arguments[i] === '') {
+                continue;
+            }
+            var numeric = Number(arguments[i]);
+            if (isFinite(numeric) && numeric >= 0) {
+                return numeric;
+            }
+        }
+        return 0;
+    }
+
+    function resolvePerformanceCategory(record, exams) {
+        var metadata = record && record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        var raw = record && (record.category || metadata.category) || '';
+        var matched = String(raw).toUpperCase().match(/P([1-3])/);
+        if (matched) {
+            return 'P' + matched[1];
+        }
+        var exam = ensureArray(exams).find(function findExam(item) {
+            return item && record && (
+                (record.examId && item.id === record.examId) ||
+                (record.title && item.title === record.title)
+            );
+        });
+        var examCategory = exam && String(exam.category || '').toUpperCase().match(/P([1-3])/);
+        return examCategory ? 'P' + examCategory[1] : '';
+    }
+
+    function expandPerformanceRecords(records) {
+        var expanded = [];
+        ensureArray(records).forEach(function expandRecord(record) {
+            var entries = ensureArray(record && record.suiteEntrySummaries);
+            if (!entries.length) {
+                entries = ensureArray(record && record.suiteEntries);
+            }
+            if (!entries.length) {
+                expanded.push(record);
+                return;
+            }
+            entries.forEach(function addEntry(entry) {
+                expanded.push(Object.assign({}, entry || {}, {
+                    date: (entry && entry.date) || (record && record.date),
+                    metadata: Object.assign({}, (record && record.metadata) || {}, (entry && entry.metadata) || {})
+                }));
+            });
+        });
+        return expanded.filter(Boolean);
+    }
+
+    function calculatePerformanceBreakdown(records, exams) {
+        var questionTypes = {};
+        var categories = {
+            P1: { category: 'P1', attempts: 0, total: 0, correct: 0, duration: 0 },
+            P2: { category: 'P2', attempts: 0, total: 0, correct: 0, duration: 0 },
+            P3: { category: 'P3', attempts: 0, total: 0, correct: 0, duration: 0 }
+        };
+
+        expandPerformanceRecords(records).forEach(function aggregateRecord(record) {
+            var performanceMap = record.questionTypePerformance ||
+                (record.realData && record.realData.questionTypePerformance) || {};
+            var duration = firstPerformanceNumber(record.duration);
+            var performanceTotal = Object.keys(performanceMap).reduce(function sumTypes(sum, type) {
+                var metrics = performanceMap[type] || {};
+                return sum + firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+            }, 0);
+            var explicitTimeTotal = Object.keys(performanceMap).reduce(function sumExplicitTime(sum, type) {
+                var metrics = performanceMap[type] || {};
+                return sum + firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+            }, 0);
+            var unallocatedQuestionTotal = Object.keys(performanceMap).reduce(function sumUnallocated(sum, type) {
+                var metrics = performanceMap[type] || {};
+                var explicit = firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+                return explicit > 0 ? sum : sum + firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+            }, 0);
+
+            Object.keys(performanceMap).forEach(function aggregateType(rawType) {
+                var metrics = performanceMap[rawType] || {};
+                var type = normalizeReadingQuestionType(rawType);
+                var total = firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+                var correct = Math.min(total, firstPerformanceNumber(metrics.correctAnswers, metrics.correct));
+                var explicitTime = firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+                var allocatedTime = explicitTime > 0
+                    ? explicitTime
+                    : (unallocatedQuestionTotal > 0
+                        ? Math.max(0, duration - explicitTimeTotal) * total / unallocatedQuestionTotal
+                        : 0);
+                if (!questionTypes[type]) {
+                    questionTypes[type] = {
+                        type: type,
+                        label: formatQuestionTypeStr(type),
+                        total: 0,
+                        correct: 0,
+                        duration: 0,
+                        estimatedTime: false
+                    };
+                }
+                questionTypes[type].total += total;
+                questionTypes[type].correct += correct;
+                questionTypes[type].duration += allocatedTime;
+                if (explicitTime <= 0 && allocatedTime > 0) {
+                    questionTypes[type].estimatedTime = true;
+                }
+            });
+
+            var category = resolvePerformanceCategory(record, exams);
+            if (categories[category]) {
+                var totalQuestions = firstPerformanceNumber(record.totalQuestions);
+                var correctAnswers = Math.min(totalQuestions, firstPerformanceNumber(record.correctAnswers));
+                if (totalQuestions <= 0 && performanceTotal > 0) {
+                    totalQuestions = performanceTotal;
+                    correctAnswers = Object.keys(performanceMap).reduce(function sumCorrect(sum, type) {
+                        var metrics = performanceMap[type] || {};
+                        return sum + firstPerformanceNumber(metrics.correctAnswers, metrics.correct);
+                    }, 0);
+                }
+                categories[category].attempts += 1;
+                categories[category].total += totalQuestions;
+                categories[category].correct += Math.min(totalQuestions, correctAnswers);
+                categories[category].duration += duration;
+            }
+        });
+
+        var typeRows = Object.keys(questionTypes).map(function finalizeType(type) {
+            var row = questionTypes[type];
+            row.accuracy = row.total > 0 ? row.correct / row.total : 0;
+            row.averageTime = row.total > 0 ? row.duration / row.total : 0;
+            return row;
+        }).sort(function sortTypes(a, b) {
+            var indexA = readingQuestionTypeOrder.indexOf(a.type);
+            var indexB = readingQuestionTypeOrder.indexOf(b.type);
+            return (indexA < 0 ? 999 : indexA) - (indexB < 0 ? 999 : indexB);
+        });
+
+        var categoryRows = ['P1', 'P2', 'P3'].map(function finalizeCategory(category) {
+            var row = categories[category];
+            row.accuracy = row.total > 0 ? row.correct / row.total : 0;
+            row.averageDuration = row.attempts > 0 ? row.duration / row.attempts : 0;
+            return row;
+        });
+        return { questionTypes: typeRows, categories: categoryRows };
+    }
+
     var PracticeStats = {
         calculateSummary: calculateSummary,
         sortByDateDesc: sortByDateDesc,
-        filterByExamType: filterByExamType
+        filterByExamType: filterByExamType,
+        calculatePerformanceBreakdown: calculatePerformanceBreakdown
     };
 
     // --- Practice dashboard view ---
@@ -300,6 +460,107 @@
             element.textContent = value;
         }
     };
+
+    function PracticePerformanceView(options) {
+        options = options || {};
+        this.questionTypeId = options.questionTypeId || 'question-type-performance-list';
+        this.categoryId = options.categoryId || 'category-performance-list';
+        this.noteId = options.noteId || 'question-type-time-note';
+    }
+
+    PracticePerformanceView.prototype.update = function update(data) {
+        if (typeof document === 'undefined') return;
+        data = data || { questionTypes: [], categories: [] };
+        this._renderQuestionTypes(ensureArray(data.questionTypes));
+        this._renderCategories(ensureArray(data.categories));
+        var note = document.getElementById(this.noteId);
+        if (note) {
+            var estimated = ensureArray(data.questionTypes).some(function hasEstimate(row) {
+                return row && row.estimatedTime;
+            });
+            note.textContent = estimated
+                ? '平均耗时按整场用时与各题型题数折算；新记录若含题型计时则优先使用实际值。'
+                : '平均耗时为每题实际或记录内可用耗时。';
+        }
+    };
+
+    PracticePerformanceView.prototype._renderQuestionTypes = function renderQuestionTypes(rows) {
+        var container = document.getElementById(this.questionTypeId);
+        if (!container) return;
+        container.textContent = '';
+        if (!rows.length) {
+            container.appendChild(this._empty('完成一次阅读练习后，这里会显示题型表现。'));
+            return;
+        }
+        rows.forEach(function renderRow(row) {
+            var item = document.createElement('div');
+            item.className = 'performance-row';
+            var heading = document.createElement('div');
+            heading.className = 'performance-row__heading';
+            var name = document.createElement('strong');
+            name.textContent = row.label;
+            var count = document.createElement('span');
+            count.textContent = Math.round(row.correct * 10) / 10 + ' / ' + Math.round(row.total * 10) / 10 + ' 题';
+            heading.appendChild(name);
+            heading.appendChild(count);
+            var metrics = document.createElement('div');
+            metrics.className = 'performance-row__metrics';
+            metrics.appendChild(this._metric('正确率', formatPercentage(row.accuracy * 100)));
+            metrics.appendChild(this._metric('平均耗时', formatPerformanceDuration(row.averageTime)));
+            item.appendChild(heading);
+            item.appendChild(metrics);
+            container.appendChild(item);
+        }, this);
+    };
+
+    PracticePerformanceView.prototype._renderCategories = function renderCategories(rows) {
+        var container = document.getElementById(this.categoryId);
+        if (!container) return;
+        container.textContent = '';
+        rows.forEach(function renderCategory(row) {
+            var item = document.createElement('article');
+            item.className = 'category-performance-card' + (row.attempts ? '' : ' is-empty');
+            var title = document.createElement('h4');
+            title.textContent = row.category;
+            var accuracy = document.createElement('strong');
+            accuracy.className = 'category-performance-card__accuracy';
+            accuracy.textContent = row.attempts ? formatPercentage(row.accuracy * 100) : '暂无记录';
+            var detail = document.createElement('p');
+            detail.textContent = row.attempts
+                ? row.attempts + ' 篇 · ' + (Math.round(row.correct * 10) / 10) + '/' + (Math.round(row.total * 10) / 10) + ' 题 · 平均 ' + formatPerformanceDuration(row.averageDuration) + '/篇'
+                : '完成对应分项后生成统计';
+            item.appendChild(title);
+            item.appendChild(accuracy);
+            item.appendChild(detail);
+            container.appendChild(item);
+        });
+    };
+
+    PracticePerformanceView.prototype._metric = function metric(label, value) {
+        var wrapper = document.createElement('span');
+        var strong = document.createElement('strong');
+        strong.textContent = value;
+        var text = document.createElement('small');
+        text.textContent = label;
+        wrapper.appendChild(strong);
+        wrapper.appendChild(text);
+        return wrapper;
+    };
+
+    PracticePerformanceView.prototype._empty = function empty(message) {
+        var element = document.createElement('p');
+        element.className = 'performance-empty';
+        element.textContent = message;
+        return element;
+    };
+
+    function formatPerformanceDuration(seconds) {
+        var value = Math.max(0, Number(seconds) || 0);
+        if (value < 60) return Math.round(value) + ' 秒';
+        var minutes = Math.floor(value / 60);
+        var remainder = Math.round(value % 60);
+        return remainder ? minutes + '分' + remainder + '秒' : minutes + ' 分钟';
+    }
 
     function formatPercentage(value) {
         if (typeof value !== 'number' || isNaN(value)) {
@@ -2825,6 +3086,20 @@
         var actions = this._createElement('div', { className: 'exam-actions' });
         var actionConfig = this._resolveActionConfig(exam, options);
 
+        if (!isSelecting && !isMemorizeSelecting) {
+            var favoriteIds = Array.isArray(window.__browseFavoriteExamIds) ? window.__browseFavoriteExamIds : [];
+            var isFavorite = favoriteIds.map(String).indexOf(String(exam.id)) !== -1;
+            var favoriteBtn = this._createElement('button', {
+                className: 'btn btn-secondary exam-item-action-btn exam-favorite-btn',
+                dataset: { action: 'favorite', examId: exam.id },
+                type: 'button',
+                title: isFavorite ? '取消收藏' : '收藏题目'
+            }, isFavorite ? '★' : '☆');
+            favoriteBtn.setAttribute('aria-label', isFavorite ? '取消收藏 ' + (exam.title || '') : '收藏 ' + (exam.title || ''));
+            favoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
+            actions.appendChild(favoriteBtn);
+        }
+
         var startBtn = this._createElement('button', {
             className: actionConfig.startClass,
             dataset: { action: actionConfig.startAction, examId: exam.id },
@@ -3426,6 +3701,14 @@
         };
     };
 
+    LegacyExamListView.prototype.getCompletionStatus = function getCompletionStatus(exam) {
+        return this._getCompletionStatus(exam);
+    };
+
+    global.getBrowseCompletionStatus = function getBrowseCompletionStatus(exam) {
+        return LegacyExamListView.prototype._getCompletionStatus.call(null, exam);
+    };
+
     global.prepareBrowseCompletionIndex = prepareBrowseCompletionIndex;
     global.isPreparedBrowseCompletionIndex = isPreparedBrowseCompletionIndex;
     global.commitBrowseCompletionIndex = commitBrowseCompletionIndex;
@@ -3980,6 +4263,7 @@
 
     global.PracticeStats = PracticeStats;
     global.PracticeDashboardView = PracticeDashboardView;
+    global.PracticePerformanceView = PracticePerformanceView;
     global.PracticeTrendRenderer = PracticeTrendRenderer;
     global.PracticePriorityRenderer = PracticePriorityRenderer;
     global.PracticeHistoryRenderer = historyRenderer;
@@ -4311,9 +4595,73 @@
         return list.filter((exam) => normalizeFrequencyBucket(exam) === filter);
     }
 
-    function applyExamSort(exams, sortMode) {
+    function normalizeBrowseProgressFilter(value) {
+        const raw = String(value || '').trim().toLowerCase();
+        return ['unattempted', 'completed', 'wrong', 'favorite'].includes(raw) ? raw : 'all';
+    }
+
+    function resolveFavoriteExamIds(value) {
+        return new Set((Array.isArray(value) ? value : (global.__browseFavoriteExamIds || []))
+            .map((id) => String(id || '').trim())
+            .filter(Boolean));
+    }
+
+    function isFavoriteExam(exam, favoriteExamIds) {
+        return Boolean(exam && exam.id && resolveFavoriteExamIds(favoriteExamIds).has(String(exam.id)));
+    }
+
+    function resolveExamCompletionStatus(exam, resolver) {
+        const getStatus = typeof resolver === 'function'
+            ? resolver
+            : (typeof global.getBrowseCompletionStatus === 'function' ? global.getBrowseCompletionStatus : null);
+        if (!getStatus) return null;
+        try {
+            return getStatus(exam) || null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function applyBrowseProgressFilter(exams, progressFilter, favoriteExamIds, completionResolver) {
+        const list = Array.isArray(exams) ? exams.slice() : [];
+        const filter = normalizeBrowseProgressFilter(progressFilter || global.__browseProgressFilter || 'all');
+        if (filter === 'all') return list;
+        const favorites = resolveFavoriteExamIds(favoriteExamIds);
+        if (filter === 'favorite') {
+            return list.filter((exam) => exam && exam.id && favorites.has(String(exam.id)));
+        }
+        return list.filter((exam) => {
+            const status = resolveExamCompletionStatus(exam, completionResolver);
+            if (filter === 'unattempted') return !status;
+            if (filter === 'completed') return Boolean(status);
+            return Boolean(status && Number(status.percentage) < 100);
+        });
+    }
+
+    function recommendationScore(exam, favoriteExamIds, completionResolver) {
+        const status = resolveExamCompletionStatus(exam, completionResolver);
+        let score = resolveFrequencyRank(exam) * 8;
+        if (!status) {
+            score += 120;
+        } else if (Number(status.percentage) < 100) {
+            score += 200 + Math.max(0, 100 - Number(status.percentage || 0));
+        }
+        if (isFavoriteExam(exam, favoriteExamIds)) score += 6;
+        const difficulty = resolveDifficultyScore(exam);
+        if (Number.isFinite(difficulty)) score += difficulty;
+        return score;
+    }
+
+    function applyExamSort(exams, sortMode, favoriteExamIds, completionResolver) {
         const list = Array.isArray(exams) ? exams.slice() : [];
         const mode = String(sortMode || global.__browseSortMode || 'default').trim().toLowerCase();
+        if (mode === 'recommended') {
+            return list.sort((a, b) => {
+                const scoreDiff = recommendationScore(b, favoriteExamIds, completionResolver)
+                    - recommendationScore(a, favoriteExamIds, completionResolver);
+                return scoreDiff || compareByCategoryThenTitle(a, b);
+            });
+        }
         if (mode === 'difficulty-desc') {
             return list.sort((a, b) => {
                 const difficultyA = resolveDifficultyScore(a);
@@ -4336,10 +4684,16 @@
         });
     }
 
-    function applyBrowsePostFilters(exams, sortMode, frequencyFilter) {
+    function applyBrowsePostFilters(exams, sortMode, frequencyFilter, progressFilter, favoriteExamIds, completionResolver) {
         const deduplicated = deduplicateExams(exams);
         const frequencyFiltered = applyBrowseFrequencyFilter(deduplicated, frequencyFilter);
-        return applyExamSort(frequencyFiltered, sortMode);
+        const progressFiltered = applyBrowseProgressFilter(
+            frequencyFiltered,
+            progressFilter,
+            favoriteExamIds,
+            completionResolver
+        );
+        return applyExamSort(progressFiltered, sortMode, favoriteExamIds, completionResolver);
     }
 
     function hasListeningEntries(exams) {
@@ -4386,6 +4740,15 @@
         const frequencyFilter = normalizeBrowseFrequencyFilter(
             safeState.frequencyFilter || safeState.browseFrequencyFilter || global.__browseFrequencyFilter || 'all'
         );
+        const progressFilter = normalizeBrowseProgressFilter(
+            safeState.progressFilter || safeState.browseProgressFilter || global.__browseProgressFilter || 'all'
+        );
+        const favoriteExamIds = Array.isArray(safeState.favoriteExamIds)
+            ? safeState.favoriteExamIds
+            : global.__browseFavoriteExamIds;
+        const completionResolver = typeof safeState.completionResolver === 'function'
+            ? safeState.completionResolver
+            : null;
         const isFrequencyMode = filterMode !== 'default';
         const basePathFilter = isFrequencyMode
             && typeof safeState.basePathFilter === 'string'
@@ -4431,7 +4794,14 @@
             }
         }
 
-        return applyBrowsePostFilters(list, sortMode, frequencyFilter);
+        return applyBrowsePostFilters(
+            list,
+            sortMode,
+            frequencyFilter,
+            progressFilter,
+            favoriteExamIds,
+            completionResolver
+        );
     }
 
     function formatFrequencyLabel(frequency) {
@@ -5204,6 +5574,9 @@
         try {
             global.__browseFilterMode = 'default';
             global.__browsePath = null;
+            if (typeof global.updateBrowseProgressButtons === 'function') {
+                global.updateBrowseProgressButtons('all');
+            }
             setBrowseFrequencyFilter('all');
         } catch (error) {
             console.warn('[ExamActions] 重置题库功能状态失败:', error);
@@ -5266,6 +5639,20 @@
                 }
             });
         }
+        ['browse-category-filter-buttons', 'browse-progress-filter-buttons'].forEach((containerId) => {
+            const container = document.getElementById(containerId);
+            if (!container || typeof container.querySelectorAll !== 'function') return;
+            container.querySelectorAll('button').forEach((button) => {
+                const value = button.dataset && (button.dataset.categoryFilter || button.dataset.progressFilter);
+                const active = value === 'all';
+                if (button.classList && typeof button.classList.toggle === 'function') {
+                    button.classList.toggle('active', active);
+                }
+                if (typeof button.setAttribute === 'function') {
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                }
+            });
+        });
         return true;
     }
 
@@ -5309,6 +5696,7 @@
         try {
             await preferences.patchBrowse({
                 frequencyFilter: 'all',
+                progressFilter: 'all',
                 filter: { category: 'all', type: 'all' }
             });
             return true;
@@ -5338,7 +5726,8 @@
     function isPersistedBrowseReset(browse, requireStateManager) {
         if (!browse || !isAllBrowseFilter(browse.lastFilter)
             || !isAllBrowseFilter(browse.filter)
-            || browse.frequencyFilter !== 'all') {
+            || browse.frequencyFilter !== 'all'
+            || (browse.progressFilter && browse.progressFilter !== 'all')) {
             return false;
         }
         if (!requireStateManager) {
@@ -5910,6 +6299,20 @@
             return item;
         }
 
+        if (!isSelecting) {
+            const favoriteBtn = document.createElement('button');
+            const favorite = isFavoriteExam(exam);
+            favoriteBtn.className = 'btn btn-outline exam-item-action-btn exam-favorite-btn';
+            favoriteBtn.type = 'button';
+            favoriteBtn.dataset.action = 'favorite';
+            if (exam.id) favoriteBtn.dataset.examId = exam.id;
+            favoriteBtn.textContent = favorite ? '★' : '☆';
+            favoriteBtn.title = favorite ? '取消收藏' : '收藏题目';
+            favoriteBtn.setAttribute('aria-label', (favorite ? '取消收藏 ' : '收藏 ') + (exam.title || ''));
+            favoriteBtn.setAttribute('aria-pressed', favorite ? 'true' : 'false');
+            actions.appendChild(favoriteBtn);
+        }
+
         const startBtn = document.createElement('button');
         startBtn.className = 'btn exam-item-action-btn';
         startBtn.type = 'button';
@@ -5989,6 +6392,13 @@
                 return;
             }
 
+            if (action === 'favorite') {
+                if (typeof global.toggleBrowseFavorite === 'function') {
+                    global.toggleBrowseFavorite(examId);
+                }
+                return;
+            }
+
             if (action === 'reading-memorize-select') {
                 launchReadingMemorizeExam(examId);
                 return;
@@ -6034,6 +6444,9 @@
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="generate"]', function (event) {
+                invoke(this, event);
+            });
+            global.DOM.delegate('click', '[data-action="favorite"]', function (event) {
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="suite-custom-select"]', function (event) {
@@ -6190,7 +6603,10 @@
         applyExamSort,
         applyBrowsePostFilters,
         applyBrowseFrequencyFilter,
+        applyBrowseProgressFilter,
         normalizeBrowseFrequencyFilter,
+        normalizeBrowseProgressFilter,
+        isFavoriteExam,
         setBrowseFrequencyFilter,
         browseFilterStateOwner,
         resetBrowseFilterStateToAll,
@@ -18174,6 +18590,7 @@ Object.defineProperty(window, 'examListViewInstance', {
 });
 
 let practiceDashboardViewInstance = null;
+let practicePerformanceViewInstance = null;
 let practiceTrendRendererInstance = null;
 let practicePriorityRendererInstance = null;
 let legacyNavigationController = null;
@@ -18338,6 +18755,13 @@ function ensurePracticeDashboardView() {
         });
     }
     return practiceDashboardViewInstance;
+}
+
+function ensurePracticePerformanceView() {
+    if (!practicePerformanceViewInstance && window.PracticePerformanceView) {
+        practicePerformanceViewInstance = new window.PracticePerformanceView();
+    }
+    return practicePerformanceViewInstance;
 }
 
 function ensurePracticeTrendRenderer() {
@@ -19988,6 +20412,11 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
         applyPracticeSummaryFallback(summary);
     }
 
+    const performanceView = ensurePracticePerformanceView();
+    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
+        performanceView.update(stats.calculatePerformanceBreakdown(records, examIndex));
+    }
+
     // --- 3. Filter and Render History List ---
     const historyContainer = document.getElementById('practice-history-list') || document.getElementById('history-list');
     if (!historyContainer) {
@@ -20890,6 +21319,7 @@ async function applyBrowseFilter(
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
         browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState(normalizedCategory, effectiveType);
+        updateBrowseCategoryButtons(normalizedCategory);
 
 
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
@@ -21259,6 +21689,8 @@ async function setupBrowseControls(options = {}) {
                 updateBrowseFrequencyButtons(
                     browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
                 );
+                updateBrowseProgressButtons(browse.progressFilter || window.__browseProgressFilter || 'all');
+                window.__browseFavoriteExamIds = normalizeBrowseFavoriteIds(browse.favoriteExamIds);
             }
             browseControlsSeeded = true;
             browseControlsSeedPromise = null;
@@ -21270,6 +21702,7 @@ async function setupBrowseControls(options = {}) {
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
+    setupBrowseLearningFilterControls();
     return true;
 }
 
@@ -21290,7 +21723,7 @@ function setupBrowseSortControl() {
     }
     const normalizeSortMode = (value) => {
         const mode = String(value || 'default').trim().toLowerCase();
-        return mode === 'frequency-desc' || mode === 'difficulty-desc' ? mode : 'default';
+        return mode === 'frequency-desc' || mode === 'difficulty-desc' || mode === 'recommended' ? mode : 'default';
     };
     let savedMode = String(window.__browseSortMode || '').trim().toLowerCase();
     if (!savedMode) savedMode = 'default';
@@ -21356,6 +21789,94 @@ function filterByFrequency(filter) {
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
     refreshBrowseResults({ foreground: true });
+}
+
+function normalizeBrowseProgressFilter(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    return ['unattempted', 'completed', 'wrong', 'favorite'].includes(normalized)
+        ? normalized
+        : 'all';
+}
+
+function normalizeBrowseFavoriteIds(value) {
+    return Array.from(new Set((Array.isArray(value) ? value : [])
+        .map((id) => String(id || '').trim())
+        .filter(Boolean)))
+        .slice(0, 2000);
+}
+
+function updateBrowseProgressButtons(filter) {
+    const active = normalizeBrowseProgressFilter(filter);
+    window.__browseProgressFilter = active;
+    const container = document.getElementById('browse-progress-filter-buttons');
+    if (container) {
+        container.querySelectorAll('[data-progress-filter]').forEach((button) => {
+            const selected = button.dataset.progressFilter === active;
+            button.classList.toggle('active', selected);
+            button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        });
+    }
+    return active;
+}
+
+function updateBrowseCategoryButtons(category) {
+    const active = /^P[1-3]$/.test(String(category || '').toUpperCase())
+        ? String(category).toUpperCase()
+        : 'all';
+    const container = document.getElementById('browse-category-filter-buttons');
+    if (container) {
+        container.querySelectorAll('[data-category-filter]').forEach((button) => {
+            const selected = button.dataset.categoryFilter === active;
+            button.classList.toggle('active', selected);
+            button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        });
+    }
+    return active;
+}
+
+function setupBrowseLearningFilterControls() {
+    const categoryContainer = document.getElementById('browse-category-filter-buttons');
+    if (categoryContainer && categoryContainer.dataset.bound !== 'true') {
+        categoryContainer.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-category-filter]');
+            if (!button || !categoryContainer.contains(button)) return;
+            const category = updateBrowseCategoryButtons(button.dataset.categoryFilter);
+            applyBrowseFilter(category, getCurrentExamType());
+        });
+        categoryContainer.dataset.bound = 'true';
+    }
+    updateBrowseCategoryButtons(getCurrentCategory());
+
+    const progressContainer = document.getElementById('browse-progress-filter-buttons');
+    if (progressContainer && progressContainer.dataset.bound !== 'true') {
+        progressContainer.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-progress-filter]');
+            if (!button || !progressContainer.contains(button)) return;
+            const requested = normalizeBrowseProgressFilter(button.dataset.progressFilter);
+            const current = normalizeBrowseProgressFilter(window.__browseProgressFilter);
+            const next = requested !== 'all' && requested === current ? 'all' : requested;
+            browseControlsMutationRevision += 1;
+            updateBrowseProgressButtons(next);
+            persistBrowsePreference({ progressFilter: next }).catch(console.warn);
+            refreshBrowseResults({ foreground: true });
+        });
+        progressContainer.dataset.bound = 'true';
+    }
+    updateBrowseProgressButtons(window.__browseProgressFilter || 'all');
+}
+
+function toggleBrowseFavorite(examId) {
+    const id = String(examId || '').trim();
+    if (!id) return false;
+    const favorites = new Set(normalizeBrowseFavoriteIds(window.__browseFavoriteExamIds));
+    const selected = !favorites.has(id);
+    if (selected) favorites.add(id);
+    else favorites.delete(id);
+    window.__browseFavoriteExamIds = normalizeBrowseFavoriteIds(Array.from(favorites));
+    browseControlsMutationRevision += 1;
+    persistBrowsePreference({ favoriteExamIds: window.__browseFavoriteExamIds }).catch(console.warn);
+    refreshBrowseResults({ foreground: true });
+    return selected;
 }
 
 // 全局桥接：HTML 按钮 onclick="browseCategory('P1','reading')"
@@ -22150,7 +22671,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             basePathFilter,
             browsePath: window.__browsePath,
             sortMode: window.__browseSortMode,
-            frequencyFilter: window.__browseFrequencyFilter
+            frequencyFilter: window.__browseFrequencyFilter,
+            progressFilter: window.__browseProgressFilter,
+            favoriteExamIds: window.__browseFavoriteExamIds
         });
     }
 
@@ -22168,7 +22691,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         list = window.ExamActions.applyBrowsePostFilters(
             list,
             window.__browseSortMode,
-            window.__browseFrequencyFilter
+            window.__browseFrequencyFilter,
+            window.__browseProgressFilter,
+            window.__browseFavoriteExamIds
         );
     }
     return list;
@@ -22990,6 +23515,7 @@ if (typeof window !== 'undefined') {
     window.switchLibraryConfig = switchLibraryConfig;
     window.deleteLibraryConfig = deleteLibraryConfig;
     window.setupBrowseControls = setupBrowseControls;
+    window.toggleBrowseFavorite = toggleBrowseFavorite;
 }
 
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -290,6 +290,32 @@
         return examCategory ? 'P' + examCategory[1] : '';
     }
 
+    function resolvePerformanceExamType(record, exams) {
+        if (!record) {
+            return '';
+        }
+        var metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        var realData = record.realData && typeof record.realData === 'object' ? record.realData : {};
+        var recordType = normalizeTypeValue(
+            record.type ||
+            record.examType ||
+            metadata.type ||
+            metadata.examType ||
+            realData.type ||
+            realData.examType
+        );
+        if (recordType) {
+            return recordType;
+        }
+        var exam = ensureArray(exams).find(function findExam(item) {
+            return item && (
+                (record.examId && item.id === record.examId) ||
+                (record.title && item.title === record.title)
+            );
+        });
+        return exam ? normalizeTypeValue(exam.type || exam.examType) : '';
+    }
+
     function expandPerformanceRecords(records) {
         var expanded = [];
         ensureArray(records).forEach(function expandRecord(record) {
@@ -320,6 +346,11 @@
         };
 
         expandPerformanceRecords(records).forEach(function aggregateRecord(record) {
+            // 本面板仅展示阅读 P1/P2/P3；明确标记为听力的历史记录不能混入。
+            // 未标记类型的旧阅读记录仍保留，以兼容历史数据。
+            if (resolvePerformanceExamType(record, exams) === 'listening') {
+                return;
+            }
             var performanceMap = record.questionTypePerformance ||
                 (record.realData && record.realData.questionTypePerformance) || {};
             var duration = firstPerformanceNumber(record.duration);
@@ -4601,6 +4632,9 @@
     }
 
     function resolveFavoriteExamIds(value) {
+        if (value && typeof value.has === 'function' && Object.prototype.toString.call(value) === '[object Set]') {
+            return value;
+        }
         return new Set((Array.isArray(value) ? value : (global.__browseFavoriteExamIds || []))
             .map((id) => String(id || '').trim())
             .filter(Boolean));
@@ -4656,9 +4690,10 @@
         const list = Array.isArray(exams) ? exams.slice() : [];
         const mode = String(sortMode || global.__browseSortMode || 'default').trim().toLowerCase();
         if (mode === 'recommended') {
+            const favorites = resolveFavoriteExamIds(favoriteExamIds);
             return list.sort((a, b) => {
-                const scoreDiff = recommendationScore(b, favoriteExamIds, completionResolver)
-                    - recommendationScore(a, favoriteExamIds, completionResolver);
+                const scoreDiff = recommendationScore(b, favorites, completionResolver)
+                    - recommendationScore(a, favorites, completionResolver);
                 return scoreDiff || compareByCategoryThenTitle(a, b);
             });
         }
@@ -4743,7 +4778,7 @@
         const progressFilter = normalizeBrowseProgressFilter(
             safeState.progressFilter || safeState.browseProgressFilter || global.__browseProgressFilter || 'all'
         );
-        const favoriteExamIds = Array.isArray(safeState.favoriteExamIds)
+        const favoriteExamIds = safeState.favoriteExamIds !== undefined
             ? safeState.favoriteExamIds
             : global.__browseFavoriteExamIds;
         const completionResolver = typeof safeState.completionResolver === 'function'
@@ -20412,11 +20447,6 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
         applyPracticeSummaryFallback(summary);
     }
 
-    const performanceView = ensurePracticePerformanceView();
-    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
-        performanceView.update(stats.calculatePerformanceBreakdown(records, examIndex));
-    }
-
     // --- 3. Filter and Render History List ---
     const historyContainer = document.getElementById('practice-history-list') || document.getElementById('history-list');
     if (!historyContainer) {
@@ -20439,6 +20469,11 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
     }
 
     const recordsForInsights = recordsToShow.slice();
+
+    const performanceView = ensurePracticePerformanceView();
+    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
+        performanceView.update(stats.calculatePerformanceBreakdown(recordsForInsights, examIndex));
+    }
 
     const historyQuery = String(window.__practiceHistoryQuery || '').trim().toLowerCase();
     if (historyQuery) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -329,6 +329,12 @@
             }
             entries.forEach(function addEntry(entry) {
                 expanded.push(Object.assign({}, entry || {}, {
+                    type: (entry && (
+                        entry.type ||
+                        entry.examType ||
+                        (entry.metadata && (entry.metadata.type || entry.metadata.examType))
+                    )) ||
+                        (record && (record.type || record.examType)) || '',
                     date: (entry && entry.date) || (record && record.date),
                     metadata: Object.assign({}, (record && record.metadata) || {}, (entry && entry.metadata) || {})
                 }));

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -2816,6 +2816,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -2858,12 +2884,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -2927,6 +2955,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -2965,7 +2994,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -2485,6 +2485,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -2527,12 +2553,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -2596,6 +2624,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -2634,7 +2663,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -2485,6 +2485,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -2527,12 +2553,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -2596,6 +2624,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -2634,7 +2663,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -2485,6 +2485,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -2527,12 +2553,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -2596,6 +2624,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -2634,7 +2663,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -2485,6 +2485,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -2527,12 +2553,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -2596,6 +2624,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -2634,7 +2663,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {
@@ -7169,6 +7198,9 @@
         noteDrawerDirty: true,
         noteHighlightMetaDirty: true,
         noteEditorPendingSync: false,
+        currentActiveQuestionId: '',
+        questionTimeSpentMs: {},
+        questionTimingStartedAtMs: null,
         optionsReturnFocus: null,
         optionsInertSiblings: [],
         reviewRecordId: '',
@@ -7357,6 +7389,62 @@
         } else if (!wasRunning && running && state.suite?.inline && getActiveSuiteSlot()) {
             state.suite.activeStartedAtMs = Number(nowMs) || Date.now();
         }
+    }
+
+    function getActiveQuestionTimingStore() {
+        if (state.suite?.inline) {
+            const slot = getActiveSuiteSlot();
+            if (slot) {
+                if (!slot.questionTimeSpentMs || typeof slot.questionTimeSpentMs !== 'object' || Array.isArray(slot.questionTimeSpentMs)) {
+                    slot.questionTimeSpentMs = {};
+                }
+                return slot.questionTimeSpentMs;
+            }
+        }
+        if (!state.questionTimeSpentMs || typeof state.questionTimeSpentMs !== 'object' || Array.isArray(state.questionTimeSpentMs)) {
+            state.questionTimeSpentMs = {};
+        }
+        return state.questionTimeSpentMs;
+    }
+
+    function checkpointActiveQuestionTiming(nowMs = Date.now(), keepRunning = interaction.timerRunning) {
+        const questionId = normalizeQuestionId(state.currentActiveQuestionId) || '';
+        const startedAtMs = Number(state.questionTimingStartedAtMs);
+        const checkpointMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+        if (questionId && Number.isFinite(startedAtMs) && startedAtMs > 0) {
+            const store = getActiveQuestionTimingStore();
+            store[questionId] = Math.max(0, Number(store[questionId]) || 0)
+                + Math.max(0, checkpointMs - startedAtMs);
+        }
+        const canContinue = keepRunning !== false
+            && questionId
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted;
+        state.questionTimingStartedAtMs = canContinue ? checkpointMs : null;
+        return questionId ? Math.max(0, Number(getActiveQuestionTimingStore()[questionId]) || 0) : 0;
+    }
+
+    function syncActiveQuestionTimer(nextRunning, nowMs = Date.now()) {
+        const running = nextRunning !== false;
+        const wasRunning = interaction.timerRunning !== false;
+        if (wasRunning && !running) {
+            checkpointActiveQuestionTiming(nowMs, false);
+        } else if (!wasRunning && running && state.currentActiveQuestionId && !state.readOnly && !state.reviewMode && !state.submitted) {
+            state.questionTimingStartedAtMs = Number(nowMs) || Date.now();
+        }
+    }
+
+    function resetActiveQuestionTiming() {
+        const store = getActiveQuestionTimingStore();
+        Object.keys(store).forEach((questionId) => delete store[questionId]);
+        state.questionTimingStartedAtMs = (
+            interaction.timerRunning !== false
+            && state.currentActiveQuestionId
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted
+        ) ? Date.now() : null;
     }
 
     function resolvePracticeTiming(minDurationSeconds = 0, timerSnapshot = null) {
@@ -7583,6 +7671,7 @@
     function setTimerRunning(nextRunning) {
         const nowMs = Date.now();
         syncActiveSuiteTimer(Boolean(nextRunning), nowMs);
+        syncActiveQuestionTimer(Boolean(nextRunning), nowMs);
         interaction.timerRunning = !!nextRunning;
         syncPagePauseState(interaction.timerRunning);
         renderTimer();
@@ -8818,6 +8907,9 @@
                 draft: mergeDraft(existing?.draft, inheritedDraft),
                 navStatus: existing?.navStatus instanceof Map ? existing.navStatus : new Map(),
                 lastResults: existing?.lastResults || null,
+                questionTimeSpentMs: existing?.questionTimeSpentMs && typeof existing.questionTimeSpentMs === 'object'
+                    ? existing.questionTimeSpentMs
+                    : {},
                 durationMs: existing?.durationMs !== null
                     && existing?.durationMs !== undefined
                     && Number.isFinite(Number(existing.durationMs))
@@ -8924,6 +9016,7 @@
         }
         const activationGeneration = (Number(state.suite.activationGeneration) || 0) + 1;
         state.suite.activationGeneration = activationGeneration;
+        checkpointActiveQuestionTiming(Date.now(), false);
         if (!options.skipSave) {
             updateActiveSlotFromCurrentDom('deactivate');
         }
@@ -8934,12 +9027,15 @@
         state.dataKey = slot.dataKey || targetExamId;
         state.dataset = slot.dataset;
         state.lastResults = slot.lastResults || null;
+        state.currentActiveQuestionId = '';
+        state.questionTimingStartedAtMs = null;
         navStatus.clear();
         if (slot.navStatus instanceof Map) {
             slot.navStatus.forEach((value, key) => navStatus.set(key, value));
         }
         interaction.currentHighlightNode = null;
         renderDataset(slot.dataset);
+        updateActiveQuestionHighlight(Array.isArray(slot.dataset?.questionOrder) ? slot.dataset.questionOrder[0] : '');
         refreshDynamicQuestionEnhancements();
         clearCurrentAnswers();
         applyDraftToDom(slot.draft || buildEmptyDraft());
@@ -10459,9 +10555,20 @@
     }
 
     function updateActiveQuestionHighlight(qId) {
-        state.currentActiveQuestionId = qId;
+        const nextQuestionId = normalizeQuestionId(qId) || '';
+        if (nextQuestionId !== state.currentActiveQuestionId) {
+            checkpointActiveQuestionTiming(Date.now(), false);
+            state.currentActiveQuestionId = nextQuestionId;
+            state.questionTimingStartedAtMs = (
+                interaction.timerRunning !== false
+                && nextQuestionId
+                && !state.readOnly
+                && !state.reviewMode
+                && !state.submitted
+            ) ? Date.now() : null;
+        }
         document.querySelectorAll('.q-item').forEach((item) => {
-            if (item.dataset.questionId === qId) {
+            if (item.dataset.questionId === nextQuestionId) {
                 item.classList.add('active');
             } else {
                 item.classList.remove('active');
@@ -12568,7 +12675,7 @@
         return hasAnswerInDataset(questionId, collectAnswers(), state.dataset);
     }
 
-    function buildResultsFromAnswers(dataset, answers = {}) {
+    function buildResultsFromAnswers(dataset, answers = {}, questionTimingMs = {}) {
         const answerKey = dataset?.answerKey || {};
         const questionOrder = Array.isArray(dataset?.questionOrder) ? dataset.questionOrder : Object.keys(answerKey);
         const questionTypeMap = buildQuestionTypeMap(dataset);
@@ -12587,6 +12694,10 @@
             const normalizedQuestionId = normalizeQuestionId(questionId) || questionId;
             const questionGroup = questionGroupLookup.get(normalizedQuestionId) || null;
             const questionType = questionTypeMap[normalizedQuestionId] || 'other';
+            const questionTimeSpent = Math.max(
+                0,
+                Number(questionTimingMs?.[normalizedQuestionId] ?? questionTimingMs?.[questionId]) || 0
+            ) / 1000;
             const isMultiChoiceKind = (
                 questionGroup
                 && (questionGroup.kind === 'multi_choice' || questionGroup.kind === 'multiple_choice')
@@ -12633,11 +12744,14 @@
                 questionTypePerformance[questionType] = {
                     total: 0,
                     correct: 0,
-                    accuracy: 0
+                    accuracy: 0,
+                    timeSpent: 0,
+                    averageTime: 0
                 };
             }
             totalQuestions += weight;
             questionTypePerformance[questionType].total += weight;
+            questionTypePerformance[questionType].timeSpent += questionTimeSpent;
             if (partialCorrectCount > 0) {
                 correctCount += partialCorrectCount;
                 questionTypePerformance[questionType].correct += partialCorrectCount;
@@ -12648,6 +12762,7 @@
                 correctAnswer,
                 isCorrect,
                 questionType,
+                timeSpent: questionTimeSpent,
                 partialCorrectCount,
                 weight
             };
@@ -12657,6 +12772,7 @@
                 correctAnswer,
                 isCorrect,
                 questionType,
+                timeSpent: questionTimeSpent,
                 partialCorrectCount,
                 weight
             };
@@ -12665,6 +12781,7 @@
         Object.keys(questionTypePerformance).forEach((type) => {
             const performance = questionTypePerformance[type];
             performance.accuracy = performance.total > 0 ? performance.correct / performance.total : 0;
+            performance.averageTime = performance.total > 0 ? performance.timeSpent / performance.total : 0;
         });
 
         const accuracy = totalQuestions > 0 ? correctCount / totalQuestions : 0;
@@ -12687,7 +12804,8 @@
     }
 
     function buildResults() {
-        return buildResultsFromAnswers(state.dataset, collectAnswers());
+        checkpointActiveQuestionTiming(Date.now(), interaction.timerRunning);
+        return buildResultsFromAnswers(state.dataset, collectAnswers(), getActiveQuestionTimingStore());
     }
 
     function renderResults(results) {
@@ -13450,6 +13568,8 @@
                 applyReplayRecord,
                 setTimerRunning,
                 checkpointActiveSuiteDuration,
+                checkpointActiveQuestionTiming,
+                updateActiveQuestionHighlight,
                 getSelectionHighlightTestState() {
                     return {
                         hasLastRange: Boolean(interaction.lastRange),
@@ -13792,6 +13912,7 @@
             }
         });
         disableDragInteractions();
+        resetActiveQuestionTiming();
         setTimerRunning(true);
         setExitButtonVisible(false);
         updateNavStatuses();
@@ -14548,12 +14669,16 @@
     function mergeQuestionTypePerformance(target, source = {}) {
         Object.entries(source || {}).forEach(([type, performance]) => {
             if (!target[type]) {
-                target[type] = { total: 0, correct: 0, accuracy: 0 };
+                target[type] = { total: 0, correct: 0, accuracy: 0, timeSpent: 0, averageTime: 0 };
             }
             target[type].total += Number(performance && performance.total) || 0;
             target[type].correct += Number(performance && performance.correct) || 0;
+            target[type].timeSpent += Math.max(0, Number(performance && performance.timeSpent) || 0);
             target[type].accuracy = target[type].total > 0
                 ? target[type].correct / target[type].total
+                : 0;
+            target[type].averageTime = target[type].total > 0
+                ? target[type].timeSpent / target[type].total
                 : 0;
         });
     }
@@ -14577,7 +14702,7 @@
                 return;
             }
             const draft = mergeDraft(slot.draft, {});
-            const results = buildResultsFromAnswers(slot.dataset, draft.answers || {});
+            const results = buildResultsFromAnswers(slot.dataset, draft.answers || {}, slot.questionTimeSpentMs || {});
             slot.lastResults = results;
             slot.navStatus = new Map();
             Object.entries(results.answerComparison || {}).forEach(([questionId, comparison]) => {
@@ -15330,6 +15455,7 @@
                 return;
             }
             syncActiveSuiteTimer(detail.running, Date.now());
+            syncActiveQuestionTimer(detail.running, Date.now());
             interaction.timerRunning = detail.running;
             syncPagePauseState(detail.running);
         });
@@ -15344,6 +15470,7 @@
         renderDataset(dataset);
         updateRedesignedSubHeader();
         buildQuestionNav();
+        updateActiveQuestionHighlight(Array.isArray(dataset?.questionOrder) ? dataset.questionOrder[0] : '');
         attachNavListeners();
         attachFloatingNavListeners();
         attachMemorizeLocatorListeners();

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -13633,6 +13633,7 @@
                 setTimerRunning,
                 checkpointActiveSuiteDuration,
                 checkpointActiveQuestionTiming,
+                buildInlineSuiteSubmissionSnapshot,
                 updateActiveQuestionHighlight,
                 resolveDropzoneQuestionId,
                 activateQuestionTimingForDropzone,
@@ -14760,6 +14761,9 @@
     }
 
     function buildInlineSuiteSubmissionSnapshot() {
+        // 套题汇总直接读取各 slot 的计时缓存，因此先把当前仍在运行的题目落账；
+        // 单篇提交由 buildResults() 完成同样的 checkpoint。
+        checkpointActiveQuestionTiming(Date.now(), interaction.timerRunning);
         updateActiveSlotFromCurrentDom('submit');
         const timerSnapshot = getPracticeTimerSnapshot();
         const suiteEntries = [];

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -7250,7 +7250,10 @@
         keepToolbar: false,
         noteDragFrame: null,
         noteListDragging: false,
-        noteSuppressClickUntil: 0
+        noteSuppressClickUntil: 0,
+        questionDragStartedAtMs: null,
+        questionDragOriginId: '',
+        questionDragCommitted: false
     };
     const testOverrides = {
         renderExplanations: null
@@ -7445,6 +7448,9 @@
             && !state.reviewMode
             && !state.submitted
         ) ? Date.now() : null;
+        interaction.questionDragStartedAtMs = null;
+        interaction.questionDragOriginId = '';
+        interaction.questionDragCommitted = false;
     }
 
     function resolvePracticeTiming(minDurationSeconds = 0, timerSnapshot = null) {
@@ -10554,10 +10560,11 @@
         return { info, currentPart };
     }
 
-    function updateActiveQuestionHighlight(qId) {
+    function updateActiveQuestionHighlight(qId, nowMs = Date.now()) {
         const nextQuestionId = normalizeQuestionId(qId) || '';
+        const checkpointMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
         if (nextQuestionId !== state.currentActiveQuestionId) {
-            checkpointActiveQuestionTiming(Date.now(), false);
+            checkpointActiveQuestionTiming(checkpointMs, false);
             state.currentActiveQuestionId = nextQuestionId;
             state.questionTimingStartedAtMs = (
                 interaction.timerRunning !== false
@@ -10565,7 +10572,7 @@
                 && !state.readOnly
                 && !state.reviewMode
                 && !state.submitted
-            ) ? Date.now() : null;
+            ) ? checkpointMs : null;
         }
         document.querySelectorAll('.q-item').forEach((item) => {
             if (item.dataset.questionId === nextQuestionId) {
@@ -11758,13 +11765,65 @@
                 event.preventDefault();
                 return;
             }
+            const dragStartedAtMs = Date.now();
+            checkpointActiveQuestionTiming(dragStartedAtMs, false);
+            interaction.questionDragStartedAtMs = dragStartedAtMs;
+            interaction.questionDragOriginId = normalizeQuestionId(state.currentActiveQuestionId) || '';
+            interaction.questionDragCommitted = false;
             event.dataTransfer?.setData('text/plain', JSON.stringify(payload));
             event.dataTransfer.effectAllowed = 'move';
             item.classList.add('dragging');
         });
         item.addEventListener('dragend', () => {
             item.classList.remove('dragging');
+            const dragStartedAtMs = Number(interaction.questionDragStartedAtMs);
+            if (!interaction.questionDragCommitted
+                && Number.isFinite(dragStartedAtMs)
+                && dragStartedAtMs > 0
+                && interaction.questionDragOriginId
+                && interaction.timerRunning !== false
+                && !state.readOnly
+                && !state.reviewMode
+                && !state.submitted) {
+                state.currentActiveQuestionId = interaction.questionDragOriginId;
+                state.questionTimingStartedAtMs = dragStartedAtMs;
+            }
+            interaction.questionDragStartedAtMs = null;
+            interaction.questionDragOriginId = '';
+            interaction.questionDragCommitted = false;
         });
+    }
+
+    function resolveDropzoneQuestionId(dropzone) {
+        if (!dropzone) {
+            return '';
+        }
+        const rawQuestionId = dropzone.dataset?.question || dropzone.dataset?.questionId || '';
+        const candidates = expandQuestionSequence(rawQuestionId);
+        const questionOrder = Array.isArray(state.dataset?.questionOrder)
+            ? state.dataset.questionOrder.map((questionId) => normalizeQuestionId(questionId)).filter(Boolean)
+            : [];
+        return candidates.find((questionId) => questionOrder.includes(questionId)) || '';
+    }
+
+    function activateQuestionTimingForDropzone(dropzone) {
+        const questionId = resolveDropzoneQuestionId(dropzone);
+        if (!questionId) {
+            return false;
+        }
+        const dragStartedAtMs = Number(interaction.questionDragStartedAtMs);
+        const activationMs = Number.isFinite(dragStartedAtMs) && dragStartedAtMs > 0
+            ? dragStartedAtMs
+            : Date.now();
+        updateActiveQuestionHighlight(questionId, activationMs);
+        if (interaction.timerRunning !== false
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted) {
+            state.questionTimingStartedAtMs = activationMs;
+        }
+        interaction.questionDragCommitted = true;
+        return true;
     }
 
     function setDropzoneAnswer(dropzone, value, label) {
@@ -12038,9 +12097,14 @@
                 return;
             }
             if (target.matches(POOL_CONTAINER_SELECTOR) || target.closest(POOL_CONTAINER_SELECTOR)) {
+                const sourceDropzone = payload.sourceDropzoneId
+                    ? document.querySelector(`[data-dropzone-id="${payload.sourceDropzoneId}"]`)
+                    : null;
+                activateQuestionTimingForDropzone(sourceDropzone);
                 handleDropBackToPool(payload);
                 return;
             }
+            activateQuestionTimingForDropzone(target);
             handleDropOnDropzone(target, payload);
         });
     }
@@ -13570,6 +13634,8 @@
                 checkpointActiveSuiteDuration,
                 checkpointActiveQuestionTiming,
                 updateActiveQuestionHighlight,
+                resolveDropzoneQuestionId,
+                activateQuestionTimingForDropzone,
                 getSelectionHighlightTestState() {
                     return {
                         hasLastRange: Boolean(interaction.lastRange),
@@ -13672,6 +13738,16 @@
                             state.suite.slotsByExamId = new Map(Object.entries(slots));
                         }
                     }
+                },
+                setTestInteraction(patch = {}) {
+                    if (!patch || typeof patch !== 'object') {
+                        return;
+                    }
+                    Object.entries(patch).forEach(([key, value]) => {
+                        if (Object.prototype.hasOwnProperty.call(interaction, key)) {
+                            interaction[key] = value;
+                        }
+                    });
                 },
                 setTestOverride(name, value) {
                     if (!Object.prototype.hasOwnProperty.call(testOverrides, name)) {

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -11088,6 +11088,23 @@
         }
     }
 
+    function resolveNamedControlQuestionId(name) {
+        const order = Array.isArray(state.dataset?.questionOrder)
+            ? state.dataset.questionOrder.map((questionId) => normalizeQuestionId(questionId)).filter(Boolean)
+            : [];
+        const candidates = resolveCheckboxQuestionIds(name);
+        return candidates.find((questionId) => order.includes(normalizeQuestionId(questionId))) || '';
+    }
+
+    function activateQuestionTimingForNamedControl(name, nowMs = Date.now()) {
+        const questionId = resolveNamedControlQuestionId(name);
+        if (!questionId) {
+            return false;
+        }
+        updateActiveQuestionHighlight(questionId, nowMs);
+        return true;
+    }
+
     function attachNavListeners() {
         const handler = (event) => {
             const section = event.currentTarget;
@@ -11118,15 +11135,7 @@
             if (!input) return;
             const name = input.getAttribute('name');
             if (name) {
-                const order = Array.isArray(state.dataset?.questionOrder) ? state.dataset.questionOrder : [];
-                const cleanName = name.replace(/^q/i, '');
-                const matched = order.find(qId => {
-                    const cleanQId = qId.replace(/^q/i, '');
-                    return cleanQId === cleanName;
-                });
-                if (matched) {
-                    updateActiveQuestionHighlight(matched);
-                }
+                activateQuestionTimingForNamedControl(name);
             }
         });
     }
@@ -13635,6 +13644,8 @@
                 checkpointActiveQuestionTiming,
                 buildInlineSuiteSubmissionSnapshot,
                 updateActiveQuestionHighlight,
+                resolveNamedControlQuestionId,
+                activateQuestionTimingForNamedControl,
                 resolveDropzoneQuestionId,
                 activateQuestionTimingForDropzone,
                 getSelectionHighlightTestState() {

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -236,6 +236,32 @@
         return counts;
     }
 
+    function compactQuestionTypePerformance(source) {
+        const compact = {};
+        const entries = Object.entries(asObject(source && source.questionTypePerformance)).slice(0, 64);
+        for (const [type, value] of entries) {
+            const key = String(type || '').trim();
+            if (!key) continue;
+            const metrics = asObject(value);
+            const total = firstNonNegative(metrics.totalQuestions, metrics.total) ?? 0;
+            const correct = Math.min(total, firstNonNegative(metrics.correctAnswers, metrics.correct) ?? 0);
+            const timeSpent = firstNonNegative(
+                metrics.timeSpent,
+                metrics.duration,
+                metrics.durationSeconds,
+                metrics.elapsedSeconds
+            );
+            const summary = {
+                total,
+                correct,
+                accuracy: total > 0 ? correct / total : 0
+            };
+            if (timeSpent !== null) summary.timeSpent = timeSpent;
+            compact[key] = summary;
+        }
+        return compact;
+    }
+
     function canonicalizeRecord(input) {
         assertObject(input, 'practice record must be an object');
         const record = jsonValue(input, 'practice record');
@@ -278,12 +304,14 @@
             examId: entry.examId || metadata.examId || null,
             title: entry.title || entry.examTitle || metadata.examTitle || metadata.title || '',
             type: entry.type || metadata.type || fallbackType,
+            category: entry.category || metadata.category || null,
             date: entry.date || entry.completedAt || entry.timestamp || null,
             duration: Number(entry.duration ?? scoreInfo.duration ?? realScoreInfo.duration ?? 0) || 0,
             totalQuestions,
             correctAnswers,
             accuracy,
             percentage,
+            questionTypePerformance: compactQuestionTypePerformance(entry),
             questionTypeErrorCounts: questionTypeErrorCounts(entry)
         }, 'suite entry light projection');
     }
@@ -347,6 +375,7 @@
             accuracy,
             percentage: Number(source.percentage ?? scoreInfo.percentage ?? realScoreInfo.percentage ?? (accuracy * 100)) || 0,
             score: source.score ?? scoreInfo.score ?? realScoreInfo.score ?? null,
+            questionTypePerformance: compactQuestionTypePerformance(source),
             questionTypeErrorCounts: questionTypeErrorCounts(source),
             // 缺失时必须留空而不是写 null：消费方按 `dataSource === 'real' || === undefined`
             // 过滤记录（js/main.js updatePracticeView），null 两者都不匹配会让记录整条消失。
@@ -385,7 +414,7 @@
         return first === undefined ? {} : clone(first);
     }
 
-    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
+    const SUMMARY_FIELDS = new Set(['id', 'sessionId', 'examId', 'title', 'type', 'mode', 'timestamp', 'completedAt', 'date', 'startTime', 'endTime', 'duration', 'totalQuestions', 'correctAnswers', 'accuracy', 'percentage', 'score', 'questionTypePerformance', 'questionTypeErrorCounts', 'dataSource', 'metadata', 'suite', 'suiteEntrySummaries']);
     const ANNOTATION_FIELDS = new Set(['markedQuestions', 'highlights', 'notes', 'noteOutlines', 'noteText', 'scrollY', 'interactions', 'annotations']);
 
     function withoutRawData(value) {

--- a/js/main.js
+++ b/js/main.js
@@ -1862,11 +1862,6 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
         applyPracticeSummaryFallback(summary);
     }
 
-    const performanceView = ensurePracticePerformanceView();
-    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
-        performanceView.update(stats.calculatePerformanceBreakdown(records, examIndex));
-    }
-
     // --- 3. Filter and Render History List ---
     const historyContainer = document.getElementById('practice-history-list') || document.getElementById('history-list');
     if (!historyContainer) {
@@ -1889,6 +1884,11 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
     }
 
     const recordsForInsights = recordsToShow.slice();
+
+    const performanceView = ensurePracticePerformanceView();
+    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
+        performanceView.update(stats.calculatePerformanceBreakdown(recordsForInsights, examIndex));
+    }
 
     const historyQuery = String(window.__practiceHistoryQuery || '').trim().toLowerCase();
     if (historyQuery) {

--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,7 @@ Object.defineProperty(window, 'examListViewInstance', {
 });
 
 let practiceDashboardViewInstance = null;
+let practicePerformanceViewInstance = null;
 let practiceTrendRendererInstance = null;
 let practicePriorityRendererInstance = null;
 let legacyNavigationController = null;
@@ -204,6 +205,13 @@ function ensurePracticeDashboardView() {
         });
     }
     return practiceDashboardViewInstance;
+}
+
+function ensurePracticePerformanceView() {
+    if (!practicePerformanceViewInstance && window.PracticePerformanceView) {
+        practicePerformanceViewInstance = new window.PracticePerformanceView();
+    }
+    return practicePerformanceViewInstance;
 }
 
 function ensurePracticeTrendRenderer() {
@@ -1854,6 +1862,11 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
         applyPracticeSummaryFallback(summary);
     }
 
+    const performanceView = ensurePracticePerformanceView();
+    if (performanceView && stats && typeof stats.calculatePerformanceBreakdown === 'function') {
+        performanceView.update(stats.calculatePerformanceBreakdown(records, examIndex));
+    }
+
     // --- 3. Filter and Render History List ---
     const historyContainer = document.getElementById('practice-history-list') || document.getElementById('history-list');
     if (!historyContainer) {
@@ -2756,6 +2769,7 @@ async function applyBrowseFilter(
         // 2. 再应用具体的分类和类型筛选（确保不被重置覆盖）
         browseInitialFilterHydrationConsumed = true;
         setBrowseFilterState(normalizedCategory, effectiveType);
+        updateBrowseCategoryButtons(normalizedCategory);
 
 
         setBrowseTitle(memorizeSelectionActive ? '阅读背题选题' : formatBrowseTitle(normalizedCategory, effectiveType));
@@ -3125,6 +3139,8 @@ async function setupBrowseControls(options = {}) {
                 updateBrowseFrequencyButtons(
                     browse.frequencyFilter || window.__browseFrequencyFilter || 'all'
                 );
+                updateBrowseProgressButtons(browse.progressFilter || window.__browseProgressFilter || 'all');
+                window.__browseFavoriteExamIds = normalizeBrowseFavoriteIds(browse.favoriteExamIds);
             }
             browseControlsSeeded = true;
             browseControlsSeedPromise = null;
@@ -3136,6 +3152,7 @@ async function setupBrowseControls(options = {}) {
     }
     setupBrowseSortControl();
     setupBrowseFrequencyFilterControl();
+    setupBrowseLearningFilterControls();
     return true;
 }
 
@@ -3156,7 +3173,7 @@ function setupBrowseSortControl() {
     }
     const normalizeSortMode = (value) => {
         const mode = String(value || 'default').trim().toLowerCase();
-        return mode === 'frequency-desc' || mode === 'difficulty-desc' ? mode : 'default';
+        return mode === 'frequency-desc' || mode === 'difficulty-desc' || mode === 'recommended' ? mode : 'default';
     };
     let savedMode = String(window.__browseSortMode || '').trim().toLowerCase();
     if (!savedMode) savedMode = 'default';
@@ -3222,6 +3239,94 @@ function filterByFrequency(filter) {
     persistBrowsePreference({ frequencyFilter: next }).catch(console.warn);
     updateBrowseFrequencyButtons(next);
     refreshBrowseResults({ foreground: true });
+}
+
+function normalizeBrowseProgressFilter(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    return ['unattempted', 'completed', 'wrong', 'favorite'].includes(normalized)
+        ? normalized
+        : 'all';
+}
+
+function normalizeBrowseFavoriteIds(value) {
+    return Array.from(new Set((Array.isArray(value) ? value : [])
+        .map((id) => String(id || '').trim())
+        .filter(Boolean)))
+        .slice(0, 2000);
+}
+
+function updateBrowseProgressButtons(filter) {
+    const active = normalizeBrowseProgressFilter(filter);
+    window.__browseProgressFilter = active;
+    const container = document.getElementById('browse-progress-filter-buttons');
+    if (container) {
+        container.querySelectorAll('[data-progress-filter]').forEach((button) => {
+            const selected = button.dataset.progressFilter === active;
+            button.classList.toggle('active', selected);
+            button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        });
+    }
+    return active;
+}
+
+function updateBrowseCategoryButtons(category) {
+    const active = /^P[1-3]$/.test(String(category || '').toUpperCase())
+        ? String(category).toUpperCase()
+        : 'all';
+    const container = document.getElementById('browse-category-filter-buttons');
+    if (container) {
+        container.querySelectorAll('[data-category-filter]').forEach((button) => {
+            const selected = button.dataset.categoryFilter === active;
+            button.classList.toggle('active', selected);
+            button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        });
+    }
+    return active;
+}
+
+function setupBrowseLearningFilterControls() {
+    const categoryContainer = document.getElementById('browse-category-filter-buttons');
+    if (categoryContainer && categoryContainer.dataset.bound !== 'true') {
+        categoryContainer.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-category-filter]');
+            if (!button || !categoryContainer.contains(button)) return;
+            const category = updateBrowseCategoryButtons(button.dataset.categoryFilter);
+            applyBrowseFilter(category, getCurrentExamType());
+        });
+        categoryContainer.dataset.bound = 'true';
+    }
+    updateBrowseCategoryButtons(getCurrentCategory());
+
+    const progressContainer = document.getElementById('browse-progress-filter-buttons');
+    if (progressContainer && progressContainer.dataset.bound !== 'true') {
+        progressContainer.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-progress-filter]');
+            if (!button || !progressContainer.contains(button)) return;
+            const requested = normalizeBrowseProgressFilter(button.dataset.progressFilter);
+            const current = normalizeBrowseProgressFilter(window.__browseProgressFilter);
+            const next = requested !== 'all' && requested === current ? 'all' : requested;
+            browseControlsMutationRevision += 1;
+            updateBrowseProgressButtons(next);
+            persistBrowsePreference({ progressFilter: next }).catch(console.warn);
+            refreshBrowseResults({ foreground: true });
+        });
+        progressContainer.dataset.bound = 'true';
+    }
+    updateBrowseProgressButtons(window.__browseProgressFilter || 'all');
+}
+
+function toggleBrowseFavorite(examId) {
+    const id = String(examId || '').trim();
+    if (!id) return false;
+    const favorites = new Set(normalizeBrowseFavoriteIds(window.__browseFavoriteExamIds));
+    const selected = !favorites.has(id);
+    if (selected) favorites.add(id);
+    else favorites.delete(id);
+    window.__browseFavoriteExamIds = normalizeBrowseFavoriteIds(Array.from(favorites));
+    browseControlsMutationRevision += 1;
+    persistBrowsePreference({ favoriteExamIds: window.__browseFavoriteExamIds }).catch(console.warn);
+    refreshBrowseResults({ foreground: true });
+    return selected;
 }
 
 // 全局桥接：HTML 按钮 onclick="browseCategory('P1','reading')"
@@ -4016,7 +4121,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
             basePathFilter,
             browsePath: window.__browsePath,
             sortMode: window.__browseSortMode,
-            frequencyFilter: window.__browseFrequencyFilter
+            frequencyFilter: window.__browseFrequencyFilter,
+            progressFilter: window.__browseProgressFilter,
+            favoriteExamIds: window.__browseFavoriteExamIds
         });
     }
 
@@ -4034,7 +4141,9 @@ function getBrowseFilteredExamBase(examIndexSnapshot = []) {
         list = window.ExamActions.applyBrowsePostFilters(
             list,
             window.__browseSortMode,
-            window.__browseFrequencyFilter
+            window.__browseFrequencyFilter,
+            window.__browseProgressFilter,
+            window.__browseFavoriteExamIds
         );
     }
     return list;
@@ -4856,6 +4965,7 @@ if (typeof window !== 'undefined') {
     window.switchLibraryConfig = switchLibraryConfig;
     window.deleteLibraryConfig = deleteLibraryConfig;
     window.setupBrowseControls = setupBrowseControls;
+    window.toggleBrowseFavorite = toggleBrowseFavorite;
 }
 
 

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -6579,6 +6579,7 @@
                 setTimerRunning,
                 checkpointActiveSuiteDuration,
                 checkpointActiveQuestionTiming,
+                buildInlineSuiteSubmissionSnapshot,
                 updateActiveQuestionHighlight,
                 resolveDropzoneQuestionId,
                 activateQuestionTimingForDropzone,
@@ -7706,6 +7707,9 @@
     }
 
     function buildInlineSuiteSubmissionSnapshot() {
+        // 套题汇总直接读取各 slot 的计时缓存，因此先把当前仍在运行的题目落账；
+        // 单篇提交由 buildResults() 完成同样的 checkpoint。
+        checkpointActiveQuestionTiming(Date.now(), interaction.timerRunning);
         updateActiveSlotFromCurrentDom('submit');
         const timerSnapshot = getPracticeTimerSnapshot();
         const suiteEntries = [];

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -4034,6 +4034,23 @@
         }
     }
 
+    function resolveNamedControlQuestionId(name) {
+        const order = Array.isArray(state.dataset?.questionOrder)
+            ? state.dataset.questionOrder.map((questionId) => normalizeQuestionId(questionId)).filter(Boolean)
+            : [];
+        const candidates = resolveCheckboxQuestionIds(name);
+        return candidates.find((questionId) => order.includes(normalizeQuestionId(questionId))) || '';
+    }
+
+    function activateQuestionTimingForNamedControl(name, nowMs = Date.now()) {
+        const questionId = resolveNamedControlQuestionId(name);
+        if (!questionId) {
+            return false;
+        }
+        updateActiveQuestionHighlight(questionId, nowMs);
+        return true;
+    }
+
     function attachNavListeners() {
         const handler = (event) => {
             const section = event.currentTarget;
@@ -4064,15 +4081,7 @@
             if (!input) return;
             const name = input.getAttribute('name');
             if (name) {
-                const order = Array.isArray(state.dataset?.questionOrder) ? state.dataset.questionOrder : [];
-                const cleanName = name.replace(/^q/i, '');
-                const matched = order.find(qId => {
-                    const cleanQId = qId.replace(/^q/i, '');
-                    return cleanQId === cleanName;
-                });
-                if (matched) {
-                    updateActiveQuestionHighlight(matched);
-                }
+                activateQuestionTimingForNamedControl(name);
             }
         });
     }
@@ -6581,6 +6590,8 @@
                 checkpointActiveQuestionTiming,
                 buildInlineSuiteSubmissionSnapshot,
                 updateActiveQuestionHighlight,
+                resolveNamedControlQuestionId,
+                activateQuestionTimingForNamedControl,
                 resolveDropzoneQuestionId,
                 activateQuestionTimingForDropzone,
                 getSelectionHighlightTestState() {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -196,7 +196,10 @@
         keepToolbar: false,
         noteDragFrame: null,
         noteListDragging: false,
-        noteSuppressClickUntil: 0
+        noteSuppressClickUntil: 0,
+        questionDragStartedAtMs: null,
+        questionDragOriginId: '',
+        questionDragCommitted: false
     };
     const testOverrides = {
         renderExplanations: null
@@ -391,6 +394,9 @@
             && !state.reviewMode
             && !state.submitted
         ) ? Date.now() : null;
+        interaction.questionDragStartedAtMs = null;
+        interaction.questionDragOriginId = '';
+        interaction.questionDragCommitted = false;
     }
 
     function resolvePracticeTiming(minDurationSeconds = 0, timerSnapshot = null) {
@@ -3500,10 +3506,11 @@
         return { info, currentPart };
     }
 
-    function updateActiveQuestionHighlight(qId) {
+    function updateActiveQuestionHighlight(qId, nowMs = Date.now()) {
         const nextQuestionId = normalizeQuestionId(qId) || '';
+        const checkpointMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
         if (nextQuestionId !== state.currentActiveQuestionId) {
-            checkpointActiveQuestionTiming(Date.now(), false);
+            checkpointActiveQuestionTiming(checkpointMs, false);
             state.currentActiveQuestionId = nextQuestionId;
             state.questionTimingStartedAtMs = (
                 interaction.timerRunning !== false
@@ -3511,7 +3518,7 @@
                 && !state.readOnly
                 && !state.reviewMode
                 && !state.submitted
-            ) ? Date.now() : null;
+            ) ? checkpointMs : null;
         }
         document.querySelectorAll('.q-item').forEach((item) => {
             if (item.dataset.questionId === nextQuestionId) {
@@ -4704,13 +4711,65 @@
                 event.preventDefault();
                 return;
             }
+            const dragStartedAtMs = Date.now();
+            checkpointActiveQuestionTiming(dragStartedAtMs, false);
+            interaction.questionDragStartedAtMs = dragStartedAtMs;
+            interaction.questionDragOriginId = normalizeQuestionId(state.currentActiveQuestionId) || '';
+            interaction.questionDragCommitted = false;
             event.dataTransfer?.setData('text/plain', JSON.stringify(payload));
             event.dataTransfer.effectAllowed = 'move';
             item.classList.add('dragging');
         });
         item.addEventListener('dragend', () => {
             item.classList.remove('dragging');
+            const dragStartedAtMs = Number(interaction.questionDragStartedAtMs);
+            if (!interaction.questionDragCommitted
+                && Number.isFinite(dragStartedAtMs)
+                && dragStartedAtMs > 0
+                && interaction.questionDragOriginId
+                && interaction.timerRunning !== false
+                && !state.readOnly
+                && !state.reviewMode
+                && !state.submitted) {
+                state.currentActiveQuestionId = interaction.questionDragOriginId;
+                state.questionTimingStartedAtMs = dragStartedAtMs;
+            }
+            interaction.questionDragStartedAtMs = null;
+            interaction.questionDragOriginId = '';
+            interaction.questionDragCommitted = false;
         });
+    }
+
+    function resolveDropzoneQuestionId(dropzone) {
+        if (!dropzone) {
+            return '';
+        }
+        const rawQuestionId = dropzone.dataset?.question || dropzone.dataset?.questionId || '';
+        const candidates = expandQuestionSequence(rawQuestionId);
+        const questionOrder = Array.isArray(state.dataset?.questionOrder)
+            ? state.dataset.questionOrder.map((questionId) => normalizeQuestionId(questionId)).filter(Boolean)
+            : [];
+        return candidates.find((questionId) => questionOrder.includes(questionId)) || '';
+    }
+
+    function activateQuestionTimingForDropzone(dropzone) {
+        const questionId = resolveDropzoneQuestionId(dropzone);
+        if (!questionId) {
+            return false;
+        }
+        const dragStartedAtMs = Number(interaction.questionDragStartedAtMs);
+        const activationMs = Number.isFinite(dragStartedAtMs) && dragStartedAtMs > 0
+            ? dragStartedAtMs
+            : Date.now();
+        updateActiveQuestionHighlight(questionId, activationMs);
+        if (interaction.timerRunning !== false
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted) {
+            state.questionTimingStartedAtMs = activationMs;
+        }
+        interaction.questionDragCommitted = true;
+        return true;
     }
 
     function setDropzoneAnswer(dropzone, value, label) {
@@ -4984,9 +5043,14 @@
                 return;
             }
             if (target.matches(POOL_CONTAINER_SELECTOR) || target.closest(POOL_CONTAINER_SELECTOR)) {
+                const sourceDropzone = payload.sourceDropzoneId
+                    ? document.querySelector(`[data-dropzone-id="${payload.sourceDropzoneId}"]`)
+                    : null;
+                activateQuestionTimingForDropzone(sourceDropzone);
                 handleDropBackToPool(payload);
                 return;
             }
+            activateQuestionTimingForDropzone(target);
             handleDropOnDropzone(target, payload);
         });
     }
@@ -6516,6 +6580,8 @@
                 checkpointActiveSuiteDuration,
                 checkpointActiveQuestionTiming,
                 updateActiveQuestionHighlight,
+                resolveDropzoneQuestionId,
+                activateQuestionTimingForDropzone,
                 getSelectionHighlightTestState() {
                     return {
                         hasLastRange: Boolean(interaction.lastRange),
@@ -6618,6 +6684,16 @@
                             state.suite.slotsByExamId = new Map(Object.entries(slots));
                         }
                     }
+                },
+                setTestInteraction(patch = {}) {
+                    if (!patch || typeof patch !== 'object') {
+                        return;
+                    }
+                    Object.entries(patch).forEach(([key, value]) => {
+                        if (Object.prototype.hasOwnProperty.call(interaction, key)) {
+                            interaction[key] = value;
+                        }
+                    });
                 },
                 setTestOverride(name, value) {
                     if (!Object.prototype.hasOwnProperty.call(testOverrides, name)) {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -144,6 +144,9 @@
         noteDrawerDirty: true,
         noteHighlightMetaDirty: true,
         noteEditorPendingSync: false,
+        currentActiveQuestionId: '',
+        questionTimeSpentMs: {},
+        questionTimingStartedAtMs: null,
         optionsReturnFocus: null,
         optionsInertSiblings: [],
         reviewRecordId: '',
@@ -332,6 +335,62 @@
         } else if (!wasRunning && running && state.suite?.inline && getActiveSuiteSlot()) {
             state.suite.activeStartedAtMs = Number(nowMs) || Date.now();
         }
+    }
+
+    function getActiveQuestionTimingStore() {
+        if (state.suite?.inline) {
+            const slot = getActiveSuiteSlot();
+            if (slot) {
+                if (!slot.questionTimeSpentMs || typeof slot.questionTimeSpentMs !== 'object' || Array.isArray(slot.questionTimeSpentMs)) {
+                    slot.questionTimeSpentMs = {};
+                }
+                return slot.questionTimeSpentMs;
+            }
+        }
+        if (!state.questionTimeSpentMs || typeof state.questionTimeSpentMs !== 'object' || Array.isArray(state.questionTimeSpentMs)) {
+            state.questionTimeSpentMs = {};
+        }
+        return state.questionTimeSpentMs;
+    }
+
+    function checkpointActiveQuestionTiming(nowMs = Date.now(), keepRunning = interaction.timerRunning) {
+        const questionId = normalizeQuestionId(state.currentActiveQuestionId) || '';
+        const startedAtMs = Number(state.questionTimingStartedAtMs);
+        const checkpointMs = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+        if (questionId && Number.isFinite(startedAtMs) && startedAtMs > 0) {
+            const store = getActiveQuestionTimingStore();
+            store[questionId] = Math.max(0, Number(store[questionId]) || 0)
+                + Math.max(0, checkpointMs - startedAtMs);
+        }
+        const canContinue = keepRunning !== false
+            && questionId
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted;
+        state.questionTimingStartedAtMs = canContinue ? checkpointMs : null;
+        return questionId ? Math.max(0, Number(getActiveQuestionTimingStore()[questionId]) || 0) : 0;
+    }
+
+    function syncActiveQuestionTimer(nextRunning, nowMs = Date.now()) {
+        const running = nextRunning !== false;
+        const wasRunning = interaction.timerRunning !== false;
+        if (wasRunning && !running) {
+            checkpointActiveQuestionTiming(nowMs, false);
+        } else if (!wasRunning && running && state.currentActiveQuestionId && !state.readOnly && !state.reviewMode && !state.submitted) {
+            state.questionTimingStartedAtMs = Number(nowMs) || Date.now();
+        }
+    }
+
+    function resetActiveQuestionTiming() {
+        const store = getActiveQuestionTimingStore();
+        Object.keys(store).forEach((questionId) => delete store[questionId]);
+        state.questionTimingStartedAtMs = (
+            interaction.timerRunning !== false
+            && state.currentActiveQuestionId
+            && !state.readOnly
+            && !state.reviewMode
+            && !state.submitted
+        ) ? Date.now() : null;
     }
 
     function resolvePracticeTiming(minDurationSeconds = 0, timerSnapshot = null) {
@@ -558,6 +617,7 @@
     function setTimerRunning(nextRunning) {
         const nowMs = Date.now();
         syncActiveSuiteTimer(Boolean(nextRunning), nowMs);
+        syncActiveQuestionTimer(Boolean(nextRunning), nowMs);
         interaction.timerRunning = !!nextRunning;
         syncPagePauseState(interaction.timerRunning);
         renderTimer();
@@ -1793,6 +1853,9 @@
                 draft: mergeDraft(existing?.draft, inheritedDraft),
                 navStatus: existing?.navStatus instanceof Map ? existing.navStatus : new Map(),
                 lastResults: existing?.lastResults || null,
+                questionTimeSpentMs: existing?.questionTimeSpentMs && typeof existing.questionTimeSpentMs === 'object'
+                    ? existing.questionTimeSpentMs
+                    : {},
                 durationMs: existing?.durationMs !== null
                     && existing?.durationMs !== undefined
                     && Number.isFinite(Number(existing.durationMs))
@@ -1899,6 +1962,7 @@
         }
         const activationGeneration = (Number(state.suite.activationGeneration) || 0) + 1;
         state.suite.activationGeneration = activationGeneration;
+        checkpointActiveQuestionTiming(Date.now(), false);
         if (!options.skipSave) {
             updateActiveSlotFromCurrentDom('deactivate');
         }
@@ -1909,12 +1973,15 @@
         state.dataKey = slot.dataKey || targetExamId;
         state.dataset = slot.dataset;
         state.lastResults = slot.lastResults || null;
+        state.currentActiveQuestionId = '';
+        state.questionTimingStartedAtMs = null;
         navStatus.clear();
         if (slot.navStatus instanceof Map) {
             slot.navStatus.forEach((value, key) => navStatus.set(key, value));
         }
         interaction.currentHighlightNode = null;
         renderDataset(slot.dataset);
+        updateActiveQuestionHighlight(Array.isArray(slot.dataset?.questionOrder) ? slot.dataset.questionOrder[0] : '');
         refreshDynamicQuestionEnhancements();
         clearCurrentAnswers();
         applyDraftToDom(slot.draft || buildEmptyDraft());
@@ -3434,9 +3501,20 @@
     }
 
     function updateActiveQuestionHighlight(qId) {
-        state.currentActiveQuestionId = qId;
+        const nextQuestionId = normalizeQuestionId(qId) || '';
+        if (nextQuestionId !== state.currentActiveQuestionId) {
+            checkpointActiveQuestionTiming(Date.now(), false);
+            state.currentActiveQuestionId = nextQuestionId;
+            state.questionTimingStartedAtMs = (
+                interaction.timerRunning !== false
+                && nextQuestionId
+                && !state.readOnly
+                && !state.reviewMode
+                && !state.submitted
+            ) ? Date.now() : null;
+        }
         document.querySelectorAll('.q-item').forEach((item) => {
-            if (item.dataset.questionId === qId) {
+            if (item.dataset.questionId === nextQuestionId) {
                 item.classList.add('active');
             } else {
                 item.classList.remove('active');
@@ -5543,7 +5621,7 @@
         return hasAnswerInDataset(questionId, collectAnswers(), state.dataset);
     }
 
-    function buildResultsFromAnswers(dataset, answers = {}) {
+    function buildResultsFromAnswers(dataset, answers = {}, questionTimingMs = {}) {
         const answerKey = dataset?.answerKey || {};
         const questionOrder = Array.isArray(dataset?.questionOrder) ? dataset.questionOrder : Object.keys(answerKey);
         const questionTypeMap = buildQuestionTypeMap(dataset);
@@ -5562,6 +5640,10 @@
             const normalizedQuestionId = normalizeQuestionId(questionId) || questionId;
             const questionGroup = questionGroupLookup.get(normalizedQuestionId) || null;
             const questionType = questionTypeMap[normalizedQuestionId] || 'other';
+            const questionTimeSpent = Math.max(
+                0,
+                Number(questionTimingMs?.[normalizedQuestionId] ?? questionTimingMs?.[questionId]) || 0
+            ) / 1000;
             const isMultiChoiceKind = (
                 questionGroup
                 && (questionGroup.kind === 'multi_choice' || questionGroup.kind === 'multiple_choice')
@@ -5608,11 +5690,14 @@
                 questionTypePerformance[questionType] = {
                     total: 0,
                     correct: 0,
-                    accuracy: 0
+                    accuracy: 0,
+                    timeSpent: 0,
+                    averageTime: 0
                 };
             }
             totalQuestions += weight;
             questionTypePerformance[questionType].total += weight;
+            questionTypePerformance[questionType].timeSpent += questionTimeSpent;
             if (partialCorrectCount > 0) {
                 correctCount += partialCorrectCount;
                 questionTypePerformance[questionType].correct += partialCorrectCount;
@@ -5623,6 +5708,7 @@
                 correctAnswer,
                 isCorrect,
                 questionType,
+                timeSpent: questionTimeSpent,
                 partialCorrectCount,
                 weight
             };
@@ -5632,6 +5718,7 @@
                 correctAnswer,
                 isCorrect,
                 questionType,
+                timeSpent: questionTimeSpent,
                 partialCorrectCount,
                 weight
             };
@@ -5640,6 +5727,7 @@
         Object.keys(questionTypePerformance).forEach((type) => {
             const performance = questionTypePerformance[type];
             performance.accuracy = performance.total > 0 ? performance.correct / performance.total : 0;
+            performance.averageTime = performance.total > 0 ? performance.timeSpent / performance.total : 0;
         });
 
         const accuracy = totalQuestions > 0 ? correctCount / totalQuestions : 0;
@@ -5662,7 +5750,8 @@
     }
 
     function buildResults() {
-        return buildResultsFromAnswers(state.dataset, collectAnswers());
+        checkpointActiveQuestionTiming(Date.now(), interaction.timerRunning);
+        return buildResultsFromAnswers(state.dataset, collectAnswers(), getActiveQuestionTimingStore());
     }
 
     function renderResults(results) {
@@ -6425,6 +6514,8 @@
                 applyReplayRecord,
                 setTimerRunning,
                 checkpointActiveSuiteDuration,
+                checkpointActiveQuestionTiming,
+                updateActiveQuestionHighlight,
                 getSelectionHighlightTestState() {
                     return {
                         hasLastRange: Boolean(interaction.lastRange),
@@ -6767,6 +6858,7 @@
             }
         });
         disableDragInteractions();
+        resetActiveQuestionTiming();
         setTimerRunning(true);
         setExitButtonVisible(false);
         updateNavStatuses();
@@ -7523,12 +7615,16 @@
     function mergeQuestionTypePerformance(target, source = {}) {
         Object.entries(source || {}).forEach(([type, performance]) => {
             if (!target[type]) {
-                target[type] = { total: 0, correct: 0, accuracy: 0 };
+                target[type] = { total: 0, correct: 0, accuracy: 0, timeSpent: 0, averageTime: 0 };
             }
             target[type].total += Number(performance && performance.total) || 0;
             target[type].correct += Number(performance && performance.correct) || 0;
+            target[type].timeSpent += Math.max(0, Number(performance && performance.timeSpent) || 0);
             target[type].accuracy = target[type].total > 0
                 ? target[type].correct / target[type].total
+                : 0;
+            target[type].averageTime = target[type].total > 0
+                ? target[type].timeSpent / target[type].total
                 : 0;
         });
     }
@@ -7552,7 +7648,7 @@
                 return;
             }
             const draft = mergeDraft(slot.draft, {});
-            const results = buildResultsFromAnswers(slot.dataset, draft.answers || {});
+            const results = buildResultsFromAnswers(slot.dataset, draft.answers || {}, slot.questionTimeSpentMs || {});
             slot.lastResults = results;
             slot.navStatus = new Map();
             Object.entries(results.answerComparison || {}).forEach(([questionId, comparison]) => {
@@ -8305,6 +8401,7 @@
                 return;
             }
             syncActiveSuiteTimer(detail.running, Date.now());
+            syncActiveQuestionTimer(detail.running, Date.now());
             interaction.timerRunning = detail.running;
             syncPagePauseState(detail.running);
         });
@@ -8319,6 +8416,7 @@
         renderDataset(dataset);
         updateRedesignedSubHeader();
         buildQuestionNav();
+        updateActiveQuestionHighlight(Array.isArray(dataset?.questionOrder) ? dataset.questionOrder[0] : '');
         attachNavListeners();
         attachFloatingNavListeners();
         attachMemorizeLocatorListeners();

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -326,6 +326,12 @@
             }
             entries.forEach(function addEntry(entry) {
                 expanded.push(Object.assign({}, entry || {}, {
+                    type: (entry && (
+                        entry.type ||
+                        entry.examType ||
+                        (entry.metadata && (entry.metadata.type || entry.metadata.examType))
+                    )) ||
+                        (record && (record.type || record.examType)) || '',
                     date: (entry && entry.date) || (record && record.date),
                     metadata: Object.assign({}, (record && record.metadata) || {}, (entry && entry.metadata) || {})
                 }));

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -257,10 +257,170 @@
         });
     }
 
+    function firstPerformanceNumber() {
+        for (var i = 0; i < arguments.length; i += 1) {
+            if (arguments[i] === undefined || arguments[i] === null || arguments[i] === '') {
+                continue;
+            }
+            var numeric = Number(arguments[i]);
+            if (isFinite(numeric) && numeric >= 0) {
+                return numeric;
+            }
+        }
+        return 0;
+    }
+
+    function resolvePerformanceCategory(record, exams) {
+        var metadata = record && record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        var raw = record && (record.category || metadata.category) || '';
+        var matched = String(raw).toUpperCase().match(/P([1-3])/);
+        if (matched) {
+            return 'P' + matched[1];
+        }
+        var exam = ensureArray(exams).find(function findExam(item) {
+            return item && record && (
+                (record.examId && item.id === record.examId) ||
+                (record.title && item.title === record.title)
+            );
+        });
+        var examCategory = exam && String(exam.category || '').toUpperCase().match(/P([1-3])/);
+        return examCategory ? 'P' + examCategory[1] : '';
+    }
+
+    function expandPerformanceRecords(records) {
+        var expanded = [];
+        ensureArray(records).forEach(function expandRecord(record) {
+            var entries = ensureArray(record && record.suiteEntrySummaries);
+            if (!entries.length) {
+                entries = ensureArray(record && record.suiteEntries);
+            }
+            if (!entries.length) {
+                expanded.push(record);
+                return;
+            }
+            entries.forEach(function addEntry(entry) {
+                expanded.push(Object.assign({}, entry || {}, {
+                    date: (entry && entry.date) || (record && record.date),
+                    metadata: Object.assign({}, (record && record.metadata) || {}, (entry && entry.metadata) || {})
+                }));
+            });
+        });
+        return expanded.filter(Boolean);
+    }
+
+    function calculatePerformanceBreakdown(records, exams) {
+        var questionTypes = {};
+        var categories = {
+            P1: { category: 'P1', attempts: 0, total: 0, correct: 0, duration: 0 },
+            P2: { category: 'P2', attempts: 0, total: 0, correct: 0, duration: 0 },
+            P3: { category: 'P3', attempts: 0, total: 0, correct: 0, duration: 0 }
+        };
+
+        expandPerformanceRecords(records).forEach(function aggregateRecord(record) {
+            var performanceMap = record.questionTypePerformance ||
+                (record.realData && record.realData.questionTypePerformance) || {};
+            var duration = firstPerformanceNumber(record.duration);
+            var performanceTotal = Object.keys(performanceMap).reduce(function sumTypes(sum, type) {
+                var metrics = performanceMap[type] || {};
+                return sum + firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+            }, 0);
+            var explicitTimeTotal = Object.keys(performanceMap).reduce(function sumExplicitTime(sum, type) {
+                var metrics = performanceMap[type] || {};
+                return sum + firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+            }, 0);
+            var unallocatedQuestionTotal = Object.keys(performanceMap).reduce(function sumUnallocated(sum, type) {
+                var metrics = performanceMap[type] || {};
+                var explicit = firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+                return explicit > 0 ? sum : sum + firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+            }, 0);
+
+            Object.keys(performanceMap).forEach(function aggregateType(rawType) {
+                var metrics = performanceMap[rawType] || {};
+                var type = normalizeReadingQuestionType(rawType);
+                var total = firstPerformanceNumber(metrics.totalQuestions, metrics.total);
+                var correct = Math.min(total, firstPerformanceNumber(metrics.correctAnswers, metrics.correct));
+                var explicitTime = firstPerformanceNumber(
+                    metrics.timeSpent,
+                    metrics.duration,
+                    metrics.durationSeconds,
+                    metrics.elapsedSeconds
+                );
+                var allocatedTime = explicitTime > 0
+                    ? explicitTime
+                    : (unallocatedQuestionTotal > 0
+                        ? Math.max(0, duration - explicitTimeTotal) * total / unallocatedQuestionTotal
+                        : 0);
+                if (!questionTypes[type]) {
+                    questionTypes[type] = {
+                        type: type,
+                        label: formatQuestionTypeStr(type),
+                        total: 0,
+                        correct: 0,
+                        duration: 0,
+                        estimatedTime: false
+                    };
+                }
+                questionTypes[type].total += total;
+                questionTypes[type].correct += correct;
+                questionTypes[type].duration += allocatedTime;
+                if (explicitTime <= 0 && allocatedTime > 0) {
+                    questionTypes[type].estimatedTime = true;
+                }
+            });
+
+            var category = resolvePerformanceCategory(record, exams);
+            if (categories[category]) {
+                var totalQuestions = firstPerformanceNumber(record.totalQuestions);
+                var correctAnswers = Math.min(totalQuestions, firstPerformanceNumber(record.correctAnswers));
+                if (totalQuestions <= 0 && performanceTotal > 0) {
+                    totalQuestions = performanceTotal;
+                    correctAnswers = Object.keys(performanceMap).reduce(function sumCorrect(sum, type) {
+                        var metrics = performanceMap[type] || {};
+                        return sum + firstPerformanceNumber(metrics.correctAnswers, metrics.correct);
+                    }, 0);
+                }
+                categories[category].attempts += 1;
+                categories[category].total += totalQuestions;
+                categories[category].correct += Math.min(totalQuestions, correctAnswers);
+                categories[category].duration += duration;
+            }
+        });
+
+        var typeRows = Object.keys(questionTypes).map(function finalizeType(type) {
+            var row = questionTypes[type];
+            row.accuracy = row.total > 0 ? row.correct / row.total : 0;
+            row.averageTime = row.total > 0 ? row.duration / row.total : 0;
+            return row;
+        }).sort(function sortTypes(a, b) {
+            var indexA = readingQuestionTypeOrder.indexOf(a.type);
+            var indexB = readingQuestionTypeOrder.indexOf(b.type);
+            return (indexA < 0 ? 999 : indexA) - (indexB < 0 ? 999 : indexB);
+        });
+
+        var categoryRows = ['P1', 'P2', 'P3'].map(function finalizeCategory(category) {
+            var row = categories[category];
+            row.accuracy = row.total > 0 ? row.correct / row.total : 0;
+            row.averageDuration = row.attempts > 0 ? row.duration / row.attempts : 0;
+            return row;
+        });
+        return { questionTypes: typeRows, categories: categoryRows };
+    }
+
     var PracticeStats = {
         calculateSummary: calculateSummary,
         sortByDateDesc: sortByDateDesc,
-        filterByExamType: filterByExamType
+        filterByExamType: filterByExamType,
+        calculatePerformanceBreakdown: calculatePerformanceBreakdown
     };
 
     // --- Practice dashboard view ---
@@ -297,6 +457,107 @@
             element.textContent = value;
         }
     };
+
+    function PracticePerformanceView(options) {
+        options = options || {};
+        this.questionTypeId = options.questionTypeId || 'question-type-performance-list';
+        this.categoryId = options.categoryId || 'category-performance-list';
+        this.noteId = options.noteId || 'question-type-time-note';
+    }
+
+    PracticePerformanceView.prototype.update = function update(data) {
+        if (typeof document === 'undefined') return;
+        data = data || { questionTypes: [], categories: [] };
+        this._renderQuestionTypes(ensureArray(data.questionTypes));
+        this._renderCategories(ensureArray(data.categories));
+        var note = document.getElementById(this.noteId);
+        if (note) {
+            var estimated = ensureArray(data.questionTypes).some(function hasEstimate(row) {
+                return row && row.estimatedTime;
+            });
+            note.textContent = estimated
+                ? '平均耗时按整场用时与各题型题数折算；新记录若含题型计时则优先使用实际值。'
+                : '平均耗时为每题实际或记录内可用耗时。';
+        }
+    };
+
+    PracticePerformanceView.prototype._renderQuestionTypes = function renderQuestionTypes(rows) {
+        var container = document.getElementById(this.questionTypeId);
+        if (!container) return;
+        container.textContent = '';
+        if (!rows.length) {
+            container.appendChild(this._empty('完成一次阅读练习后，这里会显示题型表现。'));
+            return;
+        }
+        rows.forEach(function renderRow(row) {
+            var item = document.createElement('div');
+            item.className = 'performance-row';
+            var heading = document.createElement('div');
+            heading.className = 'performance-row__heading';
+            var name = document.createElement('strong');
+            name.textContent = row.label;
+            var count = document.createElement('span');
+            count.textContent = Math.round(row.correct * 10) / 10 + ' / ' + Math.round(row.total * 10) / 10 + ' 题';
+            heading.appendChild(name);
+            heading.appendChild(count);
+            var metrics = document.createElement('div');
+            metrics.className = 'performance-row__metrics';
+            metrics.appendChild(this._metric('正确率', formatPercentage(row.accuracy * 100)));
+            metrics.appendChild(this._metric('平均耗时', formatPerformanceDuration(row.averageTime)));
+            item.appendChild(heading);
+            item.appendChild(metrics);
+            container.appendChild(item);
+        }, this);
+    };
+
+    PracticePerformanceView.prototype._renderCategories = function renderCategories(rows) {
+        var container = document.getElementById(this.categoryId);
+        if (!container) return;
+        container.textContent = '';
+        rows.forEach(function renderCategory(row) {
+            var item = document.createElement('article');
+            item.className = 'category-performance-card' + (row.attempts ? '' : ' is-empty');
+            var title = document.createElement('h4');
+            title.textContent = row.category;
+            var accuracy = document.createElement('strong');
+            accuracy.className = 'category-performance-card__accuracy';
+            accuracy.textContent = row.attempts ? formatPercentage(row.accuracy * 100) : '暂无记录';
+            var detail = document.createElement('p');
+            detail.textContent = row.attempts
+                ? row.attempts + ' 篇 · ' + (Math.round(row.correct * 10) / 10) + '/' + (Math.round(row.total * 10) / 10) + ' 题 · 平均 ' + formatPerformanceDuration(row.averageDuration) + '/篇'
+                : '完成对应分项后生成统计';
+            item.appendChild(title);
+            item.appendChild(accuracy);
+            item.appendChild(detail);
+            container.appendChild(item);
+        });
+    };
+
+    PracticePerformanceView.prototype._metric = function metric(label, value) {
+        var wrapper = document.createElement('span');
+        var strong = document.createElement('strong');
+        strong.textContent = value;
+        var text = document.createElement('small');
+        text.textContent = label;
+        wrapper.appendChild(strong);
+        wrapper.appendChild(text);
+        return wrapper;
+    };
+
+    PracticePerformanceView.prototype._empty = function empty(message) {
+        var element = document.createElement('p');
+        element.className = 'performance-empty';
+        element.textContent = message;
+        return element;
+    };
+
+    function formatPerformanceDuration(seconds) {
+        var value = Math.max(0, Number(seconds) || 0);
+        if (value < 60) return Math.round(value) + ' 秒';
+        var minutes = Math.floor(value / 60);
+        var remainder = Math.round(value % 60);
+        return remainder ? minutes + '分' + remainder + '秒' : minutes + ' 分钟';
+    }
 
     function formatPercentage(value) {
         if (typeof value !== 'number' || isNaN(value)) {
@@ -2822,6 +3083,20 @@
         var actions = this._createElement('div', { className: 'exam-actions' });
         var actionConfig = this._resolveActionConfig(exam, options);
 
+        if (!isSelecting && !isMemorizeSelecting) {
+            var favoriteIds = Array.isArray(window.__browseFavoriteExamIds) ? window.__browseFavoriteExamIds : [];
+            var isFavorite = favoriteIds.map(String).indexOf(String(exam.id)) !== -1;
+            var favoriteBtn = this._createElement('button', {
+                className: 'btn btn-secondary exam-item-action-btn exam-favorite-btn',
+                dataset: { action: 'favorite', examId: exam.id },
+                type: 'button',
+                title: isFavorite ? '取消收藏' : '收藏题目'
+            }, isFavorite ? '★' : '☆');
+            favoriteBtn.setAttribute('aria-label', isFavorite ? '取消收藏 ' + (exam.title || '') : '收藏 ' + (exam.title || ''));
+            favoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
+            actions.appendChild(favoriteBtn);
+        }
+
         var startBtn = this._createElement('button', {
             className: actionConfig.startClass,
             dataset: { action: actionConfig.startAction, examId: exam.id },
@@ -3423,6 +3698,14 @@
         };
     };
 
+    LegacyExamListView.prototype.getCompletionStatus = function getCompletionStatus(exam) {
+        return this._getCompletionStatus(exam);
+    };
+
+    global.getBrowseCompletionStatus = function getBrowseCompletionStatus(exam) {
+        return LegacyExamListView.prototype._getCompletionStatus.call(null, exam);
+    };
+
     global.prepareBrowseCompletionIndex = prepareBrowseCompletionIndex;
     global.isPreparedBrowseCompletionIndex = isPreparedBrowseCompletionIndex;
     global.commitBrowseCompletionIndex = commitBrowseCompletionIndex;
@@ -3977,6 +4260,7 @@
 
     global.PracticeStats = PracticeStats;
     global.PracticeDashboardView = PracticeDashboardView;
+    global.PracticePerformanceView = PracticePerformanceView;
     global.PracticeTrendRenderer = PracticeTrendRenderer;
     global.PracticePriorityRenderer = PracticePriorityRenderer;
     global.PracticeHistoryRenderer = historyRenderer;

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -287,6 +287,32 @@
         return examCategory ? 'P' + examCategory[1] : '';
     }
 
+    function resolvePerformanceExamType(record, exams) {
+        if (!record) {
+            return '';
+        }
+        var metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        var realData = record.realData && typeof record.realData === 'object' ? record.realData : {};
+        var recordType = normalizeTypeValue(
+            record.type ||
+            record.examType ||
+            metadata.type ||
+            metadata.examType ||
+            realData.type ||
+            realData.examType
+        );
+        if (recordType) {
+            return recordType;
+        }
+        var exam = ensureArray(exams).find(function findExam(item) {
+            return item && (
+                (record.examId && item.id === record.examId) ||
+                (record.title && item.title === record.title)
+            );
+        });
+        return exam ? normalizeTypeValue(exam.type || exam.examType) : '';
+    }
+
     function expandPerformanceRecords(records) {
         var expanded = [];
         ensureArray(records).forEach(function expandRecord(record) {
@@ -317,6 +343,11 @@
         };
 
         expandPerformanceRecords(records).forEach(function aggregateRecord(record) {
+            // 本面板仅展示阅读 P1/P2/P3；明确标记为听力的历史记录不能混入。
+            // 未标记类型的旧阅读记录仍保留，以兼容历史数据。
+            if (resolvePerformanceExamType(record, exams) === 'listening') {
+                return;
+            }
             var performanceMap = record.questionTypePerformance ||
                 (record.realData && record.realData.questionTypePerformance) || {};
             var duration = firstPerformanceNumber(record.duration);


### PR DESCRIPTION
## Summary
- add per-question-type accuracy and average-time insights, plus P1/P2/P3 performance cards
- add P1/P2/P3, unattempted/completed/wrong/favorite filters and a learning-state-aware recommendation sort
- persist favorite/filter state and compact performance metrics, with actual active-question timing for new reading attempts and explicit historical estimates
- rebuild generated bundles and add regression coverage

## Validation
- npm test --prefix developer (112 passed)
- node scripts/build-bundles.mjs --check
- git diff --check
- Playwright browser validation: P1 filter, favorite toggle/filter, and both performance panels