### PR TITLE
feat(reading): establish the intensive reading integration baseline

### DIFF
--- a/assets/generated/reading-exams/reading-practice-unified.html
+++ b/assets/generated/reading-exams/reading-practice-unified.html
@@ -1831,7 +1831,103 @@
                 transition-duration: 0.01ms !important;
             }
         }
+
+        /* 划词生词本顶栏按钮与结果页入口 */
+        .reading-vocab-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 7px 11px;
+            font-size: 0.88rem;
+            line-height: 1;
+            color: var(--text);
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.15s ease;
+            user-select: none;
+        }
+
+        .reading-vocab-btn:hover {
+            background: #f1f5f9;
+            border-color: #94a3b8;
+        }
+
+        body.dark-mode .reading-vocab-btn {
+            background: #1e293b;
+            border-color: #475569;
+            color: #cbd5e1;
+        }
+
+        body.dark-mode .reading-vocab-btn:hover {
+            background: #334155;
+            border-color: #64748b;
+            color: #f8fafc;
+        }
+
+        .reading-vocab-btn .vocab-btn-icon {
+            font-size: 13px;
+            line-height: 1;
+        }
+
+        .reading-vocab-btn .vocab-btn-label {
+            font-size: 0.88rem;
+        }
+
+        .results-header-bar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 8px;
+            flex-wrap: wrap;
+        }
+
+        .results-header-bar h4 {
+            margin: 0;
+        }
+
+        .results-score-text {
+            margin: 4px 0 0 0;
+            color: var(--muted, #64748b);
+            font-size: 0.95rem;
+        }
+
+        .results-vocab-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 7px 14px;
+            font-size: 0.88rem;
+            font-weight: 600;
+            color: #1d4ed8;
+            background: #eff6ff;
+            border: 1px solid #bfdbfe;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+
+        .results-vocab-btn:hover {
+            background: #dbeafe;
+            border-color: #93c5fd;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(37, 99, 235, 0.12);
+        }
+
+        body.dark-mode .results-vocab-btn {
+            color: #93c5fd;
+            background: rgba(30, 58, 138, 0.35);
+            border-color: rgba(96, 165, 250, 0.4);
+        }
+
+        body.dark-mode .results-vocab-btn:hover {
+            background: rgba(30, 58, 138, 0.6);
+            border-color: #60a5fa;
+        }
     </style>
+    <link rel="stylesheet" href="../../../css/vocab-reader.css">
 </head>
 
 <body data-page-node-id="AS04mOy4HONAkSIVdf9fOD">

--- a/css/vocab-reader.css
+++ b/css/vocab-reader.css
@@ -1,0 +1,1655 @@
+/* ==========================================================================
+   雅思阅读生词本与全文精读样式 (Vocab Reader & Notebook)
+   ========================================================================== */
+
+/* 题库浏览卡片中的“生词本”按钮布局适配 */
+.exam-actions.has-vocab-btn {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+}
+
+.exam-item-vocab-btn {
+    border-color: rgba(37, 99, 235, 0.3) !important;
+    background: rgba(239, 246, 255, 0.85) !important;
+    color: #1d4ed8 !important;
+    font-weight: 600 !important;
+}
+
+.exam-item-vocab-btn:hover:not(:disabled) {
+    background: #1d4ed8 !important;
+    color: #ffffff !important;
+    border-color: #1d4ed8 !important;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(29, 78, 216, 0.2);
+}
+
+@media (max-width: 640px) {
+    .exam-actions.has-vocab-btn {
+        grid-template-columns: 1fr !important;
+    }
+}
+
+/* 全屏沉浸式阅读器浮层 */
+body.vocab-reader-open {
+    overflow: hidden !important;
+}
+
+.vocab-reader-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background-color: #f8fafc;
+    color: #0f172a;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+    -webkit-overflow-scrolling: touch;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.vocab-reader-overlay.is-hidden {
+    display: none !important;
+}
+
+.vocab-reader-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    background-color: #f8fafc;
+    position: relative;
+}
+
+/* 顶部吸顶导航栏：紧凑标题、全平铺陈列段落与题目 Tabs，永远置顶不动 */
+.vocab-reader-header {
+    position: sticky;
+    top: 0;
+    flex-shrink: 0;
+    width: 100%;
+    box-sizing: border-box;
+    z-index: 100;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid #e2e8f0;
+    padding: 8px 18px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 14px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+}
+
+.vocab-reader-header__left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.vocab-reader-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 10px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #334155;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+}
+
+.vocab-reader-back-btn:hover {
+    background: #e2e8f0;
+    color: #0f172a;
+    border-color: #94a3b8;
+}
+
+/* 缩小文章标题这一块，为全文与各段落按钮腾出充裕空间 */
+.vocab-reader-title-wrap {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 220px;
+}
+
+.vocab-reader-title {
+    margin: 0;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #0f172a;
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.3;
+}
+
+.vocab-reader-badges {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.vocab-badge {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    border-radius: 4px;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+.vocab-badge--cat {
+    background: #dbeafe;
+    color: #1e40af;
+}
+
+.vocab-badge--freq {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.vocab-badge--info {
+    background: #f1f5f9;
+    color: #475569;
+}
+
+/* 导航段落 Tabs：完全陈列平铺展开，杜绝横向滚动/滑动 */
+.vocab-reader-header__center {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    overflow: visible;
+}
+
+.vocab-reader-tabs {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 2px 0;
+    overflow: visible;
+}
+
+.vocab-tab-btn {
+    padding: 4px 10px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    border-radius: 6px;
+    border: 1px solid #cbd5e1;
+    background: #ffffff;
+    color: #475569;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+    line-height: 1.3;
+}
+
+.vocab-tab-btn:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+    border-color: #94a3b8;
+}
+
+.vocab-tab-btn.active {
+    background: #2563eb;
+    color: #ffffff;
+    border-color: #2563eb;
+    box-shadow: 0 1px 4px rgba(37, 99, 235, 0.25);
+    font-weight: 600;
+}
+
+.vocab-tab-btn--questions {
+    border-color: #fbbf24;
+    color: #b45309;
+    background: #fffbeb;
+}
+
+.vocab-tab-btn--questions:hover {
+    background: #fef3c7;
+    color: #92400e;
+    border-color: #f59e0b;
+}
+
+.vocab-tab-btn--questions.active {
+    background: #d97706;
+    color: #ffffff;
+    border-color: #d97706;
+    box-shadow: 0 1px 4px rgba(217, 119, 6, 0.25);
+    font-weight: 600;
+}
+
+/* 导航右侧工具 */
+.vocab-reader-header__right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.vocab-tool-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 12px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    background: #ffffff;
+    color: #334155;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.vocab-tool-btn:hover {
+    background: #f8fafc;
+    border-color: #94a3b8;
+}
+
+.vocab-tool-btn.active {
+    background: #fef3c7;
+    border-color: #f59e0b;
+    color: #92400e;
+}
+
+.vocab-notebook-btn {
+    background: #eff6ff;
+    border-color: #93c5fd;
+    color: #1d4ed8;
+}
+
+.vocab-notebook-btn:hover {
+    background: #dbeafe;
+}
+
+.vocab-badge-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    border-radius: 10px;
+    background: #ef4444;
+    color: #ffffff;
+}
+
+/* 顶部划词收录提示 Banner */
+.vocab-reader-banner {
+    flex-shrink: 0;
+    background: linear-gradient(90deg, #ecfdf5, #f0fdf4);
+    border-bottom: 1px solid #bbf7d0;
+    padding: 8px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 0.88rem;
+    color: #166534;
+}
+
+.vocab-banner-icon {
+    font-size: 1rem;
+}
+
+/* 独立滚动主体区域（确保顶部 header 永远固定在视口顶部不动） */
+.vocab-reader-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+    width: 100%;
+    min-height: 0;
+}
+
+/* 阅读核心主内容区 */
+.vocab-reader-body {
+    max-width: 920px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 28px 20px 80px 20px;
+    box-sizing: border-box;
+}
+
+/* 划词高亮样式 */
+.vocab-reader-body ::selection {
+    background: #fed7aa;
+    color: #7c2d12;
+}
+
+/* 文章区域 */
+.vocab-passage-section {
+    margin-bottom: 40px;
+}
+
+.vocab-passage-header {
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 2px solid #e2e8f0;
+}
+
+.vocab-passage-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #0f172a;
+    margin: 0 0 8px 0;
+}
+
+.vocab-passage-intro {
+    font-size: 0.95rem;
+    color: #64748b;
+    margin: 0;
+}
+
+/* 前置考试题目说明指导语：独立说明卡片，绝不带段落A标签 */
+.vocab-passage-instruction {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-left: 4px solid #3b82f6;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-top: 10px;
+    color: #334155;
+    font-size: 0.92rem;
+    line-height: 1.6;
+}
+
+.vocab-instruction-icon {
+    font-size: 1.15rem;
+    line-height: 1.4;
+    flex-shrink: 0;
+}
+
+.vocab-instruction-text {
+    flex: 1;
+    font-weight: 500;
+    color: #334155;
+}
+
+.vocab-instruction-text p {
+    margin: 0;
+}
+
+.vocab-passage-subtitle {
+    font-size: 0.95rem;
+    color: #64748b;
+    font-style: italic;
+    margin-top: 6px;
+}
+
+/* 段落卡片 */
+.vocab-paragraph-card {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 20px;
+    scroll-margin-top: 16px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.02);
+    transition: box-shadow 0.2s;
+}
+
+.vocab-paragraph-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.vocab-paragraph-tag {
+    margin-bottom: 12px;
+}
+
+.vocab-para-letter {
+    display: inline-block;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    color: #1e293b;
+    padding: 2px 10px;
+    border-radius: 6px;
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+
+.vocab-paragraph-text {
+    font-size: 1.1rem;
+    line-height: 1.85;
+    color: #334155;
+    user-select: text;
+}
+
+.vocab-paragraph-text p {
+    margin: 0 0 12px 0;
+}
+
+.vocab-paragraph-text p:last-child {
+    margin-bottom: 0;
+}
+
+/* 生词黄色高亮标记 (Yellow Highlight for Vocabulary) */
+mark.vocab-highlight,
+.vocab-highlight {
+    background-color: #fef08a !important; /* 明亮舒适的经典纯正柔黄 */
+    color: #0f172a !important;
+    padding: 2px 4px !important;
+    margin: 0 1px !important;
+    border-radius: 4px !important;
+    border-bottom: 2px solid #eab308 !important; /* 黄色强化底边 */
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+    font-weight: 600 !important;
+    cursor: pointer !important;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    display: inline;
+}
+
+mark.vocab-highlight:hover,
+.vocab-highlight:hover {
+    background-color: #fde047 !important; /* 悬停交互更鲜明的明黄 */
+    border-bottom-color: #ca8a04 !important;
+    box-shadow: 0 2px 5px rgba(234, 179, 8, 0.35);
+}
+
+mark.vocab-highlight:active,
+.vocab-highlight:active {
+    transform: scale(0.97);
+}
+
+@keyframes vocabHighlightPop {
+    0% {
+        background-color: #fef9c3;
+        transform: scale(1.05);
+    }
+    100% {
+        background-color: #fef08a;
+        transform: scale(1);
+    }
+}
+
+.vocab-highlight--pulse {
+    animation: vocabHighlightPop 0.4s ease-out;
+}
+
+/* 段落译文卡片 */
+.vocab-translation-card {
+    margin-top: 16px;
+    background: #fefce8;
+    border-left: 4px solid #eab308;
+    border-radius: 6px;
+    padding: 12px 16px;
+    font-size: 0.95rem;
+    color: #713f12;
+    line-height: 1.7;
+}
+
+.vocab-trans-label {
+    font-weight: 700;
+    margin-bottom: 4px;
+    color: #854d0e;
+}
+
+/* 题目区域 */
+.vocab-questions-section {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 30px;
+    margin-top: 36px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.02);
+}
+
+.vocab-questions-header {
+    border-bottom: 2px dashed #cbd5e1;
+    padding-bottom: 16px;
+    margin-bottom: 24px;
+}
+
+.vocab-questions-title {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: #0f172a;
+    margin: 0 0 6px 0;
+}
+
+.vocab-questions-subtitle {
+    font-size: 0.9rem;
+    color: #64748b;
+    margin: 0;
+}
+
+.vocab-question-group {
+    margin-bottom: 30px;
+    font-size: 1.05rem;
+    line-height: 1.75;
+    color: #334155;
+    user-select: text;
+}
+
+.vocab-question-group h4 {
+    font-size: 1.15rem;
+    color: #0f172a;
+    margin: 0 0 12px 0;
+}
+
+.vocab-question-group .drag-item,
+.vocab-question-group .pool-items {
+    user-select: text !important;
+}
+
+/* 划词轻提示 Toast (仿 untitled.html) */
+.vocab-toast-msg {
+    position: fixed;
+    bottom: 90px;
+    right: 28px;
+    background: rgba(16, 185, 129, 0.95);
+    color: #ffffff;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 700;
+    opacity: 0;
+    transform: translateY(12px);
+    transition: opacity 0.25s, transform 0.25s;
+    z-index: 10000;
+    pointer-events: none;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+}
+
+.vocab-toast-msg.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* 悬浮生词本 FAB 按钮 (仿 untitled.html) */
+.vocab-fab {
+    position: fixed;
+    bottom: 28px;
+    right: 28px;
+    background: linear-gradient(135deg, #e11d48, #be123c);
+    color: #ffffff;
+    padding: 12px 22px;
+    border-radius: 30px;
+    box-shadow: 0 6px 20px rgba(225, 29, 72, 0.4);
+    cursor: pointer;
+    font-weight: 700;
+    font-size: 0.95rem;
+    z-index: 9998;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: transform 0.2s, box-shadow 0.2s;
+    user-select: none;
+}
+
+.vocab-fab:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(225, 29, 72, 0.5);
+}
+
+.vocab-fab-count {
+    background: rgba(255, 255, 255, 0.25);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.85rem;
+}
+
+/* 生词本 Modal 弹窗 (仿 untitled.html) */
+.vocab-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    z-index: 10001;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.vocab-modal.active {
+    display: flex;
+    animation: vocabFadeIn 0.2s ease-out;
+}
+
+.vocab-modal-content {
+    background: #ffffff;
+    width: 440px;
+    max-width: 95vw;
+    max-height: 82vh;
+    border-radius: 14px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.vocab-modal-header {
+    background: #1e293b;
+    color: #ffffff;
+    padding: 16px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.vocab-modal-title-wrap {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.vocab-modal-title-wrap h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.vocab-modal-tabs {
+    display: flex;
+    gap: 4px;
+    background: rgba(255, 255, 255, 0.12);
+    padding: 2px;
+    border-radius: 8px;
+}
+
+.v-tab-btn {
+    background: transparent;
+    border: none;
+    color: #94a3b8;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.v-tab-btn.active {
+    background: #ffffff;
+    color: #0f172a;
+}
+
+.vocab-modal-close {
+    background: transparent;
+    border: none;
+    color: #94a3b8;
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+    transition: color 0.2s;
+}
+
+.vocab-modal-close:hover {
+    color: #ffffff;
+}
+
+/* 手动添加生词 */
+.vocab-modal-add-row {
+    display: flex;
+    padding: 10px 16px;
+    gap: 8px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #f8fafc;
+}
+
+.vocab-modal-add-row input {
+    flex: 1;
+    padding: 7px 12px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    outline: none;
+}
+
+.vocab-modal-add-row input:focus {
+    border-color: #2563eb;
+}
+
+.vocab-modal-add-row button {
+    padding: 7px 14px;
+    background: #2563eb;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.vocab-modal-add-row button:hover {
+    background: #1d4ed8;
+}
+
+/* 单词列表 */
+.vocab-list {
+    padding: 12px 18px;
+    overflow-y: auto;
+    flex: 1;
+    max-height: 400px;
+}
+
+.vocab-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 10px 0;
+    border-bottom: 1px solid #f1f5f9;
+    gap: 12px;
+}
+
+.vocab-item:last-child {
+    border-bottom: none;
+}
+
+.vocab-item__main {
+    flex: 1;
+}
+
+.vocab-item__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.vocab-item__word {
+    font-weight: 700;
+    font-size: 1rem;
+    color: #1e293b;
+}
+
+.vocab-speak-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 2px 4px;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+}
+
+.vocab-speak-btn:hover {
+    opacity: 1;
+}
+
+.vocab-item__context {
+    margin: 4px 0 0 0;
+    font-size: 0.8rem;
+    color: #64748b;
+    font-style: italic;
+    line-height: 1.4;
+}
+
+.vocab-item__source {
+    display: inline-block;
+    margin-top: 4px;
+    font-size: 0.72rem;
+    color: #94a3b8;
+    background: #f8fafc;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.vocab-delete-btn {
+    background: #fee2e2;
+    color: #b91c1c;
+    border: none;
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.vocab-delete-btn:hover {
+    background: #ef4444;
+    color: #ffffff;
+}
+
+/* 空状态 */
+.vocab-empty-box {
+    text-align: center;
+    padding: 40px 20px;
+    color: #94a3b8;
+}
+
+.vocab-empty-icon {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+}
+
+.vocab-empty-title {
+    font-weight: 700;
+    color: #64748b;
+    margin: 0 0 6px 0;
+}
+
+.vocab-empty-desc {
+    font-size: 0.85rem;
+    margin: 0;
+    line-height: 1.5;
+}
+
+/* 底部操作 */
+.vocab-modal-footer {
+    padding: 14px 18px;
+    background: #f8fafc;
+    border-top: 1px solid #e2e8f0;
+    display: flex;
+    gap: 10px;
+}
+
+.v-action-btn {
+    flex: 1;
+    padding: 10px;
+    border: none;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.v-export-btn {
+    background: #10b981;
+    color: #ffffff;
+}
+
+.v-export-btn:hover {
+    background: #059669;
+}
+
+.v-clear-btn {
+    background: #ef4444;
+    color: #ffffff;
+}
+
+.v-clear-btn:hover {
+    background: #dc2626;
+}
+
+@keyframes vocabFadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* 模态框顶部操作组与书架快捷入口 */
+.vocab-modal-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.vocab-modal-bookshelf-btn {
+    background: #f1f5f9;
+    color: #334155;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 5px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.vocab-modal-bookshelf-btn:hover {
+    background: #e2e8f0;
+    color: #0f172a;
+    border-color: #94a3b8;
+}
+
+/* ==========================================================================
+   阅读书架样式 (Bookshelf View)
+   ========================================================================== */
+
+#bookshelf-view {
+    width: 100%;
+    min-height: calc(100vh - 80px);
+    background: #f8fafc;
+    padding: 24px 20px 60px;
+    box-sizing: border-box;
+}
+
+.bookshelf-view-shell {
+    max-width: 1160px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.bookshelf-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* 顶部栏 */
+.bookshelf-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.bookshelf-topbar__left {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.bookshelf-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #475569;
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.bookshelf-back-btn:hover {
+    background: #f1f5f9;
+    color: #0f172a;
+    border-color: #94a3b8;
+}
+
+.bookshelf-back-arrow {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.bookshelf-heading-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bookshelf-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #0f172a;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bookshelf-subtitle {
+    font-size: 0.85rem;
+    color: #64748b;
+    margin: 0;
+}
+
+.bookshelf-topbar__right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.bookshelf-export-all-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    background: #ecfdf5;
+    color: #047857;
+    border: 1px solid #a7f3d0;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.bookshelf-export-all-btn:hover:not(:disabled) {
+    background: #d1fae5;
+    border-color: #6ee7b7;
+}
+
+.bookshelf-export-all-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: #f1f5f9;
+    color: #94a3b8;
+    border-color: #e2e8f0;
+}
+
+.bookshelf-notebook-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    background: #2563eb;
+    color: #ffffff;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.bookshelf-notebook-btn:hover {
+    background: #1d4ed8;
+}
+
+/* 统计横幅 */
+.bookshelf-stats-banner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+}
+
+.bookshelf-stat-card {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 14px 18px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+}
+
+.bookshelf-stat-icon {
+    font-size: 1.8rem;
+    line-height: 1;
+}
+
+.bookshelf-stat-content {
+    display: flex;
+    flex-direction: column;
+}
+
+.bookshelf-stat-value {
+    font-size: 1.35rem;
+    font-weight: 800;
+    color: #0f172a;
+    line-height: 1.2;
+}
+
+.bookshelf-stat-label {
+    font-size: 0.78rem;
+    color: #64748b;
+    font-weight: 500;
+}
+
+/* 工具条 (搜索与筛选) */
+.bookshelf-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 10px 14px;
+}
+
+.bookshelf-search-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 6px 10px;
+    flex: 1;
+    min-width: 240px;
+    max-width: 440px;
+}
+
+.bookshelf-search-icon {
+    font-size: 0.9rem;
+    color: #94a3b8;
+}
+
+.bookshelf-search-input {
+    border: none;
+    background: transparent;
+    font-size: 0.88rem;
+    color: #0f172a;
+    outline: none;
+    width: 100%;
+}
+
+.bookshelf-search-clear {
+    background: none;
+    border: none;
+    color: #94a3b8;
+    font-size: 1.1rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 2px;
+}
+
+.bookshelf-search-clear:hover {
+    color: #475569;
+}
+
+.bookshelf-filter-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.bookshelf-segmented {
+    display: flex;
+    background: #f1f5f9;
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+}
+
+.bookshelf-segment-btn {
+    border: none;
+    background: transparent;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #64748b;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.bookshelf-segment-btn.active {
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.bookshelf-sort-select {
+    padding: 6px 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #ffffff;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #334155;
+    outline: none;
+    cursor: pointer;
+}
+
+/* 卡片网格 */
+.bookshelf-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+}
+
+.bookshelf-card {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+}
+
+.bookshelf-card:hover {
+    border-color: #cbd5e1;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    transform: translateY(-2px);
+}
+
+.bookshelf-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.bookshelf-card__tags {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.bookshelf-card__badge {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 6px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+}
+
+.bookshelf-card__badge--category {
+    background: #f1f5f9;
+    color: #475569;
+}
+
+.bookshelf-card__badge--vocab {
+    background: #fef3c7;
+    color: #b45309;
+}
+
+.bookshelf-card__badge--read {
+    background: #eff6ff;
+    color: #2563eb;
+}
+
+.bookshelf-card__remove-btn {
+    background: transparent;
+    border: none;
+    font-size: 0.85rem;
+    cursor: pointer;
+    opacity: 0.4;
+    transition: opacity 0.2s;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.bookshelf-card__remove-btn:hover {
+    opacity: 1;
+    background: #fee2e2;
+}
+
+.bookshelf-card__body {
+    flex: 1;
+    margin-bottom: 14px;
+}
+
+.bookshelf-card__title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #0f172a;
+    line-height: 1.4;
+    margin: 0 0 6px 0;
+    cursor: pointer;
+    transition: color 0.15s;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.bookshelf-card__title:hover {
+    color: #2563eb;
+}
+
+.bookshelf-card__meta {
+    font-size: 0.76rem;
+    color: #94a3b8;
+    margin-bottom: 10px;
+}
+
+/* 生词预览药丸标签 */
+.bookshelf-card__vocab-preview {
+    min-height: 38px;
+    display: flex;
+    align-items: center;
+}
+
+.bookshelf-vocab-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.bookshelf-vocab-chip {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #334155;
+    padding: 3px 8px;
+    border-radius: 6px;
+    font-size: 0.76rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.bookshelf-vocab-chip:hover {
+    background: #eff6ff;
+    color: #1d4ed8;
+    border-color: #bfdbfe;
+}
+
+.bookshelf-chip-audio {
+    font-size: 0.7rem;
+    opacity: 0.6;
+}
+
+.bookshelf-vocab-chip-more {
+    font-size: 0.72rem;
+    color: #64748b;
+    font-weight: 600;
+    padding: 3px 6px;
+    background: #f1f5f9;
+    border-radius: 6px;
+    align-self: center;
+}
+
+.bookshelf-vocab-empty-hint {
+    font-size: 0.78rem;
+    color: #94a3b8;
+    margin: 0;
+    font-style: italic;
+}
+
+/* 卡片操作按钮 */
+.bookshelf-card__footer {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding-top: 10px;
+    border-top: 1px solid #f1f5f9;
+}
+
+.bookshelf-action-btn {
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.bookshelf-action-btn--main {
+    flex: 1;
+    min-width: 100px;
+    background: #2563eb;
+    color: #ffffff;
+    border: none;
+}
+
+.bookshelf-action-btn--main:hover {
+    background: #1d4ed8;
+}
+
+.bookshelf-card__footer .btn-secondary {
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    color: #334155;
+}
+
+.bookshelf-card__footer .btn-secondary:hover:not(:disabled) {
+    background: #e2e8f0;
+    color: #0f172a;
+}
+
+.bookshelf-card__footer .btn-secondary:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+/* 空状态 */
+.bookshelf-empty-state {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    padding: 60px 24px;
+    text-align: center;
+    max-width: 540px;
+    margin: 20px auto;
+}
+
+.bookshelf-empty-icon {
+    font-size: 3.5rem;
+    margin-bottom: 12px;
+}
+
+.bookshelf-empty-title {
+    font-size: 1.25rem;
+    font-weight: 800;
+    color: #0f172a;
+    margin: 0 0 8px 0;
+}
+
+.bookshelf-empty-desc {
+    font-size: 0.88rem;
+    color: #64748b;
+    line-height: 1.6;
+    margin: 0 0 20px 0;
+}
+
+.bookshelf-empty-actions {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+/* Toast 轻量反馈 */
+.bookshelf-toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background: rgba(15, 23, 42, 0.92);
+    color: #ffffff;
+    padding: 10px 18px;
+    border-radius: 10px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    z-index: 10000;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    backdrop-filter: blur(4px);
+    pointer-events: none;
+}
+
+.bookshelf-toast.is-hidden {
+    opacity: 0;
+    transform: translateY(10px);
+    display: none;
+}
+
+.bookshelf-toast.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    display: block;
+}
+
+/* 响应式断点 */
+@media (max-width: 768px) {
+    #bookshelf-view {
+        padding: 16px 12px 40px;
+    }
+
+    .bookshelf-topbar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .bookshelf-topbar__right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .bookshelf-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .bookshelf-search-box {
+        max-width: 100%;
+    }
+
+    .bookshelf-filter-group {
+        justify-content: space-between;
+    }
+
+    .bookshelf-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* 书架移除安全确认模态框（纯 DOM 模态，免疫 iframe 拦截） */
+.bookshelf-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10002;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    animation: bookshelfFadeIn 0.2s ease-out;
+}
+
+.bookshelf-confirm-overlay.is-hidden {
+    display: none !important;
+}
+
+.bookshelf-confirm-box {
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.12), 0 8px 10px -6px rgba(0, 0, 0, 0.08);
+    max-width: 440px;
+    width: 100%;
+    padding: 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    border: 1px solid #e2e8f0;
+    box-sizing: border-box;
+    animation: bookshelfSlideUp 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.bookshelf-confirm-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.bookshelf-confirm-icon {
+    font-size: 1.35rem;
+    line-height: 1;
+}
+
+.bookshelf-confirm-title {
+    margin: 0;
+    font-size: 1.12rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.bookshelf-confirm-msg {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #334155;
+    line-height: 1.55;
+    font-weight: 500;
+    word-break: break-word;
+}
+
+.bookshelf-confirm-notice {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.bookshelf-notice-badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #0284c7;
+    background: #e0f2fe;
+    padding: 2px 7px;
+    border-radius: 4px;
+    align-self: flex-start;
+}
+
+.bookshelf-notice-text {
+    margin: 0;
+    font-size: 0.83rem;
+    color: #475569;
+    line-height: 1.48;
+}
+
+.bookshelf-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 4px;
+}
+
+.bookshelf-confirm-btn {
+    padding: 7px 16px;
+    font-size: 0.9rem;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.btn-danger {
+    background: #dc2626 !important;
+    color: #ffffff !important;
+    border: 1px solid #dc2626 !important;
+}
+
+.btn-danger:hover {
+    background: #b91c1c !important;
+    border-color: #b91c1c !important;
+}
+
+@keyframes bookshelfFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes bookshelfSlideUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}

--- a/developer/tests/e2e/unified_submit_readonly_regression.py
+++ b/developer/tests/e2e/unified_submit_readonly_regression.py
@@ -93,13 +93,13 @@ def require(condition: bool, detail: str) -> None:
         raise RuntimeError(detail)
 
 
-async def open_practice(page: Page, session_id: str, token: str):
-    url = f"{UNIFIED_HTML.as_uri()}?examId={TARGET_EXAM}&dataKey={TARGET_EXAM}&test_env=1"
+async def open_practice(page: Page, session_id: str, token: str, exam_id: str = TARGET_EXAM):
+    url = f"{UNIFIED_HTML.as_uri()}?examId={exam_id}&dataKey={exam_id}&test_env=1"
     await page.goto(HOST_FIXTURE.as_uri(), wait_until="load")
     await page.set_content(HOST_HTML, wait_until="load")
     await page.evaluate(
         "config => window.__hostConfigure(config)",
-        {"url": url, "examId": TARGET_EXAM, "sessionId": session_id, "token": token},
+        {"url": url, "examId": exam_id, "sessionId": session_id, "token": token},
     )
     await page.wait_for_selector("#practice-frame")
     frame = page.frame(name="practice")
@@ -373,12 +373,35 @@ async def run_timeout_scenario(context) -> Dict[str, Any]:
     return {"afterTimeout": after_timeout, "lateAfterTimeout": late_after_timeout, "afterRetryAck": after_retry_ack}
 
 
+async def run_vocab_entry_gate_scenario(context) -> Dict[str, Any]:
+    page = await context.new_page()
+    frame = await open_practice(page, "session-vocab-gate", "token-vocab-gate", "p2-low-08")
+    await frame.check('#question-groups input[name="q1"][value="A"]')
+    require(await frame.locator("#reading-vocab-header-btn").count() == 0, "unsafe_vocab_entry_available")
+    require(await frame.locator("#reading-vocab-reader-overlay").count() == 0, "reader_controls_in_practice")
+    require(await frame.locator('input[name="q1"][value="A"]').is_checked(), "practice_answer_changed")
+
+    await frame.click("#submit-btn")
+    await wait_for_submission_count(page, 1)
+    submission = (await submissions(page))[0]
+    require(submission.get("data", {}).get("answers", {}).get("q1") == "A", f"practice_payload_changed:{submission}")
+    await send_host(page, "PRACTICE_SUBMIT_ACK", correlation(submission))
+    await frame.wait_for_function(
+        "() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.getTestState().submissionStatus === 'submitted'"
+    )
+    require(await frame.locator("#reading-vocab-header-btn").count() == 0, "unsafe_vocab_entry_after_submit")
+    require(await frame.locator("#reading-vocab-reader-overlay").count() == 0, "reader_controls_after_submit")
+    await page.close()
+    return {"examId": "p2-low-08", "entryAvailable": False, "submittedAnswer": "A"}
+
+
 async def run() -> Dict[str, Any]:
     async with async_playwright() as playwright:
         browser = await playwright.chromium.launch(headless=True, args=["--allow-file-access-from-files"])
         context = await browser.new_context(viewport={"width": 1440, "height": 1000})
         await context.add_init_script(script="window.__IELTS_READING_PAGE_TEST_HOOKS__ = true;")
         try:
+            vocab_entry_gate = await run_vocab_entry_gate_scenario(context)
             ack_and_nack = await run_ack_and_nack_scenario(context)
             timeout = await run_timeout_scenario(context)
         finally:
@@ -387,7 +410,7 @@ async def run() -> Dict[str, Any]:
     return {
         "status": "pass",
         "detail": "unified reliable submit acknowledgement regression passed",
-        "data": {"ackAndNack": ack_and_nack, "timeout": timeout},
+        "data": {"vocabEntryGate": vocab_entry_gate, "ackAndNack": ack_and_nack, "timeout": timeout},
     }
 
 

--- a/developer/tests/js/appDataV2.test.js
+++ b/developer/tests/js/appDataV2.test.js
@@ -124,6 +124,30 @@ function harness() {
     const context = vm.createContext(sandbox); vm.runInContext(recordSource, context, { filename: 'practiceRecordSource.js' }); vm.runInContext(appDataSource, context, { filename: 'appData.js' }); return { app: sandbox.AppData, shared, envelope, sandbox, context };
 }
 
+async function testReadingCollectionPresenceMetadata() {
+    const fixture = harness();
+    await fixture.app.ready;
+    const readingCollections = [
+        ['vocab.readingVocabWords', fixture.app.vocab.listReadingWords, fixture.app.vocab.saveReadingWords],
+        ['vocab.readingBookshelfExams', fixture.app.vocab.listReadingBookshelfExams, fixture.app.vocab.saveReadingBookshelfExams]
+    ];
+    for (const [logicalKey, list, save] of readingCollections) {
+        assert.deepStrictEqual(await list(), [], 'default reading list callers retain the array API');
+        const absent = await list({ withMeta: true });
+        assert.deepStrictEqual(absent.data, []);
+        assert.strictEqual(absent.envelope, null, 'metadata distinguishes an unmigrated default from an authoritative empty array');
+        await save([]);
+        const empty = await list({ withMeta: true });
+        assert.deepStrictEqual(empty.data, []);
+        assert.strictEqual(empty.envelope.state, 'present');
+        fixture.shared.docs.set(logicalKey, fixture.envelope(logicalKey, null, 'cleared'));
+        const cleared = await list({ withMeta: true });
+        assert.deepStrictEqual(await list(), []);
+        assert.deepStrictEqual(cleared.data, []);
+        assert.strictEqual(cleared.envelope.state, 'cleared', 'cleared collections retain their canonical presence');
+    }
+}
+
 async function testVocabPhoneticMutationProtection() {
     const fixture = harness();
     await fixture.app.ready;
@@ -1484,6 +1508,7 @@ async function testRecoveryThirtyDayTtlBoundary() {
 }
 
 async function run() {
+    await testReadingCollectionPresenceMetadata();
     await testClearInterruptedRecoveryIsolation();
     await testRecoveryThirtyDayTtlBoundary();
     await testVocabPhoneticMutationProtection();
@@ -2034,6 +2059,6 @@ async function run() {
     assert.strictEqual(await app.practice.get('legacy-1'), null);
     assert.strictEqual((await app.practice.get('snake-1')).answers[1], 'yes');
 
-    console.log(JSON.stringify({ status: 'pass', tests: 54 }));
+    console.log(JSON.stringify({ status: 'pass', tests: 55 }));
 }
 run().catch((error) => { console.error(error.stack || error); process.exitCode = 1; });

--- a/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
+++ b/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
@@ -130,3 +130,49 @@ test('Bookshelf delete button and vocab isolation test', async () => {
 
     console.log('✅ 书架删除生词本记录且严格隔离做题练习记录测试全部通过！');
 });
+
+test('Bookshelf initialization adopts empty and smaller canonical collections without reimporting stale mirrors', async () => {
+    const bookshelfCode = fs.readFileSync(new URL('../../../js/components/bookshelfView.js', import.meta.url), 'utf8');
+    const key = 'ielts_reading_bookshelf_exams_v1';
+    const stale = [{ examId: 'keep', lastOpenedAt: 999 }, { examId: 'removed' }];
+    const storage = new Map([[key, JSON.stringify(stale)]]);
+    let canonical = { data: [], envelope: { state: 'present' } };
+    let saves = 0;
+    const sandbox = {
+        console,
+        localStorage: {
+            getItem: (name) => storage.get(name) || null,
+            setItem: (name, value) => storage.set(name, String(value))
+        },
+        AppData: {
+            ready: Promise.resolve(),
+            vocab: {
+                listReadingBookshelfExams: async (options) => {
+                    assert.equal(options.withMeta, true);
+                    return canonical;
+                },
+                saveReadingBookshelfExams: async () => { saves += 1; }
+            }
+        },
+        addEventListener() {}
+    };
+    sandbox.window = sandbox;
+    vm.runInNewContext(bookshelfCode, sandbox);
+    await sandbox.ReadingBookshelfStore.init();
+    assert.deepEqual(JSON.parse(storage.get(key)), [], 'an empty canonical bookshelf clears the stale mirror');
+
+    canonical = { data: [{ examId: 'keep', lastOpenedAt: 100 }], envelope: { state: 'present' } };
+    storage.set(key, JSON.stringify(stale));
+    await sandbox.ReadingBookshelfStore.init();
+    assert.deepEqual(JSON.parse(storage.get(key)), canonical.data,
+        'the restored metadata and membership must replace stale local records');
+    canonical = { data: [], envelope: null };
+    storage.set(key, JSON.stringify(stale));
+    await sandbox.ReadingBookshelfStore.init();
+    assert.deepEqual(JSON.parse(storage.get(key)), stale,
+        'an absent canonical envelope must preserve the only local copy if migration failed');
+    canonical = { data: [], envelope: { state: 'cleared' } };
+    await sandbox.ReadingBookshelfStore.init();
+    assert.deepEqual(JSON.parse(storage.get(key)), [], 'a cleared envelope remains authoritative');
+    assert.equal(saves, 0, 'loading a canonical bookshelf must never save the old mirror back to AppData');
+});

--- a/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
+++ b/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+test('Bookshelf delete button and vocab isolation test', async () => {
+    const bookshelfPath = new URL('../../../js/components/bookshelfView.js', import.meta.url);
+    const bookshelfCode = fs.readFileSync(bookshelfPath, 'utf8');
+
+    // 1. 静态断言：确认已移除脆弱的 window.confirm，使用安全的 openConfirmDialog
+    assert.ok(!bookshelfCode.includes('if (confirm('), '应当不再依赖沙箱 iframe 中易被拦截的 window.confirm');
+    assert.ok(bookshelfCode.includes('openConfirmDialog'), '应当具有 openConfirmDialog 自定义模态确认');
+    assert.ok(bookshelfCode.includes('bookshelf-confirm-dialog'), '应当包含 bookshelf-confirm-dialog 确认对话框');
+
+    // 2. 模拟运行环境测试 ReadingBookshelfStore.removeExam
+    const mockStorage = new Map();
+    const localStorageShim = {
+        getItem: (k) => mockStorage.get(k) || null,
+        setItem: (k, v) => mockStorage.set(k, String(v)),
+        removeItem: (k) => mockStorage.delete(k)
+    };
+
+    let readingVocabStoreClearedExamId = null;
+    const mockReadingVocabStore = {
+        clear: (eid) => {
+            readingVocabStoreClearedExamId = eid;
+        }
+    };
+
+    let appDataSavedWords = null;
+    const mockAppData = {
+        vocab: {
+            saveReadingWords: async (words) => {
+                appDataSavedWords = words;
+            }
+        },
+        // 练习做题记录（严格隔离，绝不允许被删除）
+        practice: {
+            records: [
+                { id: 'rec_1', examId: 'cambridge-18-test-1-p1', score: 11, total: 13, timeSpent: 1200 },
+                { id: 'rec_2', examId: 'cambridge-18-test-1-p2', score: 9, total: 13, timeSpent: 1100 }
+            ]
+        }
+    };
+
+    const sandbox = {
+        console,
+        localStorage: localStorageShim,
+        CustomEvent: class { constructor(type, detail) { this.type = type; this.detail = detail; } },
+        setTimeout,
+        clearTimeout,
+        Date,
+        JSON,
+        Set,
+        Map,
+        Array,
+        String,
+        Math,
+        ReadingVocabStore: mockReadingVocabStore,
+        AppData: mockAppData
+    };
+    sandbox.window = sandbox;
+    sandbox.global = sandbox;
+    sandbox.document = {
+        getElementById: () => null,
+        createElement: () => ({ setAttribute: () => {}, querySelector: () => null }),
+        querySelector: () => null,
+        body: { appendChild: () => {} }
+    };
+    sandbox.addEventListener = () => {};
+    sandbox.dispatchEvent = () => {};
+
+    vm.createContext(sandbox);
+    vm.runInContext(bookshelfCode, sandbox);
+
+    const store = sandbox.ReadingBookshelfStore;
+    assert.ok(store, 'ReadingBookshelfStore 必须正常导出到全局');
+
+    // 初始化测试数据：
+    // - 篇目 1: cambridge-18-test-1-p1 (有书架记录 + 2个生词)
+    // - 篇目 2: cambridge-18-test-1-p2 (有书架记录 + 1个生词)
+    const initialBookshelf = [
+        { examId: 'cambridge-18-test-1-p1', examTitle: 'Reading Passage 1', firstUsedAt: 1000, lastOpenedAt: 2000 },
+        { examId: 'cambridge-18-test-1-p2', examTitle: 'Reading Passage 2', firstUsedAt: 1000, lastOpenedAt: 3000 }
+    ];
+    const initialVocab = [
+        { id: 'w1', examId: 'cambridge-18-test-1-p1', word: 'urbanisation', createdAt: 2000 },
+        { id: 'w2', examId: 'cambridge-18-test-1-p1', word: 'infrastructure', createdAt: 2100 },
+        { id: 'w3', examId: 'cambridge-18-test-1-p2', word: 'biodiversity', createdAt: 3000 }
+    ];
+
+    mockStorage.set('ielts_reading_bookshelf_exams_v1', JSON.stringify(initialBookshelf));
+    mockStorage.set('ielts_reading_vocab_words_v1', JSON.stringify(initialVocab));
+
+    // 检查删除前书架列表
+    const beforeExams = store.getBookshelfExams();
+    assert.equal(beforeExams.length, 2, '初始书架应当包含2篇');
+    const p1Before = beforeExams.find(e => e.examId === 'cambridge-18-test-1-p1');
+    assert.ok(p1Before);
+    assert.equal(p1Before.wordCount, 2);
+
+    // 记录做题练习数据基线（必须严格保持一致）
+    const initialPracticeSnapshot = JSON.stringify(mockAppData.practice.records);
+
+    // 执行从书架移除 cambridge-18-test-1-p1
+    const res = store.removeExam('cambridge-18-test-1-p1', true);
+    assert.ok(res, 'removeExam 执行应当成功');
+
+    // 检查删除后的书架列表
+    const afterExams = store.getBookshelfExams();
+    assert.equal(afterExams.length, 1, '删除后书架应仅剩 1 篇');
+    assert.equal(afterExams[0].examId, 'cambridge-18-test-1-p2', '剩余篇目应为 p2');
+
+    // 检查生词本数据：p1 的词汇已被清除，p2 的词汇完整保留
+    const currentVocabRaw = mockStorage.get('ielts_reading_vocab_words_v1');
+    const currentVocab = JSON.parse(currentVocabRaw || '[]');
+    assert.equal(currentVocab.length, 1, '生词本中只保留非删除篇目的词');
+    assert.equal(currentVocab[0].word, 'biodiversity');
+
+    // 检查 ReadingVocabStore.clear 调用
+    assert.equal(readingVocabStoreClearedExamId, 'cambridge-18-test-1-p1');
+
+    // 核心断言：做题练习记录严格隔离，分毫未动！
+    const finalPracticeSnapshot = JSON.stringify(mockAppData.practice.records);
+    assert.equal(
+        finalPracticeSnapshot,
+        initialPracticeSnapshot,
+        '做题练习记录与答题历史必须完好无损，严格与生词本/书架删除隔离'
+    );
+
+    console.log('✅ 书架删除生词本记录且严格隔离做题练习记录测试全部通过！');
+});

--- a/developer/tests/js/browseNavigationReset.test.js
+++ b/developer/tests/js/browseNavigationReset.test.js
@@ -44,6 +44,17 @@ function createClassList(initial = []) {
     };
 }
 
+function createView(id, active = false) {
+    return {
+        id,
+        hidden: !active,
+        classList: createClassList(active ? ['active'] : []),
+        removeAttribute(name) {
+            if (name === 'hidden') this.hidden = false;
+        }
+    };
+}
+
 function createButton(dataset, active = false) {
     return {
         dataset: Object.assign({}, dataset),
@@ -928,8 +939,8 @@ test('a newer navigation cancels a delayed hot pending Browse filter', async () 
     const app = vm.runInContext('new ExamSystemApp()', harness.context);
     const initialization = deferred();
     const appliedFilters = [];
-    const browseView = { id: 'browse-view', classList: createClassList() };
-    const overviewView = { id: 'overview-view', classList: createClassList(['active']) };
+    const browseView = createView('browse-view');
+    const overviewView = createView('overview-view', true);
     const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
     const originalQuerySelector = harness.window.document.querySelector.bind(harness.window.document);
     const originalQuerySelectorAll = harness.window.document.querySelectorAll.bind(harness.window.document);
@@ -960,6 +971,7 @@ test('a newer navigation cancels a delayed hot pending Browse filter', async () 
     app.refreshOverviewData = () => {};
 
     app.browseCategory('P3', 'reading');
+    assert.equal(browseView.hidden, false, 'navigation must reveal the target view');
     app.navigateToView('overview');
     initialization.resolve();
     await flushMicrotasks();
@@ -979,8 +991,8 @@ test('a fallback navigation round trip invalidates a delayed hot Browse filter',
     const initialization = deferred();
     const appliedFilters = [];
     let sharedNavigationGeneration = 0;
-    const browseView = { id: 'browse-view', classList: createClassList() };
-    const overviewView = { id: 'overview-view', classList: createClassList(['active']) };
+    const browseView = createView('browse-view');
+    const overviewView = createView('overview-view', true);
     const views = [browseView, overviewView];
     const originalGetElementById = harness.window.document.getElementById.bind(harness.window.document);
     const originalQuerySelector = harness.window.document.querySelector.bind(harness.window.document);
@@ -1021,6 +1033,7 @@ test('a fallback navigation round trip invalidates a delayed hot Browse filter',
     };
 
     app.browseCategory('P3', 'reading');
+    assert.equal(browseView.hidden, false, 'navigation must reveal the target view');
     const capturedPendingFilter = harness.window.__pendingBrowseFilter;
     harness.window.showView('overview', false);
     harness.window.showView('browse', false);

--- a/developer/tests/js/legacyMigrationBrickRegression.test.js
+++ b/developer/tests/js/legacyMigrationBrickRegression.test.js
@@ -152,12 +152,16 @@ async function run() {
         { word: 'new-only', source: 'v2' }
     ]));
     partialDocuments.docs.set('preferences.values', seedEnvelope({ theme: 'v2-theme', v2Only: true }));
+    partialDocuments.docs.set('vocab.readingVocabWords', seedEnvelope([]));
+    partialDocuments.docs.set('vocab.readingBookshelfExams', seedEnvelope([{ examId: 'canonical-only' }]));
     const retriedMigration = harness({
         vocab_words: [
             { word: 'shared', source: 'legacy' },
             { word: 'legacy-only', source: 'legacy' }
         ],
-        ui_preferences: { theme: 'legacy-theme', legacyOnly: true }
+        ui_preferences: { theme: 'legacy-theme', legacyOnly: true },
+        ielts_reading_vocab_words_v1: [{ id: 'removed-word', word: 'removed' }],
+        ielts_reading_bookshelf_exams_v1: [{ examId: 'removed-exam' }, { examId: 'canonical-only' }]
     }, { shared: partialDocuments });
     await retriedMigration.app.ready;
     const reconciledWords = await retriedMigration.app.vocab.listWords();
@@ -169,6 +173,10 @@ async function run() {
         v2Only: true
     });
     assert.strictEqual(partialDocuments.docs.get('system.migrations').data.v1ToV2.status, 'complete');
+    assert.deepStrictEqual(await retriedMigration.app.vocab.listReadingWords(), [],
+        'retrying legacy migration must preserve an explicitly empty canonical reading collection');
+    assert.deepStrictEqual(await retriedMigration.app.vocab.listReadingBookshelfExams(), [{ examId: 'canonical-only' }],
+        'retrying legacy migration must not merge removed bookshelf records back into a smaller canonical collection');
 
     const tombstonedExternal = {
         docs: new Map(),
@@ -189,13 +197,18 @@ async function run() {
     tombstonedExternal.docs.set('system.migrations', seedEnvelope({
         v1ToV2: { version: 1, status: 'complete' }
     }));
+    tombstonedExternal.docs.set('vocab.readingVocabWords', Object.assign(seedEnvelope(null), { state: 'cleared' }));
+    tombstonedExternal.docs.set('vocab.readingBookshelfExams', Object.assign(seedEnvelope(null), { state: 'cleared' }));
     const lateExternalPayload = { practiceRecords: [{
         id: 'late-external',
         type: 'reading',
         title: 'Recovered after tombstone',
         totalQuestions: 1,
         correctAnswers: 1
-    }] };
+    }],
+        ielts_reading_vocab_words_v1: [{ id: 'removed-word', word: 'removed' }],
+        ielts_reading_bookshelf_exams_v1: [{ examId: 'removed-exam' }]
+    };
     const restoredTombstone = harness({}, {
         shared: tombstonedExternal,
         externalBackup: lateExternalPayload
@@ -210,6 +223,10 @@ async function run() {
     }
     assert.strictEqual(tombstonedExternal.docs.get('system.migrations').data.externalBackupV1.status, 'consumed');
     assert.strictEqual(tombstonedExternal.legacyReads, 0, 'a late external backup must not rescan completed v1 data');
+    assert.deepStrictEqual(await restoredTombstone.app.vocab.listReadingWords(), [],
+        'late external migration must preserve the cleared canonical reading vocabulary');
+    assert.deepStrictEqual(await restoredTombstone.app.vocab.listReadingBookshelfExams(), [],
+        'late external migration must preserve the cleared canonical bookshelf');
 
     const tombstoneSecondBoot = harness({}, {
         shared: tombstonedExternal,

--- a/developer/tests/js/readingDataBackupAuthority.test.js
+++ b/developer/tests/js/readingDataBackupAuthority.test.js
@@ -16,10 +16,11 @@ const bookshelfKey = 'ielts_reading_bookshelf_exams_v1';
 const staleWords = [{ id: 'keep', word: 'keep', examId: 'keep' }, { id: 'removed', word: 'removed', examId: 'removed' }];
 const staleBookshelf = [{ examId: 'keep', firstUsedAt: 10 }, { examId: 'removed', firstUsedAt: 20 }];
 
-async function loadAppData(page, { interceptInstall = false, failReadingMigration = false } = {}) {
+async function loadAppData(page, { interceptInstall = false, failReadingMigration = false, trackReadingMigration = false } = {}) {
     await page.addScriptTag({ content: catalogSource });
     await page.addScriptTag({ content: kernelSource });
     await page.addScriptTag({ content: recordSource });
+    if (trackReadingMigration) await trackReadingMigrationFault(page);
     if (failReadingMigration) {
         await page.evaluate(() => {
             const put = IDBObjectStore.prototype.put;
@@ -65,6 +66,58 @@ async function readingState(page) {
         bookshelf: await AppData.vocab.listReadingBookshelfExams(),
         localWords: JSON.parse(localStorage.getItem(wordsKey) || '[]'),
         localBookshelf: JSON.parse(localStorage.getItem(bookshelfKey) || '[]')
+    }), { wordsKey, bookshelfKey });
+}
+
+async function trackReadingMigrationFault(page) {
+    await page.evaluate(() => {
+        const fault = { enabled: false, logicalKey: null, migrationWrites: 0, installCalls: 0 };
+        window.readingMigrationFault = fault;
+        const put = IDBObjectStore.prototype.put;
+        IDBObjectStore.prototype.put = function (value, ...args) {
+            // Fail only the migration: a snapshot install could still succeed
+            // and erase the local-only collection if the error is swallowed.
+            if (fault.enabled && value?.logicalKey === fault.logicalKey
+                && value.envelope?.operationId.startsWith('migrate-reading_')) {
+                fault.migrationWrites += 1;
+                throw new DOMException('Reading migration quota regression', 'QuotaExceededError');
+            }
+            return put.call(this, value, ...args);
+        };
+        const internals = window.__AppDataV2Internals;
+        const prototype = internals.DataKernel.prototype;
+        const install = prototype.installSnapshot;
+        prototype.installSnapshot = function (...args) {
+            fault.installCalls += 1;
+            return install.apply(this, args);
+        };
+        window.makeReadingSnapshotForTest = (logicalKey, data) => {
+            const catalog = internals.catalog;
+            const snapshot = {
+                format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: 'partial',
+                envelopes: { [logicalKey]: internals.makeEnvelope(catalog.get(logicalKey), data) }, entities: {}
+            };
+            snapshot.checksum = internals.checksum({ envelopes: snapshot.envelopes, entities: snapshot.entities });
+            return snapshot;
+        };
+    });
+}
+
+async function failReadingMigration(page, logicalKey) {
+    await page.evaluate((logicalKey) => {
+        Object.assign(window.readingMigrationFault, { enabled: true, logicalKey, migrationWrites: 0, installCalls: 0 });
+    }, logicalKey);
+}
+
+async function backupFailureState(page) {
+    return page.evaluate(async ({ wordsKey, bookshelfKey }) => ({
+        settings: await AppData.settings.getAll(),
+        backupIds: (await AppData.backups.list()).map((entry) => entry.id),
+        words: await AppData.vocab.listReadingWords({ withMeta: true }),
+        bookshelf: await AppData.vocab.listReadingBookshelfExams({ withMeta: true }),
+        rawWords: localStorage.getItem(wordsKey),
+        rawBookshelf: localStorage.getItem(bookshelfKey),
+        fault: { ...window.readingMigrationFault }
     }), { wordsKey, bookshelfKey });
 }
 
@@ -184,6 +237,169 @@ test('reading collections retain canonical authority through backup workflows in
             assert.deepEqual(await readingState(page), {
                 words: staleWords, bookshelf: staleBookshelf, localWords: staleWords, localBookshelf: staleBookshelf
             }, 'the preserved legacy copy remains available for the next successful migration');
+        } finally {
+            await context.close();
+        }
+    });
+
+    for (const workflow of ['restore', 'replace-preview', 'replace-commit', 'replace-smaller']) {
+        for (const logicalKey of ['vocab.readingVocabWords', 'vocab.readingBookshelfExams']) {
+            await t.test(`${workflow} aborts when the only legacy copy of ${logicalKey} cannot migrate`, async () => {
+                const context = await browser.newContext();
+                try {
+                    const page = await context.newPage();
+                    await page.goto(url);
+                    await loadAppData(page, { trackReadingMigration: true });
+                    await page.evaluate(async ({ workflow, logicalKey, staleWords, staleBookshelf }) => {
+                        await AppData.settings.patch({ theme: 'original' });
+                        window.targetSnapshot = await AppData.backups.export();
+                        await AppData.backups.create({ id: 'target' });
+                        await AppData.settings.patch({ theme: 'changed' });
+                        if (workflow === 'replace-commit') {
+                            // A legacy tab can introduce local-only records after
+                            // preview, so commit must recheck migration safety.
+                            window.pendingPlan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                        }
+                        if (workflow === 'replace-smaller') {
+                            const data = logicalKey === 'vocab.readingVocabWords' ? staleWords : staleBookshelf;
+                            window.targetSnapshot = window.makeReadingSnapshotForTest(logicalKey, data.slice(0, 1));
+                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                            window.smallerPlanDestructive = plan.destructive;
+                        }
+                    }, { workflow, logicalKey, staleWords, staleBookshelf });
+                    if (workflow === 'replace-smaller') {
+                        assert.equal(await page.evaluate(() => window.smallerPlanDestructive), false,
+                            'present smaller reading arrays must be protected even when the preview is not marked destructive');
+                    }
+                    await setMirrors(page);
+                    await failReadingMigration(page, logicalKey);
+                    const before = await backupFailureState(page);
+                    const failure = await page.evaluate(async (workflow) => {
+                        try {
+                            if (workflow === 'restore') await AppData.backups.restore('target');
+                            else {
+                                const plan = workflow === 'replace-commit'
+                                    ? window.pendingPlan
+                                    : await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                                if (workflow === 'replace-preview') {
+                                    await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+                                }
+                                await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                            }
+                            return null;
+                        } catch (error) {
+                            return { code: error.code, message: error.message };
+                        }
+                    }, workflow);
+                    assert.equal(failure?.code, 'QUOTA_EXCEEDED', 'destructive workflow must surface the required migration failure');
+                    const after = await backupFailureState(page);
+                    assert.ok(after.fault.migrationWrites > 0, 'exercise an actual failed IndexedDB migration write');
+                    assert.equal(after.fault.installCalls, 0, 'abort before attempting snapshot installation');
+                    assert.deepEqual(after.settings, before.settings, 'failed migration must not install target settings');
+                    assert.deepEqual(after.backupIds, before.backupIds, 'do not create a misleading safety backup without the only legacy copy');
+                    assert.equal(after.rawWords, before.rawWords, 'preserve the original words mirror byte for byte');
+                    assert.equal(after.rawBookshelf, before.rawBookshelf, 'preserve the original bookshelf mirror byte for byte');
+                    assert.equal(after[logicalKey === 'vocab.readingVocabWords' ? 'words' : 'bookshelf'].envelope, null,
+                        'failed migration leaves this collection recoverable only from its preserved mirror');
+
+                    await page.evaluate(() => { window.readingMigrationFault.enabled = false; });
+                    if (workflow === 'replace-commit') {
+                        const conflict = await page.evaluate(async () => {
+                            try {
+                                await AppData.backups.commitImport(window.pendingPlan.id, { confirmDestructive: true });
+                                return null;
+                            } catch (error) {
+                                return error.code;
+                            }
+                        });
+                        assert.equal(conflict, 'CONFLICT', 'late migration must preserve the original preview token and require a fresh preview');
+                        assert.equal((await backupFailureState(page)).settings.theme, 'changed');
+                        assert.deepEqual(await readingState(page), {
+                            words: staleWords, bookshelf: staleBookshelf, localWords: staleWords, localBookshelf: staleBookshelf
+                        }, 'successful migration after quota recovery must preserve records when the old plan conflicts');
+                    }
+                    const result = await page.evaluate(async (workflow) => {
+                        let receipt;
+                        let safety;
+                        if (workflow === 'restore') {
+                            receipt = await AppData.backups.restore('target');
+                            safety = (await AppData.backups.list()).find((entry) => entry.id === receipt.preRestoreBackupId);
+                        } else {
+                            // Re-preview after a failed commit so newly migrated
+                            // records are covered by its revision token.
+                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                            safety = await AppData.backups.create({ id: 'pre-import-retry', type: 'pre-import' });
+                            receipt = await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                        }
+                        return { receipt, safety, settings: await AppData.settings.getAll() };
+                    }, workflow);
+                    assert.equal(result.receipt.committed, true, 'retry succeeds after the migration write becomes available');
+                    assert.equal(result.settings.theme, workflow === 'replace-smaller' ? 'changed' : 'original');
+                    assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
+                    assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
+                    assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
+                    const words = workflow === 'replace-smaller'
+                        ? (logicalKey === 'vocab.readingVocabWords' ? staleWords.slice(0, 1) : staleWords) : [];
+                    const bookshelf = workflow === 'replace-smaller'
+                        ? (logicalKey === 'vocab.readingBookshelfExams' ? staleBookshelf.slice(0, 1) : staleBookshelf) : [];
+                    assert.deepEqual(await readingState(page), { words, bookshelf, localWords: words, localBookshelf: bookshelf });
+                } finally {
+                    await context.close();
+                }
+            });
+        }
+    }
+
+    await t.test('settings-only import leaves broken reading migration alone, while a safety backup requires it', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            await page.goto(url);
+            await loadAppData(page, { trackReadingMigration: true });
+            await page.evaluate(async () => {
+                await AppData.settings.patch({ theme: 'original' });
+                window.settingsSnapshot = await AppData.backups.export({ domains: ['settings'] });
+                await AppData.settings.patch({ theme: 'changed' });
+            });
+            await setMirrors(page);
+            await failReadingMigration(page, 'vocab.readingBookshelfExams');
+            const before = await backupFailureState(page);
+            const receipt = await page.evaluate(async () => {
+                const plan = await AppData.backups.previewImport(window.settingsSnapshot, { replace: true });
+                return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+            });
+            assert.equal(receipt.committed, true);
+            const imported = await backupFailureState(page);
+            assert.equal(imported.settings.theme, 'original');
+            assert.equal(imported.fault.migrationWrites, 0, 'an unrelated partial import must not require reading migration');
+            assert.equal(imported.words.envelope, null);
+            assert.equal(imported.bookshelf.envelope, null);
+            assert.equal(imported.rawWords, before.rawWords);
+            assert.equal(imported.rawBookshelf, before.rawBookshelf);
+
+            const failure = await page.evaluate(async () => {
+                try {
+                    await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+                    return null;
+                } catch (error) {
+                    return error.code;
+                }
+            });
+            assert.equal(failure, 'QUOTA_EXCEEDED', 'explicit safety backups must include recoverable local-only collections');
+            const failed = await backupFailureState(page);
+            assert.ok(failed.fault.migrationWrites > 0);
+            assert.equal(failed.fault.installCalls, imported.fault.installCalls);
+            assert.deepEqual(failed.settings, imported.settings);
+            assert.deepEqual(failed.backupIds, before.backupIds, 'a failed backup must not leave an incomplete safety entry');
+            assert.equal(failed.rawWords, before.rawWords);
+            assert.equal(failed.rawBookshelf, before.rawBookshelf);
+
+            const safety = await page.evaluate(async () => {
+                window.readingMigrationFault.enabled = false;
+                return AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+            });
+            assert.deepEqual(safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
+            assert.deepEqual(safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
         } finally {
             await context.close();
         }

--- a/developer/tests/js/readingDataBackupAuthority.test.js
+++ b/developer/tests/js/readingDataBackupAuthority.test.js
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const catalogSource = source('data/v2/dataCatalog.js');
+const kernelSource = source('data/v2/dataKernel.js');
+const recordSource = source('data/practiceRecordSource.js');
+const appDataSource = source('data/v2/appData.js');
+const bookshelfSource = source('components/bookshelfView.js');
+const readerSource = source('components/readingVocabReader.js');
+const wordsKey = 'ielts_reading_vocab_words_v1';
+const bookshelfKey = 'ielts_reading_bookshelf_exams_v1';
+const staleWords = [{ id: 'keep', word: 'keep', examId: 'keep' }, { id: 'removed', word: 'removed', examId: 'removed' }];
+const staleBookshelf = [{ examId: 'keep', firstUsedAt: 10 }, { examId: 'removed', firstUsedAt: 20 }];
+
+async function loadAppData(page, { interceptInstall = false, failReadingMigration = false } = {}) {
+    await page.addScriptTag({ content: catalogSource });
+    await page.addScriptTag({ content: kernelSource });
+    await page.addScriptTag({ content: recordSource });
+    if (failReadingMigration) {
+        await page.evaluate(() => {
+            const put = IDBObjectStore.prototype.put;
+            IDBObjectStore.prototype.put = function (value, ...args) {
+                if (['vocab.readingVocabWords', 'vocab.readingBookshelfExams'].includes(value?.logicalKey)) {
+                    throw new DOMException('Reading migration quota regression', 'QuotaExceededError');
+                }
+                return put.call(this, value, ...args);
+            };
+        });
+    }
+    if (interceptInstall) {
+        // Only the competing-writer test intercepts this boundary. The write and
+        // snapshot installation still use the real kernel and IndexedDB.
+        await page.evaluate(() => {
+            const prototype = window.__AppDataV2Internals.DataKernel.prototype;
+            const install = prototype.installSnapshot;
+            prototype.installSnapshot = async function (snapshot, options) {
+                if (window.beforeSnapshotInstall) {
+                    const beforeInstall = window.beforeSnapshotInstall;
+                    window.beforeSnapshotInstall = null;
+                    await beforeInstall();
+                }
+                return install.call(this, snapshot, options);
+            };
+        });
+    }
+    await page.addScriptTag({ content: appDataSource });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2', 'exercise the actual IndexedDB backend');
+}
+
+async function setMirrors(page, words = staleWords, bookshelf = staleBookshelf) {
+    await page.evaluate(({ wordsKey, bookshelfKey, words, bookshelf }) => {
+        localStorage.setItem(wordsKey, JSON.stringify(words));
+        localStorage.setItem(bookshelfKey, JSON.stringify(bookshelf));
+    }, { wordsKey, bookshelfKey, words, bookshelf });
+}
+
+async function readingState(page) {
+    return page.evaluate(async ({ wordsKey, bookshelfKey }) => ({
+        words: await AppData.vocab.listReadingWords(),
+        bookshelf: await AppData.vocab.listReadingBookshelfExams(),
+        localWords: JSON.parse(localStorage.getItem(wordsKey) || '[]'),
+        localBookshelf: JSON.parse(localStorage.getItem(bookshelfKey) || '[]')
+    }), { wordsKey, bookshelfKey });
+}
+
+test('reading collections retain canonical authority through backup workflows in IndexedDB', { timeout: 120000 }, async (t) => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Reading backup regression</title>');
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+    });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+
+    for (const workflow of ['restore', 'replace']) {
+        for (const collection of ['cleared', 'empty', 'smaller']) {
+            await t.test(`${workflow} preserves ${collection} collections without a loaded reader`, async () => {
+                const context = await browser.newContext();
+                try {
+                    const page = await context.newPage();
+                    await page.goto(url);
+                    await loadAppData(page);
+                    const words = collection === 'smaller' ? staleWords.slice(0, 1) : [];
+                    const bookshelf = collection === 'smaller' ? staleBookshelf.slice(0, 1) : [];
+                    await page.evaluate(async ({ words, bookshelf, collection }) => {
+                        if (collection !== 'cleared') {
+                            await AppData.vocab.saveReadingWords(words);
+                            await AppData.vocab.saveReadingBookshelfExams(bookshelf);
+                        }
+                        window.targetSnapshot = await AppData.backups.export();
+                        await AppData.backups.create({ id: 'target' });
+                    }, { words, bookshelf, collection });
+                    await page.evaluate(async ({ staleWords, staleBookshelf }) => {
+                        await AppData.vocab.saveReadingWords(staleWords);
+                        await AppData.vocab.saveReadingBookshelfExams(staleBookshelf);
+                    }, { staleWords, staleBookshelf });
+                    await setMirrors(page);
+                    assert.equal(await page.evaluate(() => typeof ReadingVocabStore), 'undefined');
+                    await page.evaluate(async (workflow) => {
+                        if (workflow === 'restore') await AppData.backups.restore('target');
+                        else {
+                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                            await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                        }
+                    }, workflow);
+                    const expected = { words, bookshelf, localWords: words, localBookshelf: bookshelf };
+                    assert.deepEqual(await readingState(page), expected, 'snapshot installation refreshes both mirrors with no reader listener');
+
+                    // An old tab can leave a stale mirror again. It must not win on
+                    // a cold startup, subsequent export, or bookshelf lazy load.
+                    await setMirrors(page);
+                    await page.reload();
+                    await loadAppData(page);
+                    assert.deepEqual(await readingState(page), expected);
+                    const exported = await page.evaluate(() => AppData.backups.export());
+                    assert.deepEqual(exported.envelopes['vocab.readingVocabWords'].data || [], words);
+                    assert.deepEqual(exported.envelopes['vocab.readingBookshelfExams'].data || [], bookshelf);
+                    await setMirrors(page, words, staleBookshelf);
+                    await page.addScriptTag({ content: bookshelfSource });
+                    await page.evaluate(() => ReadingBookshelfStore.init());
+                    assert.deepEqual(await readingState(page), expected, 'bookshelf initialization adopts the canonical array without merging stale records');
+                } finally {
+                    await context.close();
+                }
+            });
+        }
+    }
+
+    await t.test('genuine legacy words and bookshelf migrate on the first startup and survive a reload', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            await page.goto(url);
+            await setMirrors(page);
+            await loadAppData(page);
+            const expected = {
+                words: staleWords, bookshelf: staleBookshelf,
+                localWords: staleWords, localBookshelf: staleBookshelf
+            };
+            assert.deepEqual(await readingState(page), expected, 'legacy data seeds previously absent canonical documents');
+            await page.reload();
+            await loadAppData(page);
+            assert.deepEqual(await readingState(page), expected);
+        } finally {
+            await context.close();
+        }
+    });
+
+    await t.test('failed initial migration preserves the only legacy copy through lazy stores and retries on reload', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            await page.goto(url);
+            await setMirrors(page);
+            await loadAppData(page, { failReadingMigration: true });
+            await page.addScriptTag({ content: bookshelfSource });
+            await page.addScriptTag({ content: readerSource });
+            await page.evaluate(async () => {
+                await ReadingBookshelfStore.init();
+                await ReadingVocabStore.init();
+            });
+            assert.deepEqual(await readingState(page), {
+                words: [], bookshelf: [], localWords: staleWords, localBookshelf: staleBookshelf
+            }, 'absent documents after a failed migration must not overwrite legacy data with defaults');
+            assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll()), staleWords);
+
+            await page.reload();
+            await loadAppData(page);
+            assert.deepEqual(await readingState(page), {
+                words: staleWords, bookshelf: staleBookshelf, localWords: staleWords, localBookshelf: staleBookshelf
+            }, 'the preserved legacy copy remains available for the next successful migration');
+        } finally {
+            await context.close();
+        }
+    });
+
+    await t.test('restore migrates late legacy mirrors before its revision token and retains its safety backup', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            await page.goto(url);
+            await loadAppData(page);
+            await page.evaluate(async () => {
+                await AppData.settings.patch({ theme: 'original' });
+                await AppData.backups.create({ id: 'target' });
+                await AppData.settings.patch({ theme: 'changed' });
+            });
+            await setMirrors(page);
+            const result = await page.evaluate(async () => {
+                const receipt = await AppData.backups.restore('target');
+                const safety = (await AppData.backups.list()).find((entry) => entry.id === receipt.preRestoreBackupId);
+                return { receipt, settings: await AppData.settings.getAll(), safety };
+            });
+            assert.equal(result.receipt.committed, true, 'restore succeeds on its first attempt without a competing writer');
+            assert.equal(result.settings.theme, 'original');
+            assert.equal(result.safety.type, 'pre-restore');
+            assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
+            assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
+            assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
+            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
+            await page.reload();
+            await loadAppData(page);
+            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'original');
+            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
+        } finally {
+            await context.close();
+        }
+    });
+
+    await t.test('replace import migrates late mirrors before preview so its safety backup does not invalidate the plan', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            await page.goto(url);
+            await loadAppData(page);
+            await page.evaluate(async () => {
+                await AppData.settings.patch({ theme: 'original' });
+                window.targetSnapshot = await AppData.backups.export();
+                await AppData.settings.patch({ theme: 'changed' });
+            });
+            await setMirrors(page);
+            const result = await page.evaluate(async () => {
+                const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                const safety = await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+                const receipt = await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                return { receipt, safety, settings: await AppData.settings.getAll() };
+            });
+            assert.equal(result.receipt.committed, true, 'preview, safety backup, and commit succeed on the first attempt');
+            assert.equal(result.settings.theme, 'original');
+            assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
+            assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
+            assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
+            await page.reload();
+            await loadAppData(page);
+            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
+            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'original');
+        } finally {
+            await context.close();
+        }
+    });
+
+    await t.test('a competing reading writer still aborts restore after the safety backup', async () => {
+        const context = await browser.newContext();
+        try {
+            const page = await context.newPage();
+            const writer = await context.newPage();
+            await page.goto(url);
+            await loadAppData(page, { interceptInstall: true });
+            await page.evaluate(async () => {
+                await AppData.settings.patch({ theme: 'original' });
+                await AppData.backups.create({ id: 'target' });
+                await AppData.settings.patch({ theme: 'changed' });
+            });
+            await writer.goto(url);
+            await loadAppData(writer);
+            await page.exposeFunction('commitConcurrentReading', () => writer.evaluate(async () => {
+                await AppData.vocab.saveReadingWords([{ id: 'concurrent', word: 'concurrent' }]);
+            }));
+            const result = await page.evaluate(async () => {
+                window.beforeSnapshotInstall = () => window.commitConcurrentReading();
+                try { await AppData.backups.restore('target'); } catch (error) {
+                    return { code: error.code, settings: await AppData.settings.getAll(), backups: await AppData.backups.list() };
+                }
+                return null;
+            });
+            assert.equal(result.code, 'CONFLICT');
+            assert.equal(result.settings.theme, 'changed', 'failed restore must not partially install the target snapshot');
+            assert.ok(result.backups.some((entry) => entry.type === 'pre-restore'));
+            assert.deepEqual((await readingState(writer)).words, [{ id: 'concurrent', word: 'concurrent' }]);
+        } finally {
+            await context.close();
+        }
+    });
+});

--- a/developer/tests/js/readingVocabHighlightInstance.test.js
+++ b/developer/tests/js/readingVocabHighlightInstance.test.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..', '..', '..');
+const vocabReaderPath = path.join(root, 'js/components/readingVocabReader.js');
+const vocabReaderSource = fs.readFileSync(vocabReaderPath, 'utf8');
+
+// 1. 验证 ReadingVocabStore.add 支持 highlight 存储，且能够保存选区实例位置信息
+assert.match(
+    vocabReaderSource,
+    /add\(rawWord,\s*examId,\s*examTitle,\s*context\s*=\s*'',\s*highlight\s*=\s*null\)/,
+    'ReadingVocabStore.add must accept highlight metadata parameter'
+);
+
+assert.match(
+    vocabReaderSource,
+    /highlights:\s*highlight\s*\?\s*\[highlight\]\s*:\s*\[\]/,
+    'New vocab items must initialize highlights array with highlight parameter'
+);
+
+assert.match(
+    vocabReaderSource,
+    /item\.highlights\.push\(highlight\)/,
+    'Existing vocab items must append new highlight instances'
+);
+
+// 2. 验证 handleSelectionCapture 仅高亮当前选中的具体单词实例，不执行全篇盲匹配
+assert.match(
+    vocabReaderSource,
+    /const locInfo = this\.calculateRangeLocation\(scopeElement,\s*trimmedRange,\s*text\);/,
+    'Must calculate exact range location within scopeElement'
+);
+
+assert.match(
+    vocabReaderSource,
+    /const wrappedMark = this\.wrapRangeWithHighlight\(trimmedRange,\s*cleanWord\);/,
+    'Must wrap ONLY the trimmedRange with highlight'
+);
+
+// 确保在划词捕获时绝不调用全局 applyVocabHighlights (这曾是全篇所有相同单词都被高亮的根本原因)
+const captureBlock = vocabReaderSource.match(/const handleSelectionCapture = \(\) => \{([\s\S]*?)\n                \};/)?.[1] || '';
+assert.ok(captureBlock.length > 0, 'handleSelectionCapture must exist');
+assert.doesNotMatch(
+    captureBlock,
+    /this\.applyVocabHighlights\(/,
+    'handleSelectionCapture must NOT trigger global applyVocabHighlights across the whole text'
+);
+
+// 3. 验证 applyVocabHighlights 是基于保存的实例元数据精确恢复单处高亮，而非全篇盲目正则
+assert.match(
+    vocabReaderSource,
+    /this\.restoreVocabHighlight\(overlay,\s*hl,\s*item\.word\)/,
+    'applyVocabHighlights must restore each highlight record individually'
+);
+
+assert.doesNotMatch(
+    vocabReaderSource,
+    /new RegExp\(`\(\$\{patternParts\.join\('\|'\)\}\)`,\s*'gi'\)/,
+    'Global regex multi-match replacement over entire document must be removed'
+);
+
+// 4. 验证删除单词时针对性清理该单词的高亮 mark
+assert.match(
+    vocabReaderSource,
+    /this\.removeVocabHighlightForWord\(word\)/,
+    'Deleting a word must specifically remove only that word marks'
+);
+
+// 5. 模拟验证实例定位算法：当文本中出现多个相同单词时，精准命中目标实例
+function simulateResolveInstance(fullText, targetWord, targetOccurrence) {
+    const lowerFull = fullText.toLowerCase();
+    const lowerWord = targetWord.toLowerCase();
+    let currentOccurrence = 0;
+    let pos = 0;
+    let matchPos = -1;
+    while ((matchPos = lowerFull.indexOf(lowerWord, pos)) !== -1) {
+        if (currentOccurrence === targetOccurrence) {
+            return { start: matchPos, end: matchPos + targetWord.length };
+        }
+        currentOccurrence += 1;
+        pos = matchPos + 1;
+    }
+    return null;
+}
+
+const sampleArticle = "Clean water is essential for life, but contaminated water causes severe diseases. Stored water must be protected.";
+// 文中有 3 个 "water":
+// 0: offset 6..11 ("Clean water")
+// 1: offset 52..57 ("contaminated water")
+// 2: offset 87..92 ("Stored water")
+const hit0 = simulateResolveInstance(sampleArticle, "water", 0);
+const hit1 = simulateResolveInstance(sampleArticle, "water", 1);
+const hit2 = simulateResolveInstance(sampleArticle, "water", 2);
+
+assert.strictEqual(hit0.start, 6);
+assert.strictEqual(hit0.end, 11);
+assert.strictEqual(hit1.start, 52);
+assert.strictEqual(hit1.end, 57);
+assert.strictEqual(hit2.start, 89);
+assert.strictEqual(hit2.end, 94);
+
+// 验证命中第 1 个（第二个出现）时，只定位第 1 个，而不影响第 0 和第 2 个
+assert.notStrictEqual(hit1.start, hit0.start);
+assert.notStrictEqual(hit1.start, hit2.start);
+
+// 6. 验证 header 右侧的生词本按钮已被移除，保留右下角悬浮 FAB 按钮
+assert.doesNotMatch(
+    vocabReaderSource,
+    /id="vocab-open-modal-btn"/,
+    'Right header vocab-open-modal-btn must be removed'
+);
+
+assert.match(
+    vocabReaderSource,
+    /id="vocab-fab"/,
+    'Floating vocab FAB must be preserved'
+);
+
+// 7. 验证段落切换 Tab 生成文案为 "Para ${b.letter}"，并完全陈列展开
+assert.match(
+    vocabReaderSource,
+    /Para \$\{b\.letter\}/,
+    'Tab button text must use English abbreviation Para ${b.letter}'
+);
+
+const vocabCssPath = path.join(root, 'css/vocab-reader.css');
+const vocabCssSource = fs.readFileSync(vocabCssPath, 'utf8');
+
+// 8. 验证 CSS 中 tabs 样式已移除滑动限制并支持 flex-wrap 陈列
+assert.match(
+    vocabCssSource,
+    /\.vocab-reader-tabs\s*\{[\s\S]*?flex-wrap:\s*wrap;/m,
+    'Tabs must use flex-wrap: wrap for complete expansion without horizontal scrolling'
+);
+
+assert.doesNotMatch(
+    vocabCssSource,
+    /\.vocab-reader-tabs\s*\{[\s\S]*?overflow-x:\s*auto;/m,
+    'Tabs must NOT use overflow-x: auto'
+);
+
+console.log(JSON.stringify({
+    status: 'pass',
+    detail: 'Reading vocab highlight and layout customization verified'
+}));

--- a/developer/tests/js/readingVocabReaderLayout.test.js
+++ b/developer/tests/js/readingVocabReaderLayout.test.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..', '..', '..');
+const vocabReaderPath = path.join(root, 'js/components/readingVocabReader.js');
+const cssPath = path.join(root, 'css/vocab-reader.css');
+
+const vocabReaderSource = fs.readFileSync(vocabReaderPath, 'utf8');
+const cssSource = fs.readFileSync(cssPath, 'utf8');
+
+// 1. 验证 isPassageInstruction 函数存在并能够识别指导语句子
+assert.match(
+    vocabReaderSource,
+    /function isPassageInstruction\(text\)/,
+    'isPassageInstruction function must be defined'
+);
+
+// 2. 验证 extractPassageData 函数能够分离指导语与段落
+assert.match(
+    vocabReaderSource,
+    /function extractPassageData\(rawHtml/,
+    'extractPassageData function must be defined'
+);
+
+// 3. 验证 Tab 按钮文本改为 "全文"，并且不再是 "全部全文"
+assert.doesNotMatch(
+    vocabReaderSource,
+    />全部全文</,
+    'Tab button must not contain 全部全文'
+);
+
+assert.match(
+    vocabReaderSource,
+    /data-para="all">全文<\/button>/,
+    'Tab button must be 全文'
+);
+
+// 4. 验证段落标题与标签使用英文缩写 Para A、Para B 等，而非中文“段落 A”
+assert.doesNotMatch(
+    vocabReaderSource,
+    /data-para="\$\{b\.letter\}">段落 \$\{b\.letter\}<\/button>/,
+    'Tab buttons must not use Chinese 段落'
+);
+
+assert.match(
+    vocabReaderSource,
+    /data-para="\$\{b\.letter\}">Para \$\{b\.letter\}<\/button>/,
+    'Tab buttons must use English abbreviation Para ${b.letter}'
+);
+
+assert.match(
+    vocabReaderSource,
+    /<span class="vocab-para-letter">Para \$\{b\.letter\}<\/span>/,
+    'Paragraph card tag must use English abbreviation Para ${b.letter}'
+);
+
+// 5. 验证指导语在展示时作为独立说明呈现，没有段落标签
+assert.match(
+    vocabReaderSource,
+    /vocab-passage-instruction/,
+    'Instruction note must use dedicated vocab-passage-instruction markup'
+);
+
+// 6. 验证 DOM 结构与 CSS：header 置顶不随页面滚动收起
+assert.match(
+    vocabReaderSource,
+    /<div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">/,
+    'ensureOverlay must have a dedicated vocab-reader-scroll-area wrapper'
+);
+
+assert.match(
+    cssSource,
+    /\.vocab-reader-scroll-area\s*\{[\s\S]*?overflow-y:\s*auto;/,
+    'CSS must declare .vocab-reader-scroll-area with overflow-y: auto'
+);
+
+assert.match(
+    cssSource,
+    /\.vocab-reader-header\s*\{[\s\S]*?flex-shrink:\s*0;/,
+    'CSS .vocab-reader-header must have flex-shrink: 0 to stay pinned at top'
+);
+
+console.log(JSON.stringify({
+    status: 'pass',
+    detail: 'Reading vocab reader layout, instruction filtering, English abbreviation tabs, and sticky header verified'
+}));

--- a/developer/tests/js/readingVocabReaderSafety.test.js
+++ b/developer/tests/js/readingVocabReaderSafety.test.js
@@ -1,0 +1,345 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const readerSource = fs.readFileSync(path.join(repoRoot, 'js/components/readingVocabReader.js'), 'utf8');
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
+async function createPage(browser, { localWords = [], canonicalWords, canonicalResult } = {}) {
+    const page = await browser.newPage();
+    await page.route('https://reader.test/**', route => route.fulfill({
+        contentType: 'text/html', body: '<!doctype html><html><head></head><body></body></html>'
+    }));
+    await page.goto('https://reader.test/');
+    await page.evaluate(({ localWords, canonicalWords, canonicalResult }) => {
+        localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify(localWords));
+        window.__savedWords = [];
+        if (canonicalWords !== undefined || canonicalResult !== undefined) {
+            window.AppData = {
+                ready: Promise.resolve(),
+                vocab: {
+                    listReadingWords: async options => options?.withMeta && canonicalResult !== undefined
+                        ? canonicalResult : (canonicalWords ?? canonicalResult.data),
+                    saveReadingWords: async words => window.__savedWords.push(words)
+                }
+            };
+        }
+        window.__recordedExams = [];
+        window.ReadingBookshelfStore = { recordExamUsed: id => window.__recordedExams.push(id) };
+        window.__spokenWords = [];
+        window.SpeechSynthesisUtterance = class { constructor(text) { this.text = text; } };
+        Object.defineProperty(window, 'speechSynthesis', {
+            value: { cancel() {}, speak: utterance => window.__spokenWords.push(utterance.text) }
+        });
+        window.__READING_EXAM_MANIFEST__ = {};
+        window.__READING_EXPLANATION_MANIFEST__ = {};
+        window.__pendingScripts = [];
+        const appendChild = document.head.appendChild.bind(document.head);
+        document.head.appendChild = node => {
+            if (node.tagName === 'SCRIPT' && node.src) {
+                window.__pendingScripts.push(node);
+                return node;
+            }
+            return appendChild(node);
+        };
+        window.__queueOpen = (id, key = id, script = `${id}.js`, options = {}) => {
+            window.__READING_EXAM_MANIFEST__[id] = { examId: id, script };
+            window.__READING_EXPLANATION_MANIFEST__[id] = { examId: id, script: `${id}-explanation.js` };
+            window[key] = window.ReadingVocabReader.open(id, options);
+        };
+        window.__finishScript = (scriptName, id, { error = false, explanation = false, title = id } = {}) => {
+            const index = window.__pendingScripts.findIndex(script => script.src.endsWith(`/${scriptName}`));
+            if (index < 0) throw new Error(`Missing pending script: ${scriptName}`);
+            const [script] = window.__pendingScripts.splice(index, 1);
+            if (error) {
+                script.onerror();
+                return;
+            }
+            if (explanation) {
+                window.__READING_EXPLANATION_DATA__.register(id, {
+                    passageNotes: [{ label: 'Paragraph A', text: title }]
+                });
+            } else {
+                window.__READING_EXAM_DATA__.register(id, {
+                    meta: { title },
+                    passage: { blocks: [{ html: `<div class="paragraph-wrapper"><p><strong>A</strong> This is the <em>${title}</em> passage with enough text for reading.</p></div>` }] },
+                    questionGroups: [{ bodyHtml: `<p>Questions for ${title}</p>` }]
+                });
+            }
+            script.onload();
+        };
+    }, { localWords, canonicalWords, canonicalResult });
+    await page.addScriptTag({ content: readerSource });
+    return page;
+}
+
+test('reading vocab reader preserves text boundaries and the active reading session', async t => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    try {
+        await t.test('stored and imported text never creates markup or event attributes; speak and delete preserve values', async () => {
+            const attacks = [{
+                id: 'id" onclick="window.__injected=true" data-extra="',
+                word: '<img src=x onerror="window.__injected=true">',
+                context: '</p><svg onload="window.__injected=true"></svg>',
+                examTitle: '<iframe srcdoc="<script>parent.__injected=true</script>"></iframe>',
+                examId: 'exam-a'
+            }, {
+                id: 'ordinary-id', word: 'research & development', context: 'A "quoted" context',
+                examTitle: 'Ordinary exam', examId: 'exam-a'
+            }, {
+                id: "alternate-'\"-id", word: '&lt;svg onload=alert(1)&gt;',
+                context: '&#34; & < >', examTitle: 'Title &amp; literal', examId: 'exam-a'
+            }];
+            for (const source of ['local', 'canonical']) {
+                const page = await createPage(browser, source === 'local'
+                    ? { localWords: attacks } : { canonicalWords: attacks });
+                try {
+                    const state = await page.evaluate(async () => {
+                        await ReadingVocabStore.init();
+                        ReadingVocabReader.modalTab = 'all';
+                        ReadingVocabReader.openModal();
+                        const list = document.getElementById('vocab-list');
+                        return {
+                            unsafeNodes: list.querySelectorAll('img, svg, iframe, script, [onclick], [onload], [onerror], [data-extra]').length,
+                            rows: [...list.querySelectorAll('.vocab-item')].map(row => ({
+                                id: row.dataset.wordId, word: row.querySelector('.vocab-item__word').textContent,
+                                speak: row.querySelector('.vocab-speak-btn').dataset.speakWord,
+                                deleteId: row.querySelector('.vocab-delete-btn').dataset.delId,
+                                context: row.querySelector('.vocab-item__context').textContent,
+                                title: row.querySelector('.vocab-item__source').textContent
+                            }))
+                        };
+                    });
+                    assert.equal(state.unsafeNodes, 0, `${source} vocabulary must remain inert text`);
+                    assert.deepEqual(state.rows, attacks.map(item => ({
+                        id: item.id, word: item.word, speak: item.word, deleteId: item.id,
+                        context: `"${item.context}"`, title: item.examTitle
+                    })));
+                    await page.locator('.vocab-speak-btn').first().click();
+                    assert.deepEqual(await page.evaluate(() => window.__spokenWords), [attacks[0].word]);
+                    await page.locator('.vocab-delete-btn').first().click();
+                    assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll().map(item => item.id)), attacks.slice(1).map(item => item.id));
+                    assert.equal(await page.evaluate(() => !!window.__injected), false);
+                } finally { await page.close(); }
+            }
+        });
+
+        await t.test('canonical empty and smaller vocab lists replace stale local mirrors without saving them back', async () => {
+            const localWords = [{ id: 'old', word: 'stale' }, { id: 'new', word: 'current' }];
+            for (const canonicalWords of [[], [localWords[1]]]) {
+                const page = await createPage(browser, { localWords, canonicalResult: { data: canonicalWords, envelope: { revision: 2 } } });
+                try {
+                    const state = await page.evaluate(async () => {
+                        await ReadingVocabStore.init();
+                        return { words: ReadingVocabStore.getAll(), local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: window.__savedWords };
+                    });
+                    assert.deepEqual(state, { words: canonicalWords, local: canonicalWords, saves: [] });
+                } finally { await page.close(); }
+            }
+        });
+
+        await t.test('absent canonical metadata preserves the only local copy when migration has failed', async () => {
+            const localWords = [{ id: 'legacy', word: 'preserved' }];
+            const page = await createPage(browser, { localWords, canonicalResult: { data: [], envelope: null } });
+            try {
+                const state = await page.evaluate(async () => {
+                    await ReadingVocabStore.init();
+                    return { words: ReadingVocabStore.getAll(), local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: window.__savedWords };
+                });
+                assert.deepEqual(state, { words: localWords, local: localWords, saves: [] });
+            } finally { await page.close(); }
+        });
+
+        await t.test('exam badges render literal text while generated passage formatting remains intact', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    __queueOpen('metadata', '__openMetadata');
+                    __READING_EXAM_DATA__.register('metadata', {
+                        meta: { title: 'Ordinary article', category: '<img src=x onerror="window.__injected=true">', frequency: '&lt;svg&gt; & "quoted"' },
+                        passage: { blocks: [{ html: '<p><strong>A</strong> A sufficiently long <em>formatted</em> passage for reading.</p>' }] }
+                    });
+                    __pendingScripts.shift().onload();
+                    await __openMetadata;
+                    return {
+                        category: document.querySelector('.vocab-badge--cat').textContent,
+                        frequency: document.querySelector('.vocab-badge--freq').textContent,
+                        unsafeNodes: document.querySelectorAll('#vocab-reader-badges img, #vocab-reader-badges [onerror]').length,
+                        formatted: document.querySelector('#vocab-passage-content em').textContent
+                    };
+                });
+                assert.deepEqual(state, { category: '<img src=x onerror="window.__injected=true">', frequency: '&lt;svg&gt; & "quoted"', unsafeNodes: 0, formatted: 'formatted' });
+            } finally { await page.close(); }
+        });
+
+        await t.test('out-of-order exam success and failure cannot change the latest article or bookshelf', async () => {
+            for (const error of [false, true]) {
+                const page = await createPage(browser);
+                try {
+                    const state = await page.evaluate(async error => {
+                        __queueOpen('a', '__openA');
+                        __queueOpen('b', '__openB');
+                        __finishScript('b.js', 'b');
+                        await __openB;
+                        __finishScript('a.js', 'a', { error });
+                        await __openA;
+                        return {
+                            current: ReadingVocabReader.currentExamId, title: ReadingVocabReader.currentExam.title,
+                            rendered: document.getElementById('vocab-reader-title').textContent,
+                            passage: document.querySelector('#vocab-passage-content em')?.textContent,
+                            error: !!document.querySelector('.vocab-error-state'), recorded: __recordedExams,
+                            pending: __pendingScripts.map(script => script.src.split('/').pop())
+                        };
+                    }, error);
+                    assert.deepEqual(state, { current: 'b', title: 'b', rendered: 'b', passage: 'b', error: false, recorded: ['b'], pending: ['b-explanation.js'] });
+                } finally { await page.close(); }
+            }
+        });
+
+        await t.test('explanations reset between articles and late translations cannot overwrite the latest article', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    __queueOpen('a', '__openA');
+                    __finishScript('a.js', 'a');
+                    await __openA;
+                    ReadingVocabReader.currentExplanation = { passageNotes: [{ label: 'Paragraph A', text: 'old cached translation' }] };
+                    __queueOpen('b', '__openB');
+                    const cleared = ReadingVocabReader.currentPayload === null && ReadingVocabReader.currentExam === null && ReadingVocabReader.currentExplanation === null;
+                    __finishScript('b.js', 'b');
+                    await __openB;
+                    const before = document.getElementById('vocab-trans-text-A').textContent;
+                    __finishScript('b-explanation.js', 'b', { explanation: true, title: 'B translation' });
+                    await Promise.resolve();
+                    await Promise.resolve();
+                    __finishScript('a-explanation.js', 'a', { explanation: true, title: 'A translation' });
+                    await Promise.resolve();
+                    await Promise.resolve();
+                    return { cleared, before, translation: document.getElementById('vocab-trans-text-A').textContent, current: ReadingVocabReader.currentExplanation.passageNotes[0].text };
+                });
+                assert.deepEqual(state, { cleared: true, before: '加载中...', translation: 'B translation', current: 'B translation' });
+            } finally { await page.close(); }
+        });
+
+        await t.test('delayed selections belong to their opening and a new article resets the visible tab', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    __queueOpen('a', '__openA');
+                    __finishScript('a.js', 'a');
+                    await __openA;
+                    ReadingVocabReader.switchViewTab('questions');
+                    const callbacks = [];
+                    const setTimer = window.setTimeout;
+                    window.setTimeout = callback => { callbacks.push(callback); return callbacks.length; };
+                    const select = selector => {
+                        const range = document.createRange();
+                        range.selectNodeContents(document.querySelector(selector));
+                        window.getSelection().removeAllRanges();
+                        window.getSelection().addRange(range);
+                    };
+                    const queueCapture = () => document.getElementById('vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
+                    select('#vocab-passage-content em');
+                    queueCapture();
+                    __queueOpen('b', '__openB');
+                    __finishScript('b.js', 'b');
+                    await __openB;
+                    select('#vocab-passage-content em');
+                    callbacks.shift()();
+                    const staleCount = ReadingVocabStore.getAll().length;
+                    queueCapture();
+                    callbacks.shift()();
+                    const currentWords = ReadingVocabStore.getAll().map(item => ({ word: item.word, examId: item.examId }));
+                    select('#vocab-passage-content strong');
+                    queueCapture();
+                    ReadingVocabReader.close();
+                    callbacks.splice(0).forEach(callback => callback());
+                    window.setTimeout = setTimer;
+                    return {
+                        staleCount, currentWords, afterCloseCount: ReadingVocabStore.getAll().length,
+                        passageDisplay: document.getElementById('vocab-passage-section').style.display,
+                        questionsDisplay: document.getElementById('vocab-questions-section').style.display
+                    };
+                });
+                assert.deepEqual(state, { staleCount: 0, currentWords: [{ word: 'b', examId: 'b' }], afterCloseCount: 1, passageDisplay: 'block', questionsDisplay: 'block' });
+            } finally { await page.close(); }
+        });
+
+        await t.test('close invalidates pending loads, errors and explanations, including reopening the same exam', async () => {
+            for (const error of [false, true]) {
+                const page = await createPage(browser);
+                try {
+                    const state = await page.evaluate(async error => {
+                        __queueOpen('a', '__openA');
+                        ReadingVocabReader.openModal();
+                        ReadingVocabReader.close();
+                        const before = document.getElementById('vocab-passage-content').innerHTML;
+                        __finishScript('a.js', 'a', { error });
+                        await __openA;
+                        return {
+                            hidden: document.getElementById('reading-vocab-reader-overlay').classList.contains('is-hidden'),
+                            unchanged: before === document.getElementById('vocab-passage-content').innerHTML,
+                            recorded: __recordedExams, pending: __pendingScripts.length,
+                            modalHidden: document.getElementById('vocab-modal').getAttribute('aria-hidden'),
+                            modalActive: document.getElementById('vocab-modal').classList.contains('active')
+                        };
+                    }, error);
+                    assert.deepEqual(state, { hidden: true, unchanged: true, recorded: [], pending: 0, modalHidden: 'true', modalActive: false });
+                } finally { await page.close(); }
+            }
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    __queueOpen('a', '__openA');
+                    __finishScript('a.js', 'a');
+                    await __openA;
+                    ReadingVocabReader.close();
+                    const before = document.getElementById('vocab-trans-text-A').textContent;
+                    __finishScript('a-explanation.js', 'a', { explanation: true, title: 'closed translation' });
+                    await Promise.resolve();
+                    await Promise.resolve();
+                    const closedUnchanged = before === document.getElementById('vocab-trans-text-A').textContent;
+                    __READING_EXAM_DATA__.clear();
+                    __queueOpen('a', '__oldOpen', 'old-a.js');
+                    ReadingVocabReader.close();
+                    __queueOpen('a', '__newOpen', 'new-a.js');
+                    __finishScript('new-a.js', 'a', { title: 'new article' });
+                    await __newOpen;
+                    __finishScript('old-a.js', 'a', { title: 'stale article' });
+                    await __oldOpen;
+                    return { closedUnchanged, title: document.getElementById('vocab-reader-title').textContent, recorded: __recordedExams };
+                });
+                assert.deepEqual(state, { closedUnchanged: true, title: 'new article', recorded: ['a', 'a'] });
+            } finally { await page.close(); }
+        });
+
+        await t.test('error messages and retry IDs remain text; retry loads the intended exam', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    const id = "exam');window.__injected=true;//";
+                    const scriptName = 'missing-<img src=x onerror=alert(1)>.js';
+                    __queueOpen(id, '__failed', scriptName, { fromPractice: true });
+                    const script = __pendingScripts.shift();
+                    // Preserve the raw malicious manifest text in the loader's error message.
+                    script.onerror();
+                    await __failed;
+                    const errorText = document.querySelector('.vocab-error-state p').textContent;
+                    const unsafeNodes = document.querySelectorAll('.vocab-error-state img, .vocab-error-state [onclick]').length;
+                    document.querySelector('.vocab-error-state button').click();
+                    return { errorText, unsafeNodes, current: ReadingVocabReader.currentExamId, retryCount: __pendingScripts.length, injected: !!window.__injected, back: document.querySelector('#vocab-reader-back-btn span').textContent };
+                });
+                assert.ok(state.errorText.includes('<img src=x onerror=alert(1)>'));
+                assert.equal(state.unsafeNodes, 0);
+                assert.equal(state.current, "exam');window.__injected=true;//");
+                assert.equal(state.retryCount, 1);
+                assert.equal(state.injected, false);
+                assert.equal(state.back, '返回练习');
+            } finally { await page.close(); }
+        });
+    } finally { await browser.close(); }
+});

--- a/developer/tests/js/siteDataReset.test.js
+++ b/developer/tests/js/siteDataReset.test.js
@@ -296,10 +296,34 @@ async function testDeletionFailureIsVisible() {
     const result = await harness.windowStub.clearCache();
     assert.equal(result.success, false);
     assert.equal(result.reason, 'partial_reset');
+    assert.equal(result.retryable, true);
     assert.equal(result.terminal, false);
+    assert.equal(result.externalBackupFilesPreserved, true);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].stage, 'delete-database');
+    assert.equal(result.errors[0].database, 'ExamSystemDB');
+    assert.match(result.errors[0].error.message, /delete failed: ExamSystemDB/);
+    assert.deepEqual(
+        harness.events.filter((entry) => entry.startsWith('deleted:')).sort(),
+        [
+            'deleted:ExamSystemExternalBackup',
+            'deleted:IELTSAtlasDataV2',
+            'deleted:IELTSAtlasExternalBackupV2'
+        ],
+        'a failed database deletion does not undo the other completed deletions'
+    );
+    assert.equal(harness.externalBackup.rollbackCalls, 1);
+    assert.equal(harness.externalBackup.commitCalls, 0);
     assert.equal(harness.windowStub.location.reloadCalls, 0);
     assert.equal(harness.localStorage.clearCalls, 1);
-    assert.ok(harness.messages.some((entry) => entry.type === 'error'));
+    assert.equal(harness.sessionStorage.clearCalls, 1);
+    assert.equal(harness.localStorage.values.size, 0,
+        'rolling back backup preparation does not restore cleared local storage');
+    assert.equal(harness.sessionStorage.values.size, 0,
+        'rolling back backup preparation does not restore cleared session storage');
+    assert.ok(harness.messages.some((entry) => entry.type === 'error'
+        && /仅部分清除/.test(entry.message)));
+    assert.equal(harness.messages.some((entry) => entry.type === 'success'), false);
 }
 
 async function testRejectedDatabaseDeletionRollsBackPreparation() {
@@ -360,6 +384,38 @@ async function testExternalFailureStopsBeforeDeletion() {
     assert.equal(harness.localStorage.clearCalls, 0);
     assert.equal(harness.sessionStorage.clearCalls, 0);
     assert.equal(harness.windowStub.location.reloadCalls, 0);
+}
+
+async function testFullResetLockFailureStopsBeforeDestructiveCleanup() {
+    const lockError = new Error('cross-tab lock rejected');
+    const cases = [
+        async () => { throw lockError; },
+        async () => undefined
+    ];
+    for (const withFullResetLock of cases) {
+        const harness = createHarness();
+        harness.externalBackup.withFullResetLock = withFullResetLock;
+        const result = await harness.windowStub.clearCache();
+        assert.equal(result.success, false);
+        assert.equal(result.reason, 'external_backup_busy');
+        assert.equal(result.retryable, true);
+        assert.equal(result.terminal, false);
+        assert.ok(result.error instanceof Error);
+        assert.equal(harness.externalBackup.prepareCalls, 0);
+        assert.equal(harness.externalBackup.commitCalls, 0);
+        assert.equal(harness.externalBackup.rollbackCalls, 0);
+        assert.deepEqual(harness.events, []);
+        assert.equal(harness.requests.length, 0);
+        assert.equal(harness.localStorage.clearCalls, 0);
+        assert.equal(harness.sessionStorage.clearCalls, 0);
+        assert.equal(harness.localStorage.values.get('consent'), 'yes');
+        assert.equal(harness.sessionStorage.values.get('recovery'), 'active');
+        assert.equal(harness.externalBackup.status.suspended, false);
+        assert.equal(harness.externalBackup.status.bound, true);
+        assert.equal(harness.windowStub.location.reloadCalls, 0);
+        assert.ok(harness.messages.some((entry) => entry.type === 'error'));
+        assert.equal(harness.messages.some((entry) => entry.type === 'success'), false);
+    }
 }
 
 async function testMissingExternalBackupServiceFailsClosed() {
@@ -464,6 +520,7 @@ await testSkippedDatabaseDeletionRollsBackPreparation();
 await testStorageClearFailureRollsBackPreparation();
 await testPartialDeletionRetryRestoresPreparationState();
 await testExternalFailureStopsBeforeDeletion();
+await testFullResetLockFailureStopsBeforeDestructiveCleanup();
 await testExternalFailureResultStopsBeforeDeletion();
 await testBindingCleanupFailureStopsBeforeDeletion();
 await testMissingExternalBackupServiceFailsClosed();

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <link rel="stylesheet" href="css/heroui-bridge.css" />
         <link rel="stylesheet" href="css/theme-switcher-scroll.css" />
         <link rel="stylesheet" href="css/onboarding.css" />
+        <link rel="stylesheet" href="css/vocab-reader.css" />
     </head>
 
     <body class="hero-body boot-active" data-theme="heroui">
@@ -1000,6 +1001,19 @@
                     <button
                         class="tool-card"
                         type="button"
+                        data-action="open-bookshelf"
+                        id="bookshelf-tool-card"
+                    >
+                        <div class="tool-card-icon">📚</div>
+                        <div class="tool-card-content">
+                            <h3>书架</h3>
+                            <p>收录使用过生词本的题目，支持分类检索、快速复习与导出。</p>
+                        </div>
+                        <div class="tool-card-arrow">进入</div>
+                    </button>
+                    <button
+                        class="tool-card"
+                        type="button"
                         data-index-action="show-achievements"
                     >
                         <div class="tool-card-icon">🏆</div>
@@ -1013,6 +1027,9 @@
             </div>
             <section id="vocab-view" class="view" data-view="vocab" hidden>
                 <div class="vocab-view-shell" data-vocab-role="root"></div>
+            </section>
+            <section id="bookshelf-view" class="view" data-view="bookshelf" hidden>
+                <div class="bookshelf-view-shell" id="bookshelf-root"></div>
             </section>
         </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -642,6 +642,7 @@ class ExamSystemApp {
             const targetView = document.getElementById(`${viewName}-view`);
             if (targetView) {
                 targetView.classList.add('active');
+                targetView.removeAttribute('hidden');
                 this.currentView = viewName;
                 document.querySelectorAll('.nav-btn').forEach((btn) => {
                     btn.classList.remove('active');
@@ -649,6 +650,11 @@ class ExamSystemApp {
                 const activeNavBtn = document.querySelector(`[data-view="${viewName}"]`);
                 if (activeNavBtn) {
                     activeNavBtn.classList.add('active');
+                } else if (viewName === 'bookshelf' || viewName === 'vocab') {
+                    const moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+                    if (moreNavBtn) {
+                        moreNavBtn.classList.add('active');
+                    }
                 }
                 const url = new URL(window.location);
                 url.searchParams.set('view', viewName);
@@ -829,6 +835,30 @@ class ExamSystemApp {
                         })
                         .catch((error) => {
                             console.warn('[App] 激活更多视图时加载工具模块失败:', error);
+                        });
+                    break;
+                case 'bookshelf':
+                    Promise.resolve()
+                        .then(() => {
+                            if (window.AppEntry && typeof window.AppEntry.ensureMoreToolsGroup === 'function') {
+                                return window.AppEntry.ensureMoreToolsGroup();
+                            }
+                            if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
+                                return window.AppLazyLoader.ensureGroup('more-tools');
+                            }
+                            return null;
+                        })
+                        .then(() => {
+                            const bookshelfView = document.getElementById('bookshelf-view');
+                            if (bookshelfView) {
+                                bookshelfView.removeAttribute('hidden');
+                            }
+                            if (window.BookshelfView && typeof window.BookshelfView.mount === 'function') {
+                                window.BookshelfView.mount('#bookshelf-view');
+                            }
+                        })
+                        .catch((error) => {
+                            console.warn('[App] 激活书架视图时加载工具模块失败:', error);
                         });
                     break;
                 default:

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1743,6 +1743,24 @@
         }
         actions.appendChild(pdfBtn);
 
+        if (isReadingMemorizeExam(exam)) {
+            const vocabBtn = document.createElement('button');
+            vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
+            vocabBtn.type = 'button';
+            vocabBtn.dataset.action = 'vocab-book';
+            if (exam.id) {
+                vocabBtn.dataset.examId = exam.id;
+            }
+            vocabBtn.textContent = '精读';
+            vocabBtn.title = '打开该题全文精读与生词本';
+            if (isSelecting) {
+                vocabBtn.disabled = true;
+                vocabBtn.setAttribute('aria-disabled', 'true');
+            }
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
+
         item.appendChild(info);
         item.appendChild(actions);
         return item;
@@ -1815,6 +1833,21 @@
                 return;
             }
 
+            if (action === 'vocab-book') {
+                if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+                    global.ReadingVocabReader.open(examId);
+                    return;
+                }
+                if (typeof global.openReadingVocabReader === 'function') {
+                    global.openReadingVocabReader(examId);
+                    return;
+                }
+                if (typeof global.showMessage === 'function') {
+                    global.showMessage('生词本阅读模块未就绪', 'warning');
+                }
+                return;
+            }
+
             if (action === 'generate' && typeof global.generateHTML === 'function') {
                 global.generateHTML(examId);
             }
@@ -1836,6 +1869,9 @@
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="pdf"]', function (event) {
+                invoke(this, event);
+            });
+            global.DOM.delegate('click', '[data-action="vocab-book"]', function (event) {
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="generate"]', function (event) {

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -15551,6 +15551,15 @@ if (typeof module !== 'undefined' && module.exports) {
     const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
     const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
 
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
         if (!examId) return;
         try {
@@ -15782,36 +15791,15 @@ if (typeof module !== 'undefined' && module.exports) {
                     await global.AppData.ready;
                 }
                 if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const appDataWords = await global.AppData.vocab.listReadingWords();
-                    const localWords = this.getAll();
-                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
-                        const map = new Map();
-                        localWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) map.set(key, w);
-                        });
-                        appDataWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) {
-                                if (map.has(key)) {
-                                    const existing = map.get(key);
-                                    map.set(key, Object.assign({}, existing, w, {
-                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
-                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
-                                    }));
-                                } else {
-                                    map.set(key, w);
-                                }
-                            }
-                        });
-                        const merged = Array.from(map.values());
-                        this._cache = merged;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
-                        if (merged.length !== appDataWords.length) {
-                            await global.AppData.vocab.saveReadingWords(merged);
-                        }
-                    } else if (localWords.length > 0) {
-                        await global.AppData.vocab.saveReadingWords(localWords);
+                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
+                    const appDataWords = Array.isArray(result)
+                        ? result
+                        : (result && result.envelope ? result.data : null);
+                    if (Array.isArray(appDataWords)) {
+                        // An existing AppData document owns restores, including empty lists.
+                        // An absent document may mean migration failed; preserve the local copy.
+                        this._cache = appDataWords;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
                     }
                 }
             } catch (e) {
@@ -16263,6 +16251,7 @@ if (typeof module !== 'undefined' && module.exports) {
         modalTab: 'current', // 'current' or 'all'
         modalOpen: false,
         toastTimer: null,
+        _openRequestId: 0,
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -16564,7 +16553,9 @@ if (typeof module !== 'undefined' && module.exports) {
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
                 const handleSelectionCapture = () => {
+                    const requestId = this._openRequestId;
                     setTimeout(() => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -16711,7 +16702,12 @@ if (typeof module !== 'undefined' && module.exports) {
             if (!examId) return;
 
             const overlay = this.ensureOverlay();
+            const requestId = ++this._openRequestId;
             this.currentExamId = examId;
+            this.currentExam = null;
+            this.currentPayload = null;
+            this.currentExplanation = null;
+            this.closeModal();
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -16737,10 +16733,16 @@ if (typeof module !== 'undefined' && module.exports) {
             if (badgesEl) badgesEl.innerHTML = '';
             if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
             if (questionsContent) questionsContent.innerHTML = '';
+            ['#vocab-passage-title', '#vocab-passage-intro', '#vocab-reader-tabs'].forEach(selector => {
+                const element = overlay.querySelector(selector);
+                if (element) element.textContent = '';
+            });
+            this.switchViewTab('all');
 
             try {
                 // 加载试卷数据
                 const payload = await loadReadingExamPayload(examId);
+                if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
@@ -16748,6 +16750,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
+                    if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
@@ -16766,14 +16769,20 @@ if (typeof module !== 'undefined' && module.exports) {
                 this.renderContent();
                 this.updateCounts();
             } catch (err) {
+                if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
                 if (passageContent) {
-                    passageContent.innerHTML = `
-                        <div class="vocab-error-state">
-                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
-                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
-                        </div>
-                    `;
+                    const errorState = document.createElement('div');
+                    errorState.className = 'vocab-error-state';
+                    const message = document.createElement('p');
+                    message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
+                    const retry = document.createElement('button');
+                    retry.type = 'button';
+                    retry.className = 'btn btn-primary';
+                    retry.textContent = '重试';
+                    retry.addEventListener('click', () => this.open(examId, options));
+                    errorState.append(message, retry);
+                    passageContent.replaceChildren(errorState);
                 }
             }
         },
@@ -16793,8 +16802,8 @@ if (typeof module !== 'undefined' && module.exports) {
             }
             if (badgesEl) {
                 badgesEl.innerHTML = `
-                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
-                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                    <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
 
@@ -17352,16 +17361,16 @@ if (typeof module !== 'undefined' && module.exports) {
             let html = '';
             list.forEach(item => {
                 html += `
-                    <div class="vocab-item" data-word-id="${item.id}">
+                    <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
                             <div class="vocab-item__header">
-                                <span class="vocab-item__word">${item.word}</span>
-                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                                <span class="vocab-item__word">${escapeHtml(item.word)}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
-                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
-                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                            ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
-                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
                     </div>
                 `;
             });
@@ -17431,12 +17440,13 @@ if (typeof module !== 'undefined' && module.exports) {
         },
 
         close() {
+            ++this._openRequestId;
             const overlay = this.ensureOverlay();
             if (overlay) {
                 overlay.classList.add('is-hidden');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.modalOpen = false;
+            this.closeModal();
         }
     };
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -2850,6 +2850,22 @@
             actions.appendChild(pdfBtn);
         }
 
+        var isReadingExam = exam && (exam.type === 'reading' || !exam.type || String(exam.type).toLowerCase() !== 'listening') && exam.hasHtml !== false;
+        if (isReadingExam && exam.id) {
+            var vocabBtn = this._createElement('button', {
+                className: 'btn btn-outline exam-item-action-btn exam-item-vocab-btn',
+                dataset: { action: 'vocab-book', examId: exam.id },
+                type: 'button',
+                title: '打开该题全文精读与生词本'
+            }, '精读');
+            if (isSelecting) {
+                vocabBtn.disabled = true;
+                vocabBtn.setAttribute('aria-disabled', 'true');
+            }
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
+
         if (this._shouldShowGenerate(exam, options)) {
             var generateBtn = this._createElement('button', {
                 className: 'btn btn-info exam-item-action-btn',
@@ -5938,6 +5954,24 @@
         }
         actions.appendChild(pdfBtn);
 
+        if (isReadingMemorizeExam(exam)) {
+            const vocabBtn = document.createElement('button');
+            vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
+            vocabBtn.type = 'button';
+            vocabBtn.dataset.action = 'vocab-book';
+            if (exam.id) {
+                vocabBtn.dataset.examId = exam.id;
+            }
+            vocabBtn.textContent = '精读';
+            vocabBtn.title = '打开该题全文精读与生词本';
+            if (isSelecting) {
+                vocabBtn.disabled = true;
+                vocabBtn.setAttribute('aria-disabled', 'true');
+            }
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
+
         item.appendChild(info);
         item.appendChild(actions);
         return item;
@@ -6010,6 +6044,21 @@
                 return;
             }
 
+            if (action === 'vocab-book') {
+                if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+                    global.ReadingVocabReader.open(examId);
+                    return;
+                }
+                if (typeof global.openReadingVocabReader === 'function') {
+                    global.openReadingVocabReader(examId);
+                    return;
+                }
+                if (typeof global.showMessage === 'function') {
+                    global.showMessage('生词本阅读模块未就绪', 'warning');
+                }
+                return;
+            }
+
             if (action === 'generate' && typeof global.generateHTML === 'function') {
                 global.generateHTML(examId);
             }
@@ -6031,6 +6080,9 @@
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="pdf"]', function (event) {
+                invoke(this, event);
+            });
+            global.DOM.delegate('click', '[data-action="vocab-book"]', function (event) {
                 invoke(this, event);
             });
             global.DOM.delegate('click', '[data-action="generate"]', function (event) {
@@ -15492,6 +15544,1926 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 
+/* ===== js/components/readingVocabReader.js ===== */
+(function initReadingVocabReader(global) {
+    'use strict';
+
+    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
+    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+
+    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+        if (!examId) return;
+        try {
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
+                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
+                return;
+            }
+            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
+            const records = raw ? JSON.parse(raw) : [];
+            const idx = records.findIndex(r => String(r.examId) === String(examId));
+            const now = Date.now();
+            if (idx !== -1) {
+                records[idx].lastOpenedAt = now;
+                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
+                if (category && !records[idx].category) records[idx].category = category;
+            } else {
+                records.unshift({
+                    examId: String(examId),
+                    examTitle: examTitle || '',
+                    category: category || '',
+                    firstUsedAt: now,
+                    lastOpenedAt: now
+                });
+            }
+            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
+                global.ReadingBookshelfStore.syncToAppData(records);
+            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
+                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
+            }
+        } catch (e) {
+            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
+        }
+    }
+
+    // ============================================================================
+    // 生词本数据管理 (Store)
+    // ============================================================================
+    const ReadingVocabStore = {
+        _cache: null,
+        _commitBound: false,
+
+        getAll() {
+            if (this._cache) {
+                return this._cache;
+            }
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                if (raw) {
+                    const parsed = JSON.parse(raw);
+                    if (Array.isArray(parsed)) {
+                        this._cache = parsed;
+                        return this._cache;
+                    }
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 读取失败:', err);
+            }
+            this._cache = [];
+            return this._cache;
+        },
+
+        _save() {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 保存失败:', err);
+            }
+            this.syncToAppData();
+        },
+
+        async syncToAppData() {
+            try {
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
+                    await global.AppData.vocab.saveReadingWords(this._cache || []);
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
+            }
+        },
+
+        async flushToAppData() {
+            return this.syncToAppData();
+        },
+
+        getByExam(examId) {
+            if (!examId) return [];
+            const all = this.getAll();
+            return all.filter(item => String(item.examId) === String(examId));
+        },
+
+        add(rawWord, examId, examTitle, context = '', highlight = null) {
+            const word = this.cleanWord(rawWord);
+            if (!word || word.length > 50) {
+                return { added: false, reason: 'invalid_word' };
+            }
+
+            const all = this.getAll();
+            const lowerWord = word.toLowerCase();
+
+            // 检查当前文章或全局是否存在
+            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
+            if (existingIndex !== -1) {
+                const item = all[existingIndex];
+                item.updatedAt = Date.now();
+                if (examId && !item.examId) {
+                    item.examId = examId;
+                    item.examTitle = examTitle || '';
+                }
+                if (highlight) {
+                    if (!Array.isArray(item.highlights)) {
+                        item.highlights = [];
+                    }
+                    const isDup = item.highlights.some(h =>
+                        String(h.examId) === String(highlight.examId) &&
+                        String(h.scope) === String(highlight.scope) &&
+                        h.startOffset === highlight.startOffset
+                    );
+                    if (!isDup) {
+                        item.highlights.push(highlight);
+                    }
+                }
+                this._save();
+                return { added: true, item: item, isDuplicate: true };
+            }
+
+            const newItem = {
+                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                word: word,
+                examId: examId || '',
+                examTitle: examTitle || '',
+                context: context ? String(context).trim().slice(0, 150) : '',
+                createdAt: Date.now(),
+                highlights: highlight ? [highlight] : []
+            };
+
+            all.unshift(newItem);
+            this._save();
+
+            if (examId) {
+                recordBookshelfExamDirect(examId, examTitle);
+            }
+
+            return { added: true, item: newItem, isDuplicate: false };
+        },
+
+        remove(wordOrId) {
+            const all = this.getAll();
+            const target = String(wordOrId).trim().toLowerCase();
+            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
+            if (index !== -1) {
+                all.splice(index, 1);
+                this._save();
+                return true;
+            }
+            return false;
+        },
+
+        clear(examId = null) {
+            if (!examId) {
+                this._cache = [];
+                this._save();
+                return true;
+            }
+            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
+            this._save();
+            return true;
+        },
+
+        cleanWord(str) {
+            if (!str) return '';
+            return str
+                .replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '')
+                .trim();
+        },
+
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
+            const list = examId ? this.getByExam(examId) : this.getAll();
+            if (!list || list.length === 0) {
+                return false;
+            }
+
+            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
+            const words = [];
+            const seen = new Set();
+            list.forEach(item => {
+                const raw = typeof item === 'string' ? item : item?.word;
+                const w = (raw || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            let filename = customFilename;
+            if (!filename) {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const day = String(now.getDate()).padStart(2, '0');
+                const dateStr = `${year}-${month}-${day}`;
+
+                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                filename = `${dateStr}_${safeTitle}.txt`;
+            }
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return true;
+        },
+
+        async init() {
+            this.bindCommitListener();
+            try {
+                if (global.AppData && global.AppData.ready) {
+                    await global.AppData.ready;
+                }
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
+                    const appDataWords = await global.AppData.vocab.listReadingWords();
+                    const localWords = this.getAll();
+                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
+                        const map = new Map();
+                        localWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) map.set(key, w);
+                        });
+                        appDataWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) {
+                                if (map.has(key)) {
+                                    const existing = map.get(key);
+                                    map.set(key, Object.assign({}, existing, w, {
+                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
+                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
+                                    }));
+                                } else {
+                                    map.set(key, w);
+                                }
+                            }
+                        });
+                        const merged = Array.from(map.values());
+                        this._cache = merged;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
+                        if (merged.length !== appDataWords.length) {
+                            await global.AppData.vocab.saveReadingWords(merged);
+                        }
+                    } else if (localWords.length > 0) {
+                        await global.AppData.vocab.saveReadingWords(localWords);
+                    }
+                }
+            } catch (e) {
+                console.warn('[ReadingVocabStore] init failed:', e);
+            }
+        },
+
+        bindCommitListener() {
+            if (this._commitBound) return;
+            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+                this._commitBound = true;
+                global.AppData.backups.onDataCommitted(async (event) => {
+                    const targets = event && event.targets;
+                    if (!Array.isArray(targets)) return;
+                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
+                    if (hasVocab) {
+                        try {
+                            const updated = await global.AppData.vocab.listReadingWords();
+                            if (Array.isArray(updated)) {
+                                this._cache = updated;
+                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
+                            }
+                        } catch (err) {
+                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
+                        }
+                    }
+                });
+            }
+        }
+    };
+
+    // ============================================================================
+    // 语音朗读
+    // ============================================================================
+    function speakWord(word) {
+        if (!('speechSynthesis' in window) || !word) {
+            return;
+        }
+        try {
+            window.speechSynthesis.cancel();
+            const utterance = new SpeechSynthesisUtterance(word);
+            utterance.lang = 'en-US';
+            utterance.rate = 0.9;
+            window.speechSynthesis.speak(utterance);
+        } catch (e) {
+            console.warn('[ReadingVocabReader] 朗读失败:', e);
+        }
+    }
+
+    // ============================================================================
+    // 异步加载试卷与解析数据
+    // ============================================================================
+    function getExamRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXAM_DATA__ || typeof root.__READING_EXAM_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXAM_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_exam_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXAM_DATA__;
+    }
+
+    function getExplanationRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXPLANATION_DATA__ || typeof root.__READING_EXPLANATION_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXPLANATION_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_explanation_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXPLANATION_DATA__;
+    }
+
+    async function loadReadingExamPayload(examId) {
+        if (!examId) return null;
+
+        const examRegistry = getExamRegistry();
+        const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || global.__READING_EXAM_MANIFEST__ || {};
+        const entry = manifest[examId] || Object.values(manifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        // 1. 检查已注册数据
+        if (examRegistry && typeof examRegistry.get === 'function') {
+            const cached = examRegistry.get(examId) || (entry && (examRegistry.get(entry.dataKey) || examRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        // 2. 检查 manifest
+        if (!entry || !entry.script) {
+            console.warn('[ReadingVocabReader] 未找到试卷元信息:', examId);
+            return null;
+        }
+
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+        let scriptSrc;
+        if (isExamPage) {
+            scriptSrc = entry.script.startsWith('./') ? entry.script : `./${entry.script}`;
+        } else {
+            scriptSrc = `assets/generated/reading-exams/${entry.script.replace(/^\.\//, '')}`;
+        }
+
+        await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = scriptSrc;
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error('Failed to load reading exam: ' + scriptSrc));
+            document.head.appendChild(script);
+        });
+
+        const registryAfterLoad = getExamRegistry();
+        return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
+    }
+
+    async function loadReadingExplanationPayload(examId) {
+        if (!examId) return null;
+
+        const expRegistry = getExplanationRegistry();
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+
+        // 确保 explanation manifest 存在
+        if (!global.__READING_EXPLANATION_MANIFEST__ && !(typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__)) {
+            const manifestSrc = isExamPage ? '../reading-explanations/manifest.js' : 'assets/generated/reading-explanations/manifest.js';
+            try {
+                await new Promise((resolve, reject) => {
+                    const script = document.createElement('script');
+                    script.src = manifestSrc;
+                    script.onload = () => resolve();
+                    script.onerror = () => resolve();
+                    document.head.appendChild(script);
+                });
+            } catch (_) {}
+        }
+
+        const expManifest = (typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__) || global.__READING_EXPLANATION_MANIFEST__ || {};
+        const entry = expManifest[examId] || Object.values(expManifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        if (expRegistry && typeof expRegistry.get === 'function') {
+            const cached = expRegistry.get(examId) || (entry && (expRegistry.get(entry.dataKey) || expRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        if (!entry || !entry.script) {
+            return null;
+        }
+
+        try {
+            const cleanScript = entry.script.replace(/^(\.\/|\.\.\/reading-explanations\/)/, '');
+            const scriptSrc = isExamPage
+                ? `../reading-explanations/${cleanScript}`
+                : `assets/generated/reading-explanations/${cleanScript}`;
+            await new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = scriptSrc;
+                script.onload = () => resolve();
+                script.onerror = () => reject(new Error('Failed to load explanation'));
+                document.head.appendChild(script);
+            });
+            const expRegistryAfterLoad = getExplanationRegistry();
+            return expRegistryAfterLoad.get(examId) || (entry && (expRegistryAfterLoad.get(entry.dataKey) || expRegistryAfterLoad.get(entry.examId))) || null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // ============================================================================
+    // 阅读文本与段落清洗器
+    // ============================================================================
+    function cleanPassageHtml(rawHtml) {
+        if (!rawHtml) return '';
+        const temp = document.createElement('div');
+        temp.innerHTML = rawHtml;
+
+        // 移除练习交互用的 dropzone 提示与容器
+        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
+        dropzones.forEach(dz => dz.remove());
+
+        // 移除多余的空占位与 divider
+        const empties = temp.querySelectorAll('.empty-space, #divider');
+        empties.forEach(el => el.remove());
+
+        return temp.innerHTML;
+    }
+
+    /**
+     * 判断文本是否属于考试指导语/前置题目说明
+     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
+     */
+    function isPassageInstruction(text) {
+        if (!text) return false;
+        const s = text.trim();
+        if (/spend about \d+ minutes/i.test(s)) return true;
+        if (/which are based on reading passage/i.test(s)) return true;
+        if (/based on reading passage \d*/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
+        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
+        return false;
+    }
+
+    /**
+     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
+     */
+    function extractPassageData(rawHtml, fallbackTitle = '') {
+        if (!rawHtml) {
+            return {
+                passageTitle: fallbackTitle,
+                subtitleHtml: '',
+                instructionHtml: '',
+                blocks: []
+            };
+        }
+
+        const cleaned = cleanPassageHtml(rawHtml);
+        const temp = document.createElement('div');
+        temp.innerHTML = cleaned;
+
+        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
+        let passageTitle = fallbackTitle;
+        const h3 = temp.querySelector('h3');
+        if (h3 && h3.textContent.trim()) {
+            passageTitle = h3.textContent.trim();
+            h3.remove();
+        } else {
+            const h2 = temp.querySelector('h2');
+            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
+                passageTitle = h2.textContent.trim();
+                h2.remove();
+            }
+        }
+
+        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
+        const readingPassageHeadings = temp.querySelectorAll('h2');
+        readingPassageHeadings.forEach(h => {
+            if (/^reading passage/i.test(h.textContent.trim())) {
+                h.remove();
+            }
+        });
+
+        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
+        let instructionHtml = '';
+        const allPs = Array.from(temp.querySelectorAll('p'));
+        for (const p of allPs) {
+            const text = p.textContent.trim();
+            if (isPassageInstruction(text)) {
+                if (!instructionHtml) {
+                    instructionHtml = p.innerHTML.trim();
+                }
+                p.remove(); // 绝不作为正文段落，不分配任何段落标签
+            }
+        }
+
+        // 3. 提取副标题 (如 h4)
+        let subtitleHtml = '';
+        const h4 = temp.querySelector('h4');
+        if (h4 && h4.textContent.trim()) {
+            subtitleHtml = h4.innerHTML.trim();
+            h4.remove();
+        }
+
+        // 4. 解析段落 blocks
+        const blocks = [];
+        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
+
+        if (wrappers && wrappers.length > 0) {
+            wrappers.forEach((wrap, index) => {
+                // 查找段落标识 letter
+                let letter = '';
+                const strong = wrap.querySelector('strong');
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
+                    if (match) {
+                        letter = match[1];
+                    } else {
+                        letter = String.fromCharCode(65 + index);
+                    }
+                }
+
+                // 获取段落主体 HTML
+                const p = wrap.querySelector('p');
+                const html = p ? p.innerHTML : wrap.innerHTML;
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: html,
+                    text: wrap.textContent.trim()
+                });
+            });
+        } else {
+            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
+            const remainingPs = temp.querySelectorAll('p');
+            let validIdx = 0;
+            remainingPs.forEach((p) => {
+                const text = p.textContent.trim();
+                if (!text || text.length < 20) return;
+                // 防御：若依然属于指导语，跳过
+                if (isPassageInstruction(text)) return;
+
+                const strong = p.querySelector('strong');
+                let letter = '';
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
+                    if (leadMatch) {
+                        letter = leadMatch[1];
+                    } else {
+                        letter = String.fromCharCode(65 + validIdx);
+                    }
+                }
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: p.innerHTML,
+                    text: text
+                });
+                validIdx++;
+            });
+        }
+
+        return {
+            passageTitle,
+            subtitleHtml,
+            instructionHtml,
+            blocks
+        };
+    }
+
+    function extractParagraphBlocks(rawHtml) {
+        return extractPassageData(rawHtml).blocks;
+    }
+
+    function getTextNodes(root) {
+        if (!root) return [];
+        const textNodes = [];
+        const walker = document.createTreeWalker(
+            root,
+            NodeFilter.SHOW_TEXT,
+            {
+                acceptNode(node) {
+                    const parent = node.parentElement;
+                    if (!parent) return NodeFilter.FILTER_REJECT;
+                    const tag = parent.tagName.toUpperCase();
+                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+            },
+            false
+        );
+        let n;
+        while ((n = walker.nextNode())) {
+            textNodes.push(n);
+        }
+        return textNodes;
+    }
+
+    function resolveRangeFromOffsets(root, start, end) {
+        const nodes = getTextNodes(root);
+        let offset = 0;
+        let startNode = null;
+        let endNode = null;
+        let startOffset = 0;
+        let endOffset = 0;
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            const text = node.nodeValue || '';
+            const nextOffset = offset + text.length;
+            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
+                startNode = node;
+                startOffset = Math.max(0, start - offset);
+            }
+            if (!endNode && end > offset && end <= nextOffset) {
+                endNode = node;
+                endOffset = Math.max(0, end - offset);
+            }
+            if (startNode && endNode) break;
+            offset = nextOffset;
+        }
+        if (!startNode || !endNode) return null;
+        const range = document.createRange();
+        range.setStart(startNode, startOffset);
+        range.setEnd(endNode, endOffset);
+        return range;
+    }
+
+    // ============================================================================
+    // 阅读器主控制器 (ReadingVocabReader)
+    // ============================================================================
+    const ReadingVocabReader = {
+        currentExamId: null,
+        currentExam: null,
+        currentPayload: null,
+        currentExplanation: null,
+        activeTab: 'all', // 'all', 'questions', or paragraph letter e.g. 'A'
+        showTranslation: false,
+        modalTab: 'current', // 'current' or 'all'
+        modalOpen: false,
+        toastTimer: null,
+
+        ensureOverlay() {
+            let overlay = document.getElementById('reading-vocab-reader-overlay');
+            if (overlay) {
+                return overlay;
+            }
+
+            overlay = document.createElement('div');
+            overlay.id = 'reading-vocab-reader-overlay';
+            overlay.className = 'vocab-reader-overlay is-hidden';
+            overlay.setAttribute('role', 'dialog');
+            overlay.setAttribute('aria-label', '阅读生词本');
+
+            overlay.innerHTML = `
+                <div class="vocab-reader-container">
+                    <!-- 顶部吸顶导航栏 -->
+                    <header class="vocab-reader-header">
+                        <div class="vocab-reader-header__left">
+                            <button type="button" class="vocab-reader-back-btn" id="vocab-reader-back-btn" title="返回题库浏览">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+                                    <path d="M19 12H5M12 19l-7-7 7-7"/>
+                                </svg>
+                                <span>返回</span>
+                            </button>
+                            <div class="vocab-reader-title-wrap">
+                                <h2 class="vocab-reader-title" id="vocab-reader-title">阅读文章与题目</h2>
+                                <div class="vocab-reader-badges" id="vocab-reader-badges"></div>
+                            </div>
+                        </div>
+
+                        <div class="vocab-reader-header__center">
+                            <div class="vocab-reader-tabs" id="vocab-reader-tabs" role="tablist">
+                                <!-- 动态插入段落与题目标签，完全平铺陈列展开 -->
+                            </div>
+                        </div>
+                    </header>
+
+                    <!-- 沉浸式提示栏 -->
+                    <div class="vocab-reader-banner">
+                        <span class="vocab-banner-icon">✨</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                    </div>
+
+                    <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
+                    <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
+                        <!-- 阅读核心主内容区 -->
+                        <main class="vocab-reader-body" id="vocab-reader-body">
+                            <!-- 文章区域 -->
+                            <section class="vocab-passage-section" id="vocab-passage-section">
+                                <div class="vocab-passage-header">
+                                    <h3 class="vocab-passage-title" id="vocab-passage-title">Reading Passage</h3>
+                                    <div class="vocab-passage-intro" id="vocab-passage-intro"></div>
+                                </div>
+                                <div class="vocab-passage-content" id="vocab-passage-content">
+                                    <!-- 段落内容 -->
+                                </div>
+                            </section>
+
+                            <!-- 题目区域 -->
+                            <section class="vocab-questions-section" id="vocab-questions-section">
+                                <div class="vocab-questions-header">
+                                    <h3 class="vocab-questions-title">📝 题目与问题 (Questions)</h3>
+                                    <p class="vocab-questions-subtitle">题目中的生词同样支持划词自动收录</p>
+                                </div>
+                                <div class="vocab-questions-content" id="vocab-questions-content">
+                                    <!-- 题目内容 -->
+                                </div>
+                            </section>
+                        </main>
+                    </div>
+
+                    <!-- 悬浮生词本 FAB 按钮 -->
+                    <div class="vocab-fab" id="vocab-fab" role="button" tabindex="0" title="打开生词本">
+                        <span class="vocab-fab-icon">📝</span>
+                        <span class="vocab-fab-label">生词本</span>
+                        <span class="vocab-fab-count" id="vocab-fab-count">0</span>
+                    </div>
+
+                    <!-- 划词收录 Toast 提示 -->
+                    <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+
+                    <!-- 生词本弹窗 Modal -->
+                    <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
+                        <div class="vocab-modal-content">
+                            <div class="vocab-modal-header">
+                                <div class="vocab-modal-title-wrap">
+                                    <h3>📖 我的生词本</h3>
+                                    <div class="vocab-modal-tabs">
+                                        <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                    </div>
+                                </div>
+                                <div class="vocab-modal-header-actions">
+                                    <button type="button" class="vocab-modal-bookshelf-btn" id="vocab-modal-bookshelf-btn" title="查看阅读书架">📚 书架</button>
+                                    <button type="button" class="vocab-modal-close" id="vocab-modal-close" title="关闭">✖</button>
+                                </div>
+                            </div>
+
+                            <!-- 手动添加生词栏 -->
+                            <div class="vocab-modal-add-row">
+                                <input type="text" id="vocab-manual-input" placeholder="手动添加生词..." maxlength="50" />
+                                <button type="button" id="vocab-manual-add-btn">收录</button>
+                            </div>
+
+                            <!-- 生词列表 -->
+                            <div class="vocab-list" id="vocab-list">
+                                <!-- 动态插入 -->
+                            </div>
+
+                            <!-- 底部操作栏 -->
+                            <div class="vocab-modal-footer">
+                                <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
+                                    <span>⬇️ 导出为 TXT</span>
+                                </button>
+                                <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
+                                    <span>🗑️ 清空生词</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            document.body.appendChild(overlay);
+            this.bindEvents(overlay);
+            return overlay;
+        },
+
+        bindEvents(overlay) {
+            // 返回按钮
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            if (backBtn) {
+                backBtn.addEventListener('click', () => this.close());
+            }
+
+            // 开启生词本弹窗
+            const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
+            const fab = overlay.querySelector('#vocab-fab');
+            if (openModalBtn) {
+                openModalBtn.addEventListener('click', () => this.openModal());
+            }
+            if (fab) {
+                fab.addEventListener('click', () => this.openModal());
+            }
+
+            // 关闭生词本弹窗
+            const closeModalBtn = overlay.querySelector('#vocab-modal-close');
+            const modal = overlay.querySelector('#vocab-modal');
+            if (closeModalBtn) {
+                closeModalBtn.addEventListener('click', () => this.closeModal());
+            }
+            if (modal) {
+                modal.addEventListener('click', (e) => {
+                    if (e.target === modal) {
+                        this.closeModal();
+                    }
+                });
+            }
+
+            // 前往阅读书架
+            const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
+            if (bookshelfBtn) {
+                bookshelfBtn.addEventListener('click', () => {
+                    this.closeModal();
+                    this.close();
+                    if (global.opener && !global.opener.closed) {
+                        try {
+                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
+                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            }
+                            if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
+                                global.opener.app.navigateToView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            } else if (typeof global.opener.switchView === 'function') {
+                                global.opener.switchView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            }
+                        } catch (_) {}
+                    }
+                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                        global.BookshelfView.mount('#bookshelf-view');
+                    }
+                    if (global.app && typeof global.app.navigateToView === 'function') {
+                        global.app.navigateToView('bookshelf');
+                    } else if (typeof global.switchView === 'function') {
+                        global.switchView('bookshelf');
+                    }
+                });
+            }
+
+            // 生词本切换标签 (本篇 / 全部)
+            const tabCurrent = overlay.querySelector('#v-tab-current');
+            const tabAll = overlay.querySelector('#v-tab-all');
+            if (tabCurrent) {
+                tabCurrent.addEventListener('click', () => {
+                    this.modalTab = 'current';
+                    tabCurrent.classList.add('active');
+                    tabAll.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+            if (tabAll) {
+                tabAll.addEventListener('click', () => {
+                    this.modalTab = 'all';
+                    tabAll.classList.add('active');
+                    tabCurrent.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+
+            // 手动收录
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
+            const handleManualAdd = () => {
+                if (!manualInput) return;
+                const val = manualInput.value.trim();
+                if (!val) return;
+                const result = ReadingVocabStore.add(
+                    val,
+                    this.currentExamId,
+                    this.currentExam?.title || '',
+                    ''
+                );
+                if (result.added) {
+                    manualInput.value = '';
+                    this.updateCounts();
+                    this.renderVocabList();
+                    this.applyVocabHighlights(val);
+                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                }
+            };
+            if (manualAddBtn) {
+                manualAddBtn.addEventListener('click', handleManualAdd);
+            }
+            if (manualInput) {
+                manualInput.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleManualAdd();
+                    }
+                });
+            }
+
+            // 导出与清空
+            const exportBtn = overlay.querySelector('#vocab-export-btn');
+            if (exportBtn) {
+                exportBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+
+                    const now = new Date();
+                    const year = now.getFullYear();
+                    const month = String(now.getMonth() + 1).padStart(2, '0');
+                    const day = String(now.getDate()).padStart(2, '0');
+                    const dateStr = `${year}-${month}-${day}`;
+
+                    // 当前文章名字
+                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
+                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
+                    const filename = `${dateStr}_${safeArticleName}.txt`;
+
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    if (success) {
+                        this.showToast(`✅ 已导出：${filename}`);
+                    } else {
+                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    }
+                });
+            }
+
+            const clearBtn = overlay.querySelector('#vocab-clear-btn');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+                    const count = isCurrent
+                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        : ReadingVocabStore.getAll().length;
+
+                    if (count === 0) {
+                        this.showToast('生词本已经是空的了');
+                        return;
+                    }
+
+                    ReadingVocabStore.clear(examId);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    const passageContent = overlay.querySelector('#vocab-passage-content');
+                    const questionsContent = overlay.querySelector('#vocab-questions-content');
+                    this.removeVocabHighlights(passageContent);
+                    this.removeVocabHighlights(questionsContent);
+                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                });
+            }
+
+            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
+            const readerBody = overlay.querySelector('#vocab-reader-body');
+            if (readerBody) {
+                const handleSelectionCapture = () => {
+                    setTimeout(() => {
+                        const selection = window.getSelection();
+                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+                        const rawText = selection.toString();
+                        const text = rawText.trim();
+
+                        // 限制在1到45个字符之间，避免大段全文误选
+                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
+                            return;
+                        }
+
+                        let range;
+                        try {
+                            range = selection.getRangeAt(0);
+                        } catch (_) {
+                            return;
+                        }
+                        if (!range || range.collapsed) return;
+
+                        // 确保选区位于文章正文或题目区域内
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        const commonNode = range.commonAncestorContainer;
+                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
+                        if (!commonEl) return;
+                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
+                            return;
+                        }
+                        // 忽略译文卡片、段落标签、按钮等非正文区域
+                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
+                            return;
+                        }
+
+                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
+                        const existingMark = commonEl.closest('mark.vocab-highlight');
+                        if (existingMark) {
+                            return;
+                        }
+
+                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
+                        const trimmedRange = this.trimRangeWhitespace(range);
+                        if (!trimmedRange || trimmedRange.collapsed) return;
+
+                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
+                        const targetCard = commonEl.closest('.vocab-paragraph-card');
+                        const targetQGroup = commonEl.closest('.vocab-question-group');
+                        let scope = 'passage';
+                        let scopeElement = passageContent;
+
+                        if (targetCard) {
+                            const letter = targetCard.dataset.letter || '';
+                            scope = letter ? `para-${letter}` : 'passage';
+                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
+                        } else if (targetQGroup) {
+                            scope = targetQGroup.id || 'questions';
+                            scopeElement = targetQGroup;
+                        } else if (questionsContent?.contains(commonEl)) {
+                            scope = 'questions';
+                            scopeElement = questionsContent;
+                        }
+
+                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
+                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
+
+                        // 获取上下文句子
+                        let contextSentence = '';
+                        try {
+                            const parentBlock = commonEl;
+                            if (parentBlock) {
+                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
+                            }
+                        } catch (_) {}
+
+                        const cleanWord = ReadingVocabStore.cleanWord(text);
+                        if (!cleanWord) return;
+
+                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
+                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
+                        if (!wrappedMark) return;
+
+                        const highlightRecord = {
+                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                            examId: this.currentExamId || '',
+                            scope: scope,
+                            startOffset: locInfo.startOffset,
+                            endOffset: locInfo.endOffset,
+                            before: locInfo.before,
+                            after: locInfo.after,
+                            occurrence: locInfo.occurrence,
+                            text: cleanWord
+                        };
+
+                        const result = ReadingVocabStore.add(
+                            cleanWord,
+                            this.currentExamId,
+                            this.currentExam?.title || '',
+                            contextSentence,
+                            highlightRecord
+                        );
+
+                        if (result.added) {
+                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                            this.updateCounts();
+                            if (this.modalOpen) {
+                                this.renderVocabList();
+                            }
+                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        }
+                    }, 20);
+                };
+
+                readerBody.addEventListener('mouseup', handleSelectionCapture);
+                readerBody.addEventListener('touchend', handleSelectionCapture);
+
+                // 点击黄色高亮生词：朗读发音并轻量提示
+                readerBody.addEventListener('click', (e) => {
+                    const mark = e.target.closest('mark.vocab-highlight');
+                    if (mark) {
+                        const selection = window.getSelection();
+                        if (selection && selection.toString().trim().length > 0) {
+                            return; // 划选操作中不触发点击发音
+                        }
+                        const word = mark.dataset.word || mark.textContent.trim();
+                        if (word) {
+                            speakWord(word);
+                            this.showToast(`🔊 ${word} (已收录生词)`);
+                        }
+                    }
+                });
+            }
+
+            // ESC 键监听
+            window.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    if (this.modalOpen) {
+                        this.closeModal();
+                    } else if (overlay && !overlay.classList.contains('is-hidden')) {
+                        this.close();
+                    }
+                }
+            });
+        },
+
+        async open(examId, options = {}) {
+            if (!examId) return;
+
+            const overlay = this.ensureOverlay();
+            this.currentExamId = examId;
+
+            // 根据来源动态调整返回按钮提示
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            const backBtnText = overlay.querySelector('#vocab-reader-back-btn span');
+            if (options && options.fromPractice) {
+                if (backBtnText) backBtnText.textContent = '返回练习';
+                if (backBtn) backBtn.title = '返回练习试卷';
+            } else {
+                if (backBtnText) backBtnText.textContent = '返回题库';
+                if (backBtn) backBtn.title = '返回题库浏览';
+            }
+
+            // 显示加载状态
+            overlay.classList.remove('is-hidden');
+            document.body.classList.add('vocab-reader-open');
+
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            if (titleEl) titleEl.textContent = '正在加载试卷全文...';
+            if (badgesEl) badgesEl.innerHTML = '';
+            if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
+            if (questionsContent) questionsContent.innerHTML = '';
+
+            try {
+                // 加载试卷数据
+                const payload = await loadReadingExamPayload(examId);
+                if (!payload) {
+                    throw new Error('未找到该试卷的数据文件');
+                }
+                this.currentPayload = payload;
+
+                // 异步加载解析（不阻塞主内容）
+                loadReadingExplanationPayload(examId).then(exp => {
+                    this.currentExplanation = exp;
+                    this.enhanceWithExplanation(exp);
+                }).catch(() => {});
+
+                // 获取 Exam Meta
+                const manifest = global.__READING_EXAM_MANIFEST__ || {};
+                const manifestEntry = manifest[examId] || {};
+                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+
+                // 记录至阅读书架
+                const examTitle = this.currentExam.title || this.currentExam.name || examId;
+                const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
+                recordBookshelfExamDirect(examId, examTitle, examCategory);
+
+                // 渲染界面
+                this.renderContent();
+                this.updateCounts();
+            } catch (err) {
+                console.error('[ReadingVocabReader] 加载失败:', err);
+                if (passageContent) {
+                    passageContent.innerHTML = `
+                        <div class="vocab-error-state">
+                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
+                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
+                        </div>
+                    `;
+                }
+            }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+
+            // 标题与标签（紧凑精致）
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            if (titleEl) {
+                const titleText = exam.title || '阅读文章与题目';
+                titleEl.textContent = titleText;
+                titleEl.title = titleText;
+            }
+            if (badgesEl) {
+                badgesEl.innerHTML = `
+                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                `;
+            }
+
+            // 解析文章大标题、考试指导语与真实段落
+            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
+            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const blocks = passageData.blocks;
+            const instructionHtml = passageData.instructionHtml;
+            const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
+
+            // 设置文章标题
+            const passageTitleEl = overlay.querySelector('#vocab-passage-title');
+            if (passageTitleEl) {
+                passageTitleEl.textContent = passageTitle;
+            }
+
+            // 渲染前置说明指导语（如 "You should spend about 20 minutes on questions 1 to 30..."）
+            // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
+            const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
+            if (passageIntroEl) {
+                if (instructionHtml) {
+                    passageIntroEl.innerHTML = `
+                        <div class="vocab-passage-instruction" role="note">
+                            <span class="vocab-instruction-icon">📋</span>
+                            <div class="vocab-instruction-text">${instructionHtml}</div>
+                        </div>
+                    `;
+                    passageIntroEl.style.display = 'block';
+                } else if (passageData.subtitleHtml) {
+                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
+                    passageIntroEl.style.display = 'block';
+                } else {
+                    passageIntroEl.innerHTML = '';
+                    passageIntroEl.style.display = 'none';
+                }
+            }
+
+            // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
+            const tabsContainer = overlay.querySelector('#vocab-reader-tabs');
+            if (tabsContainer) {
+                let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
+                blocks.forEach(b => {
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                });
+                tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
+                tabsContainer.innerHTML = tabsHtml;
+
+                // 绑定 Tab 点击事件
+                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
+                        btn.classList.add('active');
+                        const target = btn.dataset.para;
+                        this.switchViewTab(target);
+                    });
+                });
+            }
+
+            // 渲染文章段落
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            if (passageContent) {
+                if (blocks.length > 0) {
+                    let passageHtml = '';
+                    blocks.forEach(b => {
+                        passageHtml += `
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                                <div class="vocab-paragraph-tag">
+                                    <span class="vocab-para-letter">Para ${b.letter}</span>
+                                </div>
+                                <div class="vocab-paragraph-text">${b.html}</div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                    <div class="vocab-trans-label">中文参考译文：</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                </div>
+                            </div>
+                        `;
+                    });
+                    passageContent.innerHTML = passageHtml;
+                } else {
+                    // 原生清洗后渲染
+                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                }
+            }
+
+            // 渲染题目
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            if (questionsContent) {
+                const questionGroups = payload?.questionGroups || [];
+                if (questionGroups.length > 0) {
+                    let qHtml = '';
+                    questionGroups.forEach((g, idx) => {
+                        qHtml += `
+                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
+                                ${g.bodyHtml || ''}
+                            </div>
+                        `;
+                    });
+                    questionsContent.innerHTML = qHtml;
+                } else {
+                    questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
+                }
+            }
+
+            // 如果已有解析数据，填充中文译文
+            if (this.currentExplanation) {
+                this.enhanceWithExplanation(this.currentExplanation);
+            }
+
+            // 应用生词黄色高亮
+            this.applyVocabHighlights();
+        },
+
+        trimRangeWhitespace(range) {
+            if (!range || range.collapsed) return range;
+            const startNode = range.startContainer;
+            let startOffset = range.startOffset;
+            const endNode = range.endContainer;
+            let endOffset = range.endOffset;
+
+            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
+                const text = startNode.nodeValue || '';
+                const segment = text.slice(startOffset, endOffset);
+                const leadSpace = segment.search(/\S/);
+                if (leadSpace > 0) {
+                    startOffset += leadSpace;
+                } else if (leadSpace === -1) {
+                    return null;
+                }
+                const trailSpace = segment.length - segment.trimEnd().length;
+                if (trailSpace > 0) {
+                    endOffset -= trailSpace;
+                }
+                if (endOffset <= startOffset) return null;
+
+                const trimmed = document.createRange();
+                trimmed.setStart(startNode, startOffset);
+                trimmed.setEnd(endNode, endOffset);
+                return trimmed;
+            }
+
+            if (startNode.nodeType === Node.TEXT_NODE) {
+                const text = (startNode.nodeValue || '').slice(startOffset);
+                const m = text.match(/^\s+/);
+                if (m) {
+                    range.setStart(startNode, startOffset + m[0].length);
+                }
+            }
+            if (endNode.nodeType === Node.TEXT_NODE) {
+                const text = (endNode.nodeValue || '').slice(0, endOffset);
+                const m = text.match(/\s+$/);
+                if (m) {
+                    range.setEnd(endNode, endOffset - m[0].length);
+                }
+            }
+            return range;
+        },
+
+        calculateRangeLocation(scopeElement, range, text) {
+            const textNodes = getTextNodes(scopeElement);
+            let runningOffset = 0;
+            let startOffset = -1;
+
+            for (let i = 0; i < textNodes.length; i++) {
+                const node = textNodes[i];
+                if (node === range.startContainer) {
+                    startOffset = runningOffset + range.startOffset;
+                    break;
+                }
+                runningOffset += (node.nodeValue || '').length;
+            }
+
+            if (startOffset === -1) {
+                startOffset = 0;
+            }
+
+            const endOffset = startOffset + text.length;
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
+            const after = fullText.slice(endOffset, endOffset + 30);
+
+            let occurrence = 0;
+            const lowerFull = fullText.toLowerCase();
+            const lowerWord = text.toLowerCase();
+            let idx = -1;
+            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
+                occurrence += 1;
+            }
+
+            return { startOffset, endOffset, before, after, occurrence };
+        },
+
+        wrapRangeWithHighlight(range, word) {
+            if (!range || range.collapsed) return null;
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight vocab-highlight--pulse';
+            mark.dataset.word = word;
+            mark.title = `生词本: ${word} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+            } catch (e) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                } catch (err) {
+                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
+                    return null;
+                }
+            }
+
+            setTimeout(() => {
+                mark.classList.remove('vocab-highlight--pulse');
+            }, 1500);
+
+            return mark;
+        },
+
+        applyVocabHighlights() {
+            const overlay = this.ensureOverlay();
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
+            this.removeVocabHighlights(passageContent);
+            this.removeVocabHighlights(questionsContent);
+
+            if (!this.currentExamId) return;
+
+            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            if (!examItems || examItems.length === 0) return;
+
+            examItems.forEach(item => {
+                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
+                    item.highlights.forEach(hl => {
+                        if (String(hl.examId) === String(this.currentExamId)) {
+                            this.restoreVocabHighlight(overlay, hl, item.word);
+                        }
+                    });
+                } else if (item.context && item.word) {
+                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
+                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
+                }
+            });
+        },
+
+        restoreVocabHighlight(overlay, hl, word) {
+            if (!overlay || !hl) return false;
+            let scopeElement = null;
+
+            if (hl.scope && hl.scope.startsWith('para-')) {
+                const letter = hl.scope.replace('para-', '');
+                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
+                if (card) {
+                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
+                }
+            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
+                scopeElement = overlay.querySelector(`#${hl.scope}`);
+            } else if (hl.scope === 'questions') {
+                scopeElement = overlay.querySelector('#vocab-questions-content');
+            } else {
+                scopeElement = overlay.querySelector('#vocab-passage-content');
+            }
+
+            if (!scopeElement) {
+                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
+            }
+            if (!scopeElement) return false;
+
+            const range = this.resolveRangeForHighlight(scopeElement, hl);
+            if (!range || range.collapsed) return false;
+
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight';
+            mark.dataset.word = word || hl.text;
+            mark.title = `生词本: ${word || hl.text} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+                return true;
+            } catch (_) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+        },
+
+        resolveRangeForHighlight(root, hl) {
+            if (!root || !hl) return null;
+            const textNodes = getTextNodes(root);
+            if (!textNodes.length) return null;
+
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const targetText = String(hl.text || '').trim();
+            if (!targetText) return null;
+
+            const startOffset = Number(hl.startOffset);
+            const endOffset = Number(hl.endOffset);
+
+            // 1. 优先尝试 offset 精确匹配
+            if (
+                Number.isFinite(startOffset) &&
+                Number.isFinite(endOffset) &&
+                endOffset > startOffset &&
+                startOffset >= 0 &&
+                endOffset <= fullText.length
+            ) {
+                const segment = fullText.slice(startOffset, endOffset);
+                if (segment.toLowerCase() === targetText.toLowerCase()) {
+                    return resolveRangeFromOffsets(root, startOffset, endOffset);
+                }
+            }
+
+            // 2. 次优：使用 before / after 上下文精确定位单处实例
+            if (hl.before || hl.after) {
+                let searchPos = 0;
+                let matchIdx = -1;
+                let bestIdx = -1;
+                let bestScore = -1;
+                const lowerFull = fullText.toLowerCase();
+                const lowerTarget = targetText.toLowerCase();
+
+                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
+                    let score = 0;
+                    if (hl.before) {
+                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
+                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
+                            score += 3;
+                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (hl.after) {
+                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
+                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
+                            score += 3;
+                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (score > bestScore) {
+                        bestScore = score;
+                        bestIdx = matchIdx;
+                    }
+                    searchPos = matchIdx + 1;
+                }
+
+                if (bestIdx !== -1 && bestScore > 0) {
+                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
+                }
+            }
+
+            // 3. 兜底：使用 occurrence（第 N 次出现）
+            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
+            let currentOccurrence = 0;
+            let pos = 0;
+            let matchPos = -1;
+            const lowerFull = fullText.toLowerCase();
+            const lowerTarget = targetText.toLowerCase();
+
+            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
+                if (currentOccurrence === occurrence) {
+                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
+                }
+                currentOccurrence += 1;
+                pos = matchPos + 1;
+            }
+
+            return null;
+        },
+
+        restoreLegacyHighlightByContext(overlay, word, context) {
+            if (!overlay || !word) return false;
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            const roots = [passageContent, questionsContent].filter(Boolean);
+
+            const targetWord = String(word).trim();
+            const lowerWord = targetWord.toLowerCase();
+            const lowerContext = String(context || '').trim().toLowerCase();
+
+            for (const root of roots) {
+                const textNodes = getTextNodes(root);
+                const fullText = textNodes.map(n => n.nodeValue || '').join('');
+                const lowerFull = fullText.toLowerCase();
+
+                let targetIdx = -1;
+                if (lowerContext && lowerFull.includes(lowerContext)) {
+                    const ctxIdx = lowerFull.indexOf(lowerContext);
+                    const wordInCtx = lowerContext.indexOf(lowerWord);
+                    if (wordInCtx !== -1) {
+                        targetIdx = ctxIdx + wordInCtx;
+                    }
+                }
+
+                // 无论如何，只恢复单处实例，绝不全篇高亮
+                if (targetIdx !== -1) {
+                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
+                    if (range && !range.collapsed) {
+                        const mark = document.createElement('mark');
+                        mark.className = 'vocab-highlight';
+                        mark.dataset.word = targetWord;
+                        mark.title = `生词本: ${targetWord} (点击发音)`;
+                        try {
+                            range.surroundContents(mark);
+                            return true;
+                        } catch (_) {
+                            try {
+                                const frag = range.extractContents();
+                                mark.appendChild(frag);
+                                range.insertNode(mark);
+                                return true;
+                            } catch (e) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        },
+
+        removeVocabHighlights(container) {
+            if (!container) return;
+            const marks = container.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const parent = mark.parentNode;
+                if (parent) {
+                    while (mark.firstChild) {
+                        parent.insertBefore(mark.firstChild, mark);
+                    }
+                    parent.removeChild(mark);
+                    parent.normalize();
+                }
+            });
+        },
+
+        removeVocabHighlightForWord(word) {
+            const overlay = this.ensureOverlay();
+            if (!overlay || !word) return;
+            const lower = String(word).trim().toLowerCase();
+            const marks = overlay.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const markWord = (mark.dataset.word || mark.textContent || '').trim().toLowerCase();
+                if (markWord === lower) {
+                    const parent = mark.parentNode;
+                    if (parent) {
+                        while (mark.firstChild) {
+                            parent.insertBefore(mark.firstChild, mark);
+                        }
+                        parent.removeChild(mark);
+                        parent.normalize();
+                    }
+                }
+            });
+        },
+
+        enhanceWithExplanation(explanation) {
+            if (!explanation || !Array.isArray(explanation.passageNotes)) return;
+            const overlay = this.ensureOverlay();
+            explanation.passageNotes.forEach(note => {
+                const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
+                if (match) {
+                    const letter = match[1].toUpperCase();
+                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    if (transEl) {
+                        transEl.textContent = note.text || '';
+                    }
+                }
+            });
+        },
+
+        switchViewTab(target) {
+            const overlay = this.ensureOverlay();
+            const passageSection = overlay.querySelector('#vocab-passage-section');
+            const questionsSection = overlay.querySelector('#vocab-questions-section');
+            const cards = overlay.querySelectorAll('.vocab-paragraph-card');
+            const scrollArea = overlay.querySelector('#vocab-reader-scroll-area');
+
+            if (target === 'all') {
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'block';
+                cards.forEach(c => c.style.display = 'block');
+                if (scrollArea && typeof scrollArea.scrollTo === 'function') {
+                    scrollArea.scrollTo({ top: 0, behavior: 'smooth' });
+                } else if (passageSection) {
+                    passageSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else if (target === 'questions') {
+                if (passageSection) passageSection.style.display = 'none';
+                if (questionsSection) {
+                    questionsSection.style.display = 'block';
+                    questionsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else {
+                // 单个段落展示
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'none';
+                cards.forEach(c => {
+                    if (c.dataset.letter === target) {
+                        c.style.display = 'block';
+                        c.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    } else {
+                        c.style.display = 'none';
+                    }
+                });
+            }
+        },
+
+        updateCounts() {
+            const overlay = this.ensureOverlay();
+            const examId = this.currentExamId;
+            const currentList = ReadingVocabStore.getByExam(examId);
+            const allList = ReadingVocabStore.getAll();
+
+            const headerCount = overlay.querySelector('#vocab-header-count');
+            const fabCount = overlay.querySelector('#vocab-fab-count');
+            const tabCurrentCount = overlay.querySelector('#v-count-current');
+            const tabAllCount = overlay.querySelector('#v-count-all');
+
+            const countToShow = currentList.length;
+            if (headerCount) headerCount.textContent = countToShow;
+            if (fabCount) fabCount.textContent = countToShow;
+            if (tabCurrentCount) tabCurrentCount.textContent = currentList.length;
+            if (tabAllCount) tabAllCount.textContent = allList.length;
+        },
+
+        renderVocabList() {
+            const overlay = this.ensureOverlay();
+            const listEl = overlay.querySelector('#vocab-list');
+            if (!listEl) return;
+
+            const isCurrent = this.modalTab === 'current';
+            const list = isCurrent
+                ? ReadingVocabStore.getByExam(this.currentExamId)
+                : ReadingVocabStore.getAll();
+
+            if (!list || list.length === 0) {
+                listEl.innerHTML = `
+                    <div class="vocab-empty-box">
+                        <div class="vocab-empty-icon">📝</div>
+                        <p class="vocab-empty-title">生词本是空的哦~</p>
+                        <p class="vocab-empty-desc">在文章或题目中划选任意英文单词，即可自动收入此生词本。</p>
+                    </div>
+                `;
+                return;
+            }
+
+            let html = '';
+            list.forEach(item => {
+                html += `
+                    <div class="vocab-item" data-word-id="${item.id}">
+                        <div class="vocab-item__main">
+                            <div class="vocab-item__header">
+                                <span class="vocab-item__word">${item.word}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                            </div>
+                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                        </div>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                    </div>
+                `;
+            });
+
+            listEl.innerHTML = html;
+
+            // 绑定发音与删除
+            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    speakWord(btn.dataset.speakWord);
+                });
+            });
+
+            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const id = btn.dataset.delId;
+                    const allItems = ReadingVocabStore.getAll();
+                    const item = allItems.find(w => w.id === id);
+                    const word = item?.word;
+                    ReadingVocabStore.remove(id);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    if (word) {
+                        this.removeVocabHighlightForWord(word);
+                    }
+                    this.showToast('已从生词本删除');
+                });
+            });
+        },
+
+        openModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = true;
+                this.updateCounts();
+                this.renderVocabList();
+                modal.classList.add('active');
+                modal.setAttribute('aria-hidden', 'false');
+            }
+        },
+
+        closeModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = false;
+                modal.classList.remove('active');
+                modal.setAttribute('aria-hidden', 'true');
+            }
+        },
+
+        showToast(msg) {
+            const overlay = this.ensureOverlay();
+            const toast = overlay.querySelector('#vocab-toast');
+            if (!toast) return;
+
+            toast.textContent = msg;
+            toast.classList.add('show');
+
+            clearTimeout(this.toastTimer);
+            this.toastTimer = setTimeout(() => {
+                toast.classList.remove('show');
+            }, 2000);
+        },
+
+        close() {
+            const overlay = this.ensureOverlay();
+            if (overlay) {
+                overlay.classList.add('is-hidden');
+            }
+            document.body.classList.remove('vocab-reader-open');
+            this.modalOpen = false;
+        }
+    };
+
+    // 监听生词更新事件以即时刷新打开的视图
+    if (typeof window !== 'undefined') {
+        window.addEventListener('reading-vocab-store-updated', () => {
+            if (ReadingVocabReader.modalOpen) {
+                ReadingVocabReader.renderVocabList();
+                ReadingVocabReader.updateCounts();
+                ReadingVocabReader.applyVocabHighlights();
+            }
+        });
+    }
+
+    // 暴露全局命名空间
+    global.ReadingVocabStore = ReadingVocabStore;
+    global.ReadingVocabReader = ReadingVocabReader;
+    global.openReadingVocabReader = function(examId, options = {}) {
+        ReadingVocabReader.open(examId, options);
+    };
+
+    // 启动数据同步初始化
+    ReadingVocabStore.init();
+
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
 /* ===== js/components/BrowseStateManager.js ===== */
 /**
  * 浏览状态管理器
@@ -21927,6 +23899,27 @@ function createFallbackExamCard(exam, options = {}) {
             viewPDF(exam.id);
         });
         actions.appendChild(pdfBtn);
+
+        const isReading = exam && (exam.type === 'reading' || !exam.type || String(exam.type).toLowerCase() !== 'listening') && exam.hasHtml !== false;
+        if (isReading && exam && exam.id) {
+            const vocabBtn = document.createElement('button');
+            vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
+            vocabBtn.type = 'button';
+            vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examId = exam.id;
+            vocabBtn.textContent = '精读';
+            vocabBtn.title = '打开该题全文精读与生词本';
+            vocabBtn.addEventListener('click', function (e) {
+                e.preventDefault();
+                if (window.ReadingVocabReader && typeof window.ReadingVocabReader.open === 'function') {
+                    window.ReadingVocabReader.open(exam.id);
+                } else if (typeof window.openReadingVocabReader === 'function') {
+                    window.openReadingVocabReader(exam.id);
+                }
+            });
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
     }
 
     item.appendChild(info);
@@ -23481,6 +25474,7 @@ ensurePracticeSessionSyncListener();
     "js/app/examSessionMixin.js",
     "js/app/browseController.js",
     "js/components/PDFHandler.js",
+    "js/components/readingVocabReader.js",
     "js/components/BrowseStateManager.js",
     "js/utils/suiteBackGuard.js",
     "js/utils/answerMatchCore.js",

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -4303,6 +4303,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -4428,18 +4436,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -4447,6 +4456,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -4469,7 +4481,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -4558,9 +4570,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -4575,6 +4584,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -674,6 +674,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'
@@ -805,7 +815,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }
@@ -4165,11 +4177,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -4186,9 +4208,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -4390,6 +4425,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -4399,7 +4470,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -4424,6 +4497,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4862,6 +4936,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -4992,6 +5092,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -5323,6 +5425,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })
@@ -13101,6 +13208,88 @@
 })(typeof window !== "undefined" ? window : globalThis);
 
 
+/* ===== js/runtime/readingExamRegistry.js ===== */
+(function initReadingExamRegistry(global) {
+    'use strict';
+
+    const store = new Map();
+
+    function deepClone(value) {
+        if (value == null) {
+            return value;
+        }
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    const api = {
+        register(id, payload) {
+            if (!id || !payload || typeof payload !== 'object') {
+                throw new Error('reading_exam_payload_invalid');
+            }
+            store.set(String(id), deepClone(payload));
+        },
+        get(id) {
+            if (!id) {
+                return null;
+            }
+            return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+        },
+        has(id) {
+            return !!id && store.has(String(id));
+        },
+        keys() {
+            return Array.from(store.keys());
+        },
+        clear() {
+            store.clear();
+        }
+    };
+
+    global.__READING_EXAM_DATA__ = api;
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
+/* ===== js/runtime/readingExplanationRegistry.js ===== */
+(function initReadingExplanationRegistry(global) {
+    'use strict';
+
+    const store = new Map();
+
+    function deepClone(value) {
+        if (value == null) {
+            return value;
+        }
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    const api = {
+        register(id, payload) {
+            if (!id || !payload || typeof payload !== 'object') {
+                throw new Error('reading_explanation_payload_invalid');
+            }
+            store.set(String(id), deepClone(payload));
+        },
+        get(id) {
+            if (!id) {
+                return null;
+            }
+            return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+        },
+        has(id) {
+            return !!id && store.has(String(id));
+        },
+        keys() {
+            return Array.from(store.keys());
+        },
+        clear() {
+            store.clear();
+        }
+    };
+
+    global.__READING_EXPLANATION_DATA__ = api;
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
 /* ===== js/app/state-service.js ===== */
 (function (global) {
     'use strict';
@@ -15432,6 +15621,8 @@
     "js/core/practiceCore.js",
     "js/core/resourceCore.js",
     "assets/generated/reading-exams/manifest.js",
+    "js/runtime/readingExamRegistry.js",
+    "js/runtime/readingExplanationRegistry.js",
     "js/app/state-service.js",
     "js/services/libraryDiscovery.js",
     "js/services/libraryManager.js"

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -2623,6 +2623,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -4422,43 +4426,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -4470,34 +4501,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4546,7 +4556,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -4568,6 +4584,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -4584,16 +4601,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -4937,7 +4956,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -4950,7 +4969,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -5225,6 +5244,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -5427,7 +5447,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2539,6 +2539,7 @@ class ExamSystemApp {
             const targetView = document.getElementById(`${viewName}-view`);
             if (targetView) {
                 targetView.classList.add('active');
+                targetView.removeAttribute('hidden');
                 this.currentView = viewName;
                 document.querySelectorAll('.nav-btn').forEach((btn) => {
                     btn.classList.remove('active');
@@ -2546,6 +2547,11 @@ class ExamSystemApp {
                 const activeNavBtn = document.querySelector(`[data-view="${viewName}"]`);
                 if (activeNavBtn) {
                     activeNavBtn.classList.add('active');
+                } else if (viewName === 'bookshelf' || viewName === 'vocab') {
+                    const moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+                    if (moreNavBtn) {
+                        moreNavBtn.classList.add('active');
+                    }
                 }
                 const url = new URL(window.location);
                 url.searchParams.set('view', viewName);
@@ -2726,6 +2732,30 @@ class ExamSystemApp {
                         })
                         .catch((error) => {
                             console.warn('[App] 激活更多视图时加载工具模块失败:', error);
+                        });
+                    break;
+                case 'bookshelf':
+                    Promise.resolve()
+                        .then(() => {
+                            if (window.AppEntry && typeof window.AppEntry.ensureMoreToolsGroup === 'function') {
+                                return window.AppEntry.ensureMoreToolsGroup();
+                            }
+                            if (window.AppLazyLoader && typeof window.AppLazyLoader.ensureGroup === 'function') {
+                                return window.AppLazyLoader.ensureGroup('more-tools');
+                            }
+                            return null;
+                        })
+                        .then(() => {
+                            const bookshelfView = document.getElementById('bookshelf-view');
+                            if (bookshelfView) {
+                                bookshelfView.removeAttribute('hidden');
+                            }
+                            if (window.BookshelfView && typeof window.BookshelfView.mount === 'function') {
+                                window.BookshelfView.mount('#bookshelf-view');
+                            }
+                        })
+                        .catch((error) => {
+                            console.warn('[App] 激活书架视图时加载工具模块失败:', error);
                         });
                     break;
                 default:

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -343,6 +343,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'
@@ -474,7 +484,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }
@@ -3834,11 +3846,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -3855,9 +3877,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -4059,6 +4094,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -4068,7 +4139,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -4093,6 +4166,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4531,6 +4605,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -4661,6 +4761,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -4992,6 +5094,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -2292,6 +2292,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -4091,43 +4095,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -4139,34 +4170,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4215,7 +4225,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -4237,6 +4253,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -4253,16 +4270,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -4606,7 +4625,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -4619,7 +4638,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -4894,6 +4913,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -5096,7 +5116,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -3972,6 +3972,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -4097,18 +4105,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -4116,6 +4125,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -4138,7 +4150,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -4227,9 +4239,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -4244,6 +4253,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -343,6 +343,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'
@@ -474,7 +484,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }
@@ -3834,11 +3846,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -3855,9 +3877,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -4059,6 +4094,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -4068,7 +4139,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -4093,6 +4166,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4531,6 +4605,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -4661,6 +4761,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -4992,6 +5094,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -2292,6 +2292,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -4091,43 +4095,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -4139,34 +4170,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4215,7 +4225,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -4237,6 +4253,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -4253,16 +4270,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -4606,7 +4625,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -4619,7 +4638,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -4894,6 +4913,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -5096,7 +5116,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -3972,6 +3972,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -4097,18 +4105,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -4116,6 +4125,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -4138,7 +4150,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -4227,9 +4239,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -4244,6 +4253,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -5234,35 +5234,14 @@
                     await global.AppData.ready;
                 }
                 if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
-                    const appDataRecords = await global.AppData.vocab.listReadingBookshelfExams();
-                    const localRecords = this.getRawRecords();
-                    if (Array.isArray(appDataRecords) && appDataRecords.length > 0) {
-                        const map = new Map();
-                        localRecords.forEach(r => {
-                            const eid = String(r && (r.examId || r.id) || '').trim();
-                            if (eid) map.set(eid, r);
-                        });
-                        appDataRecords.forEach(r => {
-                            const eid = String(r && (r.examId || r.id) || '').trim();
-                            if (eid) {
-                                if (map.has(eid)) {
-                                    const existing = map.get(eid);
-                                    map.set(eid, Object.assign({}, existing, r, {
-                                        firstUsedAt: Math.min(Number(existing.firstUsedAt) || Date.now(), Number(r.firstUsedAt) || Date.now()),
-                                        lastOpenedAt: Math.max(Number(existing.lastOpenedAt) || 0, Number(r.lastOpenedAt) || 0)
-                                    }));
-                                } else {
-                                    map.set(eid, r);
-                                }
-                            }
-                        });
-                        const merged = Array.from(map.values());
-                        try { localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(merged)); } catch (_) {}
-                        if (merged.length !== appDataRecords.length) {
-                            await global.AppData.vocab.saveReadingBookshelfExams(merged);
-                        }
-                    } else if (localRecords.length > 0) {
-                        await global.AppData.vocab.saveReadingBookshelfExams(localRecords);
+                    const result = await global.AppData.vocab.listReadingBookshelfExams({ withMeta: true });
+                    const appDataRecords = Array.isArray(result) ? result : result && result.envelope && result.data;
+                    // AppData owns legacy migration. Its restored collection,
+                    // including an empty array, replaces the local display mirror.
+                    // An absent envelope can mean migration failed; retain its
+                    // only legacy copy instead of treating the default [] as a clear.
+                    if (Array.isArray(appDataRecords)) {
+                        localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(appDataRecords));
                     }
                 }
             } catch (e) {

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -5181,6 +5181,1025 @@
 })(typeof window !== 'undefined' ? window : globalThis);
 
 
+/* ===== js/components/bookshelfView.js ===== */
+(function initBookshelfView(global) {
+    'use strict';
+
+    const BOOKSHELF_KEY = 'ielts_reading_bookshelf_exams_v1';
+    const VOCAB_KEY = 'ielts_reading_vocab_words_v1';
+
+    // ============================================================================
+    // 书架数据管理 (ReadingBookshelfStore)
+    // ============================================================================
+    const ReadingBookshelfStore = {
+        _commitBound: false,
+
+        getRawRecords() {
+            try {
+                const raw = localStorage.getItem(BOOKSHELF_KEY);
+                return raw ? JSON.parse(raw) : [];
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 读取书架记录失败:', e);
+                return [];
+            }
+        },
+
+        saveRecords(records) {
+            try {
+                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(records || []));
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 保存书架记录失败:', e);
+            }
+            this.syncToAppData(records);
+        },
+
+        async syncToAppData(records) {
+            try {
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
+                    await global.AppData.vocab.saveReadingBookshelfExams(records || this.getRawRecords());
+                }
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] syncToAppData failed:', e);
+            }
+        },
+
+        async flushToAppData() {
+            return this.syncToAppData(this.getRawRecords());
+        },
+
+        async init() {
+            this.bindCommitListener();
+            try {
+                if (global.AppData && global.AppData.ready) {
+                    await global.AppData.ready;
+                }
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
+                    const appDataRecords = await global.AppData.vocab.listReadingBookshelfExams();
+                    const localRecords = this.getRawRecords();
+                    if (Array.isArray(appDataRecords) && appDataRecords.length > 0) {
+                        const map = new Map();
+                        localRecords.forEach(r => {
+                            const eid = String(r && (r.examId || r.id) || '').trim();
+                            if (eid) map.set(eid, r);
+                        });
+                        appDataRecords.forEach(r => {
+                            const eid = String(r && (r.examId || r.id) || '').trim();
+                            if (eid) {
+                                if (map.has(eid)) {
+                                    const existing = map.get(eid);
+                                    map.set(eid, Object.assign({}, existing, r, {
+                                        firstUsedAt: Math.min(Number(existing.firstUsedAt) || Date.now(), Number(r.firstUsedAt) || Date.now()),
+                                        lastOpenedAt: Math.max(Number(existing.lastOpenedAt) || 0, Number(r.lastOpenedAt) || 0)
+                                    }));
+                                } else {
+                                    map.set(eid, r);
+                                }
+                            }
+                        });
+                        const merged = Array.from(map.values());
+                        try { localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(merged)); } catch (_) {}
+                        if (merged.length !== appDataRecords.length) {
+                            await global.AppData.vocab.saveReadingBookshelfExams(merged);
+                        }
+                    } else if (localRecords.length > 0) {
+                        await global.AppData.vocab.saveReadingBookshelfExams(localRecords);
+                    }
+                }
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] init failed:', e);
+            }
+        },
+
+        bindCommitListener() {
+            if (this._commitBound) return;
+            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+                this._commitBound = true;
+                global.AppData.backups.onDataCommitted(async (event) => {
+                    const targets = event && event.targets;
+                    if (!Array.isArray(targets)) return;
+                    const hasBookshelf = targets.some(t => t.logicalKey === 'vocab.readingBookshelfExams');
+                    if (hasBookshelf) {
+                        try {
+                            const updated = await global.AppData.vocab.listReadingBookshelfExams();
+                            if (Array.isArray(updated)) {
+                                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(updated));
+                                window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail: { records: updated } }));
+                            }
+                        } catch (err) {
+                            console.warn('[ReadingBookshelfStore] reload on committed failed:', err);
+                        }
+                    }
+                });
+            }
+        },
+
+        recordExamUsed(examId, examTitle = '', category = '') {
+            if (!examId) return;
+            try {
+                const records = this.getRawRecords();
+                const now = Date.now();
+                const idx = records.findIndex(r => String(r.examId) === String(examId));
+                if (idx !== -1) {
+                    records[idx].lastOpenedAt = now;
+                    if (examTitle && !records[idx].examTitle) {
+                        records[idx].examTitle = examTitle;
+                    }
+                    if (category && !records[idx].category) {
+                        records[idx].category = category;
+                    }
+                } else {
+                    records.unshift({
+                        examId: String(examId),
+                        examTitle: examTitle || '',
+                        category: category || '',
+                        firstUsedAt: now,
+                        lastOpenedAt: now
+                    });
+                }
+                this.saveRecords(records);
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 记录题目失败:', e);
+            }
+        },
+
+        getBookshelfExams() {
+            // 1. 读取全部生词
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            // 统计生词数据映射
+            const vocabMap = new Map();
+            vocabWords.forEach(item => {
+                if (!item || !item.examId) return;
+                const eid = String(item.examId);
+                if (!vocabMap.has(eid)) {
+                    vocabMap.set(eid, {
+                        count: 0,
+                        words: [],
+                        latestTime: item.createdAt || 0,
+                        examTitle: item.examTitle || ''
+                    });
+                }
+                const group = vocabMap.get(eid);
+                group.count++;
+                if (group.words.length < 6 && item.word) {
+                    group.words.push(item.word);
+                }
+                if (item.createdAt && item.createdAt > group.latestTime) {
+                    group.latestTime = item.createdAt;
+                }
+                if (!group.examTitle && item.examTitle) {
+                    group.examTitle = item.examTitle;
+                }
+            });
+
+            // 2. 读取书架记录
+            const records = this.getRawRecords();
+            const recordMap = new Map();
+            records.forEach(r => {
+                if (r && r.examId) {
+                    recordMap.set(String(r.examId), r);
+                }
+            });
+
+            // 3. 读取全局 Manifest 题库元信息
+            const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || {};
+
+            // 4. 合并集合（记录过的题目 + 拥有生词的题目）
+            const allExamIds = new Set([...recordMap.keys(), ...vocabMap.keys()]);
+            const results = [];
+
+            allExamIds.forEach(examId => {
+                const rec = recordMap.get(examId) || {};
+                const vocab = vocabMap.get(examId) || { count: 0, words: [], latestTime: 0, examTitle: '' };
+                const meta = manifest[examId] || {};
+
+                const title = rec.examTitle || vocab.examTitle || meta.title || meta.name || examId;
+                const category = rec.category || meta.category || meta.type || '雅思阅读';
+                const lastActivity = Math.max(rec.lastOpenedAt || 0, vocab.latestTime || 0, rec.firstUsedAt || 0);
+
+                results.push({
+                    examId: examId,
+                    title: title,
+                    category: category,
+                    wordCount: vocab.count,
+                    sampleWords: vocab.words,
+                    lastActivityAt: lastActivity || Date.now(),
+                    hasPdf: Boolean(meta.pdfPath || meta.pdf)
+                });
+            });
+
+            // 默认按最后活动时间倒序排序
+            results.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+            return results;
+        },
+
+        removeExam(examId, alsoDeleteWords = true) {
+            try {
+                const targetExamId = String(examId).trim();
+                if (!targetExamId) return false;
+
+                // 1. 从书架记录中移除篇目
+                const records = this.getRawRecords().filter(r => String(r.examId || r.id).trim() !== targetExamId);
+                this.saveRecords(records);
+
+                // 2. 仅删除该篇目下的生词本记录（严格与做题练习记录隔离）
+                if (alsoDeleteWords) {
+                    // 若全局内存中存在 ReadingVocabStore，同步调用 clear
+                    if (global.ReadingVocabStore && typeof global.ReadingVocabStore.clear === 'function') {
+                        try {
+                            global.ReadingVocabStore.clear(targetExamId);
+                        } catch (err) {
+                            console.warn('[ReadingBookshelfStore] ReadingVocabStore.clear 失败:', err);
+                        }
+                    }
+
+                    // 持久化存储过滤生词
+                    let vocabWords = [];
+                    const raw = localStorage.getItem(VOCAB_KEY);
+                    if (raw) {
+                        try { vocabWords = JSON.parse(raw); } catch (_) {}
+                    }
+                    const filtered = vocabWords.filter(w => String(w.examId).trim() !== targetExamId);
+                    try {
+                        localStorage.setItem(VOCAB_KEY, JSON.stringify(filtered));
+                    } catch (e) {
+                        console.warn('[ReadingBookshelfStore] 保存过滤生词失败:', e);
+                    }
+
+                    // 同步到 AppData.vocab
+                    if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
+                        global.AppData.vocab.saveReadingWords(filtered).catch(err => {
+                            console.warn('[ReadingBookshelfStore] 同步生词删除至 AppData 失败:', err);
+                        });
+                    }
+
+                    // 广播生词变更事件，通知所有打开的阅读器及组件
+                    try {
+                        window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', {
+                            detail: { examId: targetExamId, action: 'clear-exam-vocab' }
+                        }));
+                    } catch (_) {}
+                }
+
+                // 3. 严格数据隔离：绝不触碰任何做题练习记录（做题历史、得分记录、错题记录等完整保留）
+
+                // 4. 广播书架更新事件
+                try {
+                    window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', {
+                        detail: { examId: targetExamId, action: 'remove-exam' }
+                    }));
+                } catch (_) {}
+
+                return true;
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 移除题目失败:', e);
+                return false;
+            }
+        },
+
+        exportExamTxt(examId, examTitle) {
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            const examWords = vocabWords.filter(item => String(item.examId) === String(examId));
+            if (examWords.length === 0) {
+                return false;
+            }
+
+            const words = [];
+            const seen = new Set();
+            examWords.forEach(item => {
+                const w = (typeof item === 'string' ? item : item?.word || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            const dateStr = `${year}-${month}-${day}`;
+
+            const rawTitle = examTitle || examWords[0]?.examTitle || examId || '阅读生词本';
+            const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+            const filename = `${dateStr}_${safeTitle}.txt`;
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return { filename, count: words.length };
+        },
+
+        exportAllBookshelfTxt() {
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            if (vocabWords.length === 0) {
+                return false;
+            }
+
+            const words = [];
+            const seen = new Set();
+            vocabWords.forEach(item => {
+                const w = (typeof item === 'string' ? item : item?.word || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            const dateStr = `${year}-${month}-${day}`;
+            const filename = `${dateStr}_书架全部阅读生词.txt`;
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return { filename, count: words.length };
+        }
+    };
+
+    global.ReadingBookshelfStore = ReadingBookshelfStore;
+
+    // ============================================================================
+    // 书架视图控制器 (BookshelfView)
+    // ============================================================================
+    const BookshelfView = {
+        containerSelector: '#bookshelf-root',
+        state: {
+            searchQuery: '',
+            sortBy: 'recent', // 'recent' | 'words' | 'title'
+            filterMode: 'all', // 'all' | 'has-words'
+            fromView: null,
+            toastTimer: null
+        },
+
+        mount(targetSelector = '#bookshelf-view', options = {}) {
+            if (options && options.fromView) {
+                this.state.fromView = options.fromView;
+            }
+            const viewElement = document.querySelector(targetSelector);
+            if (!viewElement) return;
+
+            let root = viewElement.querySelector(this.containerSelector);
+            if (!root) {
+                root = document.createElement('div');
+                root.id = 'bookshelf-root';
+                root.className = 'bookshelf-view-shell';
+                viewElement.appendChild(root);
+            }
+
+            this.render();
+            this.bindGlobalEvents();
+        },
+
+        render() {
+            const root = document.querySelector(this.containerSelector);
+            if (!root) return;
+
+            const allExams = ReadingBookshelfStore.getBookshelfExams();
+            const totalWords = allExams.reduce((sum, item) => sum + item.wordCount, 0);
+
+            // 过滤与搜索
+            let filtered = allExams.slice();
+            if (this.state.searchQuery) {
+                const q = this.state.searchQuery.toLowerCase().trim();
+                filtered = filtered.filter(item => {
+                    const matchTitle = (item.title || '').toLowerCase().includes(q);
+                    const matchCategory = (item.category || '').toLowerCase().includes(q);
+                    const matchWords = (item.sampleWords || []).some(w => w.toLowerCase().includes(q));
+                    return matchTitle || matchCategory || matchWords;
+                });
+            }
+
+            if (this.state.filterMode === 'has-words') {
+                filtered = filtered.filter(item => item.wordCount > 0);
+            }
+
+            // 排序
+            if (this.state.sortBy === 'recent') {
+                filtered.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+            } else if (this.state.sortBy === 'words') {
+                filtered.sort((a, b) => b.wordCount - a.wordCount);
+            } else if (this.state.sortBy === 'title') {
+                filtered.sort((a, b) => a.title.localeCompare(b.title));
+            }
+
+            const isFromOverview = this.state.fromView === 'overview';
+            const backBtnTitle = isFromOverview ? '返回学习总览' : '返回更多工具';
+            const backBtnText = isFromOverview ? '返回总览' : '返回更多';
+
+            root.innerHTML = `
+                <div class="bookshelf-layout">
+                    <!-- 顶部标题栏与导航 -->
+                    <div class="bookshelf-topbar">
+                        <div class="bookshelf-topbar__left">
+                            <button type="button" class="btn btn-secondary bookshelf-back-btn" data-action="return-more" title="${backBtnTitle}">
+                                <span class="bookshelf-back-arrow">←</span>
+                                <span>${backBtnText}</span>
+                            </button>
+                            <div class="bookshelf-heading-group">
+                                <h2 class="bookshelf-title">📚 阅读书架</h2>
+                                <p class="bookshelf-subtitle">收录使用过生词本的精读篇目，温故知新，查缺补漏</p>
+                            </div>
+                        </div>
+                        <div class="bookshelf-topbar__right">
+                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="一键导出书架全部生词为 TXT">
+                                📥 导出全部生词
+                            </button>
+                            <button type="button" class="btn btn-primary bookshelf-notebook-btn" data-action="open-global-notebook" title="打开生词本总览">
+                                📖 打开生词本
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- 统计数据横幅 -->
+                    <div class="bookshelf-stats-banner">
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">📖</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${allExams.length}</span>
+                                <span class="bookshelf-stat-label">收录篇目</span>
+                            </div>
+                        </div>
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">🔤</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${totalWords}</span>
+                                <span class="bookshelf-stat-label">积累生词</span>
+                            </div>
+                        </div>
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">🕒</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${this.formatLatestTime(allExams[0]?.lastActivityAt)}</span>
+                                <span class="bookshelf-stat-label">最近精读</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 检索与筛选工具条 -->
+                    <div class="bookshelf-toolbar">
+                        <div class="bookshelf-search-box">
+                            <span class="bookshelf-search-icon">🔍</span>
+                            <input
+                                type="text"
+                                class="bookshelf-search-input"
+                                placeholder="搜索篇目名称、分类或单词..."
+                                value="${this.escapeHtml(this.state.searchQuery)}"
+                                data-action="search-input"
+                            />
+                            ${this.state.searchQuery ? '<button type="button" class="bookshelf-search-clear" data-action="clear-search" title="清空搜索">×</button>' : ''}
+                        </div>
+
+                        <div class="bookshelf-filter-group">
+                            <div class="bookshelf-segmented">
+                                <button type="button" class="bookshelf-segment-btn ${this.state.filterMode === 'all' ? 'active' : ''}" data-action="set-filter" data-mode="all">
+                                    全部 (${allExams.length})
+                                </button>
+                                <button type="button" class="bookshelf-segment-btn ${this.state.filterMode === 'has-words' ? 'active' : ''}" data-action="set-filter" data-mode="has-words">
+                                    有生词 (${allExams.filter(e => e.wordCount > 0).length})
+                                </button>
+                            </div>
+
+                            <div class="bookshelf-sort-select-wrapper">
+                                <select class="bookshelf-sort-select" data-action="change-sort">
+                                    <option value="recent" ${this.state.sortBy === 'recent' ? 'selected' : ''}>🕒 最近学习</option>
+                                    <option value="words" ${this.state.sortBy === 'words' ? 'selected' : ''}>🔥 生词最多</option>
+                                    <option value="title" ${this.state.sortBy === 'title' ? 'selected' : ''}>🔤 篇目名称</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 篇目卡片网格 -->
+                    <div class="bookshelf-content-area">
+                        ${filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
+                    </div>
+                </div>
+
+                <!-- 操作轻量反馈浮层 (Toast) -->
+                <div id="bookshelf-toast" class="bookshelf-toast is-hidden" role="status" aria-live="polite"></div>
+            `;
+
+            this.bindCardEvents(root);
+        },
+
+        renderCardGrid(exams) {
+            return `
+                <div class="bookshelf-grid">
+                    ${exams.map(exam => this.renderExamCard(exam)).join('')}
+                </div>
+            `;
+        },
+
+        renderExamCard(exam) {
+            const formattedTime = this.formatFriendlyDate(exam.lastActivityAt);
+            const wordsList = exam.sampleWords || [];
+
+            return `
+                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}">
+                    <div class="bookshelf-card__header">
+                        <div class="bookshelf-card__tags">
+                            <span class="bookshelf-card__badge bookshelf-card__badge--category">${this.escapeHtml(exam.category || '雅思阅读')}</span>
+                            ${exam.wordCount > 0
+                                ? `<span class="bookshelf-card__badge bookshelf-card__badge--vocab">🔥 ${exam.wordCount} 个生词</span>`
+                                : `<span class="bookshelf-card__badge bookshelf-card__badge--read">📖 已入精读</span>`
+                            }
+                        </div>
+                        <button type="button" class="bookshelf-card__remove-btn" data-action="remove-exam" data-exam-id="${this.escapeHtml(exam.examId)}" data-exam-title="${this.escapeHtml(exam.title)}" title="从书架移除（仅移出生词本，保留做题练习数据）">
+                            🗑️
+                        </button>
+                    </div>
+
+                    <div class="bookshelf-card__body">
+                        <h3 class="bookshelf-card__title" data-action="open-reading-vocab" data-exam-id="${this.escapeHtml(exam.examId)}" title="点击进入全文精读与生词本">
+                            ${this.escapeHtml(exam.title)}
+                        </h3>
+                        <div class="bookshelf-card__meta">
+                            <span class="bookshelf-card__time">🕒 ${formattedTime}</span>
+                        </div>
+
+                        <!-- 生词预览药丸标签 -->
+                        <div class="bookshelf-card__vocab-preview">
+                            ${wordsList.length > 0 ? `
+                                <div class="bookshelf-vocab-chips">
+                                    ${wordsList.map(w => `
+                                        <button type="button" class="bookshelf-vocab-chip" data-action="speak-word" data-word="${this.escapeHtml(w)}" title="点击朗读发音">
+                                            <span>${this.escapeHtml(w)}</span>
+                                            <span class="bookshelf-chip-audio">🔊</span>
+                                        </button>
+                                    `).join('')}
+                                    ${exam.wordCount > wordsList.length ? `<span class="bookshelf-vocab-chip-more">+${exam.wordCount - wordsList.length}</span>` : ''}
+                                </div>
+                            ` : `
+                                <p class="bookshelf-vocab-empty-hint">暂未划词收录，可在全文中自由选词加入生词本</p>
+                            `}
+                        </div>
+                    </div>
+
+                    <!-- 卡片操作底栏 -->
+                    <div class="bookshelf-card__footer">
+                        <button type="button" class="btn btn-primary bookshelf-action-btn bookshelf-action-btn--main" data-action="open-reading-vocab" data-exam-id="${this.escapeHtml(exam.examId)}" title="进入划词与生词本">
+                            📖 划词
+                        </button>
+                        <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="open-exam-practice" data-exam-id="${this.escapeHtml(exam.examId)}">
+                            📝 做题
+                        </button>
+                        ${exam.hasPdf ? `
+                            <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="open-exam-pdf" data-exam-id="${this.escapeHtml(exam.examId)}">
+                                📄 PDF
+                            </button>
+                        ` : ''}
+                        <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="export-exam-txt" data-exam-id="${this.escapeHtml(exam.examId)}" data-exam-title="${this.escapeHtml(exam.title)}" ${exam.wordCount === 0 ? 'disabled' : ''} title="导出本篇生词 TXT">
+                            📥 导出
+                        </button>
+                    </div>
+                </div>
+            `;
+        },
+
+        renderEmptyState(isCompletelyEmpty) {
+            if (isCompletelyEmpty) {
+                return `
+                    <div class="bookshelf-empty-state">
+                        <div class="bookshelf-empty-icon">📚</div>
+                        <h3 class="bookshelf-empty-title">书架尚未收录篇目</h3>
+                        <p class="bookshelf-empty-desc">
+                            在「题库浏览」中点击任意阅读题目的「精读」，或在阅读过程中划词收录生词，篇目将自动收录至此，方便您随时集中精读与复习。
+                        </p>
+                        <div class="bookshelf-empty-actions">
+                            <button type="button" class="btn btn-primary" data-action="go-to-browse">
+                                📚 前往题库浏览
+                            </button>
+                        </div>
+                    </div>
+                `;
+            }
+
+            return `
+                <div class="bookshelf-empty-state">
+                    <div class="bookshelf-empty-icon">🔍</div>
+                    <h3 class="bookshelf-empty-title">未找到匹配的篇目</h3>
+                    <p class="bookshelf-empty-desc">请尝试调整搜索关键词或重置筛选条件。</p>
+                    <div class="bookshelf-empty-actions">
+                        <button type="button" class="btn btn-secondary" data-action="reset-search">
+                            重置搜索与筛选
+                        </button>
+                    </div>
+                </div>
+            `;
+        },
+
+        bindCardEvents(root) {
+            // 搜索输入监听
+            const searchInput = root.querySelector('[data-action="search-input"]');
+            if (searchInput) {
+                searchInput.addEventListener('input', (e) => {
+                    this.state.searchQuery = e.target.value;
+                    this.render();
+                    const nextInput = root.querySelector('[data-action="search-input"]');
+                    if (nextInput) {
+                        nextInput.focus();
+                        nextInput.selectionStart = nextInput.selectionEnd = nextInput.value.length;
+                    }
+                });
+            }
+
+            // 清空搜索
+            const clearBtn = root.querySelector('[data-action="clear-search"]');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    this.state.searchQuery = '';
+                    this.render();
+                });
+            }
+
+            // 排序切换
+            const sortSelect = root.querySelector('[data-action="change-sort"]');
+            if (sortSelect) {
+                sortSelect.addEventListener('change', (e) => {
+                    this.state.sortBy = e.target.value;
+                    this.render();
+                });
+            }
+
+            // 筛选切换
+            root.querySelectorAll('[data-action="set-filter"]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    this.state.filterMode = btn.dataset.mode || 'all';
+                    this.render();
+                });
+            });
+
+            // 重置搜索与筛选
+            const resetBtn = root.querySelector('[data-action="reset-search"]');
+            if (resetBtn) {
+                resetBtn.addEventListener('click', () => {
+                    this.state.searchQuery = '';
+                    this.state.filterMode = 'all';
+                    this.render();
+                });
+            }
+
+            // 返回更多工具
+            const backBtn = root.querySelector('[data-action="return-more"]');
+            if (backBtn) {
+                backBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    this.navigateToMoreView();
+                });
+            }
+
+            // 导出全部
+            const exportAllBtn = root.querySelector('[data-action="export-all-bookshelf"]');
+            if (exportAllBtn) {
+                exportAllBtn.addEventListener('click', () => {
+                    const res = ReadingBookshelfStore.exportAllBookshelfTxt();
+                    if (res) {
+                        this.showToast(`✅ 已导出 ${res.count} 个生词（${res.filename}）`);
+                    } else {
+                        this.showToast('⚠️ 书架暂无生词可导出');
+                    }
+                });
+            }
+
+            // 打开全局生词本
+            const globalNotebookBtn = root.querySelector('[data-action="open-global-notebook"]');
+            if (globalNotebookBtn) {
+                globalNotebookBtn.addEventListener('click', () => {
+                    if (global.ReadingVocabReader && typeof global.ReadingVocabReader.openModal === 'function') {
+                        global.ReadingVocabReader.openModal();
+                    } else {
+                        this.showToast('⚠️ 生词本组件正在加载...');
+                    }
+                });
+            }
+
+            // 前往题库
+            const goToBrowseBtn = root.querySelector('[data-action="go-to-browse"]');
+            if (goToBrowseBtn) {
+                goToBrowseBtn.addEventListener('click', () => {
+                    if (global.app && typeof global.app.navigateToView === 'function') {
+                        global.app.navigateToView('browse');
+                    } else if (typeof global.switchView === 'function') {
+                        global.switchView('browse');
+                    }
+                });
+            }
+
+            // 单个卡片事件代理
+            root.addEventListener('click', (e) => {
+                // 打开生词本精读
+                const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
+                if (openVocabTrigger) {
+                    const examId = openVocabTrigger.dataset.examId;
+                    this.launchExamVocabReader(examId);
+                    return;
+                }
+
+                // 打开题目练习
+                const openPracticeTrigger = e.target.closest('[data-action="open-exam-practice"]');
+                if (openPracticeTrigger) {
+                    const examId = openPracticeTrigger.dataset.examId;
+                    if (global.app && typeof global.app.openExam === 'function') {
+                        global.app.openExam(examId);
+                    } else if (typeof global.openExam === 'function') {
+                        global.openExam(examId);
+                    }
+                    return;
+                }
+
+                // 查看 PDF
+                const openPdfTrigger = e.target.closest('[data-action="open-exam-pdf"]');
+                if (openPdfTrigger) {
+                    const examId = openPdfTrigger.dataset.examId;
+                    if (typeof global.viewPDF === 'function') {
+                        global.viewPDF(examId);
+                    }
+                    return;
+                }
+
+                // 导出单篇文章生词 TXT
+                const exportTxtTrigger = e.target.closest('[data-action="export-exam-txt"]');
+                if (exportTxtTrigger) {
+                    const examId = exportTxtTrigger.dataset.examId;
+                    const examTitle = exportTxtTrigger.dataset.examTitle || '';
+                    const res = ReadingBookshelfStore.exportExamTxt(examId, examTitle);
+                    if (res) {
+                        this.showToast(`✅ 已导出：${res.filename}`);
+                    } else {
+                        this.showToast('⚠️ 该篇目暂无可导出的生词');
+                    }
+                    return;
+                }
+
+                // 移除篇目（点击拦截冒泡并弹出安全确认对话框）
+                const removeTrigger = e.target.closest('[data-action="remove-exam"]');
+                if (removeTrigger) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    const examId = removeTrigger.dataset.examId;
+                    const examTitle = removeTrigger.dataset.examTitle || examId;
+                    this.openConfirmDialog(examId, examTitle);
+                    return;
+                }
+
+                // 朗读单词
+                const speakTrigger = e.target.closest('[data-action="speak-word"]');
+                if (speakTrigger) {
+                    const word = speakTrigger.dataset.word;
+                    this.speakWord(word);
+                    return;
+                }
+            });
+        },
+
+        bindGlobalEvents() {
+            // 可在此处理全局监听
+        },
+
+        openConfirmDialog(examId, examTitle) {
+            let overlay = document.getElementById('bookshelf-confirm-dialog');
+            if (!overlay) {
+                overlay = document.createElement('div');
+                overlay.id = 'bookshelf-confirm-dialog';
+                overlay.className = 'bookshelf-confirm-overlay is-hidden';
+                overlay.innerHTML = `
+                    <div class="bookshelf-confirm-box" role="dialog" aria-modal="true">
+                        <div class="bookshelf-confirm-header">
+                            <span class="bookshelf-confirm-icon">🗑️</span>
+                            <h4 class="bookshelf-confirm-title">从书架移除篇目</h4>
+                        </div>
+                        <p class="bookshelf-confirm-msg" id="bookshelf-confirm-text"></p>
+                        <div class="bookshelf-confirm-notice">
+                            <span class="bookshelf-notice-badge">数据安全隔离</span>
+                            <p class="bookshelf-notice-text">
+                                此操作仅从<strong>书架与生词本</strong>中移除该篇收录。<br/>
+                                <strong>您的做题练习记录、答题历史与解析数据完整保留</strong>，不受任何影响。
+                            </p>
+                        </div>
+                        <div class="bookshelf-confirm-actions">
+                            <button type="button" class="btn btn-secondary bookshelf-confirm-btn" id="bookshelf-confirm-cancel">取消</button>
+                            <button type="button" class="btn btn-danger bookshelf-confirm-btn" id="bookshelf-confirm-ok">确认移除</button>
+                        </div>
+                    </div>
+                `;
+                document.body.appendChild(overlay);
+            }
+
+            const textEl = overlay.querySelector('#bookshelf-confirm-text');
+            if (textEl) {
+                textEl.textContent = `确定要从书架移除《${examTitle || examId}》吗？`;
+            }
+
+            const okBtn = overlay.querySelector('#bookshelf-confirm-ok');
+            const cancelBtn = overlay.querySelector('#bookshelf-confirm-cancel');
+
+            const closeDialog = () => {
+                overlay.classList.add('is-hidden');
+            };
+
+            okBtn.onclick = () => {
+                closeDialog();
+                // 仅删除书架与生词本记录，严格保留练习做题数据
+                ReadingBookshelfStore.removeExam(examId, true);
+                this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
+                this.render();
+            };
+
+            cancelBtn.onclick = () => {
+                closeDialog();
+            };
+
+            overlay.onclick = (e) => {
+                if (e.target === overlay) {
+                    closeDialog();
+                }
+            };
+
+            overlay.classList.remove('is-hidden');
+        },
+
+        async launchExamVocabReader(examId) {
+            if (!examId) return;
+
+            // 确保 ReadingVocabReader 依赖加载
+            if (!global.ReadingVocabReader && global.lazyLoader && typeof global.lazyLoader.ensureGroup === 'function') {
+                try {
+                    await global.lazyLoader.ensureGroup('browse-runtime');
+                } catch (e) {
+                    console.warn('[BookshelfView] 加载 browse-runtime 失败:', e);
+                }
+            }
+
+            if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+                global.ReadingVocabReader.open(examId);
+            } else if (typeof global.openReadingVocabReader === 'function') {
+                global.openReadingVocabReader(examId);
+            } else {
+                this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
+            }
+        },
+
+        speakWord(word) {
+            if (!word) return;
+            try {
+                if (window.speechSynthesis) {
+                    window.speechSynthesis.cancel();
+                    const utterance = new SpeechSynthesisUtterance(word);
+                    utterance.lang = 'en-US';
+                    utterance.rate = 0.9;
+                    window.speechSynthesis.speak(utterance);
+                }
+            } catch (e) {
+                console.warn('[BookshelfView] 发音朗读异常:', e);
+            }
+        },
+
+        navigateToMoreView() {
+            const returnTarget = this.state.fromView || 'more';
+            this.state.fromView = null;
+            const bookshelfView = document.getElementById('bookshelf-view');
+            const targetView = document.getElementById(`${returnTarget}-view`);
+
+            if (bookshelfView) {
+                bookshelfView.classList.remove('active');
+                bookshelfView.setAttribute('hidden', '');
+            }
+
+            if (global.app && typeof global.app.navigateToView === 'function') {
+                try {
+                    global.app.navigateToView(returnTarget);
+                    return;
+                } catch (err) {
+                    console.warn('[BookshelfView] navigateToView 异常:', err);
+                }
+            }
+
+            if (targetView) {
+                targetView.classList.add('active');
+                targetView.removeAttribute('hidden');
+            }
+
+            const navBtn = document.querySelector(`.nav-btn[data-view="${returnTarget}"]`);
+            if (navBtn) {
+                document.querySelectorAll('.nav-btn').forEach(btn => btn.classList.remove('active'));
+                navBtn.classList.add('active');
+            }
+        },
+
+        showToast(msg, duration = 2500) {
+            const toast = document.getElementById('bookshelf-toast');
+            if (!toast) return;
+
+            toast.textContent = msg;
+            toast.classList.remove('is-hidden');
+            toast.classList.add('is-visible');
+
+            if (this.state.toastTimer) {
+                clearTimeout(this.state.toastTimer);
+            }
+
+            this.state.toastTimer = setTimeout(() => {
+                toast.classList.remove('is-visible');
+                setTimeout(() => toast.classList.add('is-hidden'), 250);
+            }, duration);
+        },
+
+        formatFriendlyDate(timestamp) {
+            if (!timestamp) return '未记录';
+            const date = new Date(timestamp);
+            const now = new Date();
+            const diffMs = now - date;
+            const diffMin = Math.floor(diffMs / 60000);
+            const diffHours = Math.floor(diffMin / 60);
+            const diffDays = Math.floor(diffHours / 24);
+
+            if (diffMin < 2) return '刚刚';
+            if (diffMin < 60) return `${diffMin} 分钟前`;
+            if (diffHours < 24) return `${diffHours} 小时前`;
+            if (diffDays < 7) return `${diffDays} 天前`;
+
+            const y = date.getFullYear();
+            const m = String(date.getMonth() + 1).padStart(2, '0');
+            const d = String(date.getDate()).padStart(2, '0');
+            return `${y}-${m}-${d}`;
+        },
+
+        formatLatestTime(timestamp) {
+            if (!timestamp) return '暂无';
+            return this.formatFriendlyDate(timestamp);
+        },
+
+        escapeHtml(str) {
+            if (!str) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+    };
+
+    if (typeof window !== 'undefined') {
+        window.addEventListener('reading-bookshelf-store-updated', () => {
+            const root = document.querySelector(BookshelfView.containerSelector);
+            if (root && root.offsetParent !== null) {
+                BookshelfView.render();
+            }
+        });
+        window.addEventListener('reading-vocab-store-updated', () => {
+            const root = document.querySelector(BookshelfView.containerSelector);
+            if (root && root.offsetParent !== null) {
+                BookshelfView.render();
+            }
+        });
+    }
+
+    global.BookshelfView = BookshelfView;
+    ReadingBookshelfStore.init();
+})(window);
+
+
 /* ===== js/presentation/moreView.js ===== */
 (function initMoreView(global) {
     'use strict';
@@ -5249,6 +6268,7 @@
         }
 
         var clockTrigger = moreView.querySelector('[data-action="open-clock"]');
+        var bookshelfTrigger = moreView.querySelector('[data-action="open-bookshelf"]');
         var vocabTrigger = moreView.querySelector('[data-action="open-vocab"]');
         var memorizeTrigger = moreView.querySelector('[data-action="open-reading-memorize"]');
         var closeTrigger = overlay.querySelector('[data-action="close-clock"]');
@@ -5323,11 +6343,59 @@
             vocabTrigger.addEventListener('click', handleVocabEntry);
         }
 
+        if (bookshelfTrigger) {
+            bookshelfTrigger.addEventListener('click', handleBookshelfEntry);
+        }
+
         if (memorizeTrigger) {
             memorizeTrigger.addEventListener('click', handleReadingMemorizeEntry);
         }
 
         moreViewInteractionsConfigured = true;
+    }
+
+    function handleBookshelfEntry(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        var mountView = function () {
+            if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                global.BookshelfView.mount('#bookshelf-view');
+            }
+        };
+
+        var bookshelfView = document.getElementById('bookshelf-view');
+        if (bookshelfView) {
+            bookshelfView.removeAttribute('hidden');
+        }
+
+        if (global.app && typeof global.app.navigateToView === 'function') {
+            global.app.navigateToView('bookshelf');
+            var moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn) {
+                moreNavBtn.classList.add('active');
+            }
+            mountView();
+            return;
+        }
+
+        var moreView = document.getElementById('more-view');
+        if (bookshelfView && moreView) {
+            moreView.classList.remove('active');
+            bookshelfView.classList.add('active');
+            var moreNavBtn2 = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn2) {
+                moreNavBtn2.classList.add('active');
+            }
+            mountView();
+            return;
+        }
+
+        if (typeof global.showMessage === 'function') {
+            global.showMessage('未能打开阅读书架，请检查页面结构。', 'warning');
+        } else if (typeof global.alert === 'function') {
+            global.alert('未能打开阅读书架，请检查页面结构。');
+        }
     }
 
     function handleReadingMemorizeEntry(event) {
@@ -7382,6 +8450,7 @@
     "js/app/vocabListSwitcher.js",
     "js/components/vocabDashboardCards.js",
     "js/components/vocabSessionView.js",
+    "js/components/bookshelfView.js",
     "js/presentation/moreView.js",
     "js/presentation/miniGames.js",
     "js/services/achievementManager.js"

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -343,6 +343,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'
@@ -474,7 +484,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }
@@ -3834,11 +3846,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -3855,9 +3877,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -4059,6 +4094,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -4068,7 +4139,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -4093,6 +4166,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4531,6 +4605,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -4661,6 +4761,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -4992,6 +5094,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -2292,6 +2292,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -4091,43 +4095,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -4139,34 +4170,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4215,7 +4225,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -4237,6 +4253,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -4253,16 +4270,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -4606,7 +4625,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -4619,7 +4638,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -4894,6 +4913,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -5096,7 +5116,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -3972,6 +3972,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -4097,18 +4105,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -4116,6 +4125,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -4138,7 +4150,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -4227,9 +4239,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -4244,6 +4253,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -2292,6 +2292,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -4091,43 +4095,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -4139,34 +4170,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4215,7 +4225,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -4237,6 +4253,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -4253,16 +4270,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -4606,7 +4625,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -4619,7 +4638,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -4894,6 +4913,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -5096,7 +5116,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
@@ -7137,6 +7158,15 @@
     const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
     const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
 
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
         if (!examId) return;
         try {
@@ -7368,36 +7398,15 @@
                     await global.AppData.ready;
                 }
                 if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const appDataWords = await global.AppData.vocab.listReadingWords();
-                    const localWords = this.getAll();
-                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
-                        const map = new Map();
-                        localWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) map.set(key, w);
-                        });
-                        appDataWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) {
-                                if (map.has(key)) {
-                                    const existing = map.get(key);
-                                    map.set(key, Object.assign({}, existing, w, {
-                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
-                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
-                                    }));
-                                } else {
-                                    map.set(key, w);
-                                }
-                            }
-                        });
-                        const merged = Array.from(map.values());
-                        this._cache = merged;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
-                        if (merged.length !== appDataWords.length) {
-                            await global.AppData.vocab.saveReadingWords(merged);
-                        }
-                    } else if (localWords.length > 0) {
-                        await global.AppData.vocab.saveReadingWords(localWords);
+                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
+                    const appDataWords = Array.isArray(result)
+                        ? result
+                        : (result && result.envelope ? result.data : null);
+                    if (Array.isArray(appDataWords)) {
+                        // An existing AppData document owns restores, including empty lists.
+                        // An absent document may mean migration failed; preserve the local copy.
+                        this._cache = appDataWords;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
                     }
                 }
             } catch (e) {
@@ -7849,6 +7858,7 @@
         modalTab: 'current', // 'current' or 'all'
         modalOpen: false,
         toastTimer: null,
+        _openRequestId: 0,
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -8150,7 +8160,9 @@
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
                 const handleSelectionCapture = () => {
+                    const requestId = this._openRequestId;
                     setTimeout(() => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -8297,7 +8309,12 @@
             if (!examId) return;
 
             const overlay = this.ensureOverlay();
+            const requestId = ++this._openRequestId;
             this.currentExamId = examId;
+            this.currentExam = null;
+            this.currentPayload = null;
+            this.currentExplanation = null;
+            this.closeModal();
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -8323,10 +8340,16 @@
             if (badgesEl) badgesEl.innerHTML = '';
             if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
             if (questionsContent) questionsContent.innerHTML = '';
+            ['#vocab-passage-title', '#vocab-passage-intro', '#vocab-reader-tabs'].forEach(selector => {
+                const element = overlay.querySelector(selector);
+                if (element) element.textContent = '';
+            });
+            this.switchViewTab('all');
 
             try {
                 // 加载试卷数据
                 const payload = await loadReadingExamPayload(examId);
+                if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
@@ -8334,6 +8357,7 @@
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
+                    if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
@@ -8352,14 +8376,20 @@
                 this.renderContent();
                 this.updateCounts();
             } catch (err) {
+                if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
                 if (passageContent) {
-                    passageContent.innerHTML = `
-                        <div class="vocab-error-state">
-                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
-                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
-                        </div>
-                    `;
+                    const errorState = document.createElement('div');
+                    errorState.className = 'vocab-error-state';
+                    const message = document.createElement('p');
+                    message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
+                    const retry = document.createElement('button');
+                    retry.type = 'button';
+                    retry.className = 'btn btn-primary';
+                    retry.textContent = '重试';
+                    retry.addEventListener('click', () => this.open(examId, options));
+                    errorState.append(message, retry);
+                    passageContent.replaceChildren(errorState);
                 }
             }
         },
@@ -8379,8 +8409,8 @@
             }
             if (badgesEl) {
                 badgesEl.innerHTML = `
-                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
-                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                    <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
 
@@ -8938,16 +8968,16 @@
             let html = '';
             list.forEach(item => {
                 html += `
-                    <div class="vocab-item" data-word-id="${item.id}">
+                    <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
                             <div class="vocab-item__header">
-                                <span class="vocab-item__word">${item.word}</span>
-                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                                <span class="vocab-item__word">${escapeHtml(item.word)}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
-                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
-                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                            ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
-                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
                     </div>
                 `;
             });
@@ -9017,12 +9047,13 @@
         },
 
         close() {
+            ++this._openRequestId;
             const overlay = this.ensureOverlay();
             if (overlay) {
                 overlay.classList.add('is-hidden');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.modalOpen = false;
+            this.closeModal();
         }
     };
 
@@ -11314,7 +11345,12 @@
         }
     }
 
+    // Keep the practice entry unavailable until #157 isolates the reader's
+    // question controls from practice radio groups and answer collection.
+    const PRACTICE_VOCAB_READER_ENABLED = false;
+
     function openVocabReaderForCurrentExam() {
+        if (!PRACTICE_VOCAB_READER_ENABLED) return;
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
@@ -11332,6 +11368,7 @@
     }
 
     function ensureReadingVocabButton() {
+        if (!PRACTICE_VOCAB_READER_ENABLED) return null;
         let button = document.getElementById('reading-vocab-header-btn');
         if (button) return button;
         const headerRight = document.querySelector('.header-right');

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -3972,6 +3972,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -4097,18 +4105,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -4116,6 +4125,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -4138,7 +4150,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -4227,9 +4239,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -4244,6 +4253,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -343,6 +343,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'
@@ -474,7 +484,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }
@@ -3834,11 +3846,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -3855,9 +3877,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -4059,6 +4094,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -4068,7 +4139,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -4093,6 +4166,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4531,6 +4605,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -4661,6 +4761,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -4992,6 +5094,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })
@@ -7020,6 +7127,1926 @@
     };
     Object.defineProperty(api, 'ready', { enumerable: true, get: hydrateTimerPreferences });
     global.PracticeTimerPreferences = api;
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
+/* ===== js/components/readingVocabReader.js ===== */
+(function initReadingVocabReader(global) {
+    'use strict';
+
+    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
+    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+
+    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+        if (!examId) return;
+        try {
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
+                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
+                return;
+            }
+            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
+            const records = raw ? JSON.parse(raw) : [];
+            const idx = records.findIndex(r => String(r.examId) === String(examId));
+            const now = Date.now();
+            if (idx !== -1) {
+                records[idx].lastOpenedAt = now;
+                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
+                if (category && !records[idx].category) records[idx].category = category;
+            } else {
+                records.unshift({
+                    examId: String(examId),
+                    examTitle: examTitle || '',
+                    category: category || '',
+                    firstUsedAt: now,
+                    lastOpenedAt: now
+                });
+            }
+            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
+                global.ReadingBookshelfStore.syncToAppData(records);
+            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
+                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
+            }
+        } catch (e) {
+            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
+        }
+    }
+
+    // ============================================================================
+    // 生词本数据管理 (Store)
+    // ============================================================================
+    const ReadingVocabStore = {
+        _cache: null,
+        _commitBound: false,
+
+        getAll() {
+            if (this._cache) {
+                return this._cache;
+            }
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                if (raw) {
+                    const parsed = JSON.parse(raw);
+                    if (Array.isArray(parsed)) {
+                        this._cache = parsed;
+                        return this._cache;
+                    }
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 读取失败:', err);
+            }
+            this._cache = [];
+            return this._cache;
+        },
+
+        _save() {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 保存失败:', err);
+            }
+            this.syncToAppData();
+        },
+
+        async syncToAppData() {
+            try {
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
+                    await global.AppData.vocab.saveReadingWords(this._cache || []);
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
+            }
+        },
+
+        async flushToAppData() {
+            return this.syncToAppData();
+        },
+
+        getByExam(examId) {
+            if (!examId) return [];
+            const all = this.getAll();
+            return all.filter(item => String(item.examId) === String(examId));
+        },
+
+        add(rawWord, examId, examTitle, context = '', highlight = null) {
+            const word = this.cleanWord(rawWord);
+            if (!word || word.length > 50) {
+                return { added: false, reason: 'invalid_word' };
+            }
+
+            const all = this.getAll();
+            const lowerWord = word.toLowerCase();
+
+            // 检查当前文章或全局是否存在
+            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
+            if (existingIndex !== -1) {
+                const item = all[existingIndex];
+                item.updatedAt = Date.now();
+                if (examId && !item.examId) {
+                    item.examId = examId;
+                    item.examTitle = examTitle || '';
+                }
+                if (highlight) {
+                    if (!Array.isArray(item.highlights)) {
+                        item.highlights = [];
+                    }
+                    const isDup = item.highlights.some(h =>
+                        String(h.examId) === String(highlight.examId) &&
+                        String(h.scope) === String(highlight.scope) &&
+                        h.startOffset === highlight.startOffset
+                    );
+                    if (!isDup) {
+                        item.highlights.push(highlight);
+                    }
+                }
+                this._save();
+                return { added: true, item: item, isDuplicate: true };
+            }
+
+            const newItem = {
+                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                word: word,
+                examId: examId || '',
+                examTitle: examTitle || '',
+                context: context ? String(context).trim().slice(0, 150) : '',
+                createdAt: Date.now(),
+                highlights: highlight ? [highlight] : []
+            };
+
+            all.unshift(newItem);
+            this._save();
+
+            if (examId) {
+                recordBookshelfExamDirect(examId, examTitle);
+            }
+
+            return { added: true, item: newItem, isDuplicate: false };
+        },
+
+        remove(wordOrId) {
+            const all = this.getAll();
+            const target = String(wordOrId).trim().toLowerCase();
+            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
+            if (index !== -1) {
+                all.splice(index, 1);
+                this._save();
+                return true;
+            }
+            return false;
+        },
+
+        clear(examId = null) {
+            if (!examId) {
+                this._cache = [];
+                this._save();
+                return true;
+            }
+            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
+            this._save();
+            return true;
+        },
+
+        cleanWord(str) {
+            if (!str) return '';
+            return str
+                .replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '')
+                .trim();
+        },
+
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
+            const list = examId ? this.getByExam(examId) : this.getAll();
+            if (!list || list.length === 0) {
+                return false;
+            }
+
+            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
+            const words = [];
+            const seen = new Set();
+            list.forEach(item => {
+                const raw = typeof item === 'string' ? item : item?.word;
+                const w = (raw || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            let filename = customFilename;
+            if (!filename) {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const day = String(now.getDate()).padStart(2, '0');
+                const dateStr = `${year}-${month}-${day}`;
+
+                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                filename = `${dateStr}_${safeTitle}.txt`;
+            }
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return true;
+        },
+
+        async init() {
+            this.bindCommitListener();
+            try {
+                if (global.AppData && global.AppData.ready) {
+                    await global.AppData.ready;
+                }
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
+                    const appDataWords = await global.AppData.vocab.listReadingWords();
+                    const localWords = this.getAll();
+                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
+                        const map = new Map();
+                        localWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) map.set(key, w);
+                        });
+                        appDataWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) {
+                                if (map.has(key)) {
+                                    const existing = map.get(key);
+                                    map.set(key, Object.assign({}, existing, w, {
+                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
+                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
+                                    }));
+                                } else {
+                                    map.set(key, w);
+                                }
+                            }
+                        });
+                        const merged = Array.from(map.values());
+                        this._cache = merged;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
+                        if (merged.length !== appDataWords.length) {
+                            await global.AppData.vocab.saveReadingWords(merged);
+                        }
+                    } else if (localWords.length > 0) {
+                        await global.AppData.vocab.saveReadingWords(localWords);
+                    }
+                }
+            } catch (e) {
+                console.warn('[ReadingVocabStore] init failed:', e);
+            }
+        },
+
+        bindCommitListener() {
+            if (this._commitBound) return;
+            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+                this._commitBound = true;
+                global.AppData.backups.onDataCommitted(async (event) => {
+                    const targets = event && event.targets;
+                    if (!Array.isArray(targets)) return;
+                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
+                    if (hasVocab) {
+                        try {
+                            const updated = await global.AppData.vocab.listReadingWords();
+                            if (Array.isArray(updated)) {
+                                this._cache = updated;
+                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
+                            }
+                        } catch (err) {
+                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
+                        }
+                    }
+                });
+            }
+        }
+    };
+
+    // ============================================================================
+    // 语音朗读
+    // ============================================================================
+    function speakWord(word) {
+        if (!('speechSynthesis' in window) || !word) {
+            return;
+        }
+        try {
+            window.speechSynthesis.cancel();
+            const utterance = new SpeechSynthesisUtterance(word);
+            utterance.lang = 'en-US';
+            utterance.rate = 0.9;
+            window.speechSynthesis.speak(utterance);
+        } catch (e) {
+            console.warn('[ReadingVocabReader] 朗读失败:', e);
+        }
+    }
+
+    // ============================================================================
+    // 异步加载试卷与解析数据
+    // ============================================================================
+    function getExamRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXAM_DATA__ || typeof root.__READING_EXAM_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXAM_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_exam_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXAM_DATA__;
+    }
+
+    function getExplanationRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXPLANATION_DATA__ || typeof root.__READING_EXPLANATION_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXPLANATION_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_explanation_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXPLANATION_DATA__;
+    }
+
+    async function loadReadingExamPayload(examId) {
+        if (!examId) return null;
+
+        const examRegistry = getExamRegistry();
+        const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || global.__READING_EXAM_MANIFEST__ || {};
+        const entry = manifest[examId] || Object.values(manifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        // 1. 检查已注册数据
+        if (examRegistry && typeof examRegistry.get === 'function') {
+            const cached = examRegistry.get(examId) || (entry && (examRegistry.get(entry.dataKey) || examRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        // 2. 检查 manifest
+        if (!entry || !entry.script) {
+            console.warn('[ReadingVocabReader] 未找到试卷元信息:', examId);
+            return null;
+        }
+
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+        let scriptSrc;
+        if (isExamPage) {
+            scriptSrc = entry.script.startsWith('./') ? entry.script : `./${entry.script}`;
+        } else {
+            scriptSrc = `assets/generated/reading-exams/${entry.script.replace(/^\.\//, '')}`;
+        }
+
+        await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = scriptSrc;
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error('Failed to load reading exam: ' + scriptSrc));
+            document.head.appendChild(script);
+        });
+
+        const registryAfterLoad = getExamRegistry();
+        return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
+    }
+
+    async function loadReadingExplanationPayload(examId) {
+        if (!examId) return null;
+
+        const expRegistry = getExplanationRegistry();
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+
+        // 确保 explanation manifest 存在
+        if (!global.__READING_EXPLANATION_MANIFEST__ && !(typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__)) {
+            const manifestSrc = isExamPage ? '../reading-explanations/manifest.js' : 'assets/generated/reading-explanations/manifest.js';
+            try {
+                await new Promise((resolve, reject) => {
+                    const script = document.createElement('script');
+                    script.src = manifestSrc;
+                    script.onload = () => resolve();
+                    script.onerror = () => resolve();
+                    document.head.appendChild(script);
+                });
+            } catch (_) {}
+        }
+
+        const expManifest = (typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__) || global.__READING_EXPLANATION_MANIFEST__ || {};
+        const entry = expManifest[examId] || Object.values(expManifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        if (expRegistry && typeof expRegistry.get === 'function') {
+            const cached = expRegistry.get(examId) || (entry && (expRegistry.get(entry.dataKey) || expRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        if (!entry || !entry.script) {
+            return null;
+        }
+
+        try {
+            const cleanScript = entry.script.replace(/^(\.\/|\.\.\/reading-explanations\/)/, '');
+            const scriptSrc = isExamPage
+                ? `../reading-explanations/${cleanScript}`
+                : `assets/generated/reading-explanations/${cleanScript}`;
+            await new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = scriptSrc;
+                script.onload = () => resolve();
+                script.onerror = () => reject(new Error('Failed to load explanation'));
+                document.head.appendChild(script);
+            });
+            const expRegistryAfterLoad = getExplanationRegistry();
+            return expRegistryAfterLoad.get(examId) || (entry && (expRegistryAfterLoad.get(entry.dataKey) || expRegistryAfterLoad.get(entry.examId))) || null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // ============================================================================
+    // 阅读文本与段落清洗器
+    // ============================================================================
+    function cleanPassageHtml(rawHtml) {
+        if (!rawHtml) return '';
+        const temp = document.createElement('div');
+        temp.innerHTML = rawHtml;
+
+        // 移除练习交互用的 dropzone 提示与容器
+        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
+        dropzones.forEach(dz => dz.remove());
+
+        // 移除多余的空占位与 divider
+        const empties = temp.querySelectorAll('.empty-space, #divider');
+        empties.forEach(el => el.remove());
+
+        return temp.innerHTML;
+    }
+
+    /**
+     * 判断文本是否属于考试指导语/前置题目说明
+     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
+     */
+    function isPassageInstruction(text) {
+        if (!text) return false;
+        const s = text.trim();
+        if (/spend about \d+ minutes/i.test(s)) return true;
+        if (/which are based on reading passage/i.test(s)) return true;
+        if (/based on reading passage \d*/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
+        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
+        return false;
+    }
+
+    /**
+     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
+     */
+    function extractPassageData(rawHtml, fallbackTitle = '') {
+        if (!rawHtml) {
+            return {
+                passageTitle: fallbackTitle,
+                subtitleHtml: '',
+                instructionHtml: '',
+                blocks: []
+            };
+        }
+
+        const cleaned = cleanPassageHtml(rawHtml);
+        const temp = document.createElement('div');
+        temp.innerHTML = cleaned;
+
+        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
+        let passageTitle = fallbackTitle;
+        const h3 = temp.querySelector('h3');
+        if (h3 && h3.textContent.trim()) {
+            passageTitle = h3.textContent.trim();
+            h3.remove();
+        } else {
+            const h2 = temp.querySelector('h2');
+            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
+                passageTitle = h2.textContent.trim();
+                h2.remove();
+            }
+        }
+
+        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
+        const readingPassageHeadings = temp.querySelectorAll('h2');
+        readingPassageHeadings.forEach(h => {
+            if (/^reading passage/i.test(h.textContent.trim())) {
+                h.remove();
+            }
+        });
+
+        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
+        let instructionHtml = '';
+        const allPs = Array.from(temp.querySelectorAll('p'));
+        for (const p of allPs) {
+            const text = p.textContent.trim();
+            if (isPassageInstruction(text)) {
+                if (!instructionHtml) {
+                    instructionHtml = p.innerHTML.trim();
+                }
+                p.remove(); // 绝不作为正文段落，不分配任何段落标签
+            }
+        }
+
+        // 3. 提取副标题 (如 h4)
+        let subtitleHtml = '';
+        const h4 = temp.querySelector('h4');
+        if (h4 && h4.textContent.trim()) {
+            subtitleHtml = h4.innerHTML.trim();
+            h4.remove();
+        }
+
+        // 4. 解析段落 blocks
+        const blocks = [];
+        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
+
+        if (wrappers && wrappers.length > 0) {
+            wrappers.forEach((wrap, index) => {
+                // 查找段落标识 letter
+                let letter = '';
+                const strong = wrap.querySelector('strong');
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
+                    if (match) {
+                        letter = match[1];
+                    } else {
+                        letter = String.fromCharCode(65 + index);
+                    }
+                }
+
+                // 获取段落主体 HTML
+                const p = wrap.querySelector('p');
+                const html = p ? p.innerHTML : wrap.innerHTML;
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: html,
+                    text: wrap.textContent.trim()
+                });
+            });
+        } else {
+            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
+            const remainingPs = temp.querySelectorAll('p');
+            let validIdx = 0;
+            remainingPs.forEach((p) => {
+                const text = p.textContent.trim();
+                if (!text || text.length < 20) return;
+                // 防御：若依然属于指导语，跳过
+                if (isPassageInstruction(text)) return;
+
+                const strong = p.querySelector('strong');
+                let letter = '';
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
+                    if (leadMatch) {
+                        letter = leadMatch[1];
+                    } else {
+                        letter = String.fromCharCode(65 + validIdx);
+                    }
+                }
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: p.innerHTML,
+                    text: text
+                });
+                validIdx++;
+            });
+        }
+
+        return {
+            passageTitle,
+            subtitleHtml,
+            instructionHtml,
+            blocks
+        };
+    }
+
+    function extractParagraphBlocks(rawHtml) {
+        return extractPassageData(rawHtml).blocks;
+    }
+
+    function getTextNodes(root) {
+        if (!root) return [];
+        const textNodes = [];
+        const walker = document.createTreeWalker(
+            root,
+            NodeFilter.SHOW_TEXT,
+            {
+                acceptNode(node) {
+                    const parent = node.parentElement;
+                    if (!parent) return NodeFilter.FILTER_REJECT;
+                    const tag = parent.tagName.toUpperCase();
+                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+            },
+            false
+        );
+        let n;
+        while ((n = walker.nextNode())) {
+            textNodes.push(n);
+        }
+        return textNodes;
+    }
+
+    function resolveRangeFromOffsets(root, start, end) {
+        const nodes = getTextNodes(root);
+        let offset = 0;
+        let startNode = null;
+        let endNode = null;
+        let startOffset = 0;
+        let endOffset = 0;
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            const text = node.nodeValue || '';
+            const nextOffset = offset + text.length;
+            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
+                startNode = node;
+                startOffset = Math.max(0, start - offset);
+            }
+            if (!endNode && end > offset && end <= nextOffset) {
+                endNode = node;
+                endOffset = Math.max(0, end - offset);
+            }
+            if (startNode && endNode) break;
+            offset = nextOffset;
+        }
+        if (!startNode || !endNode) return null;
+        const range = document.createRange();
+        range.setStart(startNode, startOffset);
+        range.setEnd(endNode, endOffset);
+        return range;
+    }
+
+    // ============================================================================
+    // 阅读器主控制器 (ReadingVocabReader)
+    // ============================================================================
+    const ReadingVocabReader = {
+        currentExamId: null,
+        currentExam: null,
+        currentPayload: null,
+        currentExplanation: null,
+        activeTab: 'all', // 'all', 'questions', or paragraph letter e.g. 'A'
+        showTranslation: false,
+        modalTab: 'current', // 'current' or 'all'
+        modalOpen: false,
+        toastTimer: null,
+
+        ensureOverlay() {
+            let overlay = document.getElementById('reading-vocab-reader-overlay');
+            if (overlay) {
+                return overlay;
+            }
+
+            overlay = document.createElement('div');
+            overlay.id = 'reading-vocab-reader-overlay';
+            overlay.className = 'vocab-reader-overlay is-hidden';
+            overlay.setAttribute('role', 'dialog');
+            overlay.setAttribute('aria-label', '阅读生词本');
+
+            overlay.innerHTML = `
+                <div class="vocab-reader-container">
+                    <!-- 顶部吸顶导航栏 -->
+                    <header class="vocab-reader-header">
+                        <div class="vocab-reader-header__left">
+                            <button type="button" class="vocab-reader-back-btn" id="vocab-reader-back-btn" title="返回题库浏览">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+                                    <path d="M19 12H5M12 19l-7-7 7-7"/>
+                                </svg>
+                                <span>返回</span>
+                            </button>
+                            <div class="vocab-reader-title-wrap">
+                                <h2 class="vocab-reader-title" id="vocab-reader-title">阅读文章与题目</h2>
+                                <div class="vocab-reader-badges" id="vocab-reader-badges"></div>
+                            </div>
+                        </div>
+
+                        <div class="vocab-reader-header__center">
+                            <div class="vocab-reader-tabs" id="vocab-reader-tabs" role="tablist">
+                                <!-- 动态插入段落与题目标签，完全平铺陈列展开 -->
+                            </div>
+                        </div>
+                    </header>
+
+                    <!-- 沉浸式提示栏 -->
+                    <div class="vocab-reader-banner">
+                        <span class="vocab-banner-icon">✨</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                    </div>
+
+                    <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
+                    <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
+                        <!-- 阅读核心主内容区 -->
+                        <main class="vocab-reader-body" id="vocab-reader-body">
+                            <!-- 文章区域 -->
+                            <section class="vocab-passage-section" id="vocab-passage-section">
+                                <div class="vocab-passage-header">
+                                    <h3 class="vocab-passage-title" id="vocab-passage-title">Reading Passage</h3>
+                                    <div class="vocab-passage-intro" id="vocab-passage-intro"></div>
+                                </div>
+                                <div class="vocab-passage-content" id="vocab-passage-content">
+                                    <!-- 段落内容 -->
+                                </div>
+                            </section>
+
+                            <!-- 题目区域 -->
+                            <section class="vocab-questions-section" id="vocab-questions-section">
+                                <div class="vocab-questions-header">
+                                    <h3 class="vocab-questions-title">📝 题目与问题 (Questions)</h3>
+                                    <p class="vocab-questions-subtitle">题目中的生词同样支持划词自动收录</p>
+                                </div>
+                                <div class="vocab-questions-content" id="vocab-questions-content">
+                                    <!-- 题目内容 -->
+                                </div>
+                            </section>
+                        </main>
+                    </div>
+
+                    <!-- 悬浮生词本 FAB 按钮 -->
+                    <div class="vocab-fab" id="vocab-fab" role="button" tabindex="0" title="打开生词本">
+                        <span class="vocab-fab-icon">📝</span>
+                        <span class="vocab-fab-label">生词本</span>
+                        <span class="vocab-fab-count" id="vocab-fab-count">0</span>
+                    </div>
+
+                    <!-- 划词收录 Toast 提示 -->
+                    <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+
+                    <!-- 生词本弹窗 Modal -->
+                    <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
+                        <div class="vocab-modal-content">
+                            <div class="vocab-modal-header">
+                                <div class="vocab-modal-title-wrap">
+                                    <h3>📖 我的生词本</h3>
+                                    <div class="vocab-modal-tabs">
+                                        <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                    </div>
+                                </div>
+                                <div class="vocab-modal-header-actions">
+                                    <button type="button" class="vocab-modal-bookshelf-btn" id="vocab-modal-bookshelf-btn" title="查看阅读书架">📚 书架</button>
+                                    <button type="button" class="vocab-modal-close" id="vocab-modal-close" title="关闭">✖</button>
+                                </div>
+                            </div>
+
+                            <!-- 手动添加生词栏 -->
+                            <div class="vocab-modal-add-row">
+                                <input type="text" id="vocab-manual-input" placeholder="手动添加生词..." maxlength="50" />
+                                <button type="button" id="vocab-manual-add-btn">收录</button>
+                            </div>
+
+                            <!-- 生词列表 -->
+                            <div class="vocab-list" id="vocab-list">
+                                <!-- 动态插入 -->
+                            </div>
+
+                            <!-- 底部操作栏 -->
+                            <div class="vocab-modal-footer">
+                                <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
+                                    <span>⬇️ 导出为 TXT</span>
+                                </button>
+                                <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
+                                    <span>🗑️ 清空生词</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            document.body.appendChild(overlay);
+            this.bindEvents(overlay);
+            return overlay;
+        },
+
+        bindEvents(overlay) {
+            // 返回按钮
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            if (backBtn) {
+                backBtn.addEventListener('click', () => this.close());
+            }
+
+            // 开启生词本弹窗
+            const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
+            const fab = overlay.querySelector('#vocab-fab');
+            if (openModalBtn) {
+                openModalBtn.addEventListener('click', () => this.openModal());
+            }
+            if (fab) {
+                fab.addEventListener('click', () => this.openModal());
+            }
+
+            // 关闭生词本弹窗
+            const closeModalBtn = overlay.querySelector('#vocab-modal-close');
+            const modal = overlay.querySelector('#vocab-modal');
+            if (closeModalBtn) {
+                closeModalBtn.addEventListener('click', () => this.closeModal());
+            }
+            if (modal) {
+                modal.addEventListener('click', (e) => {
+                    if (e.target === modal) {
+                        this.closeModal();
+                    }
+                });
+            }
+
+            // 前往阅读书架
+            const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
+            if (bookshelfBtn) {
+                bookshelfBtn.addEventListener('click', () => {
+                    this.closeModal();
+                    this.close();
+                    if (global.opener && !global.opener.closed) {
+                        try {
+                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
+                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            }
+                            if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
+                                global.opener.app.navigateToView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            } else if (typeof global.opener.switchView === 'function') {
+                                global.opener.switchView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            }
+                        } catch (_) {}
+                    }
+                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                        global.BookshelfView.mount('#bookshelf-view');
+                    }
+                    if (global.app && typeof global.app.navigateToView === 'function') {
+                        global.app.navigateToView('bookshelf');
+                    } else if (typeof global.switchView === 'function') {
+                        global.switchView('bookshelf');
+                    }
+                });
+            }
+
+            // 生词本切换标签 (本篇 / 全部)
+            const tabCurrent = overlay.querySelector('#v-tab-current');
+            const tabAll = overlay.querySelector('#v-tab-all');
+            if (tabCurrent) {
+                tabCurrent.addEventListener('click', () => {
+                    this.modalTab = 'current';
+                    tabCurrent.classList.add('active');
+                    tabAll.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+            if (tabAll) {
+                tabAll.addEventListener('click', () => {
+                    this.modalTab = 'all';
+                    tabAll.classList.add('active');
+                    tabCurrent.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+
+            // 手动收录
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
+            const handleManualAdd = () => {
+                if (!manualInput) return;
+                const val = manualInput.value.trim();
+                if (!val) return;
+                const result = ReadingVocabStore.add(
+                    val,
+                    this.currentExamId,
+                    this.currentExam?.title || '',
+                    ''
+                );
+                if (result.added) {
+                    manualInput.value = '';
+                    this.updateCounts();
+                    this.renderVocabList();
+                    this.applyVocabHighlights(val);
+                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                }
+            };
+            if (manualAddBtn) {
+                manualAddBtn.addEventListener('click', handleManualAdd);
+            }
+            if (manualInput) {
+                manualInput.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleManualAdd();
+                    }
+                });
+            }
+
+            // 导出与清空
+            const exportBtn = overlay.querySelector('#vocab-export-btn');
+            if (exportBtn) {
+                exportBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+
+                    const now = new Date();
+                    const year = now.getFullYear();
+                    const month = String(now.getMonth() + 1).padStart(2, '0');
+                    const day = String(now.getDate()).padStart(2, '0');
+                    const dateStr = `${year}-${month}-${day}`;
+
+                    // 当前文章名字
+                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
+                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
+                    const filename = `${dateStr}_${safeArticleName}.txt`;
+
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    if (success) {
+                        this.showToast(`✅ 已导出：${filename}`);
+                    } else {
+                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    }
+                });
+            }
+
+            const clearBtn = overlay.querySelector('#vocab-clear-btn');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+                    const count = isCurrent
+                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        : ReadingVocabStore.getAll().length;
+
+                    if (count === 0) {
+                        this.showToast('生词本已经是空的了');
+                        return;
+                    }
+
+                    ReadingVocabStore.clear(examId);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    const passageContent = overlay.querySelector('#vocab-passage-content');
+                    const questionsContent = overlay.querySelector('#vocab-questions-content');
+                    this.removeVocabHighlights(passageContent);
+                    this.removeVocabHighlights(questionsContent);
+                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                });
+            }
+
+            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
+            const readerBody = overlay.querySelector('#vocab-reader-body');
+            if (readerBody) {
+                const handleSelectionCapture = () => {
+                    setTimeout(() => {
+                        const selection = window.getSelection();
+                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+                        const rawText = selection.toString();
+                        const text = rawText.trim();
+
+                        // 限制在1到45个字符之间，避免大段全文误选
+                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
+                            return;
+                        }
+
+                        let range;
+                        try {
+                            range = selection.getRangeAt(0);
+                        } catch (_) {
+                            return;
+                        }
+                        if (!range || range.collapsed) return;
+
+                        // 确保选区位于文章正文或题目区域内
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        const commonNode = range.commonAncestorContainer;
+                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
+                        if (!commonEl) return;
+                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
+                            return;
+                        }
+                        // 忽略译文卡片、段落标签、按钮等非正文区域
+                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
+                            return;
+                        }
+
+                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
+                        const existingMark = commonEl.closest('mark.vocab-highlight');
+                        if (existingMark) {
+                            return;
+                        }
+
+                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
+                        const trimmedRange = this.trimRangeWhitespace(range);
+                        if (!trimmedRange || trimmedRange.collapsed) return;
+
+                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
+                        const targetCard = commonEl.closest('.vocab-paragraph-card');
+                        const targetQGroup = commonEl.closest('.vocab-question-group');
+                        let scope = 'passage';
+                        let scopeElement = passageContent;
+
+                        if (targetCard) {
+                            const letter = targetCard.dataset.letter || '';
+                            scope = letter ? `para-${letter}` : 'passage';
+                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
+                        } else if (targetQGroup) {
+                            scope = targetQGroup.id || 'questions';
+                            scopeElement = targetQGroup;
+                        } else if (questionsContent?.contains(commonEl)) {
+                            scope = 'questions';
+                            scopeElement = questionsContent;
+                        }
+
+                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
+                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
+
+                        // 获取上下文句子
+                        let contextSentence = '';
+                        try {
+                            const parentBlock = commonEl;
+                            if (parentBlock) {
+                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
+                            }
+                        } catch (_) {}
+
+                        const cleanWord = ReadingVocabStore.cleanWord(text);
+                        if (!cleanWord) return;
+
+                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
+                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
+                        if (!wrappedMark) return;
+
+                        const highlightRecord = {
+                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                            examId: this.currentExamId || '',
+                            scope: scope,
+                            startOffset: locInfo.startOffset,
+                            endOffset: locInfo.endOffset,
+                            before: locInfo.before,
+                            after: locInfo.after,
+                            occurrence: locInfo.occurrence,
+                            text: cleanWord
+                        };
+
+                        const result = ReadingVocabStore.add(
+                            cleanWord,
+                            this.currentExamId,
+                            this.currentExam?.title || '',
+                            contextSentence,
+                            highlightRecord
+                        );
+
+                        if (result.added) {
+                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                            this.updateCounts();
+                            if (this.modalOpen) {
+                                this.renderVocabList();
+                            }
+                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        }
+                    }, 20);
+                };
+
+                readerBody.addEventListener('mouseup', handleSelectionCapture);
+                readerBody.addEventListener('touchend', handleSelectionCapture);
+
+                // 点击黄色高亮生词：朗读发音并轻量提示
+                readerBody.addEventListener('click', (e) => {
+                    const mark = e.target.closest('mark.vocab-highlight');
+                    if (mark) {
+                        const selection = window.getSelection();
+                        if (selection && selection.toString().trim().length > 0) {
+                            return; // 划选操作中不触发点击发音
+                        }
+                        const word = mark.dataset.word || mark.textContent.trim();
+                        if (word) {
+                            speakWord(word);
+                            this.showToast(`🔊 ${word} (已收录生词)`);
+                        }
+                    }
+                });
+            }
+
+            // ESC 键监听
+            window.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    if (this.modalOpen) {
+                        this.closeModal();
+                    } else if (overlay && !overlay.classList.contains('is-hidden')) {
+                        this.close();
+                    }
+                }
+            });
+        },
+
+        async open(examId, options = {}) {
+            if (!examId) return;
+
+            const overlay = this.ensureOverlay();
+            this.currentExamId = examId;
+
+            // 根据来源动态调整返回按钮提示
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            const backBtnText = overlay.querySelector('#vocab-reader-back-btn span');
+            if (options && options.fromPractice) {
+                if (backBtnText) backBtnText.textContent = '返回练习';
+                if (backBtn) backBtn.title = '返回练习试卷';
+            } else {
+                if (backBtnText) backBtnText.textContent = '返回题库';
+                if (backBtn) backBtn.title = '返回题库浏览';
+            }
+
+            // 显示加载状态
+            overlay.classList.remove('is-hidden');
+            document.body.classList.add('vocab-reader-open');
+
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            if (titleEl) titleEl.textContent = '正在加载试卷全文...';
+            if (badgesEl) badgesEl.innerHTML = '';
+            if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
+            if (questionsContent) questionsContent.innerHTML = '';
+
+            try {
+                // 加载试卷数据
+                const payload = await loadReadingExamPayload(examId);
+                if (!payload) {
+                    throw new Error('未找到该试卷的数据文件');
+                }
+                this.currentPayload = payload;
+
+                // 异步加载解析（不阻塞主内容）
+                loadReadingExplanationPayload(examId).then(exp => {
+                    this.currentExplanation = exp;
+                    this.enhanceWithExplanation(exp);
+                }).catch(() => {});
+
+                // 获取 Exam Meta
+                const manifest = global.__READING_EXAM_MANIFEST__ || {};
+                const manifestEntry = manifest[examId] || {};
+                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+
+                // 记录至阅读书架
+                const examTitle = this.currentExam.title || this.currentExam.name || examId;
+                const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
+                recordBookshelfExamDirect(examId, examTitle, examCategory);
+
+                // 渲染界面
+                this.renderContent();
+                this.updateCounts();
+            } catch (err) {
+                console.error('[ReadingVocabReader] 加载失败:', err);
+                if (passageContent) {
+                    passageContent.innerHTML = `
+                        <div class="vocab-error-state">
+                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
+                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
+                        </div>
+                    `;
+                }
+            }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+
+            // 标题与标签（紧凑精致）
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            if (titleEl) {
+                const titleText = exam.title || '阅读文章与题目';
+                titleEl.textContent = titleText;
+                titleEl.title = titleText;
+            }
+            if (badgesEl) {
+                badgesEl.innerHTML = `
+                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                `;
+            }
+
+            // 解析文章大标题、考试指导语与真实段落
+            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
+            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const blocks = passageData.blocks;
+            const instructionHtml = passageData.instructionHtml;
+            const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
+
+            // 设置文章标题
+            const passageTitleEl = overlay.querySelector('#vocab-passage-title');
+            if (passageTitleEl) {
+                passageTitleEl.textContent = passageTitle;
+            }
+
+            // 渲染前置说明指导语（如 "You should spend about 20 minutes on questions 1 to 30..."）
+            // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
+            const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
+            if (passageIntroEl) {
+                if (instructionHtml) {
+                    passageIntroEl.innerHTML = `
+                        <div class="vocab-passage-instruction" role="note">
+                            <span class="vocab-instruction-icon">📋</span>
+                            <div class="vocab-instruction-text">${instructionHtml}</div>
+                        </div>
+                    `;
+                    passageIntroEl.style.display = 'block';
+                } else if (passageData.subtitleHtml) {
+                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
+                    passageIntroEl.style.display = 'block';
+                } else {
+                    passageIntroEl.innerHTML = '';
+                    passageIntroEl.style.display = 'none';
+                }
+            }
+
+            // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
+            const tabsContainer = overlay.querySelector('#vocab-reader-tabs');
+            if (tabsContainer) {
+                let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
+                blocks.forEach(b => {
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                });
+                tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
+                tabsContainer.innerHTML = tabsHtml;
+
+                // 绑定 Tab 点击事件
+                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
+                        btn.classList.add('active');
+                        const target = btn.dataset.para;
+                        this.switchViewTab(target);
+                    });
+                });
+            }
+
+            // 渲染文章段落
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            if (passageContent) {
+                if (blocks.length > 0) {
+                    let passageHtml = '';
+                    blocks.forEach(b => {
+                        passageHtml += `
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                                <div class="vocab-paragraph-tag">
+                                    <span class="vocab-para-letter">Para ${b.letter}</span>
+                                </div>
+                                <div class="vocab-paragraph-text">${b.html}</div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                    <div class="vocab-trans-label">中文参考译文：</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                </div>
+                            </div>
+                        `;
+                    });
+                    passageContent.innerHTML = passageHtml;
+                } else {
+                    // 原生清洗后渲染
+                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                }
+            }
+
+            // 渲染题目
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            if (questionsContent) {
+                const questionGroups = payload?.questionGroups || [];
+                if (questionGroups.length > 0) {
+                    let qHtml = '';
+                    questionGroups.forEach((g, idx) => {
+                        qHtml += `
+                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
+                                ${g.bodyHtml || ''}
+                            </div>
+                        `;
+                    });
+                    questionsContent.innerHTML = qHtml;
+                } else {
+                    questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
+                }
+            }
+
+            // 如果已有解析数据，填充中文译文
+            if (this.currentExplanation) {
+                this.enhanceWithExplanation(this.currentExplanation);
+            }
+
+            // 应用生词黄色高亮
+            this.applyVocabHighlights();
+        },
+
+        trimRangeWhitespace(range) {
+            if (!range || range.collapsed) return range;
+            const startNode = range.startContainer;
+            let startOffset = range.startOffset;
+            const endNode = range.endContainer;
+            let endOffset = range.endOffset;
+
+            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
+                const text = startNode.nodeValue || '';
+                const segment = text.slice(startOffset, endOffset);
+                const leadSpace = segment.search(/\S/);
+                if (leadSpace > 0) {
+                    startOffset += leadSpace;
+                } else if (leadSpace === -1) {
+                    return null;
+                }
+                const trailSpace = segment.length - segment.trimEnd().length;
+                if (trailSpace > 0) {
+                    endOffset -= trailSpace;
+                }
+                if (endOffset <= startOffset) return null;
+
+                const trimmed = document.createRange();
+                trimmed.setStart(startNode, startOffset);
+                trimmed.setEnd(endNode, endOffset);
+                return trimmed;
+            }
+
+            if (startNode.nodeType === Node.TEXT_NODE) {
+                const text = (startNode.nodeValue || '').slice(startOffset);
+                const m = text.match(/^\s+/);
+                if (m) {
+                    range.setStart(startNode, startOffset + m[0].length);
+                }
+            }
+            if (endNode.nodeType === Node.TEXT_NODE) {
+                const text = (endNode.nodeValue || '').slice(0, endOffset);
+                const m = text.match(/\s+$/);
+                if (m) {
+                    range.setEnd(endNode, endOffset - m[0].length);
+                }
+            }
+            return range;
+        },
+
+        calculateRangeLocation(scopeElement, range, text) {
+            const textNodes = getTextNodes(scopeElement);
+            let runningOffset = 0;
+            let startOffset = -1;
+
+            for (let i = 0; i < textNodes.length; i++) {
+                const node = textNodes[i];
+                if (node === range.startContainer) {
+                    startOffset = runningOffset + range.startOffset;
+                    break;
+                }
+                runningOffset += (node.nodeValue || '').length;
+            }
+
+            if (startOffset === -1) {
+                startOffset = 0;
+            }
+
+            const endOffset = startOffset + text.length;
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
+            const after = fullText.slice(endOffset, endOffset + 30);
+
+            let occurrence = 0;
+            const lowerFull = fullText.toLowerCase();
+            const lowerWord = text.toLowerCase();
+            let idx = -1;
+            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
+                occurrence += 1;
+            }
+
+            return { startOffset, endOffset, before, after, occurrence };
+        },
+
+        wrapRangeWithHighlight(range, word) {
+            if (!range || range.collapsed) return null;
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight vocab-highlight--pulse';
+            mark.dataset.word = word;
+            mark.title = `生词本: ${word} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+            } catch (e) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                } catch (err) {
+                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
+                    return null;
+                }
+            }
+
+            setTimeout(() => {
+                mark.classList.remove('vocab-highlight--pulse');
+            }, 1500);
+
+            return mark;
+        },
+
+        applyVocabHighlights() {
+            const overlay = this.ensureOverlay();
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
+            this.removeVocabHighlights(passageContent);
+            this.removeVocabHighlights(questionsContent);
+
+            if (!this.currentExamId) return;
+
+            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            if (!examItems || examItems.length === 0) return;
+
+            examItems.forEach(item => {
+                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
+                    item.highlights.forEach(hl => {
+                        if (String(hl.examId) === String(this.currentExamId)) {
+                            this.restoreVocabHighlight(overlay, hl, item.word);
+                        }
+                    });
+                } else if (item.context && item.word) {
+                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
+                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
+                }
+            });
+        },
+
+        restoreVocabHighlight(overlay, hl, word) {
+            if (!overlay || !hl) return false;
+            let scopeElement = null;
+
+            if (hl.scope && hl.scope.startsWith('para-')) {
+                const letter = hl.scope.replace('para-', '');
+                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
+                if (card) {
+                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
+                }
+            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
+                scopeElement = overlay.querySelector(`#${hl.scope}`);
+            } else if (hl.scope === 'questions') {
+                scopeElement = overlay.querySelector('#vocab-questions-content');
+            } else {
+                scopeElement = overlay.querySelector('#vocab-passage-content');
+            }
+
+            if (!scopeElement) {
+                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
+            }
+            if (!scopeElement) return false;
+
+            const range = this.resolveRangeForHighlight(scopeElement, hl);
+            if (!range || range.collapsed) return false;
+
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight';
+            mark.dataset.word = word || hl.text;
+            mark.title = `生词本: ${word || hl.text} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+                return true;
+            } catch (_) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+        },
+
+        resolveRangeForHighlight(root, hl) {
+            if (!root || !hl) return null;
+            const textNodes = getTextNodes(root);
+            if (!textNodes.length) return null;
+
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const targetText = String(hl.text || '').trim();
+            if (!targetText) return null;
+
+            const startOffset = Number(hl.startOffset);
+            const endOffset = Number(hl.endOffset);
+
+            // 1. 优先尝试 offset 精确匹配
+            if (
+                Number.isFinite(startOffset) &&
+                Number.isFinite(endOffset) &&
+                endOffset > startOffset &&
+                startOffset >= 0 &&
+                endOffset <= fullText.length
+            ) {
+                const segment = fullText.slice(startOffset, endOffset);
+                if (segment.toLowerCase() === targetText.toLowerCase()) {
+                    return resolveRangeFromOffsets(root, startOffset, endOffset);
+                }
+            }
+
+            // 2. 次优：使用 before / after 上下文精确定位单处实例
+            if (hl.before || hl.after) {
+                let searchPos = 0;
+                let matchIdx = -1;
+                let bestIdx = -1;
+                let bestScore = -1;
+                const lowerFull = fullText.toLowerCase();
+                const lowerTarget = targetText.toLowerCase();
+
+                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
+                    let score = 0;
+                    if (hl.before) {
+                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
+                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
+                            score += 3;
+                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (hl.after) {
+                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
+                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
+                            score += 3;
+                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (score > bestScore) {
+                        bestScore = score;
+                        bestIdx = matchIdx;
+                    }
+                    searchPos = matchIdx + 1;
+                }
+
+                if (bestIdx !== -1 && bestScore > 0) {
+                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
+                }
+            }
+
+            // 3. 兜底：使用 occurrence（第 N 次出现）
+            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
+            let currentOccurrence = 0;
+            let pos = 0;
+            let matchPos = -1;
+            const lowerFull = fullText.toLowerCase();
+            const lowerTarget = targetText.toLowerCase();
+
+            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
+                if (currentOccurrence === occurrence) {
+                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
+                }
+                currentOccurrence += 1;
+                pos = matchPos + 1;
+            }
+
+            return null;
+        },
+
+        restoreLegacyHighlightByContext(overlay, word, context) {
+            if (!overlay || !word) return false;
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            const roots = [passageContent, questionsContent].filter(Boolean);
+
+            const targetWord = String(word).trim();
+            const lowerWord = targetWord.toLowerCase();
+            const lowerContext = String(context || '').trim().toLowerCase();
+
+            for (const root of roots) {
+                const textNodes = getTextNodes(root);
+                const fullText = textNodes.map(n => n.nodeValue || '').join('');
+                const lowerFull = fullText.toLowerCase();
+
+                let targetIdx = -1;
+                if (lowerContext && lowerFull.includes(lowerContext)) {
+                    const ctxIdx = lowerFull.indexOf(lowerContext);
+                    const wordInCtx = lowerContext.indexOf(lowerWord);
+                    if (wordInCtx !== -1) {
+                        targetIdx = ctxIdx + wordInCtx;
+                    }
+                }
+
+                // 无论如何，只恢复单处实例，绝不全篇高亮
+                if (targetIdx !== -1) {
+                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
+                    if (range && !range.collapsed) {
+                        const mark = document.createElement('mark');
+                        mark.className = 'vocab-highlight';
+                        mark.dataset.word = targetWord;
+                        mark.title = `生词本: ${targetWord} (点击发音)`;
+                        try {
+                            range.surroundContents(mark);
+                            return true;
+                        } catch (_) {
+                            try {
+                                const frag = range.extractContents();
+                                mark.appendChild(frag);
+                                range.insertNode(mark);
+                                return true;
+                            } catch (e) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        },
+
+        removeVocabHighlights(container) {
+            if (!container) return;
+            const marks = container.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const parent = mark.parentNode;
+                if (parent) {
+                    while (mark.firstChild) {
+                        parent.insertBefore(mark.firstChild, mark);
+                    }
+                    parent.removeChild(mark);
+                    parent.normalize();
+                }
+            });
+        },
+
+        removeVocabHighlightForWord(word) {
+            const overlay = this.ensureOverlay();
+            if (!overlay || !word) return;
+            const lower = String(word).trim().toLowerCase();
+            const marks = overlay.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const markWord = (mark.dataset.word || mark.textContent || '').trim().toLowerCase();
+                if (markWord === lower) {
+                    const parent = mark.parentNode;
+                    if (parent) {
+                        while (mark.firstChild) {
+                            parent.insertBefore(mark.firstChild, mark);
+                        }
+                        parent.removeChild(mark);
+                        parent.normalize();
+                    }
+                }
+            });
+        },
+
+        enhanceWithExplanation(explanation) {
+            if (!explanation || !Array.isArray(explanation.passageNotes)) return;
+            const overlay = this.ensureOverlay();
+            explanation.passageNotes.forEach(note => {
+                const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
+                if (match) {
+                    const letter = match[1].toUpperCase();
+                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    if (transEl) {
+                        transEl.textContent = note.text || '';
+                    }
+                }
+            });
+        },
+
+        switchViewTab(target) {
+            const overlay = this.ensureOverlay();
+            const passageSection = overlay.querySelector('#vocab-passage-section');
+            const questionsSection = overlay.querySelector('#vocab-questions-section');
+            const cards = overlay.querySelectorAll('.vocab-paragraph-card');
+            const scrollArea = overlay.querySelector('#vocab-reader-scroll-area');
+
+            if (target === 'all') {
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'block';
+                cards.forEach(c => c.style.display = 'block');
+                if (scrollArea && typeof scrollArea.scrollTo === 'function') {
+                    scrollArea.scrollTo({ top: 0, behavior: 'smooth' });
+                } else if (passageSection) {
+                    passageSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else if (target === 'questions') {
+                if (passageSection) passageSection.style.display = 'none';
+                if (questionsSection) {
+                    questionsSection.style.display = 'block';
+                    questionsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else {
+                // 单个段落展示
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'none';
+                cards.forEach(c => {
+                    if (c.dataset.letter === target) {
+                        c.style.display = 'block';
+                        c.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    } else {
+                        c.style.display = 'none';
+                    }
+                });
+            }
+        },
+
+        updateCounts() {
+            const overlay = this.ensureOverlay();
+            const examId = this.currentExamId;
+            const currentList = ReadingVocabStore.getByExam(examId);
+            const allList = ReadingVocabStore.getAll();
+
+            const headerCount = overlay.querySelector('#vocab-header-count');
+            const fabCount = overlay.querySelector('#vocab-fab-count');
+            const tabCurrentCount = overlay.querySelector('#v-count-current');
+            const tabAllCount = overlay.querySelector('#v-count-all');
+
+            const countToShow = currentList.length;
+            if (headerCount) headerCount.textContent = countToShow;
+            if (fabCount) fabCount.textContent = countToShow;
+            if (tabCurrentCount) tabCurrentCount.textContent = currentList.length;
+            if (tabAllCount) tabAllCount.textContent = allList.length;
+        },
+
+        renderVocabList() {
+            const overlay = this.ensureOverlay();
+            const listEl = overlay.querySelector('#vocab-list');
+            if (!listEl) return;
+
+            const isCurrent = this.modalTab === 'current';
+            const list = isCurrent
+                ? ReadingVocabStore.getByExam(this.currentExamId)
+                : ReadingVocabStore.getAll();
+
+            if (!list || list.length === 0) {
+                listEl.innerHTML = `
+                    <div class="vocab-empty-box">
+                        <div class="vocab-empty-icon">📝</div>
+                        <p class="vocab-empty-title">生词本是空的哦~</p>
+                        <p class="vocab-empty-desc">在文章或题目中划选任意英文单词，即可自动收入此生词本。</p>
+                    </div>
+                `;
+                return;
+            }
+
+            let html = '';
+            list.forEach(item => {
+                html += `
+                    <div class="vocab-item" data-word-id="${item.id}">
+                        <div class="vocab-item__main">
+                            <div class="vocab-item__header">
+                                <span class="vocab-item__word">${item.word}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                            </div>
+                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                        </div>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                    </div>
+                `;
+            });
+
+            listEl.innerHTML = html;
+
+            // 绑定发音与删除
+            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    speakWord(btn.dataset.speakWord);
+                });
+            });
+
+            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const id = btn.dataset.delId;
+                    const allItems = ReadingVocabStore.getAll();
+                    const item = allItems.find(w => w.id === id);
+                    const word = item?.word;
+                    ReadingVocabStore.remove(id);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    if (word) {
+                        this.removeVocabHighlightForWord(word);
+                    }
+                    this.showToast('已从生词本删除');
+                });
+            });
+        },
+
+        openModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = true;
+                this.updateCounts();
+                this.renderVocabList();
+                modal.classList.add('active');
+                modal.setAttribute('aria-hidden', 'false');
+            }
+        },
+
+        closeModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = false;
+                modal.classList.remove('active');
+                modal.setAttribute('aria-hidden', 'true');
+            }
+        },
+
+        showToast(msg) {
+            const overlay = this.ensureOverlay();
+            const toast = overlay.querySelector('#vocab-toast');
+            if (!toast) return;
+
+            toast.textContent = msg;
+            toast.classList.add('show');
+
+            clearTimeout(this.toastTimer);
+            this.toastTimer = setTimeout(() => {
+                toast.classList.remove('show');
+            }, 2000);
+        },
+
+        close() {
+            const overlay = this.ensureOverlay();
+            if (overlay) {
+                overlay.classList.add('is-hidden');
+            }
+            document.body.classList.remove('vocab-reader-open');
+            this.modalOpen = false;
+        }
+    };
+
+    // 监听生词更新事件以即时刷新打开的视图
+    if (typeof window !== 'undefined') {
+        window.addEventListener('reading-vocab-store-updated', () => {
+            if (ReadingVocabReader.modalOpen) {
+                ReadingVocabReader.renderVocabList();
+                ReadingVocabReader.updateCounts();
+                ReadingVocabReader.applyVocabHighlights();
+            }
+        });
+    }
+
+    // 暴露全局命名空间
+    global.ReadingVocabStore = ReadingVocabStore;
+    global.ReadingVocabReader = ReadingVocabReader;
+    global.openReadingVocabReader = function(examId, options = {}) {
+        ReadingVocabReader.open(examId, options);
+    };
+
+    // 启动数据同步初始化
+    ReadingVocabStore.init();
+
 })(typeof window !== 'undefined' ? window : globalThis);
 
 
@@ -9185,6 +11212,150 @@
             // Dismiss the Options overlay if it happens to be open.
             closeFloatingPanels();
             toggleNotesDrawer();
+        });
+        return button;
+    }
+
+    function ensureVocabReaderStyles() {
+        if (!document.getElementById('vocab-reader-stylesheet')) {
+            const link = document.createElement('link');
+            link.id = 'vocab-reader-stylesheet';
+            link.rel = 'stylesheet';
+            link.href = '../../../css/vocab-reader.css';
+            document.head.appendChild(link);
+        }
+        if (!document.getElementById('reading-vocab-button-styles')) {
+            const style = document.createElement('style');
+            style.id = 'reading-vocab-button-styles';
+            style.textContent = `
+                .reading-vocab-btn {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 4px;
+                    padding: 7px 11px;
+                    font-size: 0.88rem;
+                    line-height: 1;
+                    color: var(--text);
+                    background: var(--panel);
+                    border: 1px solid var(--line);
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: all 0.15s ease;
+                    user-select: none;
+                }
+                .reading-vocab-btn:hover {
+                    background: #f1f5f9;
+                    border-color: #94a3b8;
+                }
+                body.dark-mode .reading-vocab-btn {
+                    background: #1e293b;
+                    border-color: #475569;
+                    color: #cbd5e1;
+                }
+                body.dark-mode .reading-vocab-btn:hover {
+                    background: #334155;
+                    border-color: #64748b;
+                    color: #f8fafc;
+                }
+                .reading-vocab-btn .vocab-btn-icon {
+                    font-size: 13px;
+                    line-height: 1;
+                }
+                .reading-vocab-btn .vocab-btn-label {
+                    font-size: 0.88rem;
+                }
+                .results-header-bar {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 12px;
+                    margin-bottom: 8px;
+                    flex-wrap: wrap;
+                }
+                .results-header-bar h4 {
+                    margin: 0;
+                }
+                .results-score-text {
+                    margin: 4px 0 0 0;
+                    color: var(--muted, #64748b);
+                    font-size: 0.95rem;
+                }
+                .results-vocab-btn {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 7px 14px;
+                    font-size: 0.88rem;
+                    font-weight: 600;
+                    color: #1d4ed8;
+                    background: #eff6ff;
+                    border: 1px solid #bfdbfe;
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: all 0.15s ease;
+                }
+                .results-vocab-btn:hover {
+                    background: #dbeafe;
+                    border-color: #93c5fd;
+                    transform: translateY(-1px);
+                    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.12);
+                }
+                body.dark-mode .results-vocab-btn {
+                    color: #93c5fd;
+                    background: rgba(30, 58, 138, 0.35);
+                    border-color: rgba(96, 165, 250, 0.4);
+                }
+                body.dark-mode .results-vocab-btn:hover {
+                    background: rgba(30, 58, 138, 0.6);
+                    border-color: #60a5fa;
+                }
+            `;
+            document.head.appendChild(style);
+        }
+    }
+
+    function openVocabReaderForCurrentExam() {
+        const examId = state.suite?.activeExamId || state.examId;
+        if (!examId) {
+            console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
+            return;
+        }
+        ensureVocabReaderStyles();
+
+        if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+            global.ReadingVocabReader.open(examId, { fromPractice: true });
+        } else if (typeof global.openReadingVocabReader === 'function') {
+            global.openReadingVocabReader(examId, { fromPractice: true });
+        } else {
+            console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
+        }
+    }
+
+    function ensureReadingVocabButton() {
+        let button = document.getElementById('reading-vocab-header-btn');
+        if (button) return button;
+        const headerRight = document.querySelector('.header-right');
+        if (!headerRight) return null;
+        ensureVocabReaderStyles();
+
+        button = document.createElement('button');
+        button.id = 'reading-vocab-header-btn';
+        button.type = 'button';
+        button.className = 'header-btn reading-vocab-btn';
+        button.title = '划词生词本 (段落精读与单词记录)';
+        button.setAttribute('aria-label', '打开划词生词本');
+        button.innerHTML = '<span class="vocab-btn-icon" aria-hidden="true">📖</span><span class="vocab-btn-label">生词本</span>';
+
+        const notesBtn = document.getElementById('notes-drawer-btn');
+        if (notesBtn && notesBtn.parentNode === headerRight) {
+            headerRight.insertBefore(button, notesBtn.nextSibling);
+        } else {
+            headerRight.insertBefore(button, headerRight.firstChild);
+        }
+
+        button.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openVocabReaderForCurrentExam();
         });
         return button;
     }
@@ -12717,8 +14888,16 @@
             `;
         }).join('');
         dom.results.innerHTML = `
-            <h4>答题结果</h4>
-            <p>得分 ${results.scoreInfo.correct} / ${results.scoreInfo.totalQuestions} · ${results.scoreInfo.percentage}%</p>
+            <div class="results-header-bar">
+                <div class="results-header-summary">
+                    <h4>答题结果</h4>
+                    <p class="results-score-text">得分 ${results.scoreInfo.correct} / ${results.scoreInfo.totalQuestions} · ${results.scoreInfo.percentage}%</p>
+                </div>
+                <button type="button" class="results-vocab-btn" id="results-vocab-btn" title="进入划词生词本模式（段落精读、查词发音、加入生词本）">
+                    <span class="results-vocab-icon" aria-hidden="true">📖</span>
+                    <span>划词生词本</span>
+                </button>
+            </div>
             <table class="results-table">
                 <thead>
                     <tr>
@@ -12735,6 +14914,13 @@
         dom.results.querySelectorAll?.('[data-result-question-id]').forEach((button) => {
             button.addEventListener('click', () => jumpToQuestionEvidence(button.dataset.resultQuestionId || ''));
         });
+        const resultsVocabBtn = dom.results.querySelector('#results-vocab-btn');
+        if (resultsVocabBtn) {
+            resultsVocabBtn.addEventListener('click', () => {
+                openVocabReaderForCurrentExam();
+            });
+        }
+        ensureReadingVocabButton();
         applyResultsToQuestionArea(results);
     }
 
@@ -15356,6 +17542,7 @@
         attachUnifiedTimer();
         attachUnifiedPanels();
         ensureReadingNotesUi();
+        ensureReadingVocabButton();
         ensureReadingDisplayControls();
         await loadReadingDisplayPreferences();
         attachSelectionHighlightToolbar();
@@ -15406,6 +17593,7 @@
     "js/core/dictionaryService.js",
     "js/runtime/reviewHighlightDictionary.js",
     "js/utils/practiceTimerPreferences.js",
+    "js/components/readingVocabReader.js",
     "js/runtime/unifiedReadingPage.js"
 ]);
     }

--- a/js/bundles/runtime-entry.bundle.js
+++ b/js/bundles/runtime-entry.bundle.js
@@ -2388,10 +2388,58 @@
         startRandomPractice: startRandomPractice,
         // Phase 4
         startEndlessPractice: startEndlessPractice,
-        stopEndlessPractice: stopEndlessPractice
+        stopEndlessPractice: stopEndlessPractice,
+        openBookshelf: openBookshelf
     });
 
+    function openBookshelf(options) {
+        var fromView = (options && options.fromView) || 'overview';
+        return Promise.resolve().then(function () {
+            if (global.AppEntry && typeof global.AppEntry.ensureMoreToolsGroup === 'function') {
+                return global.AppEntry.ensureMoreToolsGroup();
+            }
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                return global.AppLazyLoader.ensureGroup('more-tools');
+            }
+            return null;
+        }).then(function () {
+            var bookshelfView = document.getElementById('bookshelf-view');
+            if (bookshelfView) {
+                bookshelfView.removeAttribute('hidden');
+            }
+            if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                global.BookshelfView.mount('#bookshelf-view', { fromView: fromView });
+            }
+            if (global.app && typeof global.app.navigateToView === 'function') {
+                global.app.navigateToView('bookshelf');
+            } else if (typeof global.switchView === 'function') {
+                global.switchView('bookshelf');
+            }
+            var allViews = document.querySelectorAll('.view');
+            for (var i = 0; i < allViews.length; i++) {
+                allViews[i].classList.remove('active');
+            }
+            if (bookshelfView) {
+                bookshelfView.classList.add('active');
+            }
+            var allNavBtns = document.querySelectorAll('.nav-btn');
+            for (var j = 0; j < allNavBtns.length; j++) {
+                allNavBtns[j].classList.remove('active');
+            }
+            var moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn) {
+                moreNavBtn.classList.add('active');
+            }
+        }).catch(function (error) {
+            console.warn('[AppActions] 打开书架失败:', error);
+            if (typeof global.showMessage === 'function') {
+                global.showMessage('未能打开阅读书架，请稍后重试。', 'warning');
+            }
+        });
+    }
+
     // 挂载到全局（向后兼容）
+    global.openBookshelfView = openBookshelf;
     global.startSuitePractice = startSuitePractice;
     global.continueSuitePractice = continueSuitePractice;
     global.openExamWithFallback = openExamWithFallback;

--- a/js/bundles/ui-shell.bundle.js
+++ b/js/bundles/ui-shell.bundle.js
@@ -656,6 +656,23 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 }
             });
 
+            this.events.delegate('click', `${this.containerSelector} [data-action="open-bookshelf"], ${this.containerSelector} [data-action="open-vocab-book"]`, function (event) {
+                event.preventDefault();
+                if (typeof global.openBookshelfView === 'function') {
+                    global.openBookshelfView({ fromView: 'overview' });
+                    return;
+                }
+                if (global.AppActions && typeof global.AppActions.openBookshelf === 'function') {
+                    global.AppActions.openBookshelf({ fromView: 'overview' });
+                    return;
+                }
+                if (global.app && typeof global.app.navigateToView === 'function') {
+                    global.app.navigateToView('bookshelf');
+                } else if (typeof global.switchView === 'function') {
+                    global.switchView('bookshelf');
+                }
+            });
+
             this.delegatesBound = true;
         }
 
@@ -679,7 +696,7 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 icon: '📖',
                 entries: stats?.reading || [],
                 style: { gridColumn: '1 / -1' },
-                rightButtons: [this.createEndlessModeButton(), this.createSuiteModeButton()]
+                rightButtons: [this.createBookshelfButton(), this.createEndlessModeButton(), this.createSuiteModeButton()]
             });
 
             fragment.appendChild(readingSection);
@@ -870,6 +887,31 @@ console.log('[DOM] DOM工具库已加载，统一事件委托、DOM创建和样�
                 this.createSvgIcon('<path d="M20 6v5h-5"></path><path d="M4 18v-5h5"></path><path d="M6.2 11a6 6 0 0 1 10.6-2.4L20 11"></path><path d="M17.8 13a6 6 0 0 1-10.6 2.4L4 13"></path>'),
                 this.dom.create('span', {}, '无尽模式')
             ]);
+        }
+
+        createBookshelfButton() {
+            return this.dom.create('button', {
+                className: 'shui-glass-btn',
+                type: 'button',
+                id: 'bookshelf-overview-btn',
+                dataset: {
+                    action: 'open-bookshelf',
+                    overviewAction: 'bookshelf'
+                },
+                title: '打开阅读书架',
+                style: {
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px'
+                }
+            }, [
+                this.createSvgIcon('<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>'),
+                this.dom.create('span', {}, '书架')
+            ]);
+        }
+
+        createVocabBookButton() {
+            return this.createBookshelfButton();
         }
     }
 

--- a/js/components/bookshelfView.js
+++ b/js/components/bookshelfView.js
@@ -1,0 +1,1016 @@
+(function initBookshelfView(global) {
+    'use strict';
+
+    const BOOKSHELF_KEY = 'ielts_reading_bookshelf_exams_v1';
+    const VOCAB_KEY = 'ielts_reading_vocab_words_v1';
+
+    // ============================================================================
+    // 书架数据管理 (ReadingBookshelfStore)
+    // ============================================================================
+    const ReadingBookshelfStore = {
+        _commitBound: false,
+
+        getRawRecords() {
+            try {
+                const raw = localStorage.getItem(BOOKSHELF_KEY);
+                return raw ? JSON.parse(raw) : [];
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 读取书架记录失败:', e);
+                return [];
+            }
+        },
+
+        saveRecords(records) {
+            try {
+                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(records || []));
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 保存书架记录失败:', e);
+            }
+            this.syncToAppData(records);
+        },
+
+        async syncToAppData(records) {
+            try {
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
+                    await global.AppData.vocab.saveReadingBookshelfExams(records || this.getRawRecords());
+                }
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] syncToAppData failed:', e);
+            }
+        },
+
+        async flushToAppData() {
+            return this.syncToAppData(this.getRawRecords());
+        },
+
+        async init() {
+            this.bindCommitListener();
+            try {
+                if (global.AppData && global.AppData.ready) {
+                    await global.AppData.ready;
+                }
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
+                    const appDataRecords = await global.AppData.vocab.listReadingBookshelfExams();
+                    const localRecords = this.getRawRecords();
+                    if (Array.isArray(appDataRecords) && appDataRecords.length > 0) {
+                        const map = new Map();
+                        localRecords.forEach(r => {
+                            const eid = String(r && (r.examId || r.id) || '').trim();
+                            if (eid) map.set(eid, r);
+                        });
+                        appDataRecords.forEach(r => {
+                            const eid = String(r && (r.examId || r.id) || '').trim();
+                            if (eid) {
+                                if (map.has(eid)) {
+                                    const existing = map.get(eid);
+                                    map.set(eid, Object.assign({}, existing, r, {
+                                        firstUsedAt: Math.min(Number(existing.firstUsedAt) || Date.now(), Number(r.firstUsedAt) || Date.now()),
+                                        lastOpenedAt: Math.max(Number(existing.lastOpenedAt) || 0, Number(r.lastOpenedAt) || 0)
+                                    }));
+                                } else {
+                                    map.set(eid, r);
+                                }
+                            }
+                        });
+                        const merged = Array.from(map.values());
+                        try { localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(merged)); } catch (_) {}
+                        if (merged.length !== appDataRecords.length) {
+                            await global.AppData.vocab.saveReadingBookshelfExams(merged);
+                        }
+                    } else if (localRecords.length > 0) {
+                        await global.AppData.vocab.saveReadingBookshelfExams(localRecords);
+                    }
+                }
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] init failed:', e);
+            }
+        },
+
+        bindCommitListener() {
+            if (this._commitBound) return;
+            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+                this._commitBound = true;
+                global.AppData.backups.onDataCommitted(async (event) => {
+                    const targets = event && event.targets;
+                    if (!Array.isArray(targets)) return;
+                    const hasBookshelf = targets.some(t => t.logicalKey === 'vocab.readingBookshelfExams');
+                    if (hasBookshelf) {
+                        try {
+                            const updated = await global.AppData.vocab.listReadingBookshelfExams();
+                            if (Array.isArray(updated)) {
+                                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(updated));
+                                window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail: { records: updated } }));
+                            }
+                        } catch (err) {
+                            console.warn('[ReadingBookshelfStore] reload on committed failed:', err);
+                        }
+                    }
+                });
+            }
+        },
+
+        recordExamUsed(examId, examTitle = '', category = '') {
+            if (!examId) return;
+            try {
+                const records = this.getRawRecords();
+                const now = Date.now();
+                const idx = records.findIndex(r => String(r.examId) === String(examId));
+                if (idx !== -1) {
+                    records[idx].lastOpenedAt = now;
+                    if (examTitle && !records[idx].examTitle) {
+                        records[idx].examTitle = examTitle;
+                    }
+                    if (category && !records[idx].category) {
+                        records[idx].category = category;
+                    }
+                } else {
+                    records.unshift({
+                        examId: String(examId),
+                        examTitle: examTitle || '',
+                        category: category || '',
+                        firstUsedAt: now,
+                        lastOpenedAt: now
+                    });
+                }
+                this.saveRecords(records);
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 记录题目失败:', e);
+            }
+        },
+
+        getBookshelfExams() {
+            // 1. 读取全部生词
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            // 统计生词数据映射
+            const vocabMap = new Map();
+            vocabWords.forEach(item => {
+                if (!item || !item.examId) return;
+                const eid = String(item.examId);
+                if (!vocabMap.has(eid)) {
+                    vocabMap.set(eid, {
+                        count: 0,
+                        words: [],
+                        latestTime: item.createdAt || 0,
+                        examTitle: item.examTitle || ''
+                    });
+                }
+                const group = vocabMap.get(eid);
+                group.count++;
+                if (group.words.length < 6 && item.word) {
+                    group.words.push(item.word);
+                }
+                if (item.createdAt && item.createdAt > group.latestTime) {
+                    group.latestTime = item.createdAt;
+                }
+                if (!group.examTitle && item.examTitle) {
+                    group.examTitle = item.examTitle;
+                }
+            });
+
+            // 2. 读取书架记录
+            const records = this.getRawRecords();
+            const recordMap = new Map();
+            records.forEach(r => {
+                if (r && r.examId) {
+                    recordMap.set(String(r.examId), r);
+                }
+            });
+
+            // 3. 读取全局 Manifest 题库元信息
+            const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || {};
+
+            // 4. 合并集合（记录过的题目 + 拥有生词的题目）
+            const allExamIds = new Set([...recordMap.keys(), ...vocabMap.keys()]);
+            const results = [];
+
+            allExamIds.forEach(examId => {
+                const rec = recordMap.get(examId) || {};
+                const vocab = vocabMap.get(examId) || { count: 0, words: [], latestTime: 0, examTitle: '' };
+                const meta = manifest[examId] || {};
+
+                const title = rec.examTitle || vocab.examTitle || meta.title || meta.name || examId;
+                const category = rec.category || meta.category || meta.type || '雅思阅读';
+                const lastActivity = Math.max(rec.lastOpenedAt || 0, vocab.latestTime || 0, rec.firstUsedAt || 0);
+
+                results.push({
+                    examId: examId,
+                    title: title,
+                    category: category,
+                    wordCount: vocab.count,
+                    sampleWords: vocab.words,
+                    lastActivityAt: lastActivity || Date.now(),
+                    hasPdf: Boolean(meta.pdfPath || meta.pdf)
+                });
+            });
+
+            // 默认按最后活动时间倒序排序
+            results.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+            return results;
+        },
+
+        removeExam(examId, alsoDeleteWords = true) {
+            try {
+                const targetExamId = String(examId).trim();
+                if (!targetExamId) return false;
+
+                // 1. 从书架记录中移除篇目
+                const records = this.getRawRecords().filter(r => String(r.examId || r.id).trim() !== targetExamId);
+                this.saveRecords(records);
+
+                // 2. 仅删除该篇目下的生词本记录（严格与做题练习记录隔离）
+                if (alsoDeleteWords) {
+                    // 若全局内存中存在 ReadingVocabStore，同步调用 clear
+                    if (global.ReadingVocabStore && typeof global.ReadingVocabStore.clear === 'function') {
+                        try {
+                            global.ReadingVocabStore.clear(targetExamId);
+                        } catch (err) {
+                            console.warn('[ReadingBookshelfStore] ReadingVocabStore.clear 失败:', err);
+                        }
+                    }
+
+                    // 持久化存储过滤生词
+                    let vocabWords = [];
+                    const raw = localStorage.getItem(VOCAB_KEY);
+                    if (raw) {
+                        try { vocabWords = JSON.parse(raw); } catch (_) {}
+                    }
+                    const filtered = vocabWords.filter(w => String(w.examId).trim() !== targetExamId);
+                    try {
+                        localStorage.setItem(VOCAB_KEY, JSON.stringify(filtered));
+                    } catch (e) {
+                        console.warn('[ReadingBookshelfStore] 保存过滤生词失败:', e);
+                    }
+
+                    // 同步到 AppData.vocab
+                    if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
+                        global.AppData.vocab.saveReadingWords(filtered).catch(err => {
+                            console.warn('[ReadingBookshelfStore] 同步生词删除至 AppData 失败:', err);
+                        });
+                    }
+
+                    // 广播生词变更事件，通知所有打开的阅读器及组件
+                    try {
+                        window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', {
+                            detail: { examId: targetExamId, action: 'clear-exam-vocab' }
+                        }));
+                    } catch (_) {}
+                }
+
+                // 3. 严格数据隔离：绝不触碰任何做题练习记录（做题历史、得分记录、错题记录等完整保留）
+
+                // 4. 广播书架更新事件
+                try {
+                    window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', {
+                        detail: { examId: targetExamId, action: 'remove-exam' }
+                    }));
+                } catch (_) {}
+
+                return true;
+            } catch (e) {
+                console.warn('[ReadingBookshelfStore] 移除题目失败:', e);
+                return false;
+            }
+        },
+
+        exportExamTxt(examId, examTitle) {
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            const examWords = vocabWords.filter(item => String(item.examId) === String(examId));
+            if (examWords.length === 0) {
+                return false;
+            }
+
+            const words = [];
+            const seen = new Set();
+            examWords.forEach(item => {
+                const w = (typeof item === 'string' ? item : item?.word || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            const dateStr = `${year}-${month}-${day}`;
+
+            const rawTitle = examTitle || examWords[0]?.examTitle || examId || '阅读生词本';
+            const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+            const filename = `${dateStr}_${safeTitle}.txt`;
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return { filename, count: words.length };
+        },
+
+        exportAllBookshelfTxt() {
+            let vocabWords = [];
+            try {
+                const raw = localStorage.getItem(VOCAB_KEY);
+                if (raw) vocabWords = JSON.parse(raw);
+            } catch (e) {}
+
+            if (vocabWords.length === 0) {
+                return false;
+            }
+
+            const words = [];
+            const seen = new Set();
+            vocabWords.forEach(item => {
+                const w = (typeof item === 'string' ? item : item?.word || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            const dateStr = `${year}-${month}-${day}`;
+            const filename = `${dateStr}_书架全部阅读生词.txt`;
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return { filename, count: words.length };
+        }
+    };
+
+    global.ReadingBookshelfStore = ReadingBookshelfStore;
+
+    // ============================================================================
+    // 书架视图控制器 (BookshelfView)
+    // ============================================================================
+    const BookshelfView = {
+        containerSelector: '#bookshelf-root',
+        state: {
+            searchQuery: '',
+            sortBy: 'recent', // 'recent' | 'words' | 'title'
+            filterMode: 'all', // 'all' | 'has-words'
+            fromView: null,
+            toastTimer: null
+        },
+
+        mount(targetSelector = '#bookshelf-view', options = {}) {
+            if (options && options.fromView) {
+                this.state.fromView = options.fromView;
+            }
+            const viewElement = document.querySelector(targetSelector);
+            if (!viewElement) return;
+
+            let root = viewElement.querySelector(this.containerSelector);
+            if (!root) {
+                root = document.createElement('div');
+                root.id = 'bookshelf-root';
+                root.className = 'bookshelf-view-shell';
+                viewElement.appendChild(root);
+            }
+
+            this.render();
+            this.bindGlobalEvents();
+        },
+
+        render() {
+            const root = document.querySelector(this.containerSelector);
+            if (!root) return;
+
+            const allExams = ReadingBookshelfStore.getBookshelfExams();
+            const totalWords = allExams.reduce((sum, item) => sum + item.wordCount, 0);
+
+            // 过滤与搜索
+            let filtered = allExams.slice();
+            if (this.state.searchQuery) {
+                const q = this.state.searchQuery.toLowerCase().trim();
+                filtered = filtered.filter(item => {
+                    const matchTitle = (item.title || '').toLowerCase().includes(q);
+                    const matchCategory = (item.category || '').toLowerCase().includes(q);
+                    const matchWords = (item.sampleWords || []).some(w => w.toLowerCase().includes(q));
+                    return matchTitle || matchCategory || matchWords;
+                });
+            }
+
+            if (this.state.filterMode === 'has-words') {
+                filtered = filtered.filter(item => item.wordCount > 0);
+            }
+
+            // 排序
+            if (this.state.sortBy === 'recent') {
+                filtered.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+            } else if (this.state.sortBy === 'words') {
+                filtered.sort((a, b) => b.wordCount - a.wordCount);
+            } else if (this.state.sortBy === 'title') {
+                filtered.sort((a, b) => a.title.localeCompare(b.title));
+            }
+
+            const isFromOverview = this.state.fromView === 'overview';
+            const backBtnTitle = isFromOverview ? '返回学习总览' : '返回更多工具';
+            const backBtnText = isFromOverview ? '返回总览' : '返回更多';
+
+            root.innerHTML = `
+                <div class="bookshelf-layout">
+                    <!-- 顶部标题栏与导航 -->
+                    <div class="bookshelf-topbar">
+                        <div class="bookshelf-topbar__left">
+                            <button type="button" class="btn btn-secondary bookshelf-back-btn" data-action="return-more" title="${backBtnTitle}">
+                                <span class="bookshelf-back-arrow">←</span>
+                                <span>${backBtnText}</span>
+                            </button>
+                            <div class="bookshelf-heading-group">
+                                <h2 class="bookshelf-title">📚 阅读书架</h2>
+                                <p class="bookshelf-subtitle">收录使用过生词本的精读篇目，温故知新，查缺补漏</p>
+                            </div>
+                        </div>
+                        <div class="bookshelf-topbar__right">
+                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="一键导出书架全部生词为 TXT">
+                                📥 导出全部生词
+                            </button>
+                            <button type="button" class="btn btn-primary bookshelf-notebook-btn" data-action="open-global-notebook" title="打开生词本总览">
+                                📖 打开生词本
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- 统计数据横幅 -->
+                    <div class="bookshelf-stats-banner">
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">📖</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${allExams.length}</span>
+                                <span class="bookshelf-stat-label">收录篇目</span>
+                            </div>
+                        </div>
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">🔤</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${totalWords}</span>
+                                <span class="bookshelf-stat-label">积累生词</span>
+                            </div>
+                        </div>
+                        <div class="bookshelf-stat-card">
+                            <span class="bookshelf-stat-icon">🕒</span>
+                            <div class="bookshelf-stat-content">
+                                <span class="bookshelf-stat-value">${this.formatLatestTime(allExams[0]?.lastActivityAt)}</span>
+                                <span class="bookshelf-stat-label">最近精读</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 检索与筛选工具条 -->
+                    <div class="bookshelf-toolbar">
+                        <div class="bookshelf-search-box">
+                            <span class="bookshelf-search-icon">🔍</span>
+                            <input
+                                type="text"
+                                class="bookshelf-search-input"
+                                placeholder="搜索篇目名称、分类或单词..."
+                                value="${this.escapeHtml(this.state.searchQuery)}"
+                                data-action="search-input"
+                            />
+                            ${this.state.searchQuery ? '<button type="button" class="bookshelf-search-clear" data-action="clear-search" title="清空搜索">×</button>' : ''}
+                        </div>
+
+                        <div class="bookshelf-filter-group">
+                            <div class="bookshelf-segmented">
+                                <button type="button" class="bookshelf-segment-btn ${this.state.filterMode === 'all' ? 'active' : ''}" data-action="set-filter" data-mode="all">
+                                    全部 (${allExams.length})
+                                </button>
+                                <button type="button" class="bookshelf-segment-btn ${this.state.filterMode === 'has-words' ? 'active' : ''}" data-action="set-filter" data-mode="has-words">
+                                    有生词 (${allExams.filter(e => e.wordCount > 0).length})
+                                </button>
+                            </div>
+
+                            <div class="bookshelf-sort-select-wrapper">
+                                <select class="bookshelf-sort-select" data-action="change-sort">
+                                    <option value="recent" ${this.state.sortBy === 'recent' ? 'selected' : ''}>🕒 最近学习</option>
+                                    <option value="words" ${this.state.sortBy === 'words' ? 'selected' : ''}>🔥 生词最多</option>
+                                    <option value="title" ${this.state.sortBy === 'title' ? 'selected' : ''}>🔤 篇目名称</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 篇目卡片网格 -->
+                    <div class="bookshelf-content-area">
+                        ${filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
+                    </div>
+                </div>
+
+                <!-- 操作轻量反馈浮层 (Toast) -->
+                <div id="bookshelf-toast" class="bookshelf-toast is-hidden" role="status" aria-live="polite"></div>
+            `;
+
+            this.bindCardEvents(root);
+        },
+
+        renderCardGrid(exams) {
+            return `
+                <div class="bookshelf-grid">
+                    ${exams.map(exam => this.renderExamCard(exam)).join('')}
+                </div>
+            `;
+        },
+
+        renderExamCard(exam) {
+            const formattedTime = this.formatFriendlyDate(exam.lastActivityAt);
+            const wordsList = exam.sampleWords || [];
+
+            return `
+                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}">
+                    <div class="bookshelf-card__header">
+                        <div class="bookshelf-card__tags">
+                            <span class="bookshelf-card__badge bookshelf-card__badge--category">${this.escapeHtml(exam.category || '雅思阅读')}</span>
+                            ${exam.wordCount > 0
+                                ? `<span class="bookshelf-card__badge bookshelf-card__badge--vocab">🔥 ${exam.wordCount} 个生词</span>`
+                                : `<span class="bookshelf-card__badge bookshelf-card__badge--read">📖 已入精读</span>`
+                            }
+                        </div>
+                        <button type="button" class="bookshelf-card__remove-btn" data-action="remove-exam" data-exam-id="${this.escapeHtml(exam.examId)}" data-exam-title="${this.escapeHtml(exam.title)}" title="从书架移除（仅移出生词本，保留做题练习数据）">
+                            🗑️
+                        </button>
+                    </div>
+
+                    <div class="bookshelf-card__body">
+                        <h3 class="bookshelf-card__title" data-action="open-reading-vocab" data-exam-id="${this.escapeHtml(exam.examId)}" title="点击进入全文精读与生词本">
+                            ${this.escapeHtml(exam.title)}
+                        </h3>
+                        <div class="bookshelf-card__meta">
+                            <span class="bookshelf-card__time">🕒 ${formattedTime}</span>
+                        </div>
+
+                        <!-- 生词预览药丸标签 -->
+                        <div class="bookshelf-card__vocab-preview">
+                            ${wordsList.length > 0 ? `
+                                <div class="bookshelf-vocab-chips">
+                                    ${wordsList.map(w => `
+                                        <button type="button" class="bookshelf-vocab-chip" data-action="speak-word" data-word="${this.escapeHtml(w)}" title="点击朗读发音">
+                                            <span>${this.escapeHtml(w)}</span>
+                                            <span class="bookshelf-chip-audio">🔊</span>
+                                        </button>
+                                    `).join('')}
+                                    ${exam.wordCount > wordsList.length ? `<span class="bookshelf-vocab-chip-more">+${exam.wordCount - wordsList.length}</span>` : ''}
+                                </div>
+                            ` : `
+                                <p class="bookshelf-vocab-empty-hint">暂未划词收录，可在全文中自由选词加入生词本</p>
+                            `}
+                        </div>
+                    </div>
+
+                    <!-- 卡片操作底栏 -->
+                    <div class="bookshelf-card__footer">
+                        <button type="button" class="btn btn-primary bookshelf-action-btn bookshelf-action-btn--main" data-action="open-reading-vocab" data-exam-id="${this.escapeHtml(exam.examId)}" title="进入划词与生词本">
+                            📖 划词
+                        </button>
+                        <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="open-exam-practice" data-exam-id="${this.escapeHtml(exam.examId)}">
+                            📝 做题
+                        </button>
+                        ${exam.hasPdf ? `
+                            <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="open-exam-pdf" data-exam-id="${this.escapeHtml(exam.examId)}">
+                                📄 PDF
+                            </button>
+                        ` : ''}
+                        <button type="button" class="btn btn-secondary bookshelf-action-btn" data-action="export-exam-txt" data-exam-id="${this.escapeHtml(exam.examId)}" data-exam-title="${this.escapeHtml(exam.title)}" ${exam.wordCount === 0 ? 'disabled' : ''} title="导出本篇生词 TXT">
+                            📥 导出
+                        </button>
+                    </div>
+                </div>
+            `;
+        },
+
+        renderEmptyState(isCompletelyEmpty) {
+            if (isCompletelyEmpty) {
+                return `
+                    <div class="bookshelf-empty-state">
+                        <div class="bookshelf-empty-icon">📚</div>
+                        <h3 class="bookshelf-empty-title">书架尚未收录篇目</h3>
+                        <p class="bookshelf-empty-desc">
+                            在「题库浏览」中点击任意阅读题目的「精读」，或在阅读过程中划词收录生词，篇目将自动收录至此，方便您随时集中精读与复习。
+                        </p>
+                        <div class="bookshelf-empty-actions">
+                            <button type="button" class="btn btn-primary" data-action="go-to-browse">
+                                📚 前往题库浏览
+                            </button>
+                        </div>
+                    </div>
+                `;
+            }
+
+            return `
+                <div class="bookshelf-empty-state">
+                    <div class="bookshelf-empty-icon">🔍</div>
+                    <h3 class="bookshelf-empty-title">未找到匹配的篇目</h3>
+                    <p class="bookshelf-empty-desc">请尝试调整搜索关键词或重置筛选条件。</p>
+                    <div class="bookshelf-empty-actions">
+                        <button type="button" class="btn btn-secondary" data-action="reset-search">
+                            重置搜索与筛选
+                        </button>
+                    </div>
+                </div>
+            `;
+        },
+
+        bindCardEvents(root) {
+            // 搜索输入监听
+            const searchInput = root.querySelector('[data-action="search-input"]');
+            if (searchInput) {
+                searchInput.addEventListener('input', (e) => {
+                    this.state.searchQuery = e.target.value;
+                    this.render();
+                    const nextInput = root.querySelector('[data-action="search-input"]');
+                    if (nextInput) {
+                        nextInput.focus();
+                        nextInput.selectionStart = nextInput.selectionEnd = nextInput.value.length;
+                    }
+                });
+            }
+
+            // 清空搜索
+            const clearBtn = root.querySelector('[data-action="clear-search"]');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    this.state.searchQuery = '';
+                    this.render();
+                });
+            }
+
+            // 排序切换
+            const sortSelect = root.querySelector('[data-action="change-sort"]');
+            if (sortSelect) {
+                sortSelect.addEventListener('change', (e) => {
+                    this.state.sortBy = e.target.value;
+                    this.render();
+                });
+            }
+
+            // 筛选切换
+            root.querySelectorAll('[data-action="set-filter"]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    this.state.filterMode = btn.dataset.mode || 'all';
+                    this.render();
+                });
+            });
+
+            // 重置搜索与筛选
+            const resetBtn = root.querySelector('[data-action="reset-search"]');
+            if (resetBtn) {
+                resetBtn.addEventListener('click', () => {
+                    this.state.searchQuery = '';
+                    this.state.filterMode = 'all';
+                    this.render();
+                });
+            }
+
+            // 返回更多工具
+            const backBtn = root.querySelector('[data-action="return-more"]');
+            if (backBtn) {
+                backBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    this.navigateToMoreView();
+                });
+            }
+
+            // 导出全部
+            const exportAllBtn = root.querySelector('[data-action="export-all-bookshelf"]');
+            if (exportAllBtn) {
+                exportAllBtn.addEventListener('click', () => {
+                    const res = ReadingBookshelfStore.exportAllBookshelfTxt();
+                    if (res) {
+                        this.showToast(`✅ 已导出 ${res.count} 个生词（${res.filename}）`);
+                    } else {
+                        this.showToast('⚠️ 书架暂无生词可导出');
+                    }
+                });
+            }
+
+            // 打开全局生词本
+            const globalNotebookBtn = root.querySelector('[data-action="open-global-notebook"]');
+            if (globalNotebookBtn) {
+                globalNotebookBtn.addEventListener('click', () => {
+                    if (global.ReadingVocabReader && typeof global.ReadingVocabReader.openModal === 'function') {
+                        global.ReadingVocabReader.openModal();
+                    } else {
+                        this.showToast('⚠️ 生词本组件正在加载...');
+                    }
+                });
+            }
+
+            // 前往题库
+            const goToBrowseBtn = root.querySelector('[data-action="go-to-browse"]');
+            if (goToBrowseBtn) {
+                goToBrowseBtn.addEventListener('click', () => {
+                    if (global.app && typeof global.app.navigateToView === 'function') {
+                        global.app.navigateToView('browse');
+                    } else if (typeof global.switchView === 'function') {
+                        global.switchView('browse');
+                    }
+                });
+            }
+
+            // 单个卡片事件代理
+            root.addEventListener('click', (e) => {
+                // 打开生词本精读
+                const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
+                if (openVocabTrigger) {
+                    const examId = openVocabTrigger.dataset.examId;
+                    this.launchExamVocabReader(examId);
+                    return;
+                }
+
+                // 打开题目练习
+                const openPracticeTrigger = e.target.closest('[data-action="open-exam-practice"]');
+                if (openPracticeTrigger) {
+                    const examId = openPracticeTrigger.dataset.examId;
+                    if (global.app && typeof global.app.openExam === 'function') {
+                        global.app.openExam(examId);
+                    } else if (typeof global.openExam === 'function') {
+                        global.openExam(examId);
+                    }
+                    return;
+                }
+
+                // 查看 PDF
+                const openPdfTrigger = e.target.closest('[data-action="open-exam-pdf"]');
+                if (openPdfTrigger) {
+                    const examId = openPdfTrigger.dataset.examId;
+                    if (typeof global.viewPDF === 'function') {
+                        global.viewPDF(examId);
+                    }
+                    return;
+                }
+
+                // 导出单篇文章生词 TXT
+                const exportTxtTrigger = e.target.closest('[data-action="export-exam-txt"]');
+                if (exportTxtTrigger) {
+                    const examId = exportTxtTrigger.dataset.examId;
+                    const examTitle = exportTxtTrigger.dataset.examTitle || '';
+                    const res = ReadingBookshelfStore.exportExamTxt(examId, examTitle);
+                    if (res) {
+                        this.showToast(`✅ 已导出：${res.filename}`);
+                    } else {
+                        this.showToast('⚠️ 该篇目暂无可导出的生词');
+                    }
+                    return;
+                }
+
+                // 移除篇目（点击拦截冒泡并弹出安全确认对话框）
+                const removeTrigger = e.target.closest('[data-action="remove-exam"]');
+                if (removeTrigger) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    const examId = removeTrigger.dataset.examId;
+                    const examTitle = removeTrigger.dataset.examTitle || examId;
+                    this.openConfirmDialog(examId, examTitle);
+                    return;
+                }
+
+                // 朗读单词
+                const speakTrigger = e.target.closest('[data-action="speak-word"]');
+                if (speakTrigger) {
+                    const word = speakTrigger.dataset.word;
+                    this.speakWord(word);
+                    return;
+                }
+            });
+        },
+
+        bindGlobalEvents() {
+            // 可在此处理全局监听
+        },
+
+        openConfirmDialog(examId, examTitle) {
+            let overlay = document.getElementById('bookshelf-confirm-dialog');
+            if (!overlay) {
+                overlay = document.createElement('div');
+                overlay.id = 'bookshelf-confirm-dialog';
+                overlay.className = 'bookshelf-confirm-overlay is-hidden';
+                overlay.innerHTML = `
+                    <div class="bookshelf-confirm-box" role="dialog" aria-modal="true">
+                        <div class="bookshelf-confirm-header">
+                            <span class="bookshelf-confirm-icon">🗑️</span>
+                            <h4 class="bookshelf-confirm-title">从书架移除篇目</h4>
+                        </div>
+                        <p class="bookshelf-confirm-msg" id="bookshelf-confirm-text"></p>
+                        <div class="bookshelf-confirm-notice">
+                            <span class="bookshelf-notice-badge">数据安全隔离</span>
+                            <p class="bookshelf-notice-text">
+                                此操作仅从<strong>书架与生词本</strong>中移除该篇收录。<br/>
+                                <strong>您的做题练习记录、答题历史与解析数据完整保留</strong>，不受任何影响。
+                            </p>
+                        </div>
+                        <div class="bookshelf-confirm-actions">
+                            <button type="button" class="btn btn-secondary bookshelf-confirm-btn" id="bookshelf-confirm-cancel">取消</button>
+                            <button type="button" class="btn btn-danger bookshelf-confirm-btn" id="bookshelf-confirm-ok">确认移除</button>
+                        </div>
+                    </div>
+                `;
+                document.body.appendChild(overlay);
+            }
+
+            const textEl = overlay.querySelector('#bookshelf-confirm-text');
+            if (textEl) {
+                textEl.textContent = `确定要从书架移除《${examTitle || examId}》吗？`;
+            }
+
+            const okBtn = overlay.querySelector('#bookshelf-confirm-ok');
+            const cancelBtn = overlay.querySelector('#bookshelf-confirm-cancel');
+
+            const closeDialog = () => {
+                overlay.classList.add('is-hidden');
+            };
+
+            okBtn.onclick = () => {
+                closeDialog();
+                // 仅删除书架与生词本记录，严格保留练习做题数据
+                ReadingBookshelfStore.removeExam(examId, true);
+                this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
+                this.render();
+            };
+
+            cancelBtn.onclick = () => {
+                closeDialog();
+            };
+
+            overlay.onclick = (e) => {
+                if (e.target === overlay) {
+                    closeDialog();
+                }
+            };
+
+            overlay.classList.remove('is-hidden');
+        },
+
+        async launchExamVocabReader(examId) {
+            if (!examId) return;
+
+            // 确保 ReadingVocabReader 依赖加载
+            if (!global.ReadingVocabReader && global.lazyLoader && typeof global.lazyLoader.ensureGroup === 'function') {
+                try {
+                    await global.lazyLoader.ensureGroup('browse-runtime');
+                } catch (e) {
+                    console.warn('[BookshelfView] 加载 browse-runtime 失败:', e);
+                }
+            }
+
+            if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+                global.ReadingVocabReader.open(examId);
+            } else if (typeof global.openReadingVocabReader === 'function') {
+                global.openReadingVocabReader(examId);
+            } else {
+                this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
+            }
+        },
+
+        speakWord(word) {
+            if (!word) return;
+            try {
+                if (window.speechSynthesis) {
+                    window.speechSynthesis.cancel();
+                    const utterance = new SpeechSynthesisUtterance(word);
+                    utterance.lang = 'en-US';
+                    utterance.rate = 0.9;
+                    window.speechSynthesis.speak(utterance);
+                }
+            } catch (e) {
+                console.warn('[BookshelfView] 发音朗读异常:', e);
+            }
+        },
+
+        navigateToMoreView() {
+            const returnTarget = this.state.fromView || 'more';
+            this.state.fromView = null;
+            const bookshelfView = document.getElementById('bookshelf-view');
+            const targetView = document.getElementById(`${returnTarget}-view`);
+
+            if (bookshelfView) {
+                bookshelfView.classList.remove('active');
+                bookshelfView.setAttribute('hidden', '');
+            }
+
+            if (global.app && typeof global.app.navigateToView === 'function') {
+                try {
+                    global.app.navigateToView(returnTarget);
+                    return;
+                } catch (err) {
+                    console.warn('[BookshelfView] navigateToView 异常:', err);
+                }
+            }
+
+            if (targetView) {
+                targetView.classList.add('active');
+                targetView.removeAttribute('hidden');
+            }
+
+            const navBtn = document.querySelector(`.nav-btn[data-view="${returnTarget}"]`);
+            if (navBtn) {
+                document.querySelectorAll('.nav-btn').forEach(btn => btn.classList.remove('active'));
+                navBtn.classList.add('active');
+            }
+        },
+
+        showToast(msg, duration = 2500) {
+            const toast = document.getElementById('bookshelf-toast');
+            if (!toast) return;
+
+            toast.textContent = msg;
+            toast.classList.remove('is-hidden');
+            toast.classList.add('is-visible');
+
+            if (this.state.toastTimer) {
+                clearTimeout(this.state.toastTimer);
+            }
+
+            this.state.toastTimer = setTimeout(() => {
+                toast.classList.remove('is-visible');
+                setTimeout(() => toast.classList.add('is-hidden'), 250);
+            }, duration);
+        },
+
+        formatFriendlyDate(timestamp) {
+            if (!timestamp) return '未记录';
+            const date = new Date(timestamp);
+            const now = new Date();
+            const diffMs = now - date;
+            const diffMin = Math.floor(diffMs / 60000);
+            const diffHours = Math.floor(diffMin / 60);
+            const diffDays = Math.floor(diffHours / 24);
+
+            if (diffMin < 2) return '刚刚';
+            if (diffMin < 60) return `${diffMin} 分钟前`;
+            if (diffHours < 24) return `${diffHours} 小时前`;
+            if (diffDays < 7) return `${diffDays} 天前`;
+
+            const y = date.getFullYear();
+            const m = String(date.getMonth() + 1).padStart(2, '0');
+            const d = String(date.getDate()).padStart(2, '0');
+            return `${y}-${m}-${d}`;
+        },
+
+        formatLatestTime(timestamp) {
+            if (!timestamp) return '暂无';
+            return this.formatFriendlyDate(timestamp);
+        },
+
+        escapeHtml(str) {
+            if (!str) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+    };
+
+    if (typeof window !== 'undefined') {
+        window.addEventListener('reading-bookshelf-store-updated', () => {
+            const root = document.querySelector(BookshelfView.containerSelector);
+            if (root && root.offsetParent !== null) {
+                BookshelfView.render();
+            }
+        });
+        window.addEventListener('reading-vocab-store-updated', () => {
+            const root = document.querySelector(BookshelfView.containerSelector);
+            if (root && root.offsetParent !== null) {
+                BookshelfView.render();
+            }
+        });
+    }
+
+    global.BookshelfView = BookshelfView;
+    ReadingBookshelfStore.init();
+})(window);

--- a/js/components/bookshelfView.js
+++ b/js/components/bookshelfView.js
@@ -50,35 +50,14 @@
                     await global.AppData.ready;
                 }
                 if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
-                    const appDataRecords = await global.AppData.vocab.listReadingBookshelfExams();
-                    const localRecords = this.getRawRecords();
-                    if (Array.isArray(appDataRecords) && appDataRecords.length > 0) {
-                        const map = new Map();
-                        localRecords.forEach(r => {
-                            const eid = String(r && (r.examId || r.id) || '').trim();
-                            if (eid) map.set(eid, r);
-                        });
-                        appDataRecords.forEach(r => {
-                            const eid = String(r && (r.examId || r.id) || '').trim();
-                            if (eid) {
-                                if (map.has(eid)) {
-                                    const existing = map.get(eid);
-                                    map.set(eid, Object.assign({}, existing, r, {
-                                        firstUsedAt: Math.min(Number(existing.firstUsedAt) || Date.now(), Number(r.firstUsedAt) || Date.now()),
-                                        lastOpenedAt: Math.max(Number(existing.lastOpenedAt) || 0, Number(r.lastOpenedAt) || 0)
-                                    }));
-                                } else {
-                                    map.set(eid, r);
-                                }
-                            }
-                        });
-                        const merged = Array.from(map.values());
-                        try { localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(merged)); } catch (_) {}
-                        if (merged.length !== appDataRecords.length) {
-                            await global.AppData.vocab.saveReadingBookshelfExams(merged);
-                        }
-                    } else if (localRecords.length > 0) {
-                        await global.AppData.vocab.saveReadingBookshelfExams(localRecords);
+                    const result = await global.AppData.vocab.listReadingBookshelfExams({ withMeta: true });
+                    const appDataRecords = Array.isArray(result) ? result : result && result.envelope && result.data;
+                    // AppData owns legacy migration. Its restored collection,
+                    // including an empty array, replaces the local display mirror.
+                    // An absent envelope can mean migration failed; retain its
+                    // only legacy copy instead of treating the default [] as a clear.
+                    if (Array.isArray(appDataRecords)) {
+                        localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(appDataRecords));
                     }
                 }
             } catch (e) {

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -4,6 +4,15 @@
     const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
     const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
 
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
         if (!examId) return;
         try {
@@ -235,36 +244,15 @@
                     await global.AppData.ready;
                 }
                 if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const appDataWords = await global.AppData.vocab.listReadingWords();
-                    const localWords = this.getAll();
-                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
-                        const map = new Map();
-                        localWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) map.set(key, w);
-                        });
-                        appDataWords.forEach(w => {
-                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
-                            if (key) {
-                                if (map.has(key)) {
-                                    const existing = map.get(key);
-                                    map.set(key, Object.assign({}, existing, w, {
-                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
-                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
-                                    }));
-                                } else {
-                                    map.set(key, w);
-                                }
-                            }
-                        });
-                        const merged = Array.from(map.values());
-                        this._cache = merged;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
-                        if (merged.length !== appDataWords.length) {
-                            await global.AppData.vocab.saveReadingWords(merged);
-                        }
-                    } else if (localWords.length > 0) {
-                        await global.AppData.vocab.saveReadingWords(localWords);
+                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
+                    const appDataWords = Array.isArray(result)
+                        ? result
+                        : (result && result.envelope ? result.data : null);
+                    if (Array.isArray(appDataWords)) {
+                        // An existing AppData document owns restores, including empty lists.
+                        // An absent document may mean migration failed; preserve the local copy.
+                        this._cache = appDataWords;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
                     }
                 }
             } catch (e) {
@@ -716,6 +704,7 @@
         modalTab: 'current', // 'current' or 'all'
         modalOpen: false,
         toastTimer: null,
+        _openRequestId: 0,
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -1017,7 +1006,9 @@
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
                 const handleSelectionCapture = () => {
+                    const requestId = this._openRequestId;
                     setTimeout(() => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -1164,7 +1155,12 @@
             if (!examId) return;
 
             const overlay = this.ensureOverlay();
+            const requestId = ++this._openRequestId;
             this.currentExamId = examId;
+            this.currentExam = null;
+            this.currentPayload = null;
+            this.currentExplanation = null;
+            this.closeModal();
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -1190,10 +1186,16 @@
             if (badgesEl) badgesEl.innerHTML = '';
             if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
             if (questionsContent) questionsContent.innerHTML = '';
+            ['#vocab-passage-title', '#vocab-passage-intro', '#vocab-reader-tabs'].forEach(selector => {
+                const element = overlay.querySelector(selector);
+                if (element) element.textContent = '';
+            });
+            this.switchViewTab('all');
 
             try {
                 // 加载试卷数据
                 const payload = await loadReadingExamPayload(examId);
+                if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
@@ -1201,6 +1203,7 @@
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
+                    if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
@@ -1219,14 +1222,20 @@
                 this.renderContent();
                 this.updateCounts();
             } catch (err) {
+                if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
                 if (passageContent) {
-                    passageContent.innerHTML = `
-                        <div class="vocab-error-state">
-                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
-                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
-                        </div>
-                    `;
+                    const errorState = document.createElement('div');
+                    errorState.className = 'vocab-error-state';
+                    const message = document.createElement('p');
+                    message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
+                    const retry = document.createElement('button');
+                    retry.type = 'button';
+                    retry.className = 'btn btn-primary';
+                    retry.textContent = '重试';
+                    retry.addEventListener('click', () => this.open(examId, options));
+                    errorState.append(message, retry);
+                    passageContent.replaceChildren(errorState);
                 }
             }
         },
@@ -1246,8 +1255,8 @@
             }
             if (badgesEl) {
                 badgesEl.innerHTML = `
-                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
-                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                    <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
 
@@ -1805,16 +1814,16 @@
             let html = '';
             list.forEach(item => {
                 html += `
-                    <div class="vocab-item" data-word-id="${item.id}">
+                    <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
                             <div class="vocab-item__header">
-                                <span class="vocab-item__word">${item.word}</span>
-                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                                <span class="vocab-item__word">${escapeHtml(item.word)}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
-                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
-                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                            ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
-                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
                     </div>
                 `;
             });
@@ -1884,12 +1893,13 @@
         },
 
         close() {
+            ++this._openRequestId;
             const overlay = this.ensureOverlay();
             if (overlay) {
                 overlay.classList.add('is-hidden');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.modalOpen = false;
+            this.closeModal();
         }
     };
 

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -1,0 +1,1917 @@
+(function initReadingVocabReader(global) {
+    'use strict';
+
+    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
+    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+
+    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+        if (!examId) return;
+        try {
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
+                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
+                return;
+            }
+            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
+            const records = raw ? JSON.parse(raw) : [];
+            const idx = records.findIndex(r => String(r.examId) === String(examId));
+            const now = Date.now();
+            if (idx !== -1) {
+                records[idx].lastOpenedAt = now;
+                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
+                if (category && !records[idx].category) records[idx].category = category;
+            } else {
+                records.unshift({
+                    examId: String(examId),
+                    examTitle: examTitle || '',
+                    category: category || '',
+                    firstUsedAt: now,
+                    lastOpenedAt: now
+                });
+            }
+            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
+            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
+                global.ReadingBookshelfStore.syncToAppData(records);
+            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
+                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
+            }
+        } catch (e) {
+            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
+        }
+    }
+
+    // ============================================================================
+    // 生词本数据管理 (Store)
+    // ============================================================================
+    const ReadingVocabStore = {
+        _cache: null,
+        _commitBound: false,
+
+        getAll() {
+            if (this._cache) {
+                return this._cache;
+            }
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                if (raw) {
+                    const parsed = JSON.parse(raw);
+                    if (Array.isArray(parsed)) {
+                        this._cache = parsed;
+                        return this._cache;
+                    }
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 读取失败:', err);
+            }
+            this._cache = [];
+            return this._cache;
+        },
+
+        _save() {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
+            } catch (err) {
+                console.warn('[ReadingVocabStore] 保存失败:', err);
+            }
+            this.syncToAppData();
+        },
+
+        async syncToAppData() {
+            try {
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
+                    await global.AppData.vocab.saveReadingWords(this._cache || []);
+                }
+            } catch (err) {
+                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
+            }
+        },
+
+        async flushToAppData() {
+            return this.syncToAppData();
+        },
+
+        getByExam(examId) {
+            if (!examId) return [];
+            const all = this.getAll();
+            return all.filter(item => String(item.examId) === String(examId));
+        },
+
+        add(rawWord, examId, examTitle, context = '', highlight = null) {
+            const word = this.cleanWord(rawWord);
+            if (!word || word.length > 50) {
+                return { added: false, reason: 'invalid_word' };
+            }
+
+            const all = this.getAll();
+            const lowerWord = word.toLowerCase();
+
+            // 检查当前文章或全局是否存在
+            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
+            if (existingIndex !== -1) {
+                const item = all[existingIndex];
+                item.updatedAt = Date.now();
+                if (examId && !item.examId) {
+                    item.examId = examId;
+                    item.examTitle = examTitle || '';
+                }
+                if (highlight) {
+                    if (!Array.isArray(item.highlights)) {
+                        item.highlights = [];
+                    }
+                    const isDup = item.highlights.some(h =>
+                        String(h.examId) === String(highlight.examId) &&
+                        String(h.scope) === String(highlight.scope) &&
+                        h.startOffset === highlight.startOffset
+                    );
+                    if (!isDup) {
+                        item.highlights.push(highlight);
+                    }
+                }
+                this._save();
+                return { added: true, item: item, isDuplicate: true };
+            }
+
+            const newItem = {
+                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                word: word,
+                examId: examId || '',
+                examTitle: examTitle || '',
+                context: context ? String(context).trim().slice(0, 150) : '',
+                createdAt: Date.now(),
+                highlights: highlight ? [highlight] : []
+            };
+
+            all.unshift(newItem);
+            this._save();
+
+            if (examId) {
+                recordBookshelfExamDirect(examId, examTitle);
+            }
+
+            return { added: true, item: newItem, isDuplicate: false };
+        },
+
+        remove(wordOrId) {
+            const all = this.getAll();
+            const target = String(wordOrId).trim().toLowerCase();
+            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
+            if (index !== -1) {
+                all.splice(index, 1);
+                this._save();
+                return true;
+            }
+            return false;
+        },
+
+        clear(examId = null) {
+            if (!examId) {
+                this._cache = [];
+                this._save();
+                return true;
+            }
+            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
+            this._save();
+            return true;
+        },
+
+        cleanWord(str) {
+            if (!str) return '';
+            return str
+                .replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '')
+                .trim();
+        },
+
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
+            const list = examId ? this.getByExam(examId) : this.getAll();
+            if (!list || list.length === 0) {
+                return false;
+            }
+
+            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
+            const words = [];
+            const seen = new Set();
+            list.forEach(item => {
+                const raw = typeof item === 'string' ? item : item?.word;
+                const w = (raw || '').trim();
+                if (w && !seen.has(w.toLowerCase())) {
+                    seen.add(w.toLowerCase());
+                    words.push(w);
+                }
+            });
+
+            if (words.length === 0) {
+                return false;
+            }
+
+            let filename = customFilename;
+            if (!filename) {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const day = String(now.getDate()).padStart(2, '0');
+                const dateStr = `${year}-${month}-${day}`;
+
+                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                filename = `${dateStr}_${safeTitle}.txt`;
+            }
+
+            const content = words.join('\n');
+            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            return true;
+        },
+
+        async init() {
+            this.bindCommitListener();
+            try {
+                if (global.AppData && global.AppData.ready) {
+                    await global.AppData.ready;
+                }
+                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
+                    const appDataWords = await global.AppData.vocab.listReadingWords();
+                    const localWords = this.getAll();
+                    if (Array.isArray(appDataWords) && appDataWords.length > 0) {
+                        const map = new Map();
+                        localWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) map.set(key, w);
+                        });
+                        appDataWords.forEach(w => {
+                            const key = String(w && (w.word || w.id) || '').trim().toLowerCase();
+                            if (key) {
+                                if (map.has(key)) {
+                                    const existing = map.get(key);
+                                    map.set(key, Object.assign({}, existing, w, {
+                                        createdAt: Math.min(Number(existing.createdAt) || Date.now(), Number(w.createdAt) || Date.now()),
+                                        updatedAt: Math.max(Number(existing.updatedAt) || 0, Number(w.updatedAt) || 0)
+                                    }));
+                                } else {
+                                    map.set(key, w);
+                                }
+                            }
+                        });
+                        const merged = Array.from(map.values());
+                        this._cache = merged;
+                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(merged)); } catch (_) {}
+                        if (merged.length !== appDataWords.length) {
+                            await global.AppData.vocab.saveReadingWords(merged);
+                        }
+                    } else if (localWords.length > 0) {
+                        await global.AppData.vocab.saveReadingWords(localWords);
+                    }
+                }
+            } catch (e) {
+                console.warn('[ReadingVocabStore] init failed:', e);
+            }
+        },
+
+        bindCommitListener() {
+            if (this._commitBound) return;
+            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+                this._commitBound = true;
+                global.AppData.backups.onDataCommitted(async (event) => {
+                    const targets = event && event.targets;
+                    if (!Array.isArray(targets)) return;
+                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
+                    if (hasVocab) {
+                        try {
+                            const updated = await global.AppData.vocab.listReadingWords();
+                            if (Array.isArray(updated)) {
+                                this._cache = updated;
+                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
+                            }
+                        } catch (err) {
+                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
+                        }
+                    }
+                });
+            }
+        }
+    };
+
+    // ============================================================================
+    // 语音朗读
+    // ============================================================================
+    function speakWord(word) {
+        if (!('speechSynthesis' in window) || !word) {
+            return;
+        }
+        try {
+            window.speechSynthesis.cancel();
+            const utterance = new SpeechSynthesisUtterance(word);
+            utterance.lang = 'en-US';
+            utterance.rate = 0.9;
+            window.speechSynthesis.speak(utterance);
+        } catch (e) {
+            console.warn('[ReadingVocabReader] 朗读失败:', e);
+        }
+    }
+
+    // ============================================================================
+    // 异步加载试卷与解析数据
+    // ============================================================================
+    function getExamRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXAM_DATA__ || typeof root.__READING_EXAM_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXAM_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_exam_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXAM_DATA__;
+    }
+
+    function getExplanationRegistry() {
+        const root = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : global);
+        if (!root.__READING_EXPLANATION_DATA__ || typeof root.__READING_EXPLANATION_DATA__.register !== 'function') {
+            const store = new Map();
+            function deepClone(value) {
+                if (value == null) return value;
+                return JSON.parse(JSON.stringify(value));
+            }
+            root.__READING_EXPLANATION_DATA__ = {
+                register(id, payload) {
+                    if (!id || !payload || typeof payload !== 'object') {
+                        throw new Error('reading_explanation_payload_invalid');
+                    }
+                    store.set(String(id), deepClone(payload));
+                },
+                get(id) {
+                    if (!id) return null;
+                    return store.has(String(id)) ? deepClone(store.get(String(id))) : null;
+                },
+                has(id) {
+                    return !!id && store.has(String(id));
+                },
+                keys() {
+                    return Array.from(store.keys());
+                },
+                clear() {
+                    store.clear();
+                }
+            };
+        }
+        return root.__READING_EXPLANATION_DATA__;
+    }
+
+    async function loadReadingExamPayload(examId) {
+        if (!examId) return null;
+
+        const examRegistry = getExamRegistry();
+        const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || global.__READING_EXAM_MANIFEST__ || {};
+        const entry = manifest[examId] || Object.values(manifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        // 1. 检查已注册数据
+        if (examRegistry && typeof examRegistry.get === 'function') {
+            const cached = examRegistry.get(examId) || (entry && (examRegistry.get(entry.dataKey) || examRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        // 2. 检查 manifest
+        if (!entry || !entry.script) {
+            console.warn('[ReadingVocabReader] 未找到试卷元信息:', examId);
+            return null;
+        }
+
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+        let scriptSrc;
+        if (isExamPage) {
+            scriptSrc = entry.script.startsWith('./') ? entry.script : `./${entry.script}`;
+        } else {
+            scriptSrc = `assets/generated/reading-exams/${entry.script.replace(/^\.\//, '')}`;
+        }
+
+        await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = scriptSrc;
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error('Failed to load reading exam: ' + scriptSrc));
+            document.head.appendChild(script);
+        });
+
+        const registryAfterLoad = getExamRegistry();
+        return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
+    }
+
+    async function loadReadingExplanationPayload(examId) {
+        if (!examId) return null;
+
+        const expRegistry = getExplanationRegistry();
+        const isExamPage = typeof window !== 'undefined' && window.location && window.location.pathname.includes('/reading-exams/');
+
+        // 确保 explanation manifest 存在
+        if (!global.__READING_EXPLANATION_MANIFEST__ && !(typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__)) {
+            const manifestSrc = isExamPage ? '../reading-explanations/manifest.js' : 'assets/generated/reading-explanations/manifest.js';
+            try {
+                await new Promise((resolve, reject) => {
+                    const script = document.createElement('script');
+                    script.src = manifestSrc;
+                    script.onload = () => resolve();
+                    script.onerror = () => resolve();
+                    document.head.appendChild(script);
+                });
+            } catch (_) {}
+        }
+
+        const expManifest = (typeof window !== 'undefined' && window.__READING_EXPLANATION_MANIFEST__) || global.__READING_EXPLANATION_MANIFEST__ || {};
+        const entry = expManifest[examId] || Object.values(expManifest).find(e => e && (e.examId === examId || e.dataKey === examId || e.id === examId));
+
+        if (expRegistry && typeof expRegistry.get === 'function') {
+            const cached = expRegistry.get(examId) || (entry && (expRegistry.get(entry.dataKey) || expRegistry.get(entry.examId)));
+            if (cached) return cached;
+        }
+
+        if (!entry || !entry.script) {
+            return null;
+        }
+
+        try {
+            const cleanScript = entry.script.replace(/^(\.\/|\.\.\/reading-explanations\/)/, '');
+            const scriptSrc = isExamPage
+                ? `../reading-explanations/${cleanScript}`
+                : `assets/generated/reading-explanations/${cleanScript}`;
+            await new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = scriptSrc;
+                script.onload = () => resolve();
+                script.onerror = () => reject(new Error('Failed to load explanation'));
+                document.head.appendChild(script);
+            });
+            const expRegistryAfterLoad = getExplanationRegistry();
+            return expRegistryAfterLoad.get(examId) || (entry && (expRegistryAfterLoad.get(entry.dataKey) || expRegistryAfterLoad.get(entry.examId))) || null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // ============================================================================
+    // 阅读文本与段落清洗器
+    // ============================================================================
+    function cleanPassageHtml(rawHtml) {
+        if (!rawHtml) return '';
+        const temp = document.createElement('div');
+        temp.innerHTML = rawHtml;
+
+        // 移除练习交互用的 dropzone 提示与容器
+        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
+        dropzones.forEach(dz => dz.remove());
+
+        // 移除多余的空占位与 divider
+        const empties = temp.querySelectorAll('.empty-space, #divider');
+        empties.forEach(el => el.remove());
+
+        return temp.innerHTML;
+    }
+
+    /**
+     * 判断文本是否属于考试指导语/前置题目说明
+     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
+     */
+    function isPassageInstruction(text) {
+        if (!text) return false;
+        const s = text.trim();
+        if (/spend about \d+ minutes/i.test(s)) return true;
+        if (/which are based on reading passage/i.test(s)) return true;
+        if (/based on reading passage \d*/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
+        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
+        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
+        return false;
+    }
+
+    /**
+     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
+     */
+    function extractPassageData(rawHtml, fallbackTitle = '') {
+        if (!rawHtml) {
+            return {
+                passageTitle: fallbackTitle,
+                subtitleHtml: '',
+                instructionHtml: '',
+                blocks: []
+            };
+        }
+
+        const cleaned = cleanPassageHtml(rawHtml);
+        const temp = document.createElement('div');
+        temp.innerHTML = cleaned;
+
+        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
+        let passageTitle = fallbackTitle;
+        const h3 = temp.querySelector('h3');
+        if (h3 && h3.textContent.trim()) {
+            passageTitle = h3.textContent.trim();
+            h3.remove();
+        } else {
+            const h2 = temp.querySelector('h2');
+            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
+                passageTitle = h2.textContent.trim();
+                h2.remove();
+            }
+        }
+
+        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
+        const readingPassageHeadings = temp.querySelectorAll('h2');
+        readingPassageHeadings.forEach(h => {
+            if (/^reading passage/i.test(h.textContent.trim())) {
+                h.remove();
+            }
+        });
+
+        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
+        let instructionHtml = '';
+        const allPs = Array.from(temp.querySelectorAll('p'));
+        for (const p of allPs) {
+            const text = p.textContent.trim();
+            if (isPassageInstruction(text)) {
+                if (!instructionHtml) {
+                    instructionHtml = p.innerHTML.trim();
+                }
+                p.remove(); // 绝不作为正文段落，不分配任何段落标签
+            }
+        }
+
+        // 3. 提取副标题 (如 h4)
+        let subtitleHtml = '';
+        const h4 = temp.querySelector('h4');
+        if (h4 && h4.textContent.trim()) {
+            subtitleHtml = h4.innerHTML.trim();
+            h4.remove();
+        }
+
+        // 4. 解析段落 blocks
+        const blocks = [];
+        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
+
+        if (wrappers && wrappers.length > 0) {
+            wrappers.forEach((wrap, index) => {
+                // 查找段落标识 letter
+                let letter = '';
+                const strong = wrap.querySelector('strong');
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
+                    if (match) {
+                        letter = match[1];
+                    } else {
+                        letter = String.fromCharCode(65 + index);
+                    }
+                }
+
+                // 获取段落主体 HTML
+                const p = wrap.querySelector('p');
+                const html = p ? p.innerHTML : wrap.innerHTML;
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: html,
+                    text: wrap.textContent.trim()
+                });
+            });
+        } else {
+            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
+            const remainingPs = temp.querySelectorAll('p');
+            let validIdx = 0;
+            remainingPs.forEach((p) => {
+                const text = p.textContent.trim();
+                if (!text || text.length < 20) return;
+                // 防御：若依然属于指导语，跳过
+                if (isPassageInstruction(text)) return;
+
+                const strong = p.querySelector('strong');
+                let letter = '';
+                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
+                    letter = strong.textContent.trim();
+                } else {
+                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
+                    if (leadMatch) {
+                        letter = leadMatch[1];
+                    } else {
+                        letter = String.fromCharCode(65 + validIdx);
+                    }
+                }
+
+                blocks.push({
+                    id: `para-${letter}`,
+                    letter: letter,
+                    html: p.innerHTML,
+                    text: text
+                });
+                validIdx++;
+            });
+        }
+
+        return {
+            passageTitle,
+            subtitleHtml,
+            instructionHtml,
+            blocks
+        };
+    }
+
+    function extractParagraphBlocks(rawHtml) {
+        return extractPassageData(rawHtml).blocks;
+    }
+
+    function getTextNodes(root) {
+        if (!root) return [];
+        const textNodes = [];
+        const walker = document.createTreeWalker(
+            root,
+            NodeFilter.SHOW_TEXT,
+            {
+                acceptNode(node) {
+                    const parent = node.parentElement;
+                    if (!parent) return NodeFilter.FILTER_REJECT;
+                    const tag = parent.tagName.toUpperCase();
+                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+            },
+            false
+        );
+        let n;
+        while ((n = walker.nextNode())) {
+            textNodes.push(n);
+        }
+        return textNodes;
+    }
+
+    function resolveRangeFromOffsets(root, start, end) {
+        const nodes = getTextNodes(root);
+        let offset = 0;
+        let startNode = null;
+        let endNode = null;
+        let startOffset = 0;
+        let endOffset = 0;
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            const text = node.nodeValue || '';
+            const nextOffset = offset + text.length;
+            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
+                startNode = node;
+                startOffset = Math.max(0, start - offset);
+            }
+            if (!endNode && end > offset && end <= nextOffset) {
+                endNode = node;
+                endOffset = Math.max(0, end - offset);
+            }
+            if (startNode && endNode) break;
+            offset = nextOffset;
+        }
+        if (!startNode || !endNode) return null;
+        const range = document.createRange();
+        range.setStart(startNode, startOffset);
+        range.setEnd(endNode, endOffset);
+        return range;
+    }
+
+    // ============================================================================
+    // 阅读器主控制器 (ReadingVocabReader)
+    // ============================================================================
+    const ReadingVocabReader = {
+        currentExamId: null,
+        currentExam: null,
+        currentPayload: null,
+        currentExplanation: null,
+        activeTab: 'all', // 'all', 'questions', or paragraph letter e.g. 'A'
+        showTranslation: false,
+        modalTab: 'current', // 'current' or 'all'
+        modalOpen: false,
+        toastTimer: null,
+
+        ensureOverlay() {
+            let overlay = document.getElementById('reading-vocab-reader-overlay');
+            if (overlay) {
+                return overlay;
+            }
+
+            overlay = document.createElement('div');
+            overlay.id = 'reading-vocab-reader-overlay';
+            overlay.className = 'vocab-reader-overlay is-hidden';
+            overlay.setAttribute('role', 'dialog');
+            overlay.setAttribute('aria-label', '阅读生词本');
+
+            overlay.innerHTML = `
+                <div class="vocab-reader-container">
+                    <!-- 顶部吸顶导航栏 -->
+                    <header class="vocab-reader-header">
+                        <div class="vocab-reader-header__left">
+                            <button type="button" class="vocab-reader-back-btn" id="vocab-reader-back-btn" title="返回题库浏览">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+                                    <path d="M19 12H5M12 19l-7-7 7-7"/>
+                                </svg>
+                                <span>返回</span>
+                            </button>
+                            <div class="vocab-reader-title-wrap">
+                                <h2 class="vocab-reader-title" id="vocab-reader-title">阅读文章与题目</h2>
+                                <div class="vocab-reader-badges" id="vocab-reader-badges"></div>
+                            </div>
+                        </div>
+
+                        <div class="vocab-reader-header__center">
+                            <div class="vocab-reader-tabs" id="vocab-reader-tabs" role="tablist">
+                                <!-- 动态插入段落与题目标签，完全平铺陈列展开 -->
+                            </div>
+                        </div>
+                    </header>
+
+                    <!-- 沉浸式提示栏 -->
+                    <div class="vocab-reader-banner">
+                        <span class="vocab-banner-icon">✨</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                    </div>
+
+                    <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
+                    <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
+                        <!-- 阅读核心主内容区 -->
+                        <main class="vocab-reader-body" id="vocab-reader-body">
+                            <!-- 文章区域 -->
+                            <section class="vocab-passage-section" id="vocab-passage-section">
+                                <div class="vocab-passage-header">
+                                    <h3 class="vocab-passage-title" id="vocab-passage-title">Reading Passage</h3>
+                                    <div class="vocab-passage-intro" id="vocab-passage-intro"></div>
+                                </div>
+                                <div class="vocab-passage-content" id="vocab-passage-content">
+                                    <!-- 段落内容 -->
+                                </div>
+                            </section>
+
+                            <!-- 题目区域 -->
+                            <section class="vocab-questions-section" id="vocab-questions-section">
+                                <div class="vocab-questions-header">
+                                    <h3 class="vocab-questions-title">📝 题目与问题 (Questions)</h3>
+                                    <p class="vocab-questions-subtitle">题目中的生词同样支持划词自动收录</p>
+                                </div>
+                                <div class="vocab-questions-content" id="vocab-questions-content">
+                                    <!-- 题目内容 -->
+                                </div>
+                            </section>
+                        </main>
+                    </div>
+
+                    <!-- 悬浮生词本 FAB 按钮 -->
+                    <div class="vocab-fab" id="vocab-fab" role="button" tabindex="0" title="打开生词本">
+                        <span class="vocab-fab-icon">📝</span>
+                        <span class="vocab-fab-label">生词本</span>
+                        <span class="vocab-fab-count" id="vocab-fab-count">0</span>
+                    </div>
+
+                    <!-- 划词收录 Toast 提示 -->
+                    <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+
+                    <!-- 生词本弹窗 Modal -->
+                    <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
+                        <div class="vocab-modal-content">
+                            <div class="vocab-modal-header">
+                                <div class="vocab-modal-title-wrap">
+                                    <h3>📖 我的生词本</h3>
+                                    <div class="vocab-modal-tabs">
+                                        <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                    </div>
+                                </div>
+                                <div class="vocab-modal-header-actions">
+                                    <button type="button" class="vocab-modal-bookshelf-btn" id="vocab-modal-bookshelf-btn" title="查看阅读书架">📚 书架</button>
+                                    <button type="button" class="vocab-modal-close" id="vocab-modal-close" title="关闭">✖</button>
+                                </div>
+                            </div>
+
+                            <!-- 手动添加生词栏 -->
+                            <div class="vocab-modal-add-row">
+                                <input type="text" id="vocab-manual-input" placeholder="手动添加生词..." maxlength="50" />
+                                <button type="button" id="vocab-manual-add-btn">收录</button>
+                            </div>
+
+                            <!-- 生词列表 -->
+                            <div class="vocab-list" id="vocab-list">
+                                <!-- 动态插入 -->
+                            </div>
+
+                            <!-- 底部操作栏 -->
+                            <div class="vocab-modal-footer">
+                                <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
+                                    <span>⬇️ 导出为 TXT</span>
+                                </button>
+                                <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
+                                    <span>🗑️ 清空生词</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            document.body.appendChild(overlay);
+            this.bindEvents(overlay);
+            return overlay;
+        },
+
+        bindEvents(overlay) {
+            // 返回按钮
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            if (backBtn) {
+                backBtn.addEventListener('click', () => this.close());
+            }
+
+            // 开启生词本弹窗
+            const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
+            const fab = overlay.querySelector('#vocab-fab');
+            if (openModalBtn) {
+                openModalBtn.addEventListener('click', () => this.openModal());
+            }
+            if (fab) {
+                fab.addEventListener('click', () => this.openModal());
+            }
+
+            // 关闭生词本弹窗
+            const closeModalBtn = overlay.querySelector('#vocab-modal-close');
+            const modal = overlay.querySelector('#vocab-modal');
+            if (closeModalBtn) {
+                closeModalBtn.addEventListener('click', () => this.closeModal());
+            }
+            if (modal) {
+                modal.addEventListener('click', (e) => {
+                    if (e.target === modal) {
+                        this.closeModal();
+                    }
+                });
+            }
+
+            // 前往阅读书架
+            const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
+            if (bookshelfBtn) {
+                bookshelfBtn.addEventListener('click', () => {
+                    this.closeModal();
+                    this.close();
+                    if (global.opener && !global.opener.closed) {
+                        try {
+                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
+                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            }
+                            if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
+                                global.opener.app.navigateToView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            } else if (typeof global.opener.switchView === 'function') {
+                                global.opener.switchView('bookshelf');
+                                global.opener.focus();
+                                return;
+                            }
+                        } catch (_) {}
+                    }
+                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                        global.BookshelfView.mount('#bookshelf-view');
+                    }
+                    if (global.app && typeof global.app.navigateToView === 'function') {
+                        global.app.navigateToView('bookshelf');
+                    } else if (typeof global.switchView === 'function') {
+                        global.switchView('bookshelf');
+                    }
+                });
+            }
+
+            // 生词本切换标签 (本篇 / 全部)
+            const tabCurrent = overlay.querySelector('#v-tab-current');
+            const tabAll = overlay.querySelector('#v-tab-all');
+            if (tabCurrent) {
+                tabCurrent.addEventListener('click', () => {
+                    this.modalTab = 'current';
+                    tabCurrent.classList.add('active');
+                    tabAll.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+            if (tabAll) {
+                tabAll.addEventListener('click', () => {
+                    this.modalTab = 'all';
+                    tabAll.classList.add('active');
+                    tabCurrent.classList.remove('active');
+                    this.renderVocabList();
+                });
+            }
+
+            // 手动收录
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
+            const handleManualAdd = () => {
+                if (!manualInput) return;
+                const val = manualInput.value.trim();
+                if (!val) return;
+                const result = ReadingVocabStore.add(
+                    val,
+                    this.currentExamId,
+                    this.currentExam?.title || '',
+                    ''
+                );
+                if (result.added) {
+                    manualInput.value = '';
+                    this.updateCounts();
+                    this.renderVocabList();
+                    this.applyVocabHighlights(val);
+                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                }
+            };
+            if (manualAddBtn) {
+                manualAddBtn.addEventListener('click', handleManualAdd);
+            }
+            if (manualInput) {
+                manualInput.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleManualAdd();
+                    }
+                });
+            }
+
+            // 导出与清空
+            const exportBtn = overlay.querySelector('#vocab-export-btn');
+            if (exportBtn) {
+                exportBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+
+                    const now = new Date();
+                    const year = now.getFullYear();
+                    const month = String(now.getMonth() + 1).padStart(2, '0');
+                    const day = String(now.getDate()).padStart(2, '0');
+                    const dateStr = `${year}-${month}-${day}`;
+
+                    // 当前文章名字
+                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
+                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
+                    const filename = `${dateStr}_${safeArticleName}.txt`;
+
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    if (success) {
+                        this.showToast(`✅ 已导出：${filename}`);
+                    } else {
+                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    }
+                });
+            }
+
+            const clearBtn = overlay.querySelector('#vocab-clear-btn');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    const isCurrent = this.modalTab === 'current';
+                    const examId = isCurrent ? this.currentExamId : null;
+                    const count = isCurrent
+                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        : ReadingVocabStore.getAll().length;
+
+                    if (count === 0) {
+                        this.showToast('生词本已经是空的了');
+                        return;
+                    }
+
+                    ReadingVocabStore.clear(examId);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    const passageContent = overlay.querySelector('#vocab-passage-content');
+                    const questionsContent = overlay.querySelector('#vocab-questions-content');
+                    this.removeVocabHighlights(passageContent);
+                    this.removeVocabHighlights(questionsContent);
+                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                });
+            }
+
+            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
+            const readerBody = overlay.querySelector('#vocab-reader-body');
+            if (readerBody) {
+                const handleSelectionCapture = () => {
+                    setTimeout(() => {
+                        const selection = window.getSelection();
+                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+                        const rawText = selection.toString();
+                        const text = rawText.trim();
+
+                        // 限制在1到45个字符之间，避免大段全文误选
+                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
+                            return;
+                        }
+
+                        let range;
+                        try {
+                            range = selection.getRangeAt(0);
+                        } catch (_) {
+                            return;
+                        }
+                        if (!range || range.collapsed) return;
+
+                        // 确保选区位于文章正文或题目区域内
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        const commonNode = range.commonAncestorContainer;
+                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
+                        if (!commonEl) return;
+                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
+                            return;
+                        }
+                        // 忽略译文卡片、段落标签、按钮等非正文区域
+                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
+                            return;
+                        }
+
+                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
+                        const existingMark = commonEl.closest('mark.vocab-highlight');
+                        if (existingMark) {
+                            return;
+                        }
+
+                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
+                        const trimmedRange = this.trimRangeWhitespace(range);
+                        if (!trimmedRange || trimmedRange.collapsed) return;
+
+                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
+                        const targetCard = commonEl.closest('.vocab-paragraph-card');
+                        const targetQGroup = commonEl.closest('.vocab-question-group');
+                        let scope = 'passage';
+                        let scopeElement = passageContent;
+
+                        if (targetCard) {
+                            const letter = targetCard.dataset.letter || '';
+                            scope = letter ? `para-${letter}` : 'passage';
+                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
+                        } else if (targetQGroup) {
+                            scope = targetQGroup.id || 'questions';
+                            scopeElement = targetQGroup;
+                        } else if (questionsContent?.contains(commonEl)) {
+                            scope = 'questions';
+                            scopeElement = questionsContent;
+                        }
+
+                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
+                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
+
+                        // 获取上下文句子
+                        let contextSentence = '';
+                        try {
+                            const parentBlock = commonEl;
+                            if (parentBlock) {
+                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
+                            }
+                        } catch (_) {}
+
+                        const cleanWord = ReadingVocabStore.cleanWord(text);
+                        if (!cleanWord) return;
+
+                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
+                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
+                        if (!wrappedMark) return;
+
+                        const highlightRecord = {
+                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
+                            examId: this.currentExamId || '',
+                            scope: scope,
+                            startOffset: locInfo.startOffset,
+                            endOffset: locInfo.endOffset,
+                            before: locInfo.before,
+                            after: locInfo.after,
+                            occurrence: locInfo.occurrence,
+                            text: cleanWord
+                        };
+
+                        const result = ReadingVocabStore.add(
+                            cleanWord,
+                            this.currentExamId,
+                            this.currentExam?.title || '',
+                            contextSentence,
+                            highlightRecord
+                        );
+
+                        if (result.added) {
+                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                            this.updateCounts();
+                            if (this.modalOpen) {
+                                this.renderVocabList();
+                            }
+                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        }
+                    }, 20);
+                };
+
+                readerBody.addEventListener('mouseup', handleSelectionCapture);
+                readerBody.addEventListener('touchend', handleSelectionCapture);
+
+                // 点击黄色高亮生词：朗读发音并轻量提示
+                readerBody.addEventListener('click', (e) => {
+                    const mark = e.target.closest('mark.vocab-highlight');
+                    if (mark) {
+                        const selection = window.getSelection();
+                        if (selection && selection.toString().trim().length > 0) {
+                            return; // 划选操作中不触发点击发音
+                        }
+                        const word = mark.dataset.word || mark.textContent.trim();
+                        if (word) {
+                            speakWord(word);
+                            this.showToast(`🔊 ${word} (已收录生词)`);
+                        }
+                    }
+                });
+            }
+
+            // ESC 键监听
+            window.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    if (this.modalOpen) {
+                        this.closeModal();
+                    } else if (overlay && !overlay.classList.contains('is-hidden')) {
+                        this.close();
+                    }
+                }
+            });
+        },
+
+        async open(examId, options = {}) {
+            if (!examId) return;
+
+            const overlay = this.ensureOverlay();
+            this.currentExamId = examId;
+
+            // 根据来源动态调整返回按钮提示
+            const backBtn = overlay.querySelector('#vocab-reader-back-btn');
+            const backBtnText = overlay.querySelector('#vocab-reader-back-btn span');
+            if (options && options.fromPractice) {
+                if (backBtnText) backBtnText.textContent = '返回练习';
+                if (backBtn) backBtn.title = '返回练习试卷';
+            } else {
+                if (backBtnText) backBtnText.textContent = '返回题库';
+                if (backBtn) backBtn.title = '返回题库浏览';
+            }
+
+            // 显示加载状态
+            overlay.classList.remove('is-hidden');
+            document.body.classList.add('vocab-reader-open');
+
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            if (titleEl) titleEl.textContent = '正在加载试卷全文...';
+            if (badgesEl) badgesEl.innerHTML = '';
+            if (passageContent) passageContent.innerHTML = '<div class="vocab-loading-spinner">正在解析文章结构与题目...</div>';
+            if (questionsContent) questionsContent.innerHTML = '';
+
+            try {
+                // 加载试卷数据
+                const payload = await loadReadingExamPayload(examId);
+                if (!payload) {
+                    throw new Error('未找到该试卷的数据文件');
+                }
+                this.currentPayload = payload;
+
+                // 异步加载解析（不阻塞主内容）
+                loadReadingExplanationPayload(examId).then(exp => {
+                    this.currentExplanation = exp;
+                    this.enhanceWithExplanation(exp);
+                }).catch(() => {});
+
+                // 获取 Exam Meta
+                const manifest = global.__READING_EXAM_MANIFEST__ || {};
+                const manifestEntry = manifest[examId] || {};
+                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+
+                // 记录至阅读书架
+                const examTitle = this.currentExam.title || this.currentExam.name || examId;
+                const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
+                recordBookshelfExamDirect(examId, examTitle, examCategory);
+
+                // 渲染界面
+                this.renderContent();
+                this.updateCounts();
+            } catch (err) {
+                console.error('[ReadingVocabReader] 加载失败:', err);
+                if (passageContent) {
+                    passageContent.innerHTML = `
+                        <div class="vocab-error-state">
+                            <p>⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}</p>
+                            <button type="button" class="btn btn-primary" onclick="ReadingVocabReader.open('${examId}')">重试</button>
+                        </div>
+                    `;
+                }
+            }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+
+            // 标题与标签（紧凑精致）
+            const titleEl = overlay.querySelector('#vocab-reader-title');
+            const badgesEl = overlay.querySelector('#vocab-reader-badges');
+            if (titleEl) {
+                const titleText = exam.title || '阅读文章与题目';
+                titleEl.textContent = titleText;
+                titleEl.title = titleText;
+            }
+            if (badgesEl) {
+                badgesEl.innerHTML = `
+                    <span class="vocab-badge vocab-badge--cat">${exam.category || '阅读'}</span>
+                    ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${exam.frequency}</span>` : ''}
+                `;
+            }
+
+            // 解析文章大标题、考试指导语与真实段落
+            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
+            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const blocks = passageData.blocks;
+            const instructionHtml = passageData.instructionHtml;
+            const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
+
+            // 设置文章标题
+            const passageTitleEl = overlay.querySelector('#vocab-passage-title');
+            if (passageTitleEl) {
+                passageTitleEl.textContent = passageTitle;
+            }
+
+            // 渲染前置说明指导语（如 "You should spend about 20 minutes on questions 1 to 30..."）
+            // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
+            const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
+            if (passageIntroEl) {
+                if (instructionHtml) {
+                    passageIntroEl.innerHTML = `
+                        <div class="vocab-passage-instruction" role="note">
+                            <span class="vocab-instruction-icon">📋</span>
+                            <div class="vocab-instruction-text">${instructionHtml}</div>
+                        </div>
+                    `;
+                    passageIntroEl.style.display = 'block';
+                } else if (passageData.subtitleHtml) {
+                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
+                    passageIntroEl.style.display = 'block';
+                } else {
+                    passageIntroEl.innerHTML = '';
+                    passageIntroEl.style.display = 'none';
+                }
+            }
+
+            // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
+            const tabsContainer = overlay.querySelector('#vocab-reader-tabs');
+            if (tabsContainer) {
+                let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
+                blocks.forEach(b => {
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                });
+                tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
+                tabsContainer.innerHTML = tabsHtml;
+
+                // 绑定 Tab 点击事件
+                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
+                        btn.classList.add('active');
+                        const target = btn.dataset.para;
+                        this.switchViewTab(target);
+                    });
+                });
+            }
+
+            // 渲染文章段落
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            if (passageContent) {
+                if (blocks.length > 0) {
+                    let passageHtml = '';
+                    blocks.forEach(b => {
+                        passageHtml += `
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                                <div class="vocab-paragraph-tag">
+                                    <span class="vocab-para-letter">Para ${b.letter}</span>
+                                </div>
+                                <div class="vocab-paragraph-text">${b.html}</div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                    <div class="vocab-trans-label">中文参考译文：</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                </div>
+                            </div>
+                        `;
+                    });
+                    passageContent.innerHTML = passageHtml;
+                } else {
+                    // 原生清洗后渲染
+                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                }
+            }
+
+            // 渲染题目
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            if (questionsContent) {
+                const questionGroups = payload?.questionGroups || [];
+                if (questionGroups.length > 0) {
+                    let qHtml = '';
+                    questionGroups.forEach((g, idx) => {
+                        qHtml += `
+                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
+                                ${g.bodyHtml || ''}
+                            </div>
+                        `;
+                    });
+                    questionsContent.innerHTML = qHtml;
+                } else {
+                    questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
+                }
+            }
+
+            // 如果已有解析数据，填充中文译文
+            if (this.currentExplanation) {
+                this.enhanceWithExplanation(this.currentExplanation);
+            }
+
+            // 应用生词黄色高亮
+            this.applyVocabHighlights();
+        },
+
+        trimRangeWhitespace(range) {
+            if (!range || range.collapsed) return range;
+            const startNode = range.startContainer;
+            let startOffset = range.startOffset;
+            const endNode = range.endContainer;
+            let endOffset = range.endOffset;
+
+            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
+                const text = startNode.nodeValue || '';
+                const segment = text.slice(startOffset, endOffset);
+                const leadSpace = segment.search(/\S/);
+                if (leadSpace > 0) {
+                    startOffset += leadSpace;
+                } else if (leadSpace === -1) {
+                    return null;
+                }
+                const trailSpace = segment.length - segment.trimEnd().length;
+                if (trailSpace > 0) {
+                    endOffset -= trailSpace;
+                }
+                if (endOffset <= startOffset) return null;
+
+                const trimmed = document.createRange();
+                trimmed.setStart(startNode, startOffset);
+                trimmed.setEnd(endNode, endOffset);
+                return trimmed;
+            }
+
+            if (startNode.nodeType === Node.TEXT_NODE) {
+                const text = (startNode.nodeValue || '').slice(startOffset);
+                const m = text.match(/^\s+/);
+                if (m) {
+                    range.setStart(startNode, startOffset + m[0].length);
+                }
+            }
+            if (endNode.nodeType === Node.TEXT_NODE) {
+                const text = (endNode.nodeValue || '').slice(0, endOffset);
+                const m = text.match(/\s+$/);
+                if (m) {
+                    range.setEnd(endNode, endOffset - m[0].length);
+                }
+            }
+            return range;
+        },
+
+        calculateRangeLocation(scopeElement, range, text) {
+            const textNodes = getTextNodes(scopeElement);
+            let runningOffset = 0;
+            let startOffset = -1;
+
+            for (let i = 0; i < textNodes.length; i++) {
+                const node = textNodes[i];
+                if (node === range.startContainer) {
+                    startOffset = runningOffset + range.startOffset;
+                    break;
+                }
+                runningOffset += (node.nodeValue || '').length;
+            }
+
+            if (startOffset === -1) {
+                startOffset = 0;
+            }
+
+            const endOffset = startOffset + text.length;
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
+            const after = fullText.slice(endOffset, endOffset + 30);
+
+            let occurrence = 0;
+            const lowerFull = fullText.toLowerCase();
+            const lowerWord = text.toLowerCase();
+            let idx = -1;
+            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
+                occurrence += 1;
+            }
+
+            return { startOffset, endOffset, before, after, occurrence };
+        },
+
+        wrapRangeWithHighlight(range, word) {
+            if (!range || range.collapsed) return null;
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight vocab-highlight--pulse';
+            mark.dataset.word = word;
+            mark.title = `生词本: ${word} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+            } catch (e) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                } catch (err) {
+                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
+                    return null;
+                }
+            }
+
+            setTimeout(() => {
+                mark.classList.remove('vocab-highlight--pulse');
+            }, 1500);
+
+            return mark;
+        },
+
+        applyVocabHighlights() {
+            const overlay = this.ensureOverlay();
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+
+            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
+            this.removeVocabHighlights(passageContent);
+            this.removeVocabHighlights(questionsContent);
+
+            if (!this.currentExamId) return;
+
+            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            if (!examItems || examItems.length === 0) return;
+
+            examItems.forEach(item => {
+                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
+                    item.highlights.forEach(hl => {
+                        if (String(hl.examId) === String(this.currentExamId)) {
+                            this.restoreVocabHighlight(overlay, hl, item.word);
+                        }
+                    });
+                } else if (item.context && item.word) {
+                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
+                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
+                }
+            });
+        },
+
+        restoreVocabHighlight(overlay, hl, word) {
+            if (!overlay || !hl) return false;
+            let scopeElement = null;
+
+            if (hl.scope && hl.scope.startsWith('para-')) {
+                const letter = hl.scope.replace('para-', '');
+                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
+                if (card) {
+                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
+                }
+            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
+                scopeElement = overlay.querySelector(`#${hl.scope}`);
+            } else if (hl.scope === 'questions') {
+                scopeElement = overlay.querySelector('#vocab-questions-content');
+            } else {
+                scopeElement = overlay.querySelector('#vocab-passage-content');
+            }
+
+            if (!scopeElement) {
+                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
+            }
+            if (!scopeElement) return false;
+
+            const range = this.resolveRangeForHighlight(scopeElement, hl);
+            if (!range || range.collapsed) return false;
+
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight';
+            mark.dataset.word = word || hl.text;
+            mark.title = `生词本: ${word || hl.text} (点击发音)`;
+
+            try {
+                range.surroundContents(mark);
+                return true;
+            } catch (_) {
+                try {
+                    const fragment = range.extractContents();
+                    mark.appendChild(fragment);
+                    range.insertNode(mark);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+        },
+
+        resolveRangeForHighlight(root, hl) {
+            if (!root || !hl) return null;
+            const textNodes = getTextNodes(root);
+            if (!textNodes.length) return null;
+
+            const fullText = textNodes.map(n => n.nodeValue || '').join('');
+            const targetText = String(hl.text || '').trim();
+            if (!targetText) return null;
+
+            const startOffset = Number(hl.startOffset);
+            const endOffset = Number(hl.endOffset);
+
+            // 1. 优先尝试 offset 精确匹配
+            if (
+                Number.isFinite(startOffset) &&
+                Number.isFinite(endOffset) &&
+                endOffset > startOffset &&
+                startOffset >= 0 &&
+                endOffset <= fullText.length
+            ) {
+                const segment = fullText.slice(startOffset, endOffset);
+                if (segment.toLowerCase() === targetText.toLowerCase()) {
+                    return resolveRangeFromOffsets(root, startOffset, endOffset);
+                }
+            }
+
+            // 2. 次优：使用 before / after 上下文精确定位单处实例
+            if (hl.before || hl.after) {
+                let searchPos = 0;
+                let matchIdx = -1;
+                let bestIdx = -1;
+                let bestScore = -1;
+                const lowerFull = fullText.toLowerCase();
+                const lowerTarget = targetText.toLowerCase();
+
+                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
+                    let score = 0;
+                    if (hl.before) {
+                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
+                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
+                            score += 3;
+                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (hl.after) {
+                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
+                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
+                            score += 3;
+                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
+                            score += 1;
+                        }
+                    }
+                    if (score > bestScore) {
+                        bestScore = score;
+                        bestIdx = matchIdx;
+                    }
+                    searchPos = matchIdx + 1;
+                }
+
+                if (bestIdx !== -1 && bestScore > 0) {
+                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
+                }
+            }
+
+            // 3. 兜底：使用 occurrence（第 N 次出现）
+            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
+            let currentOccurrence = 0;
+            let pos = 0;
+            let matchPos = -1;
+            const lowerFull = fullText.toLowerCase();
+            const lowerTarget = targetText.toLowerCase();
+
+            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
+                if (currentOccurrence === occurrence) {
+                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
+                }
+                currentOccurrence += 1;
+                pos = matchPos + 1;
+            }
+
+            return null;
+        },
+
+        restoreLegacyHighlightByContext(overlay, word, context) {
+            if (!overlay || !word) return false;
+            const passageContent = overlay.querySelector('#vocab-passage-content');
+            const questionsContent = overlay.querySelector('#vocab-questions-content');
+            const roots = [passageContent, questionsContent].filter(Boolean);
+
+            const targetWord = String(word).trim();
+            const lowerWord = targetWord.toLowerCase();
+            const lowerContext = String(context || '').trim().toLowerCase();
+
+            for (const root of roots) {
+                const textNodes = getTextNodes(root);
+                const fullText = textNodes.map(n => n.nodeValue || '').join('');
+                const lowerFull = fullText.toLowerCase();
+
+                let targetIdx = -1;
+                if (lowerContext && lowerFull.includes(lowerContext)) {
+                    const ctxIdx = lowerFull.indexOf(lowerContext);
+                    const wordInCtx = lowerContext.indexOf(lowerWord);
+                    if (wordInCtx !== -1) {
+                        targetIdx = ctxIdx + wordInCtx;
+                    }
+                }
+
+                // 无论如何，只恢复单处实例，绝不全篇高亮
+                if (targetIdx !== -1) {
+                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
+                    if (range && !range.collapsed) {
+                        const mark = document.createElement('mark');
+                        mark.className = 'vocab-highlight';
+                        mark.dataset.word = targetWord;
+                        mark.title = `生词本: ${targetWord} (点击发音)`;
+                        try {
+                            range.surroundContents(mark);
+                            return true;
+                        } catch (_) {
+                            try {
+                                const frag = range.extractContents();
+                                mark.appendChild(frag);
+                                range.insertNode(mark);
+                                return true;
+                            } catch (e) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        },
+
+        removeVocabHighlights(container) {
+            if (!container) return;
+            const marks = container.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const parent = mark.parentNode;
+                if (parent) {
+                    while (mark.firstChild) {
+                        parent.insertBefore(mark.firstChild, mark);
+                    }
+                    parent.removeChild(mark);
+                    parent.normalize();
+                }
+            });
+        },
+
+        removeVocabHighlightForWord(word) {
+            const overlay = this.ensureOverlay();
+            if (!overlay || !word) return;
+            const lower = String(word).trim().toLowerCase();
+            const marks = overlay.querySelectorAll('mark.vocab-highlight');
+            marks.forEach(mark => {
+                const markWord = (mark.dataset.word || mark.textContent || '').trim().toLowerCase();
+                if (markWord === lower) {
+                    const parent = mark.parentNode;
+                    if (parent) {
+                        while (mark.firstChild) {
+                            parent.insertBefore(mark.firstChild, mark);
+                        }
+                        parent.removeChild(mark);
+                        parent.normalize();
+                    }
+                }
+            });
+        },
+
+        enhanceWithExplanation(explanation) {
+            if (!explanation || !Array.isArray(explanation.passageNotes)) return;
+            const overlay = this.ensureOverlay();
+            explanation.passageNotes.forEach(note => {
+                const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
+                if (match) {
+                    const letter = match[1].toUpperCase();
+                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    if (transEl) {
+                        transEl.textContent = note.text || '';
+                    }
+                }
+            });
+        },
+
+        switchViewTab(target) {
+            const overlay = this.ensureOverlay();
+            const passageSection = overlay.querySelector('#vocab-passage-section');
+            const questionsSection = overlay.querySelector('#vocab-questions-section');
+            const cards = overlay.querySelectorAll('.vocab-paragraph-card');
+            const scrollArea = overlay.querySelector('#vocab-reader-scroll-area');
+
+            if (target === 'all') {
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'block';
+                cards.forEach(c => c.style.display = 'block');
+                if (scrollArea && typeof scrollArea.scrollTo === 'function') {
+                    scrollArea.scrollTo({ top: 0, behavior: 'smooth' });
+                } else if (passageSection) {
+                    passageSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else if (target === 'questions') {
+                if (passageSection) passageSection.style.display = 'none';
+                if (questionsSection) {
+                    questionsSection.style.display = 'block';
+                    questionsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            } else {
+                // 单个段落展示
+                if (passageSection) passageSection.style.display = 'block';
+                if (questionsSection) questionsSection.style.display = 'none';
+                cards.forEach(c => {
+                    if (c.dataset.letter === target) {
+                        c.style.display = 'block';
+                        c.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    } else {
+                        c.style.display = 'none';
+                    }
+                });
+            }
+        },
+
+        updateCounts() {
+            const overlay = this.ensureOverlay();
+            const examId = this.currentExamId;
+            const currentList = ReadingVocabStore.getByExam(examId);
+            const allList = ReadingVocabStore.getAll();
+
+            const headerCount = overlay.querySelector('#vocab-header-count');
+            const fabCount = overlay.querySelector('#vocab-fab-count');
+            const tabCurrentCount = overlay.querySelector('#v-count-current');
+            const tabAllCount = overlay.querySelector('#v-count-all');
+
+            const countToShow = currentList.length;
+            if (headerCount) headerCount.textContent = countToShow;
+            if (fabCount) fabCount.textContent = countToShow;
+            if (tabCurrentCount) tabCurrentCount.textContent = currentList.length;
+            if (tabAllCount) tabAllCount.textContent = allList.length;
+        },
+
+        renderVocabList() {
+            const overlay = this.ensureOverlay();
+            const listEl = overlay.querySelector('#vocab-list');
+            if (!listEl) return;
+
+            const isCurrent = this.modalTab === 'current';
+            const list = isCurrent
+                ? ReadingVocabStore.getByExam(this.currentExamId)
+                : ReadingVocabStore.getAll();
+
+            if (!list || list.length === 0) {
+                listEl.innerHTML = `
+                    <div class="vocab-empty-box">
+                        <div class="vocab-empty-icon">📝</div>
+                        <p class="vocab-empty-title">生词本是空的哦~</p>
+                        <p class="vocab-empty-desc">在文章或题目中划选任意英文单词，即可自动收入此生词本。</p>
+                    </div>
+                `;
+                return;
+            }
+
+            let html = '';
+            list.forEach(item => {
+                html += `
+                    <div class="vocab-item" data-word-id="${item.id}">
+                        <div class="vocab-item__main">
+                            <div class="vocab-item__header">
+                                <span class="vocab-item__word">${item.word}</span>
+                                <button type="button" class="vocab-speak-btn" data-speak-word="${item.word}" title="发音">🔊</button>
+                            </div>
+                            ${item.context ? `<p class="vocab-item__context">"${item.context}"</p>` : ''}
+                            ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${item.examTitle}</span>` : ''}
+                        </div>
+                        <button type="button" class="vocab-delete-btn" data-del-id="${item.id}" title="移出生词本">删除</button>
+                    </div>
+                `;
+            });
+
+            listEl.innerHTML = html;
+
+            // 绑定发音与删除
+            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    speakWord(btn.dataset.speakWord);
+                });
+            });
+
+            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const id = btn.dataset.delId;
+                    const allItems = ReadingVocabStore.getAll();
+                    const item = allItems.find(w => w.id === id);
+                    const word = item?.word;
+                    ReadingVocabStore.remove(id);
+                    this.updateCounts();
+                    this.renderVocabList();
+                    if (word) {
+                        this.removeVocabHighlightForWord(word);
+                    }
+                    this.showToast('已从生词本删除');
+                });
+            });
+        },
+
+        openModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = true;
+                this.updateCounts();
+                this.renderVocabList();
+                modal.classList.add('active');
+                modal.setAttribute('aria-hidden', 'false');
+            }
+        },
+
+        closeModal() {
+            const overlay = this.ensureOverlay();
+            const modal = overlay.querySelector('#vocab-modal');
+            if (modal) {
+                this.modalOpen = false;
+                modal.classList.remove('active');
+                modal.setAttribute('aria-hidden', 'true');
+            }
+        },
+
+        showToast(msg) {
+            const overlay = this.ensureOverlay();
+            const toast = overlay.querySelector('#vocab-toast');
+            if (!toast) return;
+
+            toast.textContent = msg;
+            toast.classList.add('show');
+
+            clearTimeout(this.toastTimer);
+            this.toastTimer = setTimeout(() => {
+                toast.classList.remove('show');
+            }, 2000);
+        },
+
+        close() {
+            const overlay = this.ensureOverlay();
+            if (overlay) {
+                overlay.classList.add('is-hidden');
+            }
+            document.body.classList.remove('vocab-reader-open');
+            this.modalOpen = false;
+        }
+    };
+
+    // 监听生词更新事件以即时刷新打开的视图
+    if (typeof window !== 'undefined') {
+        window.addEventListener('reading-vocab-store-updated', () => {
+            if (ReadingVocabReader.modalOpen) {
+                ReadingVocabReader.renderVocabList();
+                ReadingVocabReader.updateCounts();
+                ReadingVocabReader.applyVocabHighlights();
+            }
+        });
+    }
+
+    // 暴露全局命名空间
+    global.ReadingVocabStore = ReadingVocabStore;
+    global.ReadingVocabReader = ReadingVocabReader;
+    global.openReadingVocabReader = function(examId, options = {}) {
+        ReadingVocabReader.open(examId, options);
+    };
+
+    // 启动数据同步初始化
+    ReadingVocabStore.init();
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -1585,11 +1585,21 @@
         if (logicalKey.startsWith('recovery.')) return ['id', 'sessionId', 'recordId'];
         if (logicalKey === 'backups.entries') return ['id'];
         if (logicalKey === 'vocab.words') return ['id', 'word', 'key'];
+        if (logicalKey === 'vocab.readingVocabWords') return ['id', 'word'];
+        if (logicalKey === 'vocab.readingBookshelfExams') return ['examId', 'id'];
         if (logicalKey === 'goals.items') return ['id', 'goalId'];
         return ['id', 'sessionId', 'recordId'];
     }
 
     function collectionIdentity(logicalKey, value) {
+        if (logicalKey === 'vocab.readingVocabWords') {
+            const word = value && (value.word || value.id);
+            return word ? String(word).trim().toLowerCase() : idOf(value, ['id', 'word']);
+        }
+        if (logicalKey === 'vocab.readingBookshelfExams') {
+            const examId = value && (value.examId || value.id);
+            return examId ? String(examId).trim() : idOf(value, ['examId', 'id']);
+        }
         const identity = idOf(value, collectionIdentityFields(logicalKey));
         return logicalKey === 'vocab.words' ? identity.trim().toLowerCase() : identity;
     }
@@ -1606,9 +1616,22 @@
             const identity = collectionIdentity(logicalKey, item);
             if (!identity) throw new AppDataError('VALIDATION', `${logicalKey} import item has no stable identity`);
             const position = positions.get(identity);
-            const mergedItem = logicalKey === 'vocab.words'
+            let mergedItem = logicalKey === 'vocab.words'
                 ? preserveProgressPhonetics([item], position === undefined ? [] : [result[position]])[0]
                 : item;
+            if (logicalKey === 'vocab.readingBookshelfExams' && position !== undefined) {
+                const existingRec = result[position] || {};
+                mergedItem = Object.assign({}, existingRec, item, {
+                    firstUsedAt: Math.min(Number(existingRec.firstUsedAt) || Date.now(), Number(item.firstUsedAt) || Date.now()),
+                    lastOpenedAt: Math.max(Number(existingRec.lastOpenedAt) || 0, Number(item.lastOpenedAt) || 0)
+                });
+            } else if (logicalKey === 'vocab.readingVocabWords' && position !== undefined) {
+                const existingWord = result[position] || {};
+                mergedItem = Object.assign({}, existingWord, item, {
+                    createdAt: Math.min(Number(existingWord.createdAt) || Date.now(), Number(item.createdAt) || Date.now()),
+                    updatedAt: Math.max(Number(existingWord.updatedAt) || 0, Number(item.updatedAt) || 0)
+                });
+            }
             if (position !== undefined) result[position] = mergedItem;
             else {
                 positions.set(identity, result.length);
@@ -1810,6 +1833,42 @@
         return createImportPlan(parsed, { replace: true });
     }
 
+    async function flushReadingDataToKernel() {
+        try {
+            if (typeof global.localStorage === 'undefined') return;
+            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
+            if (rawVocab) {
+                const parsed = JSON.parse(rawVocab);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingVocabWords');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
+                    }
+                }
+            }
+            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
+            if (rawBookshelf) {
+                const parsed = JSON.parse(rawBookshelf);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const current = await kernel.read('vocab.readingBookshelfExams');
+                    const currentArr = Array.isArray(current) ? current : [];
+                    if (currentArr.length === 0) {
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
+                    } else if (parsed.length > currentArr.length) {
+                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
+                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
+                    }
+                }
+            }
+        } catch (e) {
+            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
+        }
+    }
+
     const backups = Object.freeze({
         onDataCommitted(listener) { return kernel.onCommitted(listener); },
         async getSettings() { await ready; return kernel.read('backups.settings'); },
@@ -1819,7 +1878,9 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready; const current = await readCollectionMeta('backups.entries');
+            await ready;
+            await flushReadingDataToKernel();
+            const current = await readCollectionMeta('backups.entries');
             const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
             const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
             const existing = current.items.find((item) => String(item.id) === String(backupId));
@@ -1844,6 +1905,7 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
+            await flushReadingDataToKernel();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -2282,6 +2344,32 @@
                 const receipt = await kernel.mutate(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
+        },
+        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async saveReadingWords(words, options = {}) {
+            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingVocabWords',
+                    data: words,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
+        },
+        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async saveReadingBookshelfExams(records, options = {}) {
+            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
+            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
+            return retryVocabMutation(options, async () => {
+                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
+                return kernel.mutate([{
+                    logicalKey: 'vocab.readingBookshelfExams',
+                    data: records,
+                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
+                }], mutation);
+            });
         }
     });
 
@@ -2412,6 +2500,8 @@
         'backups.entries': ['manual_backups'], 'backups.settings': ['backup_settings'],
         'backups.exportHistory': ['export_history'], 'backups.importHistory': ['import_history'],
         'vocab.words': ['vocab_words'], 'vocab.userConfig': ['vocab_user_config'], 'vocab.lists': ['vocab_lists'],
+        'vocab.readingVocabWords': ['ielts_reading_vocab_words_v1'],
+        'vocab.readingBookshelfExams': ['ielts_reading_bookshelf_exams_v1'],
         'preferences.values': ['ui_preferences'], 'goals.items': ['learning_goals'],
         'achievements.manual': ['achievement_manual_state', 'user_achievements']
     });
@@ -2743,6 +2833,11 @@
                 await cleanupExpiredRecovery();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
+            }
+            try {
+                await flushReadingDataToKernel();
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
             return true;
         })

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -1711,6 +1711,14 @@
     }
     async function createImportPlan(parsed, options = {}) {
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
+        // Preserve local-only reading data before capturing revisions for any
+        // reading collection this plan will install, including present arrays.
+        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+            const envelope = asObject(parsed.envelopes)[key];
+            return (replaceDocuments && parsed.scope === 'full')
+                || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
+        });
+        await migrateLegacyReadingData({ required: true, logicalKeys: readingKeys });
         const snapshot = { format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: parsed.scope, envelopes: {}, entities: {} };
         const revisionToken = { documents: {}, entities: {}, entityEpochs: {} };
         const keys = []; const clearedKeys = [];
@@ -1836,18 +1844,19 @@
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
         // Validate the target first, then finish intentional migration before
         // capturing the revision token used by the atomic snapshot install.
-        await migrateLegacyReadingData();
+        await migrateLegacyReadingData({ required: true });
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData() {
+    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
         for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
             try {
-                if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
                 // A present empty array or a cleared envelope is authoritative too.
                 // Legacy mirrors only seed documents that have never been written.
                 if (current.envelope) continue;
+                if (!global.localStorage) return;
                 const raw = global.localStorage.getItem(storageKey);
                 const parsed = raw ? JSON.parse(raw) : null;
                 if (!Array.isArray(parsed)) continue;
@@ -1855,6 +1864,9 @@
                     operationId: randomId('migrate-reading')
                 });
             } catch (error) {
+                // Startup can retry later; a backup or destructive installation
+                // must not discard a legacy copy that has never reached the kernel.
+                if (required) throw error;
                 if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
         }
@@ -1877,7 +1889,7 @@
 
     async function createBackup(options = {}, migrateReading = true) {
         await ready;
-        if (migrateReading) await migrateLegacyReadingData();
+        if (migrateReading) await migrateLegacyReadingData({ required: true });
         const current = await readCollectionMeta('backups.entries');
         const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
         const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
@@ -1966,9 +1978,6 @@
         async previewImport(payload, options = {}) {
             await ready;
             const parsed = parseImportPayload(payload);
-            // Import callers can create a safety backup between preview and
-            // commit. Migrate before capturing the preview token for that path.
-            await migrateLegacyReadingData();
             const prepared = await createImportPlan(parsed, options);
             const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
@@ -1983,6 +1992,10 @@
             if (plan.destructive && options.confirmDestructive !== true) {
                 throw new AppDataError('VALIDATION', 'Destructive import requires explicit confirmation');
             }
+            // Mirrors may arrive after preview, including callers without a
+            // safety backup. Keep the reviewed token: a late successful migration
+            // changes its revision and requires a new preview instead of data loss.
+            await migrateLegacyReadingData({ required: true, logicalKeys: Object.keys(plan.snapshot.envelopes) });
             const mutation = optionsMutationOptions(options, 'import-commit', {
                 planId: plan.id,
                 signature: plan.signature

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -31,6 +31,10 @@
         consent: 'consent', logConfig: 'logConfig'
     });
     const PRACTICE_ENTITY_STORES = Object.freeze(['practiceSummaries', 'practiceDetails', 'practiceAnnotations']);
+    const READING_LEGACY_KEYS = Object.freeze({
+        'vocab.readingVocabWords': 'ielts_reading_vocab_words_v1',
+        'vocab.readingBookshelfExams': 'ielts_reading_bookshelf_exams_v1'
+    });
 
     function asObject(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
     function asArray(value) { return Array.isArray(value) ? value : []; }
@@ -1830,43 +1834,70 @@
         const parsed = parseImportPayload(asObject(backup && backup.data));
         if (parsed.format !== 'v2') throw new AppDataError('VALIDATION', 'Only v2 snapshots can be restored from local backups');
         if (backup.checksum && backup.checksum !== parsed.checksum) throw new AppDataError('VALIDATION', 'Backup checksum mismatch');
+        // Validate the target first, then finish intentional migration before
+        // capturing the revision token used by the atomic snapshot install.
+        await migrateLegacyReadingData();
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function flushReadingDataToKernel() {
-        try {
-            if (typeof global.localStorage === 'undefined') return;
-            const rawVocab = global.localStorage.getItem('ielts_reading_vocab_words_v1');
-            if (rawVocab) {
-                const parsed = JSON.parse(rawVocab);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingVocabWords');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: parsed }], { operationId: 'flush-reading-vocab' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingVocabWords');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingVocabWords', data: merged }], { operationId: 'flush-reading-vocab-merge' });
-                    }
-                }
+    async function migrateLegacyReadingData() {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                // A present empty array or a cleared envelope is authoritative too.
+                // Legacy mirrors only seed documents that have never been written.
+                if (current.envelope) continue;
+                const raw = global.localStorage.getItem(storageKey);
+                const parsed = raw ? JSON.parse(raw) : null;
+                if (!Array.isArray(parsed)) continue;
+                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
+                    operationId: randomId('migrate-reading')
+                });
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
             }
-            const rawBookshelf = global.localStorage.getItem('ielts_reading_bookshelf_exams_v1');
-            if (rawBookshelf) {
-                const parsed = JSON.parse(rawBookshelf);
-                if (Array.isArray(parsed) && parsed.length > 0) {
-                    const current = await kernel.read('vocab.readingBookshelfExams');
-                    const currentArr = Array.isArray(current) ? current : [];
-                    if (currentArr.length === 0) {
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: parsed }], { operationId: 'flush-reading-bookshelf' });
-                    } else if (parsed.length > currentArr.length) {
-                        const merged = mergeCollection(currentArr, parsed, 'vocab.readingBookshelfExams');
-                        await kernel.mutate([{ logicalKey: 'vocab.readingBookshelfExams', data: merged }], { operationId: 'flush-reading-bookshelf-merge' });
-                    }
-                }
-            }
-        } catch (e) {
-            if (global.console && console.warn) console.warn('[AppData v2] flushReadingDataToKernel skipped:', e);
         }
+    }
+
+    async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
+        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+            if (!logicalKeys.includes(logicalKey)) continue;
+            try {
+                if (!global.localStorage) return;
+                const current = await kernel.read(logicalKey, { withMeta: true });
+                if (current.envelope && Array.isArray(current.data)) {
+                    global.localStorage.setItem(storageKey, JSON.stringify(current.data));
+                }
+            } catch (error) {
+                if (global.console && console.warn) console.warn('[AppData v2] reading mirror refresh skipped:', error);
+            }
+        }
+    }
+
+    async function createBackup(options = {}, migrateReading = true) {
+        await ready;
+        if (migrateReading) await migrateLegacyReadingData();
+        const current = await readCollectionMeta('backups.entries');
+        const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
+        const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
+        const existing = current.items.find((item) => String(item.id) === String(backupId));
+        if (existing) {
+            if (String(existing.operationId || '') === String(mutation.operationId)
+                && String(existing.type || 'manual') === String(options.type || 'manual')) {
+                return clone(existing);
+            }
+            throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
+                backupId: String(backupId)
+            });
+        }
+        const snapshot = await kernel.exportSnapshot();
+        const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
+        current.items.unshift(backup);
+        current.items = retainBackupEntries(current.items, 20, options.preserveIds);
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
+        const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
+        return clone(committed || backup);
     }
 
     const backups = Object.freeze({
@@ -1878,34 +1909,13 @@
         async recordExport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.exportHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup export history entry'))); return kernel.mutate([{ logicalKey: 'backups.exportHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-export-history', entry)); },
         async recordImport(entry, options = {}) { await ready; const current = await readCollectionMeta('backups.importHistory'); current.items.unshift(Object.assign({ timestamp: nowIso() }, jsonValue(entry, 'backup import history entry'))); return kernel.mutate([{ logicalKey: 'backups.importHistory', data: current.items.slice(0, 100), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-import-history', entry)); },
         async create(options = {}) {
-            await ready;
-            await flushReadingDataToKernel();
-            const current = await readCollectionMeta('backups.entries');
-            const mutation = optionsMutationOptions(options, 'backup-create', { id: options.id || null, type: options.type || 'manual' });
-            const backupId = options.id || (options.operationId ? `backup_${checksum({ operationId: String(options.operationId) }).replace(/[^a-z0-9]/gi, '')}` : randomId('backup'));
-            const existing = current.items.find((item) => String(item.id) === String(backupId));
-            if (existing) {
-                if (String(existing.operationId || '') === String(mutation.operationId)
-                    && String(existing.type || 'manual') === String(options.type || 'manual')) {
-                    return clone(existing);
-                }
-                throw new AppDataError('CONFLICT', `Backup id already exists: ${backupId}`, {
-                    backupId: String(backupId)
-                });
-            }
-            const snapshot = await kernel.exportSnapshot();
-            const backup = { id: backupId, operationId: mutation.operationId, timestamp: nowIso(), type: options.type || 'manual', version: 2, data: snapshot, size: JSON.stringify(snapshot).length, checksum: snapshot.checksum };
-            current.items.unshift(backup);
-            current.items = retainBackupEntries(current.items, 20, options.preserveIds);
-            await kernel.mutate([{ logicalKey: 'backups.entries', data: current.items, expectedRevision: current.revision }], mutation);
-            const committed = (await kernel.read('backups.entries')).find((item) => String(item.id) === String(backupId));
-            return clone(committed || backup);
+            return createBackup(options);
         },
         async list() { await ready; return kernel.read('backups.entries'); },
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await flushReadingDataToKernel();
+            await migrateLegacyReadingData();
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -1954,7 +1964,13 @@
             }
         },
         async previewImport(payload, options = {}) {
-            await ready; const parsed = parseImportPayload(payload); const prepared = await createImportPlan(parsed, options); const planId = randomId('import-plan');
+            await ready;
+            const parsed = parseImportPayload(payload);
+            // Import callers can create a safety backup between preview and
+            // commit. Migrate before capturing the preview token for that path.
+            await migrateLegacyReadingData();
+            const prepared = await createImportPlan(parsed, options);
+            const planId = randomId('import-plan');
             const cutoff = Date.now() - (30 * 60 * 1000);
             for (const [id, existing] of importPlans) {
                 if (Date.parse(existing.createdAt) < cutoff || importPlans.size >= 20) importPlans.delete(id);
@@ -1976,6 +1992,7 @@
                 expectedRevisionToken: plan.revisionToken
             }));
             importPlans.delete(String(planId));
+            await refreshReadingMirrors(Object.keys(plan.snapshot.envelopes));
             return Object.assign({}, receipt, plan.practiceSummary || {}, { practice: clone(plan.practiceSummary) });
         },
         async restore(id, options = {}) {
@@ -1992,16 +2009,18 @@
                 backupId: String(id),
                 checksum: backup.checksum || checksum(backup.data)
             }).replace(/[^a-z0-9]/gi, '')}`;
-            const preRestoreBackup = await backups.create({
+            // The safety backup must not mutate targets covered by the plan token.
+            const preRestoreBackup = await createBackup({
                 id: preRestoreBackupId,
                 operationId: preRestoreOperationId,
                 type: 'pre-restore',
                 preserveIds: [String(id)]
-            });
+            }, false);
             const receipt = await kernel.installSnapshot(prepared.snapshot, Object.assign({}, restoreMutation, {
                 resetJournal: prepared.resetJournal === true,
                 expectedRevisionToken: prepared.revisionToken
             }));
+            await refreshReadingMirrors(Object.keys(prepared.snapshot.envelopes));
             return Object.assign({}, receipt, { preRestoreBackupId: preRestoreBackup.id });
         }
     });
@@ -2345,7 +2364,7 @@
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
-        async listReadingWords() { await ready; return kernel.read('vocab.readingVocabWords'); },
+        async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
@@ -2358,7 +2377,7 @@
                 }], mutation);
             });
         },
-        async listReadingBookshelfExams() { await ready; return kernel.read('vocab.readingBookshelfExams'); },
+        async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
             await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
@@ -2633,6 +2652,7 @@
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
         }
+        if (Object.prototype.hasOwnProperty.call(READING_LEGACY_KEYS, logicalKey)) return null;
         if (entry.import === 'replace' || entry.import === 'ignore') return null;
         const currentValue = await kernel.read(logicalKey);
         const next = reconcileLegacyValue(entry, legacyValue, currentValue);
@@ -2835,7 +2855,8 @@
                 if (global.console && console.warn) console.warn('[AppData v2] recovery cleanup skipped:', error);
             }
             try {
-                await flushReadingDataToKernel();
+                await migrateLegacyReadingData();
+                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/data/v2/dataCatalog.js
+++ b/js/data/v2/dataCatalog.js
@@ -138,6 +138,16 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
+            logicalKey: 'vocab.readingBookshelfExams', classification: 'authoritative',
+            defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
+            export: true, import: 'merge-by-id'
+        },
+        {
             logicalKey: 'preferences.values', classification: 'preference',
             defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
             export: true, import: 'patch'

--- a/js/data/v2/dataKernel.js
+++ b/js/data/v2/dataKernel.js
@@ -28,7 +28,9 @@
     const LEGACY_UNPREFIXED_WEB_KEYS = Object.freeze([
         'practice_records',
         'vocab_user_config',
-        'user_achievements'
+        'user_achievements',
+        'ielts_reading_vocab_words_v1',
+        'ielts_reading_bookshelf_exams_v1'
     ]);
 
     function clone(value) { return catalog.clone(value); }

--- a/js/main.js
+++ b/js/main.js
@@ -3584,6 +3584,27 @@ function createFallbackExamCard(exam, options = {}) {
             viewPDF(exam.id);
         });
         actions.appendChild(pdfBtn);
+
+        const isReading = exam && (exam.type === 'reading' || !exam.type || String(exam.type).toLowerCase() !== 'listening') && exam.hasHtml !== false;
+        if (isReading && exam && exam.id) {
+            const vocabBtn = document.createElement('button');
+            vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
+            vocabBtn.type = 'button';
+            vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examId = exam.id;
+            vocabBtn.textContent = '精读';
+            vocabBtn.title = '打开该题全文精读与生词本';
+            vocabBtn.addEventListener('click', function (e) {
+                e.preventDefault();
+                if (window.ReadingVocabReader && typeof window.ReadingVocabReader.open === 'function') {
+                    window.ReadingVocabReader.open(exam.id);
+                } else if (typeof window.openReadingVocabReader === 'function') {
+                    window.openReadingVocabReader(exam.id);
+                }
+            });
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
     }
 
     item.appendChild(info);

--- a/js/presentation/app-actions.js
+++ b/js/presentation/app-actions.js
@@ -1040,10 +1040,58 @@
         startRandomPractice: startRandomPractice,
         // Phase 4
         startEndlessPractice: startEndlessPractice,
-        stopEndlessPractice: stopEndlessPractice
+        stopEndlessPractice: stopEndlessPractice,
+        openBookshelf: openBookshelf
     });
 
+    function openBookshelf(options) {
+        var fromView = (options && options.fromView) || 'overview';
+        return Promise.resolve().then(function () {
+            if (global.AppEntry && typeof global.AppEntry.ensureMoreToolsGroup === 'function') {
+                return global.AppEntry.ensureMoreToolsGroup();
+            }
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                return global.AppLazyLoader.ensureGroup('more-tools');
+            }
+            return null;
+        }).then(function () {
+            var bookshelfView = document.getElementById('bookshelf-view');
+            if (bookshelfView) {
+                bookshelfView.removeAttribute('hidden');
+            }
+            if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                global.BookshelfView.mount('#bookshelf-view', { fromView: fromView });
+            }
+            if (global.app && typeof global.app.navigateToView === 'function') {
+                global.app.navigateToView('bookshelf');
+            } else if (typeof global.switchView === 'function') {
+                global.switchView('bookshelf');
+            }
+            var allViews = document.querySelectorAll('.view');
+            for (var i = 0; i < allViews.length; i++) {
+                allViews[i].classList.remove('active');
+            }
+            if (bookshelfView) {
+                bookshelfView.classList.add('active');
+            }
+            var allNavBtns = document.querySelectorAll('.nav-btn');
+            for (var j = 0; j < allNavBtns.length; j++) {
+                allNavBtns[j].classList.remove('active');
+            }
+            var moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn) {
+                moreNavBtn.classList.add('active');
+            }
+        }).catch(function (error) {
+            console.warn('[AppActions] 打开书架失败:', error);
+            if (typeof global.showMessage === 'function') {
+                global.showMessage('未能打开阅读书架，请稍后重试。', 'warning');
+            }
+        });
+    }
+
     // 挂载到全局（向后兼容）
+    global.openBookshelfView = openBookshelf;
     global.startSuitePractice = startSuitePractice;
     global.continueSuitePractice = continueSuitePractice;
     global.openExamWithFallback = openExamWithFallback;

--- a/js/presentation/moreView.js
+++ b/js/presentation/moreView.js
@@ -65,6 +65,7 @@
         }
 
         var clockTrigger = moreView.querySelector('[data-action="open-clock"]');
+        var bookshelfTrigger = moreView.querySelector('[data-action="open-bookshelf"]');
         var vocabTrigger = moreView.querySelector('[data-action="open-vocab"]');
         var memorizeTrigger = moreView.querySelector('[data-action="open-reading-memorize"]');
         var closeTrigger = overlay.querySelector('[data-action="close-clock"]');
@@ -139,11 +140,59 @@
             vocabTrigger.addEventListener('click', handleVocabEntry);
         }
 
+        if (bookshelfTrigger) {
+            bookshelfTrigger.addEventListener('click', handleBookshelfEntry);
+        }
+
         if (memorizeTrigger) {
             memorizeTrigger.addEventListener('click', handleReadingMemorizeEntry);
         }
 
         moreViewInteractionsConfigured = true;
+    }
+
+    function handleBookshelfEntry(event) {
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        var mountView = function () {
+            if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
+                global.BookshelfView.mount('#bookshelf-view');
+            }
+        };
+
+        var bookshelfView = document.getElementById('bookshelf-view');
+        if (bookshelfView) {
+            bookshelfView.removeAttribute('hidden');
+        }
+
+        if (global.app && typeof global.app.navigateToView === 'function') {
+            global.app.navigateToView('bookshelf');
+            var moreNavBtn = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn) {
+                moreNavBtn.classList.add('active');
+            }
+            mountView();
+            return;
+        }
+
+        var moreView = document.getElementById('more-view');
+        if (bookshelfView && moreView) {
+            moreView.classList.remove('active');
+            bookshelfView.classList.add('active');
+            var moreNavBtn2 = document.querySelector('.nav-btn[data-view="more"]');
+            if (moreNavBtn2) {
+                moreNavBtn2.classList.add('active');
+            }
+            mountView();
+            return;
+        }
+
+        if (typeof global.showMessage === 'function') {
+            global.showMessage('未能打开阅读书架，请检查页面结构。', 'warning');
+        } else if (typeof global.alert === 'function') {
+            global.alert('未能打开阅读书架，请检查页面结构。');
+        }
     }
 
     function handleReadingMemorizeEntry(event) {

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -2261,7 +2261,12 @@
         }
     }
 
+    // Keep the practice entry unavailable until #157 isolates the reader's
+    // question controls from practice radio groups and answer collection.
+    const PRACTICE_VOCAB_READER_ENABLED = false;
+
     function openVocabReaderForCurrentExam() {
+        if (!PRACTICE_VOCAB_READER_ENABLED) return;
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
@@ -2279,6 +2284,7 @@
     }
 
     function ensureReadingVocabButton() {
+        if (!PRACTICE_VOCAB_READER_ENABLED) return null;
         let button = document.getElementById('reading-vocab-header-btn');
         if (button) return button;
         const headerRight = document.querySelector('.header-right');

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -2163,6 +2163,150 @@
         return button;
     }
 
+    function ensureVocabReaderStyles() {
+        if (!document.getElementById('vocab-reader-stylesheet')) {
+            const link = document.createElement('link');
+            link.id = 'vocab-reader-stylesheet';
+            link.rel = 'stylesheet';
+            link.href = '../../../css/vocab-reader.css';
+            document.head.appendChild(link);
+        }
+        if (!document.getElementById('reading-vocab-button-styles')) {
+            const style = document.createElement('style');
+            style.id = 'reading-vocab-button-styles';
+            style.textContent = `
+                .reading-vocab-btn {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 4px;
+                    padding: 7px 11px;
+                    font-size: 0.88rem;
+                    line-height: 1;
+                    color: var(--text);
+                    background: var(--panel);
+                    border: 1px solid var(--line);
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: all 0.15s ease;
+                    user-select: none;
+                }
+                .reading-vocab-btn:hover {
+                    background: #f1f5f9;
+                    border-color: #94a3b8;
+                }
+                body.dark-mode .reading-vocab-btn {
+                    background: #1e293b;
+                    border-color: #475569;
+                    color: #cbd5e1;
+                }
+                body.dark-mode .reading-vocab-btn:hover {
+                    background: #334155;
+                    border-color: #64748b;
+                    color: #f8fafc;
+                }
+                .reading-vocab-btn .vocab-btn-icon {
+                    font-size: 13px;
+                    line-height: 1;
+                }
+                .reading-vocab-btn .vocab-btn-label {
+                    font-size: 0.88rem;
+                }
+                .results-header-bar {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 12px;
+                    margin-bottom: 8px;
+                    flex-wrap: wrap;
+                }
+                .results-header-bar h4 {
+                    margin: 0;
+                }
+                .results-score-text {
+                    margin: 4px 0 0 0;
+                    color: var(--muted, #64748b);
+                    font-size: 0.95rem;
+                }
+                .results-vocab-btn {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 7px 14px;
+                    font-size: 0.88rem;
+                    font-weight: 600;
+                    color: #1d4ed8;
+                    background: #eff6ff;
+                    border: 1px solid #bfdbfe;
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: all 0.15s ease;
+                }
+                .results-vocab-btn:hover {
+                    background: #dbeafe;
+                    border-color: #93c5fd;
+                    transform: translateY(-1px);
+                    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.12);
+                }
+                body.dark-mode .results-vocab-btn {
+                    color: #93c5fd;
+                    background: rgba(30, 58, 138, 0.35);
+                    border-color: rgba(96, 165, 250, 0.4);
+                }
+                body.dark-mode .results-vocab-btn:hover {
+                    background: rgba(30, 58, 138, 0.6);
+                    border-color: #60a5fa;
+                }
+            `;
+            document.head.appendChild(style);
+        }
+    }
+
+    function openVocabReaderForCurrentExam() {
+        const examId = state.suite?.activeExamId || state.examId;
+        if (!examId) {
+            console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
+            return;
+        }
+        ensureVocabReaderStyles();
+
+        if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
+            global.ReadingVocabReader.open(examId, { fromPractice: true });
+        } else if (typeof global.openReadingVocabReader === 'function') {
+            global.openReadingVocabReader(examId, { fromPractice: true });
+        } else {
+            console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
+        }
+    }
+
+    function ensureReadingVocabButton() {
+        let button = document.getElementById('reading-vocab-header-btn');
+        if (button) return button;
+        const headerRight = document.querySelector('.header-right');
+        if (!headerRight) return null;
+        ensureVocabReaderStyles();
+
+        button = document.createElement('button');
+        button.id = 'reading-vocab-header-btn';
+        button.type = 'button';
+        button.className = 'header-btn reading-vocab-btn';
+        button.title = '划词生词本 (段落精读与单词记录)';
+        button.setAttribute('aria-label', '打开划词生词本');
+        button.innerHTML = '<span class="vocab-btn-icon" aria-hidden="true">📖</span><span class="vocab-btn-label">生词本</span>';
+
+        const notesBtn = document.getElementById('notes-drawer-btn');
+        if (notesBtn && notesBtn.parentNode === headerRight) {
+            headerRight.insertBefore(button, notesBtn.nextSibling);
+        } else {
+            headerRight.insertBefore(button, headerRight.firstChild);
+        }
+
+        button.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openVocabReaderForCurrentExam();
+        });
+        return button;
+    }
+
     function ensureReadingNotesUi() {
         ensureReadingNoteStyles();
         ensureReadingNotesButton();
@@ -5691,8 +5835,16 @@
             `;
         }).join('');
         dom.results.innerHTML = `
-            <h4>答题结果</h4>
-            <p>得分 ${results.scoreInfo.correct} / ${results.scoreInfo.totalQuestions} · ${results.scoreInfo.percentage}%</p>
+            <div class="results-header-bar">
+                <div class="results-header-summary">
+                    <h4>答题结果</h4>
+                    <p class="results-score-text">得分 ${results.scoreInfo.correct} / ${results.scoreInfo.totalQuestions} · ${results.scoreInfo.percentage}%</p>
+                </div>
+                <button type="button" class="results-vocab-btn" id="results-vocab-btn" title="进入划词生词本模式（段落精读、查词发音、加入生词本）">
+                    <span class="results-vocab-icon" aria-hidden="true">📖</span>
+                    <span>划词生词本</span>
+                </button>
+            </div>
             <table class="results-table">
                 <thead>
                     <tr>
@@ -5709,6 +5861,13 @@
         dom.results.querySelectorAll?.('[data-result-question-id]').forEach((button) => {
             button.addEventListener('click', () => jumpToQuestionEvidence(button.dataset.resultQuestionId || ''));
         });
+        const resultsVocabBtn = dom.results.querySelector('#results-vocab-btn');
+        if (resultsVocabBtn) {
+            resultsVocabBtn.addEventListener('click', () => {
+                openVocabReaderForCurrentExam();
+            });
+        }
+        ensureReadingVocabButton();
         applyResultsToQuestionArea(results);
     }
 
@@ -8330,6 +8489,7 @@
         attachUnifiedTimer();
         attachUnifiedPanels();
         ensureReadingNotesUi();
+        ensureReadingVocabButton();
         ensureReadingDisplayControls();
         await loadReadingDisplayPreferences();
         attachSelectionHighlightToolbar();

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -2847,6 +2847,22 @@
             actions.appendChild(pdfBtn);
         }
 
+        var isReadingExam = exam && (exam.type === 'reading' || !exam.type || String(exam.type).toLowerCase() !== 'listening') && exam.hasHtml !== false;
+        if (isReadingExam && exam.id) {
+            var vocabBtn = this._createElement('button', {
+                className: 'btn btn-outline exam-item-action-btn exam-item-vocab-btn',
+                dataset: { action: 'vocab-book', examId: exam.id },
+                type: 'button',
+                title: '打开该题全文精读与生词本'
+            }, '精读');
+            if (isSelecting) {
+                vocabBtn.disabled = true;
+                vocabBtn.setAttribute('aria-disabled', 'true');
+            }
+            actions.appendChild(vocabBtn);
+            actions.classList.add('has-vocab-btn');
+        }
+
         if (this._shouldShowGenerate(exam, options)) {
             var generateBtn = this._createElement('button', {
                 className: 'btn btn-info exam-item-action-btn',

--- a/js/views/overviewView.js
+++ b/js/views/overviewView.js
@@ -71,6 +71,23 @@
                 }
             });
 
+            this.events.delegate('click', `${this.containerSelector} [data-action="open-bookshelf"], ${this.containerSelector} [data-action="open-vocab-book"]`, function (event) {
+                event.preventDefault();
+                if (typeof global.openBookshelfView === 'function') {
+                    global.openBookshelfView({ fromView: 'overview' });
+                    return;
+                }
+                if (global.AppActions && typeof global.AppActions.openBookshelf === 'function') {
+                    global.AppActions.openBookshelf({ fromView: 'overview' });
+                    return;
+                }
+                if (global.app && typeof global.app.navigateToView === 'function') {
+                    global.app.navigateToView('bookshelf');
+                } else if (typeof global.switchView === 'function') {
+                    global.switchView('bookshelf');
+                }
+            });
+
             this.delegatesBound = true;
         }
 
@@ -94,7 +111,7 @@
                 icon: '📖',
                 entries: stats?.reading || [],
                 style: { gridColumn: '1 / -1' },
-                rightButtons: [this.createEndlessModeButton(), this.createSuiteModeButton()]
+                rightButtons: [this.createBookshelfButton(), this.createEndlessModeButton(), this.createSuiteModeButton()]
             });
 
             fragment.appendChild(readingSection);
@@ -285,6 +302,31 @@
                 this.createSvgIcon('<path d="M20 6v5h-5"></path><path d="M4 18v-5h5"></path><path d="M6.2 11a6 6 0 0 1 10.6-2.4L20 11"></path><path d="M17.8 13a6 6 0 0 1-10.6 2.4L4 13"></path>'),
                 this.dom.create('span', {}, '无尽模式')
             ]);
+        }
+
+        createBookshelfButton() {
+            return this.dom.create('button', {
+                className: 'shui-glass-btn',
+                type: 'button',
+                id: 'bookshelf-overview-btn',
+                dataset: {
+                    action: 'open-bookshelf',
+                    overviewAction: 'bookshelf'
+                },
+                title: '打开阅读书架',
+                style: {
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px'
+                }
+            }, [
+                this.createSvgIcon('<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>'),
+                this.dom.create('span', {}, '书架')
+            ]);
+        }
+
+        createVocabBookButton() {
+            return this.createBookshelfButton();
         }
     }
 

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -29,6 +29,8 @@ const bundles = {
         'js/core/practiceCore.js',
         'js/core/resourceCore.js',
         'assets/generated/reading-exams/manifest.js',
+        'js/runtime/readingExamRegistry.js',
+        'js/runtime/readingExplanationRegistry.js',
         'js/app/state-service.js',
         'js/services/libraryDiscovery.js',
         'js/services/libraryManager.js'
@@ -59,6 +61,7 @@ const bundles = {
         'js/app/examSessionMixin.js',
         'js/app/browseController.js',
         'js/components/PDFHandler.js',
+        'js/components/readingVocabReader.js',
         'js/components/BrowseStateManager.js',
         'js/utils/suiteBackGuard.js',
         'js/utils/answerMatchCore.js',
@@ -101,6 +104,7 @@ const bundles = {
         'js/core/dictionaryService.js',
         'js/runtime/reviewHighlightDictionary.js',
         'js/utils/practiceTimerPreferences.js',
+        'js/components/readingVocabReader.js',
         'js/runtime/unifiedReadingPage.js'
     ],
     'js/bundles/practice-page-enhancer.bundle.js': [
@@ -145,6 +149,7 @@ const bundles = {
         'js/app/vocabListSwitcher.js',
         'js/components/vocabDashboardCards.js',
         'js/components/vocabSessionView.js',
+        'js/components/bookshelfView.js',
         'js/presentation/moreView.js',
         'js/presentation/miniGames.js',
         'js/services/achievementManager.js'


### PR DESCRIPTION
Integrates the reviewed intensive-reading implementation with current `opensource` and establishes the regression baseline for #149 while preserving existing practice submissions and backup/reset behavior.

## Changes

- Integrate the reader, vocabulary/bookshelf components, entrypoints, data envelopes, and build registration while preserving upstream data, recovery, annotation, and build fixes.
- Preserve the upstream production reset implementation and its locking, backup-service, and failure-reporting contract. Exclude the unrelated direct reset fallback, reset dialog, and SEO changes.
- Treat existing canonical reading collections, including cleared/empty/smaller snapshots, as authoritative. Refresh affected mirrors after restore/import and prevent lazy reader/bookshelf initialization from reimporting stale records. Preserve the legacy copy when initial migration fails before creating a canonical envelope.
- Require successful legacy reading migration before safety-backup creation and before restore/import plans affect reading collections. Migration failures abort before snapshot installation or mirror refresh, preserving the only local copy. Recheck affected reading data at import commit without rebasing the preview token; unrelated partial imports remain independent. Safety-backup creation cannot invalidate the restore plan, while genuine concurrent writers still cause a conflict.
- Encode stored vocabulary text and attributes, render retry errors as text, and discard obsolete exam/explanation/selection completions after switching or closing the reader.
- Keep the practice reader entry unavailable pending #157. The browser regression verifies that `p2-low-08` still submits the original `q1=A` answer.
- Repair module-relative test paths and navigation fixtures; cover reset failure paths, reader safety, real IndexedDB restore/import, and migration quota failures. Regenerate committed bundles.

## Fixed revisions

- Upstream base (`opensource`): `8a48cefc180869f34b5c1b622c0a1bb2b288cc6b`
- Reviewed author implementation: `a161cee9099a9432c9de556f0a66eb2fa02f44ac`
- Implementation head: `9c3c2312d8d9819ecaf63e2980c299886b7642e7`

## Validation

Validation completed against the committed implementation:

| Check | Result |
| --- | --- |
| `node scripts/build-bundles.mjs --check` | 14/14 outputs current |
| Package test command from `developer`: `node --test --test-concurrency=1 "tests/js/**/*.test.js"` | 175/175 passed; no skips |
| Python unit suite | 26/26 passed |
| Reading data integrity | 238 files checked; no blocking issues |
| `python developer/tests/e2e/e2e_runner.py` with the configured Playwright 1.56 runtime | 9/9 passed |
| `git diff --check` | Passed |

The new browser regressions fail against the previous vulnerable implementation and pass with these fixes. They cover literal text/attribute rendering, valid speech/deletion/retry behavior, obsolete reader loads, first-attempt restore/import, cold reload, cleared/empty/smaller collections, migration-only quota failures followed by restore/import, recoverable retries with complete safety snapshots, and retained concurrent-writer conflict checks. Existing suites continue to cover canonical data, vocabulary, annotations, interrupted practice/history, navigation, submission, backup, and reset behavior.

[Repository CI run 34187514453](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34187514453) passed for this head, including every required bundle, JavaScript, Python, reading integrity, and E2E step under the repository configuration. GitGuardian Security Checks passed. GitHub verifies the implementation commit's GPG signature as valid.

## Delivery boundary

This delivers the integration baseline. Canonical associations and persistence (#155–#156), full reader/practice isolation (#157), content and occurrence restoration (#158), bookshelf/cold entry acceptance (#159), and combined export/browser/release acceptance (#160) remain separate work. The practice entry stays gated until #157; these checks do not establish full Intensive Reading v1 acceptance or third-party import compatibility.

Closes #154.
Refs #149; the parent remains open.



