### PR TITLE
fix(practice): surface interrupted attempts in history

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8330,3 +8330,39 @@ body.blue-dark-mode .practice-settings-block__head .hero-panel__muted {
     }
 }
 
+/* Recovery-backed attempts are visible in history without looking like scores. */
+.history-item.history-item-interrupted {
+    background: #fff7ed;
+    border-color: #d97706;
+    box-shadow: 0 8px 22px rgba(217, 119, 6, 0.12);
+}
+
+.record-status-badge,
+.record-interrupted-label {
+    color: #9a3412;
+    font-weight: 700;
+}
+
+.record-status-badge {
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(251, 146, 60, 0.16);
+    white-space: nowrap;
+}
+
+.record-interrupted-container {
+    min-width: 4rem;
+}
+
+body.bloom-dark-mode .history-item.history-item-interrupted,
+body.blue-dark-mode .history-item.history-item-interrupted {
+    background: rgba(67, 38, 15, 0.78);
+    border-color: #f59e0b;
+}
+
+body.bloom-dark-mode .record-status-badge,
+body.bloom-dark-mode .record-interrupted-label,
+body.blue-dark-mode .record-status-badge,
+body.blue-dark-mode .record-interrupted-label {
+    color: #fed7aa;
+}

--- a/developer/tests/js/e2e/appE2ETest.js
+++ b/developer/tests/js/e2e/appE2ETest.js
@@ -260,6 +260,7 @@ class AppE2ETestSuite {
             await this.testExamActionButtons();
             await this.testExamEmptyStateAction();
             await this.testPracticeRecordsFlow();
+            await this.testInterruptedPracticeHistoryVisibility();
             await this.testPracticeHistoryBulkDelete();
             await this.testPracticeSubmissionMessageFlow();
             await this.testSettingsControlButtons();
@@ -1000,6 +1001,78 @@ class AppE2ETestSuite {
             this.recordResult(name, passed, stats);
         } catch (error) {
             this.recordResult(name, false, error.message || String(error));
+        }
+    }
+
+    async testInterruptedPracticeHistoryVisibility() {
+        const name = '中断练习在历史页可见且不污染统计';
+        const interruptedId = `e2e-interrupted-${Date.now()}`;
+        try {
+            if (!this.win.AppData?.recovery || typeof this.win.AppData.recovery.saveInterrupted !== 'function') {
+                this.recordResult(name, false, 'AppData.recovery 不可用');
+                return;
+            }
+            if (typeof this.win.showView === 'function') {
+                this.win.showView('practice');
+            }
+            const totalBefore = this.doc.getElementById('total-practiced')?.textContent || '';
+            await this.win.AppData.recovery.saveInterrupted({
+                id: interruptedId,
+                sessionId: interruptedId,
+                examId: 'e2e-reading-interrupted',
+                startTime: new Date(Date.now() - 300000).toISOString(),
+                endTime: new Date().toISOString(),
+                duration: 300,
+                status: 'interrupted',
+                reason: 'closed',
+                answers: { q1: 'A' },
+                metadata: {
+                    examTitle: 'E2E 中断练习',
+                    type: 'reading',
+                    category: 'P1'
+                }
+            });
+            await this.win.syncPracticeRecords({ forceRender: true });
+
+            await this.waitFor(() => this.doc.querySelector(
+                `#history-list .history-item[data-record-id="${interruptedId}"][data-record-kind="interrupted"]`
+            ), { timeout: 5000, description: '中断记录渲染' });
+
+            const card = this.doc.querySelector(`#history-list .history-item[data-record-id="${interruptedId}"]`);
+            const totalAfter = this.doc.getElementById('total-practiced')?.textContent || '';
+            const statusText = card?.querySelector('.record-interrupted-label')?.textContent?.trim() || '';
+            const hasBulkCheckbox = !!card?.querySelector('input[data-record-id]');
+            const detailsLink = card?.querySelector('[data-record-action="details"]');
+            detailsLink?.click();
+            await this.waitFor(() => this.doc.querySelector('#practice-record-modal.show'), {
+                timeout: 5000,
+                description: '中断记录详情显示'
+            });
+            const modal = this.doc.querySelector('#practice-record-modal');
+            const modalText = modal?.textContent || '';
+            const hasReplayAction = !!modal?.querySelector('.record-summary-replay-trigger');
+            const passed = totalAfter === totalBefore
+                && statusText === '中断'
+                && !hasBulkCheckbox
+                && modalText.includes('未完成练习详情')
+                && modalText.includes('已保留作答')
+                && modalText.includes('A')
+                && !hasReplayAction;
+            this.recordResult(name, passed, {
+                totalBefore,
+                totalAfter,
+                statusText,
+                hasBulkCheckbox,
+                hasReplayAction
+            });
+        } catch (error) {
+            this.recordResult(name, false, error.message || String(error));
+        } finally {
+            try { this.win.practiceRecordModal?.hide(); } catch (_) {}
+            try {
+                await this.win.AppData?.recovery?.discardInterrupted(interruptedId);
+                await this.win.syncPracticeRecords?.({ forceRender: true });
+            } catch (_) {}
         }
     }
 

--- a/developer/tests/js/e2e/appE2ETest.js
+++ b/developer/tests/js/e2e/appE2ETest.js
@@ -1038,10 +1038,18 @@ class AppE2ETestSuite {
                 `#history-list .history-item[data-record-id="${interruptedId}"][data-record-kind="interrupted"]`
             ), { timeout: 5000, description: '中断记录渲染' });
 
-            const card = this.doc.querySelector(`#history-list .history-item[data-record-id="${interruptedId}"]`);
+            let card = this.doc.querySelector(`#history-list .history-item[data-record-id="${interruptedId}"]`);
             const totalAfter = this.doc.getElementById('total-practiced')?.textContent || '';
             const statusText = card?.querySelector('.record-interrupted-label')?.textContent?.trim() || '';
             const hasBulkCheckbox = !!card?.querySelector('input[data-record-id]');
+            await this.win.toggleBulkDelete();
+            card = this.doc.querySelector(`#history-list .history-item[data-record-id="${interruptedId}"]`);
+            const selectedBeforeClick = this.win.getSelectedRecordsState().size;
+            card?.click();
+            await this.delay(100);
+            const selectedAfterClick = this.win.getSelectedRecordsState().size;
+            await this.win.toggleBulkDelete();
+            card = this.doc.querySelector(`#history-list .history-item[data-record-id="${interruptedId}"]`);
             const detailsLink = card?.querySelector('[data-record-action="details"]');
             detailsLink?.click();
             await this.waitFor(() => this.doc.querySelector('#practice-record-modal.show'), {
@@ -1054,6 +1062,7 @@ class AppE2ETestSuite {
             const passed = totalAfter === totalBefore
                 && statusText === '中断'
                 && !hasBulkCheckbox
+                && selectedAfterClick === selectedBeforeClick
                 && modalText.includes('未完成练习详情')
                 && modalText.includes('已保留作答')
                 && modalText.includes('A')
@@ -1063,6 +1072,8 @@ class AppE2ETestSuite {
                 totalAfter,
                 statusText,
                 hasBulkCheckbox,
+                selectedBeforeClick,
+                selectedAfterClick,
                 hasReplayAction
             });
         } catch (error) {

--- a/developer/tests/js/practiceHistorySignature.test.js
+++ b/developer/tests/js/practiceHistorySignature.test.js
@@ -14,6 +14,27 @@ const results = [];
 
 function loadHistoryRenderer() {
     const windowStub = {};
+    windowStub.DOMAdapter = {
+        create(tag, attributes = {}, children = []) {
+            attributes = attributes || {};
+            const node = {
+                tag,
+                attributes,
+                className: attributes.className || '',
+                dataset: { ...(attributes.dataset || {}) },
+                children: (Array.isArray(children) ? children : [children]).filter(Boolean),
+                classList: {
+                    add(...classes) {
+                        node.className = [node.className, ...classes].filter(Boolean).join(' ');
+                    }
+                },
+                appendChild(child) { node.children.push(child); },
+                querySelector() { return null; },
+                setAttribute() {}
+            };
+            return node;
+        }
+    };
     const documentStub = {
         createElement() {
             return {
@@ -96,11 +117,54 @@ async function testUpdatedAtChangesAffectSignature() {
     recordResult('practice history signature tracks updatedAt changes', true, { oldSig, newSig });
 }
 
+async function testInterruptedStatusAffectsSignature() {
+    const renderer = loadHistoryRenderer();
+    const completedSig = renderer.helpers.computeRecordsSignature([baseRecord({ status: 'completed' })]);
+    const interruptedSig = renderer.helpers.computeRecordsSignature([baseRecord({
+        status: 'interrupted',
+        historyRecordKind: 'interrupted'
+    })]);
+    assert.notStrictEqual(completedSig, interruptedSig, '历史列表签名必须区分正式成绩与中断恢复记录');
+    recordResult('practice history signature tracks interrupted status', true, { completedSig, interruptedSig });
+}
+
+function findNode(root, predicate) {
+    if (!root || typeof root !== 'object') return null;
+    if (predicate(root)) return root;
+    for (const child of root.children || []) {
+        const match = findNode(child, predicate);
+        if (match) return match;
+    }
+    return null;
+}
+
+async function testInterruptedCardUsesRecoveryActionsInsteadOfScore() {
+    const renderer = loadHistoryRenderer();
+    const card = renderer.createRecordNode(baseRecord({
+        id: 'interrupted-card',
+        status: 'interrupted',
+        historyRecordKind: 'interrupted'
+    }), { bulkDeleteMode: true, selectedRecords: new Set() });
+
+    assert(card.className.includes('history-item-interrupted'), '中断记录卡片必须有独立视觉状态');
+    assert.strictEqual(card.dataset.recordKind, 'interrupted');
+    assert(!card.className.includes('history-item-selectable'), '中断记录不能进入正式成绩批量删除选择');
+    const statusLabel = findNode(card, (node) => node.className === 'record-interrupted-label');
+    assert(statusLabel, '中断记录必须显示状态而不是伪造 0% 成绩');
+    assert(statusLabel.children.includes('中断'));
+    const deleteButton = findNode(card, (node) => node.dataset?.recordAction === 'delete');
+    assert(deleteButton, '中断记录在批量模式下仍应提供明确的独立删除动作');
+    assert.strictEqual(deleteButton.dataset.recordKind, 'interrupted');
+    recordResult('interrupted history card uses recovery-specific actions', true, { recordKind: card.dataset.recordKind });
+}
+
 async function runAllTests() {
     const tests = [
         testTitleChangesAffectSignature,
         testSuiteEntriesChangesAffectSignature,
-        testUpdatedAtChangesAffectSignature
+        testUpdatedAtChangesAffectSignature,
+        testInterruptedStatusAffectsSignature,
+        testInterruptedCardUsesRecoveryActionsInsteadOfScore
     ];
     for (const testFn of tests) {
         try {

--- a/developer/tests/js/practiceLightProjectionRenderContract.test.js
+++ b/developer/tests/js/practiceLightProjectionRenderContract.test.js
@@ -356,6 +356,9 @@ function loadRealPracticeView() {
             const last = renderedBatches.at(-1) || [];
             return Array.from(last, (record) => String(record && record.id || '')).sort();
         },
+        lastRenderedRecords() {
+            return Array.from(renderedBatches.at(-1) || []);
+        },
         lastSummaryIds() {
             const last = summaries.at(-1) || [];
             return Array.from(last, (record) => String(record && record.id || '')).sort();
@@ -807,6 +810,52 @@ async function testRenderFilterKeepsUnlabelledRecordsAfterProjectionChange() {
         ['shape-absent', 'shape-projected', 'shape-real'],
         'light 投影实际产出的 dataSource 形态（含缺失）必须全部通过 updatePracticeView 的渲染过滤'
     );
+}
+
+async function testInterruptedRecoveryIsVisibleWithoutAffectingStats() {
+    const view = loadRealPracticeView();
+    const completed = {
+        id: 'completed-session',
+        examId: 'reading-p1',
+        title: 'Completed practice',
+        date: '2026-09-05T09:00:00.000Z',
+        percentage: 80,
+        duration: 600
+    };
+    const interrupted = {
+        id: 'interrupted_session-visible',
+        sessionId: 'session-visible',
+        examId: 'reading-p2',
+        endTime: '2026-09-05T10:00:00.000Z',
+        duration: 240,
+        status: 'interrupted',
+        reason: 'closed',
+        answers: { q1: 'A' },
+        metadata: { examTitle: 'Interrupted practice' }
+    };
+
+    view.updatePracticeView([completed], [
+        { id: 'reading-p1', type: 'reading', title: 'Completed practice' },
+        { id: 'reading-p2', type: 'reading', title: 'Interrupted practice' }
+    ], [interrupted]);
+
+    assert.deepStrictEqual(
+        view.lastRenderedIds(),
+        ['completed-session', 'interrupted_session-visible'],
+        'recovery 中的中断记录必须出现在用户可见的练习历史中'
+    );
+    assert.deepStrictEqual(
+        view.lastSummaryIds(),
+        ['completed-session'],
+        '中断记录尚未提交，不能污染已练题数、正确率或成就统计'
+    );
+    const visibleInterrupted = view.lastRenderedRecords()
+        .find((record) => record.id === 'interrupted_session-visible');
+    assert(visibleInterrupted, '必须保留可见的中断记录投影');
+    assert.strictEqual(visibleInterrupted.title, 'Interrupted practice');
+    assert.strictEqual(visibleInterrupted.date, interrupted.endTime);
+    assert.strictEqual(visibleInterrupted.historyRecordKind, 'interrupted');
+    assert.deepStrictEqual({ ...visibleInterrupted.answers }, { q1: 'A' }, '可见投影必须保留已作答内容');
 }
 
 // ---------------------------------------------------------------------------
@@ -1286,6 +1335,7 @@ const tests = [
     ['light 投影的 dataSource 必须能通过渲染过滤', testLightProjectionDataSourcePassesRenderFilter],
     ['falsy dataSource 在 full/light/detail 中必须保值且 isReal 一致', testFalsyDataSourcesPreserveProjectionAndJudgement],
     ['存入的练习记录必须出现在渲染后的历史列表', testStoredRecordsReachRenderedHistoryList],
+    ['中断记录必须可见但不得计入成绩统计', testInterruptedRecoveryIsVisibleWithoutAffectingStats],
     ['light 投影产出的所有 dataSource 形态都不被渲染过滤吃掉', testRenderFilterKeepsUnlabelledRecordsAfterProjectionChange],
     ['演示/种子记录必须同时不显示、不计入统计、不计入成就', testDemoRecordsAreExcludedFromViewStatsAndAchievements],
     ['列表/统计/成就对每条记录的来源判定必须完全一致', testDemoJudgementIsIdenticalAcrossViewStatsAndAchievements],

--- a/developer/tests/js/practiceRecordModal.test.js
+++ b/developer/tests/js/practiceRecordModal.test.js
@@ -265,6 +265,14 @@ async function testInterruptedRecordIsInspectableButNotReplayable() {
         endTime: '2026-09-05T09:05:00.000Z',
         duration: 300,
         answers: { q1: 'A' },
+        __entries: [{
+            canonicalKey: 'q1',
+            displayNumber: '1',
+            correctAnswer: 'B',
+            userAnswer: 'A',
+            isCorrect: false,
+            hasUserAnswer: true
+        }],
         metadata: { category: 'P2' }
     });
 

--- a/developer/tests/js/practiceRecordModal.test.js
+++ b/developer/tests/js/practiceRecordModal.test.js
@@ -253,13 +253,43 @@ async function testCanonicalCorrectAnswerMapWinsInModalHelpers() {
     });
 }
 
+async function testInterruptedRecordIsInspectableButNotReplayable() {
+    const modal = loadModal();
+    const html = modal.createModalHtml({
+        id: 'interrupted-session',
+        examId: 'reading-p2',
+        title: 'Interrupted practice',
+        status: 'interrupted',
+        reason: 'closed',
+        startTime: '2026-09-05T09:00:00.000Z',
+        endTime: '2026-09-05T09:05:00.000Z',
+        duration: 300,
+        answers: { q1: 'A' },
+        metadata: { category: 'P2' }
+    });
+
+    assert(html.includes('未完成练习详情'), '中断记录详情必须明确标记为未完成');
+    assert(html.includes('已保留作答'), '中断记录详情必须说明已保留用户作答');
+    assert(html.includes('interrupted-answer-table'), '中断详情必须渲染专用的已保存作答表格');
+    assert(html.includes('<td class="user-answer">A</td>'), '中断详情必须展示已保存的用户答案');
+    assert(!html.includes('<th>\u6b63\u786e\u7b54\u6848</th>'), '未提交记录不能伪造正确答案或对错判定');
+    assert(!html.includes('错题数：'), '未提交记录不能把未判分答案显示成零道错题');
+    assert(html.includes('未完成（窗口已关闭）'), '详情应将关闭原因转换成用户可理解的状态');
+    assert(!html.includes('record-summary-replay-trigger'), '未提交记录不能提供依赖 canonical practice 的回放入口');
+    assert(!html.includes('aria-label="打开该练习记录回放"'), '未提交记录不能暴露误导性的回放可访问性动作');
+    recordResult('interrupted records are inspectable without a broken replay action', true, {
+        status: 'interrupted'
+    });
+}
+
 async function runAllTests() {
     const tests = [
         testSuiteEntriesDoNotCollapseAcrossPassages,
         testDuplicateRowsStillCollapseInsideSamePassage,
         testReplayKeepsCanonicalRecordSnapshot,
         testNumericCorrectAnswersAreNotAnswerMaps,
-        testCanonicalCorrectAnswerMapWinsInModalHelpers
+        testCanonicalCorrectAnswerMapWinsInModalHelpers,
+        testInterruptedRecordIsInspectableButNotReplayable
     ];
     for (const testFn of tests) {
         try {

--- a/developer/tests/js/practiceRecordPersistence.test.js
+++ b/developer/tests/js/practiceRecordPersistence.test.js
@@ -36,6 +36,14 @@ function createHarness(options = {}) {
             duration: 90
         }
     ];
+    const interruptedState = [{
+        id: 'interrupted-session-1',
+        sessionId: 'session-1',
+        examId: 'reading-p1-interrupted',
+        endTime: '2026-03-09T11:30:00.000Z',
+        status: 'interrupted',
+        metadata: { examTitle: 'Interrupted Record 1' }
+    }];
     const listeners = new Map();
     const savedSpellingErrors = [];
     const renderedSnapshots = [];
@@ -61,6 +69,7 @@ function createHarness(options = {}) {
     const deleteManyCommands = [];
     const clearCommands = [];
     const completionCommands = [];
+    const discardInterruptedCommands = [];
 
     const sandbox = {
         console: quietConsole,
@@ -87,8 +96,12 @@ function createHarness(options = {}) {
         refreshBrowseProgressFromRecords(records, index) {
             browseSnapshots.push({ records: structuredClone(records), index: structuredClone(index) });
         },
-        updatePracticeView(records, index) {
-            renderedSnapshots.push({ records: structuredClone(records), index: structuredClone(index) });
+        updatePracticeView(records, index, interruptedRecords) {
+            renderedSnapshots.push({
+                records: structuredClone(records),
+                index: structuredClone(index),
+                interruptedRecords: structuredClone(interruptedRecords || [])
+            });
         },
         normalizeRecordId(id) {
             return id == null ? '' : String(id);
@@ -217,6 +230,24 @@ function createHarness(options = {}) {
                         };
                     }
                 },
+                recovery: {
+                    async listInterrupted() {
+                        return structuredClone(interruptedState);
+                    },
+                    async getInterrupted(recordId) {
+                        return structuredClone(interruptedState.find((record) => String(record.id) === String(recordId)) || null);
+                    },
+                    async discardInterrupted(recordId) {
+                        discardInterruptedCommands.push(String(recordId));
+                        const index = interruptedState.findIndex((record) => String(record.id) === String(recordId));
+                        if (index >= 0) interruptedState.splice(index, 1);
+                        return { committed: true };
+                    },
+                    async clear() {
+                        interruptedState.splice(0, interruptedState.length);
+                        return { committed: true };
+                    }
+                },
                 settings: {
                     async reset() {
                         return {
@@ -241,8 +272,12 @@ function createHarness(options = {}) {
     if (forceCompletionNotice) {
         sandbox.shouldAnnounceCompletion = () => true;
     }
-    sandbox.updatePracticeView = function updatePracticeViewSpy(records, index) {
-        renderedSnapshots.push({ records: structuredClone(records), index: structuredClone(index) });
+    sandbox.updatePracticeView = function updatePracticeViewSpy(records, index, interruptedRecords) {
+        renderedSnapshots.push({
+            records: structuredClone(records),
+            index: structuredClone(index),
+            interruptedRecords: structuredClone(interruptedRecords || [])
+        });
     };
     sandbox.refreshBrowseProgressFromRecords = function refreshBrowseProgressFromRecordsSpy(records, index) {
         browseSnapshots.push({ records: structuredClone(records), index: structuredClone(index) });
@@ -253,6 +288,7 @@ function createHarness(options = {}) {
     return {
         sandbox,
         practiceState,
+        interruptedState,
         examIndex,
         renderedSnapshots,
         browseSnapshots,
@@ -260,6 +296,7 @@ function createHarness(options = {}) {
         deleteManyCommands,
         clearCommands,
         completionCommands,
+        discardInterruptedCommands,
         messageLog,
         savedSpellingErrors
     };
@@ -292,6 +329,31 @@ async function testDeleteRecordCommitsAndRefreshesCanonicalSnapshot() {
     );
     assert.deepStrictEqual(harness.renderedSnapshots.at(-1).index, harness.examIndex, '练习视图应接收活动题库快照');
     assert.deepStrictEqual(harness.browseSnapshots.at(-1).index, harness.examIndex, '浏览索引应接收同一活动题库快照');
+}
+
+async function testDeleteInterruptedRecordUsesRecoveryStoreAndRefreshesHistoryOnly() {
+    const harness = createHarness();
+
+    await harness.sandbox.deleteRecord('interrupted-session-1', { recordKind: 'interrupted' });
+
+    assert.deepStrictEqual(harness.discardInterruptedCommands, ['interrupted-session-1']);
+    assert.deepStrictEqual(harness.interruptedState, [], '删除中断记录必须清理 recovery，而不是 canonical practice');
+    assert.strictEqual(harness.deleteCommands.length, 0, '删除中断记录不能误删正式练习成绩');
+    assert.deepStrictEqual(
+        harness.practiceState.map((record) => record.id),
+        ['record-1', 'record-2'],
+        '正式练习记录必须保持不变'
+    );
+    assert.deepStrictEqual(
+        harness.renderedSnapshots.at(-1).interruptedRecords,
+        [],
+        '删除后刷新必须从 recovery 回读，确保中断条目立即消失'
+    );
+    assert.deepStrictEqual(
+        harness.browseSnapshots.at(-1).records.map((record) => record.id),
+        ['record-1', 'record-2'],
+        '中断记录的删除不能改变 Browse 完成投影'
+    );
 }
 
 async function testClearPracticeDataCommitsAndRefreshesCanonicalSnapshot() {
@@ -484,6 +546,7 @@ async function testSubmissionIdProducesStableCompletionOperationId() {
 async function main() {
     try {
         await testDeleteRecordCommitsAndRefreshesCanonicalSnapshot();
+        await testDeleteInterruptedRecordUsesRecoveryStoreAndRefreshesHistoryOnly();
         await testClearPracticeDataCommitsAndRefreshesCanonicalSnapshot();
         await testFallbackCompletionPersistsNormalizedSpellingErrors();
         await testCanonicalCompletionSaveRejectsWhenPersistenceFails();

--- a/developer/tests/js/practiceRecordPersistence.test.js
+++ b/developer/tests/js/practiceRecordPersistence.test.js
@@ -70,13 +70,15 @@ function createHarness(options = {}) {
     const clearCommands = [];
     const completionCommands = [];
     const discardInterruptedCommands = [];
+    const selectedRecordState = new Set();
+    const showMessageSpy = (message, type) => {
+        messageLog.push({ message, type });
+    };
 
     const sandbox = {
         console: quietConsole,
         confirm: () => true,
-        showMessage: (message, type) => {
-            messageLog.push({ message, type });
-        },
+        showMessage: showMessageSpy,
         setTimeout,
         clearTimeout,
         setInterval,
@@ -84,13 +86,15 @@ function createHarness(options = {}) {
         Date,
         Math,
         JSON,
+        async ensurePracticeSuiteReady() {},
         processedSessions: {
             clear() {}
         },
-        getSelectedRecordsState() {
-            return new Set();
-        },
-        clearSelectedRecordsState() {},
+        getBulkDeleteModeState() { return true; },
+        getSelectedRecordsState() { return selectedRecordState; },
+        addSelectedRecordState(recordId) { selectedRecordState.add(String(recordId)); },
+        removeSelectedRecordState(recordId) { selectedRecordState.delete(String(recordId)); },
+        clearSelectedRecordsState() { selectedRecordState.clear(); },
         setBulkDeleteModeState() {},
         refreshBulkDeleteButton() {},
         refreshBrowseProgressFromRecords(records, index) {
@@ -133,6 +137,7 @@ function createHarness(options = {}) {
                 }
                 listeners.get(type).push(handler);
             },
+            async ensurePracticeSuiteReady() {},
             async __dispatchWindowEvent(type, event) {
                 const handlers = listeners.get(type) || [];
                 for (const handler of handlers) {
@@ -284,6 +289,7 @@ function createHarness(options = {}) {
     };
     sandbox.window.updatePracticeView = sandbox.updatePracticeView;
     sandbox.window.refreshBrowseProgressFromRecords = sandbox.refreshBrowseProgressFromRecords;
+    sandbox.window.showMessage = showMessageSpy;
 
     return {
         sandbox,
@@ -297,6 +303,7 @@ function createHarness(options = {}) {
         clearCommands,
         completionCommands,
         discardInterruptedCommands,
+        selectedRecordState,
         messageLog,
         savedSpellingErrors
     };
@@ -356,14 +363,38 @@ async function testDeleteInterruptedRecordUsesRecoveryStoreAndRefreshesHistoryOn
     );
 }
 
+async function testMissingInterruptedDetailsUseRecoverySpecificMessage() {
+    const harness = createHarness();
+
+    await harness.sandbox.showRecordDetails('missing-interrupted', { recordKind: 'interrupted' });
+
+    assert.deepStrictEqual(
+        harness.messageLog.at(-1),
+        { message: '中断记录不存在或已清理', type: 'warning' },
+        '中断记录缺失时不能误报为详情模块加载失败'
+    );
+}
+
+async function testInterruptedRecordCannotEnterBulkSelection() {
+    const harness = createHarness();
+
+    await harness.sandbox.toggleRecordSelection('interrupted-session-1', { recordKind: 'interrupted' });
+    assert.strictEqual(harness.selectedRecordState.size, 0, '中断记录不能进入正式成绩的批量选择状态');
+
+    await harness.sandbox.toggleRecordSelection('record-1', { recordKind: 'completed' });
+    assert.deepStrictEqual([...harness.selectedRecordState], ['record-1'], '正式记录仍必须可以进入批量选择状态');
+}
+
 async function testClearPracticeDataCommitsAndRefreshesCanonicalSnapshot() {
     const harness = createHarness();
 
     await harness.sandbox.clearPracticeData();
 
     assert.strictEqual(harness.practiceState.length, 0, 'clearPracticeData 应清空 canonical store');
+    assert.strictEqual(harness.interruptedState.length, 0, 'clearPracticeData 应在刷新历史前清空 recovery store');
     assert.strictEqual(harness.clearCommands.length, 1, 'clearPracticeData 应通过 AppData.practice.clear 写入 tombstone');
     assert.deepStrictEqual(harness.renderedSnapshots.at(-1).records, [], 'clearPracticeData 后练习视图应接收空快照');
+    assert.deepStrictEqual(harness.renderedSnapshots.at(-1).interruptedRecords, [], 'clearPracticeData 后历史视图不能残留中断记录');
     assert.deepStrictEqual(harness.browseSnapshots.at(-1).records, [], 'clearPracticeData 后浏览完成索引应接收空快照');
 }
 
@@ -547,6 +578,8 @@ async function main() {
     try {
         await testDeleteRecordCommitsAndRefreshesCanonicalSnapshot();
         await testDeleteInterruptedRecordUsesRecoveryStoreAndRefreshesHistoryOnly();
+        await testMissingInterruptedDetailsUseRecoverySpecificMessage();
+        await testInterruptedRecordCannotEnterBulkSelection();
         await testClearPracticeDataCommitsAndRefreshesCanonicalSnapshot();
         await testFallbackCompletionPersistsNormalizedSpellingErrors();
         await testCanonicalCompletionSaveRejectsWhenPersistenceFails();

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -2289,6 +2289,10 @@
     historyRenderer.createRecordNode = function (record, options) {
         options = options || {};
         var bulkDeleteMode = Boolean(options.bulkDeleteMode);
+        var isInterrupted = Boolean(record && (
+            record.historyRecordKind === 'interrupted'
+            || record.status === 'interrupted'
+        ));
         var selectedRecordsInput = options.selectedRecords;
         var selectedRecords = new Set();
         if (selectedRecordsInput && typeof selectedRecordsInput.forEach === 'function') {
@@ -2320,14 +2324,14 @@
         }
 
         var item = createNode('div', {
-            className: 'history-item history-record-item',
-            dataset: { recordId: recordId }
+            className: 'history-item history-record-item' + (isInterrupted ? ' history-item-interrupted' : ''),
+            dataset: { recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
         });
 
         var isSelected = recordId && selectedRecords.has(recordId);
         var selection = createNode('div', {
-            className: 'record-selection' + (bulkDeleteMode ? '' : ' record-selection-hidden')
-        }, [
+            className: 'record-selection' + (bulkDeleteMode && !isInterrupted ? '' : ' record-selection-hidden')
+        }, isInterrupted ? [] : [
             createNode('input', {
                 type: 'checkbox',
                 checked: isSelected ? 'checked' : null,
@@ -2343,7 +2347,7 @@
             checkboxNode.setAttribute('aria-checked', isSelected ? 'true' : 'false');
         }
 
-        if (bulkDeleteMode) {
+        if (bulkDeleteMode && !isInterrupted) {
             item.classList.add('history-item-selectable');
             if (isSelected) {
                 item.classList.add('history-item-selected');
@@ -2351,12 +2355,12 @@
         }
 
         item.appendChild(selection);
-        var infoClass = 'record-info' + (bulkDeleteMode ? ' record-info-selectable' : '');
+        var infoClass = 'record-info' + (bulkDeleteMode && !isInterrupted ? ' record-info-selectable' : '');
         var info = createNode('div', { className: infoClass }, [
             createNode('a', {
                 href: '#',
                 className: 'practice-record-title',
-                dataset: { recordAction: 'details', recordId: recordId }
+                dataset: { recordAction: 'details', recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
             }, [
                 createNode('strong', null, record && record.title ? record.title : '无标题')
             ]),
@@ -2368,25 +2372,28 @@
                         className: 'duration-time',
                         style: { color: helpers.getDurationColor(durationInSeconds) }
                     }, helpers.formatDurationShort(durationInSeconds))
-                ])
+                ]),
+                isInterrupted ? createNode('small', { className: 'record-status-badge' }, '未完成 · 已保留作答') : null
             ])
         ]);
 
-        var percentageNode = createNode('div', { className: 'record-percentage-container' }, [
+        var percentageNode = createNode('div', {
+            className: 'record-percentage-container' + (isInterrupted ? ' record-interrupted-container' : '')
+        }, [
             createNode('div', {
-                className: 'record-percentage',
-                style: { color: helpers.getScoreColor(percentage) }
-            }, formatPercentage(percentage))
+                className: isInterrupted ? 'record-interrupted-label' : 'record-percentage',
+                style: isInterrupted ? null : { color: helpers.getScoreColor(percentage) }
+            }, isInterrupted ? '中断' : formatPercentage(percentage))
         ]);
 
         var actions = null;
-        if (!bulkDeleteMode) {
+        if (!bulkDeleteMode || isInterrupted) {
             actions = createNode('div', { className: 'record-actions-container' }, [
                 createNode('button', {
                     type: 'button',
                     className: 'delete-record-btn',
                     title: '删除此记录',
-                    dataset: { recordAction: 'delete', recordId: recordId }
+                    dataset: { recordAction: 'delete', recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
                 }, '🗑️')
             ]);
         }
@@ -2566,6 +2573,8 @@
                 pct,
                 dur,
                 historyRenderer.helpers.getRecordsSignatureText(title),
+                historyRenderer.helpers.getRecordsSignatureText(record && record.historyRecordKind),
+                historyRenderer.helpers.getRecordsSignatureText(record && record.status),
                 suiteEntries
             ]);
         });
@@ -18453,10 +18462,11 @@ async function syncPracticeRecords(options = {}) {
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
-    let [records, insightRecords, examIndex] = await Promise.all([
+    let [records, insightRecords, examIndex, interruptedRecords] = await Promise.all([
         listCanonicalPracticeRecordSummaries(),
         window.AppData.practice.listInsights({ limit: 10 }),
-        resolveActiveExamIndex()
+        resolveActiveExamIndex(),
+        listInterruptedPracticeRecordsForHistory()
     ]);
     const insightsById = new Map((Array.isArray(insightRecords) ? insightRecords : [])
         .filter((record) => record && record.id)
@@ -18513,7 +18523,10 @@ async function syncPracticeRecords(options = {}) {
     try {
         const renderer = window.PracticeHistoryRenderer;
         if (renderer && renderer.helpers && typeof renderer.helpers.computeRecordsSignature === 'function') {
-            const nextSignature = renderer.helpers.computeRecordsSignature(records);
+            const historyRecords = records.concat(
+                normalizeInterruptedPracticeRecordsForHistory(interruptedRecords, examIndex)
+            );
+            const nextSignature = renderer.helpers.computeRecordsSignature(historyRecords);
             if (!forceRender && lastPracticeRecordsSignature === nextSignature) {
                 console.log('[System] 练习记录未变化，跳过UI刷新');
                 recordsUnchanged = true;
@@ -18545,7 +18558,7 @@ async function syncPracticeRecords(options = {}) {
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
-        updatePracticeView(records, examIndex);
+        updatePracticeView(records, examIndex, interruptedRecords);
     }
     return records;
 }
@@ -18652,6 +18665,21 @@ async function listCanonicalPracticeRecords() {
 async function listCanonicalPracticeRecordSummaries() {
     const summaries = await window.AppData.practice.list({ projection: 'light' });
     return Array.isArray(summaries) ? summaries : [];
+}
+
+async function listInterruptedPracticeRecordsForHistory() {
+    const recovery = window.AppData && window.AppData.recovery;
+    if (!recovery || typeof recovery.listInterrupted !== 'function') {
+        return [];
+    }
+    try {
+        const records = await recovery.listInterrupted();
+        return Array.isArray(records) ? records : [];
+    } catch (error) {
+        // Recovery visibility must never make canonical history unavailable.
+        console.warn('[PracticeHistory] 读取中断记录失败，继续显示已完成记录:', error);
+        return [];
+    }
 }
 
 async function resolveActiveExamIndex() {
@@ -19810,19 +19838,19 @@ function setupPracticeHistoryInteractions() {
         return;
     }
 
-    const handleDetails = (recordId, event) => {
+    const handleDetails = (recordId, recordKind, event) => {
         if (!recordId) return;
         if (event) event.preventDefault();
         if (typeof showRecordDetails === 'function') {
-            showRecordDetails(recordId);
+            showRecordDetails(recordId, { recordKind });
         }
     };
 
-    const handleDelete = (recordId, event) => {
+    const handleDelete = (recordId, recordKind, event) => {
         if (!recordId) return;
         if (event) event.preventDefault();
         if (typeof deleteRecord === 'function') {
-            deleteRecord(recordId);
+            deleteRecord(recordId, { recordKind });
         }
     };
 
@@ -19847,11 +19875,11 @@ function setupPracticeHistoryInteractions() {
 
     if (hasDomDelegate) {
         window.DOM.delegate('click', '.practice-history-list [data-record-action="details"], #history-list [data-record-action="details"]', function (event) {
-            handleDetails(this.dataset.recordId, event);
+            handleDetails(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('click', '.practice-history-list [data-record-action="delete"], #history-list [data-record-action="delete"]', function (event) {
-            handleDelete(this.dataset.recordId, event);
+            handleDelete(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('click', '.practice-history-list .history-item, #history-list .history-item', function (event) {
@@ -19870,13 +19898,13 @@ function setupPracticeHistoryInteractions() {
         container.addEventListener('click', (event) => {
             const detailsTarget = event.target.closest('[data-record-action="details"]');
             if (detailsTarget && container.contains(detailsTarget)) {
-                handleDetails(detailsTarget.dataset.recordId, event);
+                handleDetails(detailsTarget.dataset.recordId, detailsTarget.dataset.recordKind, event);
                 return;
             }
 
             const deleteTarget = event.target.closest('[data-record-action="delete"]');
             if (deleteTarget && container.contains(deleteTarget)) {
-                handleDelete(deleteTarget.dataset.recordId, event);
+                handleDelete(deleteTarget.dataset.recordId, deleteTarget.dataset.recordKind, event);
                 return;
             }
 
@@ -19966,8 +19994,47 @@ function filterRealPracticeRecordsForView(records) {
     return classifier.filterRecordsForHistoryView(list);
 }
 
+function normalizeInterruptedPracticeRecordsForHistory(records, examIndex = []) {
+    const index = Array.isArray(examIndex) ? examIndex : [];
+    return (Array.isArray(records) ? records : []).filter(Boolean).map((record) => {
+        const metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        const exam = index.find((item) => item && item.id === record.examId) || {};
+        const id = record.id || (record.sessionId ? `interrupted_${record.sessionId}` : '');
+        const date = record.endTime || record.createdAt || record.updatedAt || record.startTime || '';
+        return {
+            ...record,
+            id,
+            title: record.title || metadata.examTitle || exam.title || record.examId || '未完成练习',
+            date,
+            type: record.type || record.examType || metadata.type || exam.type || '',
+            category: record.category || metadata.category || exam.category || '',
+            frequency: record.frequency || metadata.frequency || exam.frequency || '',
+            status: 'interrupted',
+            historyRecordKind: 'interrupted'
+        };
+    });
+}
+
+function practiceHistoryRecordMatchesQuery(record, query) {
+    if (!record) {
+        return false;
+    }
+    const fields = [
+        record.title,
+        record.examId,
+        record.category,
+        record.frequency,
+        record.status === 'interrupted' ? '未完成 中断' : '',
+        record.reason,
+        record.metadata && record.metadata.examTitle,
+        record.metadata && record.metadata.category,
+        record.date
+    ];
+    return fields.some((field) => String(field || '').toLowerCase().includes(query));
+}
+
 // Phase 3: 练习记录视图更新 - 保留在 main.js（依赖多个组件，暂不迁移）
-function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
+function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = [], interruptedSnapshot = []) {
     const rawRecords = Array.isArray(recordsSnapshot) ? recordsSnapshot : [];
     const examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
     // 排除演示/种子记录。判定必须与 practice.stats / achievements.progress 两个投影器
@@ -20013,21 +20080,7 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
 
     const historyQuery = String(window.__practiceHistoryQuery || '').trim().toLowerCase();
     if (historyQuery) {
-        recordsToShow = recordsToShow.filter((record) => {
-            if (!record) {
-                return false;
-            }
-            const fields = [
-                record.title,
-                record.examId,
-                record.category,
-                record.frequency,
-                record.metadata && record.metadata.examTitle,
-                record.metadata && record.metadata.category,
-                record.date
-            ];
-            return fields.some((field) => String(field || '').toLowerCase().includes(historyQuery));
-        });
+        recordsToShow = recordsToShow.filter((record) => practiceHistoryRecordMatchesQuery(record, historyQuery));
     }
 
     const trendRenderer = ensurePracticeTrendRenderer();
@@ -20039,6 +20092,19 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
     if (priorityRenderer && typeof priorityRenderer.update === 'function') {
         priorityRenderer.update(recordsForInsights, examIndex, { examType });
     }
+
+    // Interrupted attempts stay in recovery storage and are appended only to
+    // the visible history list. They must not affect score, trend, priority,
+    // achievement, or Browse completion projections.
+    let interruptedToShow = normalizeInterruptedPracticeRecordsForHistory(interruptedSnapshot, examIndex);
+    if (examType !== 'all') {
+        interruptedToShow = interruptedToShow.filter((record) => recordMatchesExamType(record, examType, examIndex));
+    }
+    if (historyQuery) {
+        interruptedToShow = interruptedToShow.filter((record) => practiceHistoryRecordMatchesQuery(record, historyQuery));
+    }
+    recordsToShow = recordsToShow.concat(interruptedToShow)
+        .sort((left, right) => new Date(right.date || 0) - new Date(left.date || 0));
 
     // --- 4. Render history list ---
     const renderer = window.PracticeHistoryRenderer;
@@ -21818,8 +21884,29 @@ async function viewPDF(examId) {
 }
 
 // Bridge for record details to existing enhancer/modal if present
-function showRecordDetails(recordId) {
-    ensurePracticeSuiteReady().then(() => {
+function showRecordDetails(recordId, options = {}) {
+    return ensurePracticeSuiteReady().then(async () => {
+        if (options.recordKind === 'interrupted') {
+            const recovery = window.AppData && window.AppData.recovery;
+            if (!recovery || typeof recovery.getInterrupted !== 'function') {
+                throw new Error('中断记录恢复服务不可用');
+            }
+            const record = await recovery.getInterrupted(recordId);
+            if (!record) {
+                throw new Error('中断记录不存在或已清理');
+            }
+            if (!window.practiceRecordModal || typeof window.practiceRecordModal.show !== 'function') {
+                throw new Error('记录详情组件未加载');
+            }
+            window.practiceRecordModal.show({
+                ...record,
+                title: record.title || record.metadata?.examTitle || record.examId || '未完成练习',
+                date: record.endTime || record.createdAt || record.startTime || '',
+                status: 'interrupted',
+                historyRecordKind: 'interrupted'
+            });
+            return;
+        }
         if (window.practiceHistoryEnhancer && typeof window.practiceHistoryEnhancer.showRecordDetails === 'function') {
             window.practiceHistoryEnhancer.showRecordDetails(recordId);
             return;
@@ -22329,9 +22416,31 @@ async function toggleRecordSelection(recordId) {
 }
 
 
-async function deleteRecord(recordId) {
+async function deleteRecord(recordId, options = {}) {
     if (!recordId) {
         showMessage('记录ID无效', 'error');
+        return;
+    }
+
+    if (options.recordKind === 'interrupted') {
+        const recovery = window.AppData && window.AppData.recovery;
+        if (!recovery || typeof recovery.getInterrupted !== 'function' || typeof recovery.discardInterrupted !== 'function') {
+            showMessage('中断记录恢复服务不可用', 'error');
+            return;
+        }
+        const record = await recovery.getInterrupted(recordId);
+        if (!record) {
+            showMessage('未找到中断记录', 'error');
+            return;
+        }
+        const title = record.title || record.metadata?.examTitle || record.examId || '未完成练习';
+        const date = record.endTime || record.createdAt || record.startTime;
+        const confirmMessage = `确定要删除这条未完成练习吗？\n\n题目: ${title}\n时间: ${date ? new Date(date).toLocaleString() : '未知时间'}\n\n此操作不可恢复。`;
+        if (confirm(confirmMessage)) {
+            await recovery.discardInterrupted(recordId);
+            await syncPracticeRecords({ forceRender: true, trigger: 'interrupted-delete' });
+            showMessage('未完成练习已删除', 'success');
+        }
         return;
     }
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -19854,10 +19854,10 @@ function setupPracticeHistoryInteractions() {
         }
     };
 
-    const handleSelection = (recordId, event) => {
-        if (!getBulkDeleteModeState() || !recordId) return;
+    const handleSelection = (recordId, recordKind, event) => {
+        if (!getBulkDeleteModeState() || !recordId || recordKind === 'interrupted') return;
         if (event) event.preventDefault();
-        toggleRecordSelection(recordId);
+        toggleRecordSelection(recordId, { recordKind });
     };
 
     const handleCheckbox = (recordId, event) => {
@@ -19888,7 +19888,7 @@ function setupPracticeHistoryInteractions() {
             if (event.target && event.target.matches('input[data-record-id]')) {
                 return;
             }
-            handleSelection(this.dataset.recordId, event);
+            handleSelection(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('change', '.practice-history-list input[data-record-id], #history-list input[data-record-id]', function (event) {
@@ -19914,7 +19914,7 @@ function setupPracticeHistoryInteractions() {
                 if (actionTarget || (event.target && event.target.matches('input[data-record-id]'))) {
                     return;
                 }
-                handleSelection(item.dataset.recordId, event);
+                handleSelection(item.dataset.recordId, item.dataset.recordKind, event);
             }
         });
 
@@ -21889,14 +21889,24 @@ function showRecordDetails(recordId, options = {}) {
         if (options.recordKind === 'interrupted') {
             const recovery = window.AppData && window.AppData.recovery;
             if (!recovery || typeof recovery.getInterrupted !== 'function') {
-                throw new Error('中断记录恢复服务不可用');
+                window.showMessage('中断记录恢复服务不可用', 'error');
+                return;
             }
-            const record = await recovery.getInterrupted(recordId);
+            let record;
+            try {
+                record = await recovery.getInterrupted(recordId);
+            } catch (error) {
+                console.error('[PracticeHistory] 读取中断记录详情失败:', error);
+                window.showMessage('中断记录读取失败，请稍后重试', 'error');
+                return;
+            }
             if (!record) {
-                throw new Error('中断记录不存在或已清理');
+                window.showMessage('中断记录不存在或已清理', 'warning');
+                return;
             }
             if (!window.practiceRecordModal || typeof window.practiceRecordModal.show !== 'function') {
-                throw new Error('记录详情组件未加载');
+                window.showMessage('记录详情组件未加载', 'error');
+                return;
             }
             window.practiceRecordModal.show({
                 ...record,
@@ -22398,8 +22408,8 @@ async function bulkDeleteRecords(selectedSnapshot = getSelectedRecordsState()) {
     console.log(`[System] 批量删除了 ${deletedCount} 条练习记录`);
 }
 
-async function toggleRecordSelection(recordId) {
-    if (!getBulkDeleteModeState()) return;
+async function toggleRecordSelection(recordId, options = {}) {
+    if (!getBulkDeleteModeState() || options.recordKind === 'interrupted') return;
 
     const normalizedId = normalizeRecordId(recordId);
     if (!normalizedId) {
@@ -22465,10 +22475,10 @@ async function deleteRecord(recordId, options = {}) {
 async function clearPracticeData() {
     if (confirm('确定要清除所有练习记录吗？此操作不可恢复。')) {
         await window.AppData.practice.clear();
-        await syncPracticeRecords({ forceRender: true, trigger: 'clear-all' });
         if (window.AppData && window.AppData.recovery && typeof window.AppData.recovery.clear === 'function') {
             await window.AppData.recovery.clear();
         }
+        await syncPracticeRecords({ forceRender: true, trigger: 'clear-all' });
         processedSessions.clear();
         clearSelectedRecordsState();
         setBulkDeleteModeState(false);

--- a/js/bundles/practice.bundle.js
+++ b/js/bundles/practice.bundle.js
@@ -2366,6 +2366,7 @@ class PracticeRecordModal {
 
     createModalHtml(record) {
         const metadata = record.metadata || {};
+        const isInterrupted = record.status === 'interrupted' || record.historyRecordKind === 'interrupted';
         const examTitle = metadata.examTitle || record.title || record.examId || '\u672a\u77e5\u9898\u76ee';
         const category = record.category || metadata.category || '\u672a\u77e5\u5206\u7c7b';
         const frequencyLabel = this.getFrequencyLabel(record);
@@ -2379,6 +2380,25 @@ class PracticeRecordModal {
         const summaryCounts = this.getEntriesSummary(this.collectAllEntries(record));
         const incorrectCount = summaryCounts.incorrect || 0;
         const unansweredCount = summaryCounts.unanswered || 0;
+        const modalTitle = isInterrupted ? '未完成练习详情' : '\u7ec3\u4e60\u8bb0\u5f55\u8be6\u60c5';
+        const scoreText = isInterrupted ? '未提交' : score;
+        const accuracyText = isInterrupted ? '未提交' : (accuracyPercent != null ? `${accuracyPercent}%` : '\u672a\u77e5');
+        const statusInfo = isInterrupted ? `
+            <div class="meta-item">
+                <span class="meta-label">状态：</span>
+                <span class="meta-value record-interrupted-label">未完成（${this.escapeHtml(this.formatInterruptedReason(record.reason))}）</span>
+            </div>
+        ` : '';
+        const gradingCountInfo = isInterrupted ? '' : `
+            <div class="meta-item">
+                <span class="meta-label">错题数：</span>
+                <span class="meta-value error-count">${incorrectCount}</span>
+            </div>
+            <div class="meta-item">
+                <span class="meta-label">未作答：</span>
+                <span class="meta-value unanswered-count">${unansweredCount}</span>
+            </div>
+        `;
 
         // 多套题模式的额外信息
         let multiSuiteInfo = '';
@@ -2399,17 +2419,18 @@ class PracticeRecordModal {
             <div id="${this.modalId}" class="modal-overlay">
                 <div class="modal-container">
                     <div class="modal-header">
-                        <h3 class="modal-title">\u7ec3\u4e60\u8bb0\u5f55\u8be6\u60c5</h3>
+                        <h3 class="modal-title">${modalTitle}</h3>
                         <button class="modal-close" aria-label="\u5173\u95ed\u5f39\u7a97">
                             <i class="fas fa-times"></i>
                         </button>
                     </div>
                     <div class="modal-body">
                         <div class="record-summary">
-                            <h4 class="record-summary-replay-trigger" role="button" tabindex="0" aria-label="打开该练习记录回放">
+                            <h4 class="${isInterrupted ? 'record-summary-title' : 'record-summary-replay-trigger'}"${isInterrupted ? '' : ' role="button" tabindex="0" aria-label="打开该练习记录回放"'}>
                                 ${this.escapeHtml(category)} - ${this.escapeHtml(frequencyLabel)} - ${this.escapeHtml(examTitle)}
                             </h4>
                             <div class="record-meta">
+                                ${statusInfo}
                                 <div class="meta-item">
                                     <span class="meta-label">\u7ec3\u4e60\u65f6\u95f4\uff1a</span>
                                     <span class="meta-value">${this.escapeHtml(formattedStart)}</span>
@@ -2420,25 +2441,18 @@ class PracticeRecordModal {
                                 </div>
                                 <div class="meta-item">
                                     <span class="meta-label">\u5f97\u5206\uff1a</span>
-                                    <span class="meta-value score-highlight">${this.escapeHtml(score)}</span>
+                                    <span class="meta-value score-highlight">${this.escapeHtml(scoreText)}</span>
                                 </div>
                                 <div class="meta-item">
                                     <span class="meta-label">\u51c6\u786e\u7387\uff1a</span>
-                                    <span class="meta-value">${accuracyPercent != null ? `${accuracyPercent}%` : '\u672a\u77e5'}</span>
+                                    <span class="meta-value">${this.escapeHtml(accuracyText)}</span>
                                 </div>
-                                <div class="meta-item">
-                                    <span class="meta-label">\u9519\u9898\u6570\uff1a</span>
-                                    <span class="meta-value error-count">${incorrectCount}</span>
-                                </div>
-                                <div class="meta-item">
-                                    <span class="meta-label">\u672a\u4f5c\u7b54\uff1a</span>
-                                    <span class="meta-value unanswered-count">${unansweredCount}</span>
-                                </div>
+                                ${gradingCountInfo}
                                 ${multiSuiteInfo}
                             </div>
                         </div>
                         <div class="answer-details">
-                            <h5>\u7b54\u9898\u8be6\u60c5</h5>
+                            <h5>${isInterrupted ? '已保留作答' : '\u7b54\u9898\u8be6\u60c5'}</h5>
                             ${answerSection}
                         </div>
                     </div>
@@ -2505,6 +2519,18 @@ class PracticeRecordModal {
             return `${record.score}/${record.total}`;
         }
         return '\u672a\u77e5';
+    }
+
+    formatInterruptedReason(reason) {
+        const labels = {
+            timeout: '窗口失去响应',
+            closed: '窗口已关闭',
+            cancelled: '练习已取消',
+            unload: '页面已离开',
+            error: '练习异常中断'
+        };
+        const normalized = String(reason || '').trim().toLowerCase();
+        return labels[normalized] || (normalized ? String(reason) : '异常退出');
     }
 
     resolveAccuracy(record) {
@@ -2804,6 +2830,10 @@ class PracticeRecordModal {
             return '<div class="no-answers-message"><p>\u6682\u65e0\u7b54\u9898\u6570\u636e</p></div>';
         }
 
+        if (record.status === 'interrupted' || record.historyRecordKind === 'interrupted') {
+            return this.generateInterruptedAnswerTable(record);
+        }
+
         if (record.answerComparison && Object.keys(record.answerComparison).length > 0) {
             const merged = this.mergeComparisonWithCorrections(record);
             return this.generateLegacyTableFromComparison(merged);
@@ -2856,6 +2886,32 @@ class PracticeRecordModal {
                     <tbody>
                         ${rows}
                     </tbody>
+                </table>
+            </div>
+        `;
+    }
+
+    generateInterruptedAnswerTable(record) {
+        const answers = record.answers || (record.realData && record.realData.answers) || {};
+        const questionNumbers = this.extractLegacyQuestionNumbers(answers, {});
+        if (questionNumbers.length === 0) {
+            return '<div class="no-answers-message"><p>尚未作答，练习进度已保留</p></div>';
+        }
+        const rows = questionNumbers.map((questionNumber) => {
+            const userAnswer = this.getLegacyUserAnswer(answers, questionNumber);
+            const safeUser = userAnswer != null ? this.truncateAnswer(userAnswer) : '未作答';
+            return `
+                <tr class="answer-row unknown">
+                    <td class="question-num">${this.escapeHtml(String(questionNumber))}</td>
+                    <td class="user-answer">${this.escapeHtml(safeUser)}</td>
+                </tr>
+            `;
+        }).join('');
+        return `
+            <div class="answers-table-container">
+                <table class="answer-table interrupted-answer-table">
+                    <thead><tr><th>题号</th><th>已保存作答</th></tr></thead>
+                    <tbody>${rows}</tbody>
                 </table>
             </div>
         `;

--- a/js/bundles/practice.bundle.js
+++ b/js/bundles/practice.bundle.js
@@ -2623,6 +2623,9 @@ class PracticeRecordModal {
 
     generateAnswerTable(record) {
         const preparedRecord = this.prepareRecordForDisplay(record);
+        if (record && (record.status === 'interrupted' || record.historyRecordKind === 'interrupted')) {
+            return this.generateInterruptedAnswerTable(preparedRecord);
+        }
         const suiteEntries = this.getSuiteEntries(preparedRecord);
 
         if (suiteEntries.length > 0) {

--- a/js/components/practiceRecordModal.js
+++ b/js/components/practiceRecordModal.js
@@ -189,6 +189,7 @@ class PracticeRecordModal {
 
     createModalHtml(record) {
         const metadata = record.metadata || {};
+        const isInterrupted = record.status === 'interrupted' || record.historyRecordKind === 'interrupted';
         const examTitle = metadata.examTitle || record.title || record.examId || '\u672a\u77e5\u9898\u76ee';
         const category = record.category || metadata.category || '\u672a\u77e5\u5206\u7c7b';
         const frequencyLabel = this.getFrequencyLabel(record);
@@ -202,6 +203,25 @@ class PracticeRecordModal {
         const summaryCounts = this.getEntriesSummary(this.collectAllEntries(record));
         const incorrectCount = summaryCounts.incorrect || 0;
         const unansweredCount = summaryCounts.unanswered || 0;
+        const modalTitle = isInterrupted ? '未完成练习详情' : '\u7ec3\u4e60\u8bb0\u5f55\u8be6\u60c5';
+        const scoreText = isInterrupted ? '未提交' : score;
+        const accuracyText = isInterrupted ? '未提交' : (accuracyPercent != null ? `${accuracyPercent}%` : '\u672a\u77e5');
+        const statusInfo = isInterrupted ? `
+            <div class="meta-item">
+                <span class="meta-label">状态：</span>
+                <span class="meta-value record-interrupted-label">未完成（${this.escapeHtml(this.formatInterruptedReason(record.reason))}）</span>
+            </div>
+        ` : '';
+        const gradingCountInfo = isInterrupted ? '' : `
+            <div class="meta-item">
+                <span class="meta-label">错题数：</span>
+                <span class="meta-value error-count">${incorrectCount}</span>
+            </div>
+            <div class="meta-item">
+                <span class="meta-label">未作答：</span>
+                <span class="meta-value unanswered-count">${unansweredCount}</span>
+            </div>
+        `;
 
         // 多套题模式的额外信息
         let multiSuiteInfo = '';
@@ -222,17 +242,18 @@ class PracticeRecordModal {
             <div id="${this.modalId}" class="modal-overlay">
                 <div class="modal-container">
                     <div class="modal-header">
-                        <h3 class="modal-title">\u7ec3\u4e60\u8bb0\u5f55\u8be6\u60c5</h3>
+                        <h3 class="modal-title">${modalTitle}</h3>
                         <button class="modal-close" aria-label="\u5173\u95ed\u5f39\u7a97">
                             <i class="fas fa-times"></i>
                         </button>
                     </div>
                     <div class="modal-body">
                         <div class="record-summary">
-                            <h4 class="record-summary-replay-trigger" role="button" tabindex="0" aria-label="打开该练习记录回放">
+                            <h4 class="${isInterrupted ? 'record-summary-title' : 'record-summary-replay-trigger'}"${isInterrupted ? '' : ' role="button" tabindex="0" aria-label="打开该练习记录回放"'}>
                                 ${this.escapeHtml(category)} - ${this.escapeHtml(frequencyLabel)} - ${this.escapeHtml(examTitle)}
                             </h4>
                             <div class="record-meta">
+                                ${statusInfo}
                                 <div class="meta-item">
                                     <span class="meta-label">\u7ec3\u4e60\u65f6\u95f4\uff1a</span>
                                     <span class="meta-value">${this.escapeHtml(formattedStart)}</span>
@@ -243,25 +264,18 @@ class PracticeRecordModal {
                                 </div>
                                 <div class="meta-item">
                                     <span class="meta-label">\u5f97\u5206\uff1a</span>
-                                    <span class="meta-value score-highlight">${this.escapeHtml(score)}</span>
+                                    <span class="meta-value score-highlight">${this.escapeHtml(scoreText)}</span>
                                 </div>
                                 <div class="meta-item">
                                     <span class="meta-label">\u51c6\u786e\u7387\uff1a</span>
-                                    <span class="meta-value">${accuracyPercent != null ? `${accuracyPercent}%` : '\u672a\u77e5'}</span>
+                                    <span class="meta-value">${this.escapeHtml(accuracyText)}</span>
                                 </div>
-                                <div class="meta-item">
-                                    <span class="meta-label">\u9519\u9898\u6570\uff1a</span>
-                                    <span class="meta-value error-count">${incorrectCount}</span>
-                                </div>
-                                <div class="meta-item">
-                                    <span class="meta-label">\u672a\u4f5c\u7b54\uff1a</span>
-                                    <span class="meta-value unanswered-count">${unansweredCount}</span>
-                                </div>
+                                ${gradingCountInfo}
                                 ${multiSuiteInfo}
                             </div>
                         </div>
                         <div class="answer-details">
-                            <h5>\u7b54\u9898\u8be6\u60c5</h5>
+                            <h5>${isInterrupted ? '已保留作答' : '\u7b54\u9898\u8be6\u60c5'}</h5>
                             ${answerSection}
                         </div>
                     </div>
@@ -328,6 +342,18 @@ class PracticeRecordModal {
             return `${record.score}/${record.total}`;
         }
         return '\u672a\u77e5';
+    }
+
+    formatInterruptedReason(reason) {
+        const labels = {
+            timeout: '窗口失去响应',
+            closed: '窗口已关闭',
+            cancelled: '练习已取消',
+            unload: '页面已离开',
+            error: '练习异常中断'
+        };
+        const normalized = String(reason || '').trim().toLowerCase();
+        return labels[normalized] || (normalized ? String(reason) : '异常退出');
     }
 
     resolveAccuracy(record) {
@@ -627,6 +653,10 @@ class PracticeRecordModal {
             return '<div class="no-answers-message"><p>\u6682\u65e0\u7b54\u9898\u6570\u636e</p></div>';
         }
 
+        if (record.status === 'interrupted' || record.historyRecordKind === 'interrupted') {
+            return this.generateInterruptedAnswerTable(record);
+        }
+
         if (record.answerComparison && Object.keys(record.answerComparison).length > 0) {
             const merged = this.mergeComparisonWithCorrections(record);
             return this.generateLegacyTableFromComparison(merged);
@@ -679,6 +709,32 @@ class PracticeRecordModal {
                     <tbody>
                         ${rows}
                     </tbody>
+                </table>
+            </div>
+        `;
+    }
+
+    generateInterruptedAnswerTable(record) {
+        const answers = record.answers || (record.realData && record.realData.answers) || {};
+        const questionNumbers = this.extractLegacyQuestionNumbers(answers, {});
+        if (questionNumbers.length === 0) {
+            return '<div class="no-answers-message"><p>尚未作答，练习进度已保留</p></div>';
+        }
+        const rows = questionNumbers.map((questionNumber) => {
+            const userAnswer = this.getLegacyUserAnswer(answers, questionNumber);
+            const safeUser = userAnswer != null ? this.truncateAnswer(userAnswer) : '未作答';
+            return `
+                <tr class="answer-row unknown">
+                    <td class="question-num">${this.escapeHtml(String(questionNumber))}</td>
+                    <td class="user-answer">${this.escapeHtml(safeUser)}</td>
+                </tr>
+            `;
+        }).join('');
+        return `
+            <div class="answers-table-container">
+                <table class="answer-table interrupted-answer-table">
+                    <thead><tr><th>题号</th><th>已保存作答</th></tr></thead>
+                    <tbody>${rows}</tbody>
                 </table>
             </div>
         `;

--- a/js/components/practiceRecordModal.js
+++ b/js/components/practiceRecordModal.js
@@ -446,6 +446,9 @@ class PracticeRecordModal {
 
     generateAnswerTable(record) {
         const preparedRecord = this.prepareRecordForDisplay(record);
+        if (record && (record.status === 'interrupted' || record.historyRecordKind === 'interrupted')) {
+            return this.generateInterruptedAnswerTable(preparedRecord);
+        }
         const suiteEntries = this.getSuiteEntries(preparedRecord);
 
         if (suiteEntries.length > 0) {

--- a/js/main.js
+++ b/js/main.js
@@ -1711,10 +1711,10 @@ function setupPracticeHistoryInteractions() {
         }
     };
 
-    const handleSelection = (recordId, event) => {
-        if (!getBulkDeleteModeState() || !recordId) return;
+    const handleSelection = (recordId, recordKind, event) => {
+        if (!getBulkDeleteModeState() || !recordId || recordKind === 'interrupted') return;
         if (event) event.preventDefault();
-        toggleRecordSelection(recordId);
+        toggleRecordSelection(recordId, { recordKind });
     };
 
     const handleCheckbox = (recordId, event) => {
@@ -1745,7 +1745,7 @@ function setupPracticeHistoryInteractions() {
             if (event.target && event.target.matches('input[data-record-id]')) {
                 return;
             }
-            handleSelection(this.dataset.recordId, event);
+            handleSelection(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('change', '.practice-history-list input[data-record-id], #history-list input[data-record-id]', function (event) {
@@ -1771,7 +1771,7 @@ function setupPracticeHistoryInteractions() {
                 if (actionTarget || (event.target && event.target.matches('input[data-record-id]'))) {
                     return;
                 }
-                handleSelection(item.dataset.recordId, event);
+                handleSelection(item.dataset.recordId, item.dataset.recordKind, event);
             }
         });
 
@@ -3746,14 +3746,24 @@ function showRecordDetails(recordId, options = {}) {
         if (options.recordKind === 'interrupted') {
             const recovery = window.AppData && window.AppData.recovery;
             if (!recovery || typeof recovery.getInterrupted !== 'function') {
-                throw new Error('中断记录恢复服务不可用');
+                window.showMessage('中断记录恢复服务不可用', 'error');
+                return;
             }
-            const record = await recovery.getInterrupted(recordId);
+            let record;
+            try {
+                record = await recovery.getInterrupted(recordId);
+            } catch (error) {
+                console.error('[PracticeHistory] 读取中断记录详情失败:', error);
+                window.showMessage('中断记录读取失败，请稍后重试', 'error');
+                return;
+            }
             if (!record) {
-                throw new Error('中断记录不存在或已清理');
+                window.showMessage('中断记录不存在或已清理', 'warning');
+                return;
             }
             if (!window.practiceRecordModal || typeof window.practiceRecordModal.show !== 'function') {
-                throw new Error('记录详情组件未加载');
+                window.showMessage('记录详情组件未加载', 'error');
+                return;
             }
             window.practiceRecordModal.show({
                 ...record,
@@ -4255,8 +4265,8 @@ async function bulkDeleteRecords(selectedSnapshot = getSelectedRecordsState()) {
     console.log(`[System] 批量删除了 ${deletedCount} 条练习记录`);
 }
 
-async function toggleRecordSelection(recordId) {
-    if (!getBulkDeleteModeState()) return;
+async function toggleRecordSelection(recordId, options = {}) {
+    if (!getBulkDeleteModeState() || options.recordKind === 'interrupted') return;
 
     const normalizedId = normalizeRecordId(recordId);
     if (!normalizedId) {
@@ -4322,10 +4332,10 @@ async function deleteRecord(recordId, options = {}) {
 async function clearPracticeData() {
     if (confirm('确定要清除所有练习记录吗？此操作不可恢复。')) {
         await window.AppData.practice.clear();
-        await syncPracticeRecords({ forceRender: true, trigger: 'clear-all' });
         if (window.AppData && window.AppData.recovery && typeof window.AppData.recovery.clear === 'function') {
             await window.AppData.recovery.clear();
         }
+        await syncPracticeRecords({ forceRender: true, trigger: 'clear-all' });
         processedSessions.clear();
         clearSelectedRecordsState();
         setBulkDeleteModeState(false);

--- a/js/main.js
+++ b/js/main.js
@@ -319,10 +319,11 @@ async function syncPracticeRecords(options = {}) {
     };
     let recordsUnchanged = false;
     console.log(`[System] 正在从存储中同步练习记录... (mode=${loadMode})`);
-    let [records, insightRecords, examIndex] = await Promise.all([
+    let [records, insightRecords, examIndex, interruptedRecords] = await Promise.all([
         listCanonicalPracticeRecordSummaries(),
         window.AppData.practice.listInsights({ limit: 10 }),
-        resolveActiveExamIndex()
+        resolveActiveExamIndex(),
+        listInterruptedPracticeRecordsForHistory()
     ]);
     const insightsById = new Map((Array.isArray(insightRecords) ? insightRecords : [])
         .filter((record) => record && record.id)
@@ -379,7 +380,10 @@ async function syncPracticeRecords(options = {}) {
     try {
         const renderer = window.PracticeHistoryRenderer;
         if (renderer && renderer.helpers && typeof renderer.helpers.computeRecordsSignature === 'function') {
-            const nextSignature = renderer.helpers.computeRecordsSignature(records);
+            const historyRecords = records.concat(
+                normalizeInterruptedPracticeRecordsForHistory(interruptedRecords, examIndex)
+            );
+            const nextSignature = renderer.helpers.computeRecordsSignature(historyRecords);
             if (!forceRender && lastPracticeRecordsSignature === nextSignature) {
                 console.log('[System] 练习记录未变化，跳过UI刷新');
                 recordsUnchanged = true;
@@ -411,7 +415,7 @@ async function syncPracticeRecords(options = {}) {
 
     console.log(`[System] 已从 AppData 加载 ${records.length} 条练习摘要。`);
     if (!recordsUnchanged) {
-        updatePracticeView(records, examIndex);
+        updatePracticeView(records, examIndex, interruptedRecords);
     }
     return records;
 }
@@ -518,6 +522,21 @@ async function listCanonicalPracticeRecords() {
 async function listCanonicalPracticeRecordSummaries() {
     const summaries = await window.AppData.practice.list({ projection: 'light' });
     return Array.isArray(summaries) ? summaries : [];
+}
+
+async function listInterruptedPracticeRecordsForHistory() {
+    const recovery = window.AppData && window.AppData.recovery;
+    if (!recovery || typeof recovery.listInterrupted !== 'function') {
+        return [];
+    }
+    try {
+        const records = await recovery.listInterrupted();
+        return Array.isArray(records) ? records : [];
+    } catch (error) {
+        // Recovery visibility must never make canonical history unavailable.
+        console.warn('[PracticeHistory] 读取中断记录失败，继续显示已完成记录:', error);
+        return [];
+    }
 }
 
 async function resolveActiveExamIndex() {
@@ -1676,19 +1695,19 @@ function setupPracticeHistoryInteractions() {
         return;
     }
 
-    const handleDetails = (recordId, event) => {
+    const handleDetails = (recordId, recordKind, event) => {
         if (!recordId) return;
         if (event) event.preventDefault();
         if (typeof showRecordDetails === 'function') {
-            showRecordDetails(recordId);
+            showRecordDetails(recordId, { recordKind });
         }
     };
 
-    const handleDelete = (recordId, event) => {
+    const handleDelete = (recordId, recordKind, event) => {
         if (!recordId) return;
         if (event) event.preventDefault();
         if (typeof deleteRecord === 'function') {
-            deleteRecord(recordId);
+            deleteRecord(recordId, { recordKind });
         }
     };
 
@@ -1713,11 +1732,11 @@ function setupPracticeHistoryInteractions() {
 
     if (hasDomDelegate) {
         window.DOM.delegate('click', '.practice-history-list [data-record-action="details"], #history-list [data-record-action="details"]', function (event) {
-            handleDetails(this.dataset.recordId, event);
+            handleDetails(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('click', '.practice-history-list [data-record-action="delete"], #history-list [data-record-action="delete"]', function (event) {
-            handleDelete(this.dataset.recordId, event);
+            handleDelete(this.dataset.recordId, this.dataset.recordKind, event);
         });
 
         window.DOM.delegate('click', '.practice-history-list .history-item, #history-list .history-item', function (event) {
@@ -1736,13 +1755,13 @@ function setupPracticeHistoryInteractions() {
         container.addEventListener('click', (event) => {
             const detailsTarget = event.target.closest('[data-record-action="details"]');
             if (detailsTarget && container.contains(detailsTarget)) {
-                handleDetails(detailsTarget.dataset.recordId, event);
+                handleDetails(detailsTarget.dataset.recordId, detailsTarget.dataset.recordKind, event);
                 return;
             }
 
             const deleteTarget = event.target.closest('[data-record-action="delete"]');
             if (deleteTarget && container.contains(deleteTarget)) {
-                handleDelete(deleteTarget.dataset.recordId, event);
+                handleDelete(deleteTarget.dataset.recordId, deleteTarget.dataset.recordKind, event);
                 return;
             }
 
@@ -1832,8 +1851,47 @@ function filterRealPracticeRecordsForView(records) {
     return classifier.filterRecordsForHistoryView(list);
 }
 
+function normalizeInterruptedPracticeRecordsForHistory(records, examIndex = []) {
+    const index = Array.isArray(examIndex) ? examIndex : [];
+    return (Array.isArray(records) ? records : []).filter(Boolean).map((record) => {
+        const metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+        const exam = index.find((item) => item && item.id === record.examId) || {};
+        const id = record.id || (record.sessionId ? `interrupted_${record.sessionId}` : '');
+        const date = record.endTime || record.createdAt || record.updatedAt || record.startTime || '';
+        return {
+            ...record,
+            id,
+            title: record.title || metadata.examTitle || exam.title || record.examId || '未完成练习',
+            date,
+            type: record.type || record.examType || metadata.type || exam.type || '',
+            category: record.category || metadata.category || exam.category || '',
+            frequency: record.frequency || metadata.frequency || exam.frequency || '',
+            status: 'interrupted',
+            historyRecordKind: 'interrupted'
+        };
+    });
+}
+
+function practiceHistoryRecordMatchesQuery(record, query) {
+    if (!record) {
+        return false;
+    }
+    const fields = [
+        record.title,
+        record.examId,
+        record.category,
+        record.frequency,
+        record.status === 'interrupted' ? '未完成 中断' : '',
+        record.reason,
+        record.metadata && record.metadata.examTitle,
+        record.metadata && record.metadata.category,
+        record.date
+    ];
+    return fields.some((field) => String(field || '').toLowerCase().includes(query));
+}
+
 // Phase 3: 练习记录视图更新 - 保留在 main.js（依赖多个组件，暂不迁移）
-function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
+function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = [], interruptedSnapshot = []) {
     const rawRecords = Array.isArray(recordsSnapshot) ? recordsSnapshot : [];
     const examIndex = Array.isArray(examIndexSnapshot) ? examIndexSnapshot : [];
     // 排除演示/种子记录。判定必须与 practice.stats / achievements.progress 两个投影器
@@ -1879,21 +1937,7 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
 
     const historyQuery = String(window.__practiceHistoryQuery || '').trim().toLowerCase();
     if (historyQuery) {
-        recordsToShow = recordsToShow.filter((record) => {
-            if (!record) {
-                return false;
-            }
-            const fields = [
-                record.title,
-                record.examId,
-                record.category,
-                record.frequency,
-                record.metadata && record.metadata.examTitle,
-                record.metadata && record.metadata.category,
-                record.date
-            ];
-            return fields.some((field) => String(field || '').toLowerCase().includes(historyQuery));
-        });
+        recordsToShow = recordsToShow.filter((record) => practiceHistoryRecordMatchesQuery(record, historyQuery));
     }
 
     const trendRenderer = ensurePracticeTrendRenderer();
@@ -1905,6 +1949,19 @@ function updatePracticeView(recordsSnapshot = [], examIndexSnapshot = []) {
     if (priorityRenderer && typeof priorityRenderer.update === 'function') {
         priorityRenderer.update(recordsForInsights, examIndex, { examType });
     }
+
+    // Interrupted attempts stay in recovery storage and are appended only to
+    // the visible history list. They must not affect score, trend, priority,
+    // achievement, or Browse completion projections.
+    let interruptedToShow = normalizeInterruptedPracticeRecordsForHistory(interruptedSnapshot, examIndex);
+    if (examType !== 'all') {
+        interruptedToShow = interruptedToShow.filter((record) => recordMatchesExamType(record, examType, examIndex));
+    }
+    if (historyQuery) {
+        interruptedToShow = interruptedToShow.filter((record) => practiceHistoryRecordMatchesQuery(record, historyQuery));
+    }
+    recordsToShow = recordsToShow.concat(interruptedToShow)
+        .sort((left, right) => new Date(right.date || 0) - new Date(left.date || 0));
 
     // --- 4. Render history list ---
     const renderer = window.PracticeHistoryRenderer;
@@ -3684,8 +3741,29 @@ async function viewPDF(examId) {
 }
 
 // Bridge for record details to existing enhancer/modal if present
-function showRecordDetails(recordId) {
-    ensurePracticeSuiteReady().then(() => {
+function showRecordDetails(recordId, options = {}) {
+    return ensurePracticeSuiteReady().then(async () => {
+        if (options.recordKind === 'interrupted') {
+            const recovery = window.AppData && window.AppData.recovery;
+            if (!recovery || typeof recovery.getInterrupted !== 'function') {
+                throw new Error('中断记录恢复服务不可用');
+            }
+            const record = await recovery.getInterrupted(recordId);
+            if (!record) {
+                throw new Error('中断记录不存在或已清理');
+            }
+            if (!window.practiceRecordModal || typeof window.practiceRecordModal.show !== 'function') {
+                throw new Error('记录详情组件未加载');
+            }
+            window.practiceRecordModal.show({
+                ...record,
+                title: record.title || record.metadata?.examTitle || record.examId || '未完成练习',
+                date: record.endTime || record.createdAt || record.startTime || '',
+                status: 'interrupted',
+                historyRecordKind: 'interrupted'
+            });
+            return;
+        }
         if (window.practiceHistoryEnhancer && typeof window.practiceHistoryEnhancer.showRecordDetails === 'function') {
             window.practiceHistoryEnhancer.showRecordDetails(recordId);
             return;
@@ -4195,9 +4273,31 @@ async function toggleRecordSelection(recordId) {
 }
 
 
-async function deleteRecord(recordId) {
+async function deleteRecord(recordId, options = {}) {
     if (!recordId) {
         showMessage('记录ID无效', 'error');
+        return;
+    }
+
+    if (options.recordKind === 'interrupted') {
+        const recovery = window.AppData && window.AppData.recovery;
+        if (!recovery || typeof recovery.getInterrupted !== 'function' || typeof recovery.discardInterrupted !== 'function') {
+            showMessage('中断记录恢复服务不可用', 'error');
+            return;
+        }
+        const record = await recovery.getInterrupted(recordId);
+        if (!record) {
+            showMessage('未找到中断记录', 'error');
+            return;
+        }
+        const title = record.title || record.metadata?.examTitle || record.examId || '未完成练习';
+        const date = record.endTime || record.createdAt || record.startTime;
+        const confirmMessage = `确定要删除这条未完成练习吗？\n\n题目: ${title}\n时间: ${date ? new Date(date).toLocaleString() : '未知时间'}\n\n此操作不可恢复。`;
+        if (confirm(confirmMessage)) {
+            await recovery.discardInterrupted(recordId);
+            await syncPracticeRecords({ forceRender: true, trigger: 'interrupted-delete' });
+            showMessage('未完成练习已删除', 'success');
+        }
         return;
     }
 

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -2286,6 +2286,10 @@
     historyRenderer.createRecordNode = function (record, options) {
         options = options || {};
         var bulkDeleteMode = Boolean(options.bulkDeleteMode);
+        var isInterrupted = Boolean(record && (
+            record.historyRecordKind === 'interrupted'
+            || record.status === 'interrupted'
+        ));
         var selectedRecordsInput = options.selectedRecords;
         var selectedRecords = new Set();
         if (selectedRecordsInput && typeof selectedRecordsInput.forEach === 'function') {
@@ -2317,14 +2321,14 @@
         }
 
         var item = createNode('div', {
-            className: 'history-item history-record-item',
-            dataset: { recordId: recordId }
+            className: 'history-item history-record-item' + (isInterrupted ? ' history-item-interrupted' : ''),
+            dataset: { recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
         });
 
         var isSelected = recordId && selectedRecords.has(recordId);
         var selection = createNode('div', {
-            className: 'record-selection' + (bulkDeleteMode ? '' : ' record-selection-hidden')
-        }, [
+            className: 'record-selection' + (bulkDeleteMode && !isInterrupted ? '' : ' record-selection-hidden')
+        }, isInterrupted ? [] : [
             createNode('input', {
                 type: 'checkbox',
                 checked: isSelected ? 'checked' : null,
@@ -2340,7 +2344,7 @@
             checkboxNode.setAttribute('aria-checked', isSelected ? 'true' : 'false');
         }
 
-        if (bulkDeleteMode) {
+        if (bulkDeleteMode && !isInterrupted) {
             item.classList.add('history-item-selectable');
             if (isSelected) {
                 item.classList.add('history-item-selected');
@@ -2348,12 +2352,12 @@
         }
 
         item.appendChild(selection);
-        var infoClass = 'record-info' + (bulkDeleteMode ? ' record-info-selectable' : '');
+        var infoClass = 'record-info' + (bulkDeleteMode && !isInterrupted ? ' record-info-selectable' : '');
         var info = createNode('div', { className: infoClass }, [
             createNode('a', {
                 href: '#',
                 className: 'practice-record-title',
-                dataset: { recordAction: 'details', recordId: recordId }
+                dataset: { recordAction: 'details', recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
             }, [
                 createNode('strong', null, record && record.title ? record.title : '无标题')
             ]),
@@ -2365,25 +2369,28 @@
                         className: 'duration-time',
                         style: { color: helpers.getDurationColor(durationInSeconds) }
                     }, helpers.formatDurationShort(durationInSeconds))
-                ])
+                ]),
+                isInterrupted ? createNode('small', { className: 'record-status-badge' }, '未完成 · 已保留作答') : null
             ])
         ]);
 
-        var percentageNode = createNode('div', { className: 'record-percentage-container' }, [
+        var percentageNode = createNode('div', {
+            className: 'record-percentage-container' + (isInterrupted ? ' record-interrupted-container' : '')
+        }, [
             createNode('div', {
-                className: 'record-percentage',
-                style: { color: helpers.getScoreColor(percentage) }
-            }, formatPercentage(percentage))
+                className: isInterrupted ? 'record-interrupted-label' : 'record-percentage',
+                style: isInterrupted ? null : { color: helpers.getScoreColor(percentage) }
+            }, isInterrupted ? '中断' : formatPercentage(percentage))
         ]);
 
         var actions = null;
-        if (!bulkDeleteMode) {
+        if (!bulkDeleteMode || isInterrupted) {
             actions = createNode('div', { className: 'record-actions-container' }, [
                 createNode('button', {
                     type: 'button',
                     className: 'delete-record-btn',
                     title: '删除此记录',
-                    dataset: { recordAction: 'delete', recordId: recordId }
+                    dataset: { recordAction: 'delete', recordId: recordId, recordKind: isInterrupted ? 'interrupted' : 'completed' }
                 }, '🗑️')
             ]);
         }
@@ -2563,6 +2570,8 @@
                 pct,
                 dur,
                 historyRenderer.helpers.getRecordsSignatureText(title),
+                historyRenderer.helpers.getRecordsSignatureText(record && record.historyRecordKind),
+                historyRenderer.helpers.getRecordsSignatureText(record && record.status),
                 suiteEntries
             ]);
         });


### PR DESCRIPTION
## 问题

`AppData.recovery.interrupted` 已经持久化了异常退出时的作答，但练习历史只读取正式提交的 `practice` 记录。结果是数据实际还在，用户界面却完全不可见，看起来像“记录丢失”。

## 修复

- 将 recovery 中的中断练习合并到可见历史，并明确标记为“未完成 / 中断”
- 支持查看已保存作答和单独删除中断记录
- 不提供依赖正式成绩数据的回放入口，也不伪造正确率、错题数或判分结果
- 中断记录不进入已练题数、成绩、趋势、优先练习、成就或 Browse 完成度
- recovery 读取失败时降级为只显示正式历史，不影响主记录可用性
- 更新生成 bundle，并加入投影、渲染、详情、删除及浏览器回归测试

## 验证

- 完整静态测试套件：通过
- 官方 Playwright E2E：8/8 通过
- `practiceHistorySignature.test.js`：5/5 通过
- `practiceRecordModal.test.js`：6/6 通过
- `practiceRecorder.test.js`：19/19 通过
- `practiceLightProjectionRenderContract.test.js`：14/14 通过
- `appDataV2.test.js`：52/52 通过
- 新增“中断练习可见且不污染统计”浏览器用例：单独执行通过
- bundle current check 与 `git diff --check`：通过

> 旧版聚合 app E2E runner 仍有 10 个与本修改无关的既有筛选/设置用例失败；本 PR 新增的浏览器用例已独立验证通过。