### PR TITLE
fix(reading): isolate intensive reader from practice state

### DIFF
--- a/css/vocab-reader.css
+++ b/css/vocab-reader.css
@@ -545,8 +545,20 @@ mark.vocab-highlight:active,
     margin: 0 0 12px 0;
 }
 
-.vocab-question-group .drag-item,
-.vocab-question-group .pool-items {
+.vocab-question-group .vocab-answer-blank {
+    display: inline-block;
+    margin-inline: 0.2em;
+    color: #64748b;
+    user-select: text;
+}
+
+.vocab-question-group .vocab-question-options {
+    white-space: normal;
+    user-select: text;
+}
+
+.vocab-question-group .vocab-question-option,
+.vocab-question-group .vocab-question-pool {
     user-select: text !important;
 }
 

--- a/developer/tests/e2e/e2e_runner.py
+++ b/developer/tests/e2e/e2e_runner.py
@@ -25,6 +25,7 @@ if hasattr(sys.stderr, "reconfigure"):
 E2E_CASES = [
     "browse_preference_toggle_flow.py",
     "reading_single_flow.py",
+    "reading_reader_isolation.py",
     "interrupted_history_flow.py",
     "listening_practice_flow.py",
     "suite_practice_flow.py",

--- a/developer/tests/e2e/reading_reader_isolation.node.js
+++ b/developer/tests/e2e/reading_reader_isolation.node.js
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/** Real Chromium regression for #157. Run with --baseline-only to prove the old collision. */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const reports = path.join(root, 'developer/tests/e2e/reports');
+const baselineSha = '0d6833dda6a28cf1ea7f4d92a060f3625b512505';
+const baselineOnly = process.argv.includes('--baseline-only');
+const baselineFile = path.join(reports, 'issue157-baseline-reading-page.bundle.js');
+const practicePath = 'assets/generated/reading-exams/reading-practice-unified.html';
+const examId = 'p2-low-08';
+fs.mkdirSync(reports, { recursive: true });
+if (baselineOnly && !fs.existsSync(baselineFile)) {
+    fs.writeFileSync(baselineFile, execFileSync('git', ['show', `${baselineSha}:js/bundles/reading-page.bundle.js`], { cwd: root, maxBuffer: 8_000_000 }));
+}
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+const server = http.createServer((req, res) => {
+    const relative = decodeURIComponent(new URL(req.url, 'http://localhost').pathname).replace(/^\/+/, '') || 'index.html';
+    const filename = path.resolve(root, relative);
+    if (!filename.startsWith(root + path.sep)) { res.writeHead(403).end(); return; }
+    try {
+        let body = fs.readFileSync(filename);
+        if (baselineOnly && relative === 'js/bundles/reading-page.bundle.js') {
+            // Expose the existing collector without changing its implementation.
+            body = fs.readFileSync(baselineFile, 'utf8').replace('                buildReplayResults,', '                collectAnswers,\n                collectCurrentDraft,\n                buildReplayResults,');
+        }
+        res.writeHead(200, { 'Content-Type': mime[path.extname(filename)] || 'application/octet-stream' });
+        res.end(body);
+    } catch { res.writeHead(404).end(); }
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}), args: ['--allow-file-access-from-files'] }).catch(async error => {
+    await new Promise(resolve => server.close(resolve));
+    throw error;
+});
+const report = { generatedAt: new Date().toISOString(), baselineSha, browser: browser.version(), cases: [] };
+
+async function newContext() {
+    const context = await browser.newContext();
+    await context.addInitScript(() => {
+        window.__IELTS_READING_PAGE_TEST_HOOKS__ = true;
+        const records = [];
+        const add = EventTarget.prototype.addEventListener;
+        const remove = EventTarget.prototype.removeEventListener;
+        EventTarget.prototype.addEventListener = function(type, fn, options) {
+            const capture = typeof options === 'boolean' ? options : !!options?.capture;
+            if (!records.some(item => item.target === this && item.type === type && item.fn === fn && item.capture === capture)) {
+                records.push({ target: this, type, fn, capture });
+            }
+            return add.call(this, type, fn, options);
+        };
+        EventTarget.prototype.removeEventListener = function(type, fn, options) {
+            const capture = typeof options === 'boolean' ? options : !!options?.capture;
+            const index = records.findIndex(item => item.target === this && item.type === type && item.fn === fn && item.capture === capture);
+            if (index >= 0) records.splice(index, 1);
+            return remove.call(this, type, fn, options);
+        };
+        window.__readerListenerCounts = () => {
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            return records.reduce((counts, { target, type }) => {
+                const scope = target === window ? 'window' : target === document ? 'document' : overlay?.contains(target) ? 'reader' : '';
+                if (scope) counts[`${scope}:${type}`] = (counts[`${scope}:${type}`] || 0) + 1;
+                return counts;
+            }, {});
+        };
+    });
+    return context;
+}
+
+async function practiceReady(page) {
+    await page.waitForFunction(() => document.querySelector('#question-groups input[name="q1"]') && window.__IELTS_UNIFIED_READING_PAGE_TEST__, null, { timeout: 30_000 });
+}
+
+async function openReader(page, useEntry = true) {
+    if (useEntry) await page.locator('#reading-vocab-header-btn').click();
+    else await page.evaluate(id => ReadingVocabReader.open(id, { fromPractice: true }), examId);
+    await page.locator('#vocab-reader-tabs [data-para="questions"]').waitFor();
+}
+
+async function baselineCollision() {
+    const context = await newContext();
+    try {
+        const page = await context.newPage();
+        await page.goto(`${origin}/${practicePath}?examId=${examId}`);
+        await practiceReady(page);
+        await page.locator('#question-groups input[name="q1"][value="A"]').check();
+        await openReader(page, false); // The integration baseline intentionally gates the practice button.
+        await page.locator('#vocab-reader-tabs [data-para="questions"]').click();
+        await page.locator('#vocab-questions-content input[name="q1"][value="B"]').check();
+        await page.locator('#vocab-reader-back-btn').click();
+        const collision = await page.evaluate(() => ({
+            originalA: document.querySelector('#question-groups input[name="q1"][value="A"]').checked,
+            hiddenB: document.querySelector('#vocab-questions-content input[name="q1"][value="B"]').checked,
+            collected: window.__IELTS_UNIFIED_READING_PAGE_TEST__.collectAnswers().q1
+        }));
+        assert.deepEqual(collision, { originalA: false, hiddenB: true, collected: 'B' });
+        await page.screenshot({ path: path.join(reports, 'issue157-baseline-collision.png') });
+        report.cases.push({ name: 'before-fix-real-radio-collision', status: 'pass', ...collision });
+    } finally { await context.close(); }
+}
+
+async function hostReady(page, protocol) {
+    const url = protocol === 'file' ? pathToFileURL(path.join(root, 'index.html')).href : `${origin}/index.html`;
+    await page.goto(`${url}?test_env=1`);
+    await page.waitForFunction(() => window.app?.isInitialized && window.AppData, null, { timeout: 60_000 });
+    await page.evaluate(async () => { await AppData.ready; await window.LicenseModal?.accept(); });
+    await page.evaluate(() => {
+        document.querySelector('#library-loader-overlay [data-library-action="close"]')?.click();
+        document.querySelector('nav button[data-view="browse"]')?.click();
+    });
+    await page.waitForFunction(async id => typeof window.app?.openExam === 'function' && (await window.resolveActiveLibraryIndex()).some(exam => exam.id === id), examId, { timeout: 60_000 });
+    await page.evaluate(() => window.AppLazyLoader.ensureGroup('browse-runtime'));
+    await page.waitForFunction(() => !!window.ReadingVocabReader);
+}
+
+async function hostSnapshot(page) {
+    return page.evaluate(async () => ({
+        history: await AppData.practice.list({ projection: 'full' }),
+        active: (await AppData.recovery.listActiveSessions()).map(item => ({ id: item.id, examId: item.examId, sessionId: item.sessionId })).sort((a, b) => String(a.id).localeCompare(String(b.id))),
+        interrupted: await AppData.recovery.listInterrupted(),
+        sessions: [...(window.app.components.practiceRecorder?.activeSessions || [])].map(([id, value]) => ({ id, sessionId: value.sessionId, startTime: value.startTime })),
+        windows: [...(window.app.examWindows || [])].map(([id, value]) => ({ id, sessionId: value.expectedSessionId }))
+    }));
+}
+
+async function practiceSnapshot(page) {
+    return page.evaluate(() => {
+        const api = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+        const state = api.getTestState();
+        const answers = api.collectAnswers();
+        const results = api.buildResultsFromAnswers(window.__READING_EXAM_DATA__.get(state.dataKey), answers);
+        return { state, answers, results, draft: api.collectCurrentDraft(), timer: window.__IELTS_PRACTICE_TIMER__.getSnapshot() };
+    });
+}
+
+async function selectWord(page, selector, word = '') {
+    return page.evaluate(({ selector, word }) => {
+        const target = document.querySelector(selector);
+        const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+        let text;
+        while ((text = walker.nextNode())) {
+            if (text.parentElement.closest('button, script, style, .vocab-paragraph-tag, .vocab-translation-card, .hl, mark')) continue;
+            const match = word ? text.textContent.indexOf(word) : text.textContent.search(/[A-Za-z]{5,}/);
+            if (match < 0) continue;
+            const selected = word || text.textContent.slice(match).match(/^[A-Za-z]+/)[0];
+            const range = document.createRange();
+            range.setStart(text, match);
+            range.setEnd(text, match + selected.length);
+            const selection = getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            text.parentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            return selected;
+        }
+        throw new Error(`No selectable word in ${selector}`);
+    }, { selector, word });
+}
+
+async function finalRegression(protocol) {
+    const context = await newContext();
+    const page = await context.newPage();
+    page.on('dialog', dialog => dialog.accept());
+    try {
+        await hostReady(page, protocol);
+        const empty = await hostSnapshot(page);
+        await page.evaluate(() => window.app.browseCategory('all', 'reading'));
+        const browseEntry = page.locator('#exam-list-container [data-action="vocab-book"]').first();
+        await browseEntry.waitFor();
+        const readerOnlyExamId = await browseEntry.getAttribute('data-exam-id');
+        for (const entry of ['Browse', 'Bookshelf']) {
+            if (entry === 'Browse') await browseEntry.click();
+            else {
+                await page.locator('nav button[data-view="more"]').click();
+                await page.locator('#bookshelf-tool-card').click();
+                await page.locator(`#bookshelf-view button[data-action="open-reading-vocab"][data-exam-id="${readerOnlyExamId}"]`).click();
+            }
+            await page.locator('#vocab-reader-tabs [data-para="questions"]').waitFor();
+            await page.locator('#vocab-reader-back-btn').click();
+            assert.deepEqual(await hostSnapshot(page), empty, `${protocol}: reader-only ${entry} must not create practice data`);
+        }
+        const popupPromise = page.waitForEvent('popup');
+        await page.evaluate(async id => { await window.app.openExam(id); }, examId);
+        const practice = await popupPromise;
+        practice.on('dialog', dialog => dialog.accept());
+        await practiceReady(practice);
+        await practice.waitForFunction(() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.getTestState().sessionId && window.__IELTS_UNIFIED_READING_PAGE_TEST__.getTestState().sessionReadySent);
+        await practice.locator('#question-groups input[name="q1"][value="A"]').check();
+        await practice.locator('#question-groups input[name="q13"]').fill('adhering');
+        // The reported real exam supplies radio/text/dropzone controls. Add checkbox/select
+        // fixtures to that actual rendered answer container to exercise the other supported types.
+        await practice.evaluate(() => {
+            for (const name of ['q2', 'q3']) document.querySelectorAll(`#question-groups input[name="${name}"]`).forEach(node => node.remove());
+            const fixture = document.createElement('div');
+            fixture.id = 'reader-isolation-answer-fixture';
+            fixture.innerHTML = '<input type="checkbox" name="q2" value="A" checked><input type="checkbox" name="q2" value="C" checked><select name="q3"><option value="">Choose</option><option value="D" selected>Delta</option></select>';
+            document.querySelector('#question-groups').append(fixture);
+            fixture.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        await selectWord(practice, '#left');
+        await practice.evaluate(() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.updateSelectionToolbar());
+        await practice.locator('#btnHL').click();
+        assert.ok(await practice.locator('#left .hl').count(), 'practice selection highlighting must work');
+        await selectWord(practice, '#left');
+        await practice.evaluate(() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.updateSelectionToolbar());
+        await practice.locator('#btnNote').click();
+        await practice.locator('#reading-note-editor [data-note-body]').fill('Reader isolation regression note');
+        await practice.evaluate(() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.closeNoteEditor());
+        await page.waitForFunction(async id => (await AppData.recovery.listDrafts()).some(draft => draft.examId === id && draft.answers?.q1 === 'A'), examId);
+        const before = await practiceSnapshot(practice);
+        assert.equal(before.answers.q1, 'A');
+        assert.deepEqual(before.answers.q2, ['A', 'C']);
+        assert.equal(before.answers.q3, 'D');
+        assert.equal(before.answers.q13, 'adhering');
+        assert.ok(before.state.notes.some(note => note.body === 'Reader isolation regression note'));
+        const hostBefore = await hostSnapshot(page);
+        let firstListenerCounts;
+        for (let cycle = 0; cycle < 3; cycle++) {
+            await openReader(practice);
+            assert.equal(await practice.locator('#vocab-reader-tabs [data-para="all"]').getAttribute('class').then(value => value.includes('active')), true);
+            assert.equal(await practice.locator('#vocab-passage-content').isVisible(), true);
+            await practice.locator('#vocab-reader-tabs [data-para="questions"]').click();
+            assert.equal(await practice.locator('#vocab-questions-content').isVisible(), true);
+            assert.equal(await practice.locator('#vocab-questions-content input, #vocab-questions-content select, #vocab-questions-content textarea, #vocab-questions-content [contenteditable="true"]').count(), 0);
+            assert.equal(await practice.locator('#vocab-questions-content [draggable="true"], #vocab-questions-content .drop-target-summary, #vocab-questions-content [data-question]').count(), 0);
+            const selected = await selectWord(practice, '#vocab-questions-content');
+            await practice.waitForFunction(word => ReadingVocabStore.getAll().some(entry => entry.word === word), selected);
+            assert.deepEqual((await practiceSnapshot(practice)).answers, before.answers, 'reader selection must preserve every answer');
+            if (cycle === 0) {
+                await practice.screenshot({ path: path.join(reports, `issue157-${protocol}-questions.png`) });
+                await practice.evaluate(() => {
+                    const foreign = document.createElement('div');
+                    foreign.id = 'reader-isolation-foreign-controls';
+                    foreign.hidden = true;
+                    foreign.innerHTML = '<input type="checkbox" name="q2" value="Z" checked><input type="radio" name="q16" value="B" checked><input type="text" name="q14" value="foreign"><select name="q15"><option selected value="foreign">Foreign</option></select>';
+                    document.body.append(foreign);
+                });
+                assert.deepEqual((await practiceSnapshot(practice)).answers, before.answers, 'answer collection must exclude independently injected hidden controls');
+                await practice.evaluate(() => document.getElementById('reader-isolation-foreign-controls').remove());
+                await practice.waitForFunction(duration => window.__IELTS_PRACTICE_TIMER__.getSnapshot().durationSeconds > duration, before.timer.durationSeconds);
+            }
+            await practice.locator('#vocab-reader-back-btn').click();
+            assert.equal(await practice.locator('#reading-vocab-header-btn').evaluate(node => node === document.activeElement), true, 'close must restore practice entry focus');
+            assert.equal(await practice.locator('#reading-vocab-reader-overlay input[name], #reading-vocab-reader-overlay select[name], #reading-vocab-reader-overlay textarea[name]').count(), 0);
+            const listenerCounts = await practice.evaluate(() => window.__readerListenerCounts());
+            if (!firstListenerCounts) firstListenerCounts = listenerCounts;
+            else assert.deepEqual(listenerCounts, firstListenerCounts, 'repeated cycles must not accumulate active listeners');
+        }
+        const after = await practiceSnapshot(practice);
+        assert.deepEqual(after.answers, before.answers);
+        assert.deepEqual(after.results, before.results, 'answer comparisons and score calculation must remain identical');
+        for (const key of ['examId', 'sessionId', 'windowSessionToken', 'sessionReadySent', 'submitted', 'submissionStatus', 'readOnly', 'reviewMode', 'notes']) {
+            assert.deepEqual(after.state[key], before.state[key], `${protocol}: practice ${key} changed`);
+        }
+        assert.deepEqual(after.draft.highlights, before.draft.highlights);
+        assert.deepEqual(after.draft.notes, before.draft.notes);
+        assert.equal(after.timer.anchorMs, before.timer.anchorMs);
+        assert.equal(after.timer.running, before.timer.running);
+        assert.ok(after.timer.durationSeconds > before.timer.durationSeconds);
+        assert.deepEqual(await hostSnapshot(page), hostBefore, `${protocol}: practice/history/recovery ownership changed`);
+        const draft = await page.evaluate(async id => (await AppData.recovery.listDrafts()).find(item => item.examId === id), examId);
+        assert.deepEqual(draft.answers, before.answers, 'persisted recovery answer payload must remain identical');
+        // Check annotation and dictionary UI after returning, with a deterministic lookup provider.
+        const oldHighlightCount = await practice.locator('#left .hl').count();
+        await selectWord(practice, '#left');
+        await practice.evaluate(() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.updateSelectionToolbar());
+        await practice.locator('#btnHL').click();
+        assert.ok(await practice.locator('#left .hl').count() > oldHighlightCount);
+        await practice.evaluate(() => {
+            window.__dictionaryLookups = [];
+            window.__IELTS_UNIFIED_READING_PAGE_TEST__.setTestState({ reviewMode: true });
+            window.ReviewHighlightDictionary.enhance({ lookupService: { lookup(term) {
+                window.__dictionaryLookups.push(term);
+                return { found: false, requested: term, term, reason: 'regression-fixture' };
+            } } });
+        });
+        const reviewHighlight = practice.locator('#left .hl:not([data-note-id])').first();
+        const highlightWord = await reviewHighlight.textContent();
+        await reviewHighlight.click();
+        await practice.locator('#review-highlight-dictionary-bubble').waitFor({ state: 'visible' });
+        assert.deepEqual(await practice.evaluate(() => window.__dictionaryLookups), [highlightWord]);
+        await practice.evaluate(() => {
+            window.__IELTS_UNIFIED_READING_PAGE_TEST__.setTestState({ reviewMode: false });
+            window.ReviewHighlightDictionary.close();
+        });
+        await practice.screenshot({ path: path.join(reports, `issue157-${protocol}-preserved.png`) });
+        report.cases.push({ name: `${protocol}-hosted-practice-isolation`, status: 'pass', readerOnlyEntries: ['Browse button', 'Bookshelf button'], sessionId: before.state.sessionId, answers: before.answers, timerBefore: before.timer.durationSeconds, timerAfter: after.timer.durationSeconds, annotationAndReviewDictionary: 'pass (deterministic lookup provider)', activeListenerCounts: firstListenerCounts });
+    } finally { await context.close(); }
+}
+
+try {
+    if (baselineOnly) await baselineCollision();
+    else for (const protocol of ['http', 'file']) await finalRegression(protocol);
+    report.status = 'pass';
+} catch (error) {
+    report.status = 'fail';
+    report.error = error.stack || String(error);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+    await new Promise(resolve => server.close(resolve));
+    fs.writeFileSync(path.join(reports, baselineOnly ? 'reading-reader-isolation-baseline.json' : 'reading-reader-isolation-report.json'), JSON.stringify(report, null, 2) + '\n');
+    console.log(JSON.stringify(report, null, 2));
+}

--- a/developer/tests/e2e/reading_reader_isolation.py
+++ b/developer/tests/e2e/reading_reader_isolation.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run the real-browser reader regression using the browser installed by E2E CI."""
+import os
+from pathlib import Path
+import subprocess
+
+from playwright.sync_api import sync_playwright
+
+
+def main():
+    env = os.environ.copy()
+    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
+        with sync_playwright() as playwright:
+            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
+    script = Path(__file__).with_suffix(".node.js")
+    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/developer/tests/e2e/suite_practice_flow.py
+++ b/developer/tests/e2e/suite_practice_flow.py
@@ -1002,7 +1002,7 @@ async def run() -> bool:
                 raise AssertionError("manual mode P1 submit should show enabled next nav button")
             await manual_suite_page.click(nav_after_p1_submit["nextSelector"])
             await manual_suite_page.wait_for_function(
-                "(oldId) => (document.body.dataset.examId || '') !== oldId",
+                "(oldId) => { const examId = document.body.dataset.examId || ''; return !!examId && examId !== oldId; }",
                 arg=manual_exam1,
                 timeout=30000,
             )
@@ -1051,7 +1051,7 @@ async def run() -> bool:
                 raise AssertionError("manual mode P2 submit should keep next nav enabled")
             await manual_suite_page.click(nav_after_p2_submit["nextSelector"])
             await manual_suite_page.wait_for_function(
-                "(oldId) => (document.body.dataset.examId || '') !== oldId",
+                "(oldId) => { const examId = document.body.dataset.examId || ''; return !!examId && examId !== oldId; }",
                 arg=manual_exam2,
                 timeout=30000,
             )

--- a/developer/tests/e2e/unified_submit_readonly_regression.py
+++ b/developer/tests/e2e/unified_submit_readonly_regression.py
@@ -373,26 +373,42 @@ async def run_timeout_scenario(context) -> Dict[str, Any]:
     return {"afterTimeout": after_timeout, "lateAfterTimeout": late_after_timeout, "afterRetryAck": after_retry_ack}
 
 
-async def run_vocab_entry_gate_scenario(context) -> Dict[str, Any]:
+async def run_vocab_entry_isolation_scenario(context) -> Dict[str, Any]:
     page = await context.new_page()
-    frame = await open_practice(page, "session-vocab-gate", "token-vocab-gate", "p2-low-08")
+    frame = await open_practice(page, "session-vocab-isolation", "token-vocab-isolation", "p2-low-08")
     await frame.check('#question-groups input[name="q1"][value="A"]')
-    require(await frame.locator("#reading-vocab-header-btn").count() == 0, "unsafe_vocab_entry_available")
-    require(await frame.locator("#reading-vocab-reader-overlay").count() == 0, "reader_controls_in_practice")
-    require(await frame.locator('input[name="q1"][value="A"]').is_checked(), "practice_answer_changed")
+    before_answers = await frame.evaluate("() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.collectAnswers()")
+    await frame.click("#reading-vocab-header-btn")
+    await frame.locator("#vocab-questions-content .vocab-question-group").first.wait_for(state="attached")
+    require(await frame.locator("#vocab-questions-content input, #vocab-questions-content textarea, #vocab-questions-content select").count() == 0, "reader_question_controls_available")
+    require(await frame.locator('#question-groups input[name="q1"][value="A"]').is_checked(), "practice_answer_changed")
+    during_answers = await frame.evaluate("() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.collectAnswers()")
+    require(during_answers == before_answers, "reader_changed_answer_payload")
+
+    await frame.evaluate("() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.setTimerLockMode(true)")
+    require(await frame.locator('#question-groups input[name="q1"][value="A"]').is_disabled(), "timer_lock_did_not_lock_practice_answer")
+    require(await frame.locator("#reading-note-editor [data-note-body]").is_disabled(), "timer_lock_did_not_lock_practice_notes")
+    require(await frame.locator("#vocab-manual-input").is_enabled(), "timer_lock_disabled_reader_input")
+    await frame.evaluate("() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.setTimerLockMode(false)")
+    await frame.click("#vocab-reader-back-btn")
 
     await frame.click("#submit-btn")
     await wait_for_submission_count(page, 1)
     submission = (await submissions(page))[0]
-    require(submission.get("data", {}).get("answers", {}).get("q1") == "A", f"practice_payload_changed:{submission}")
+    require(submission.get("data", {}).get("answers") == before_answers, f"practice_payload_changed:{submission}")
     await send_host(page, "PRACTICE_SUBMIT_ACK", correlation(submission))
     await frame.wait_for_function(
         "() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.getTestState().submissionStatus === 'submitted'"
     )
-    require(await frame.locator("#reading-vocab-header-btn").count() == 0, "unsafe_vocab_entry_after_submit")
-    require(await frame.locator("#reading-vocab-reader-overlay").count() == 0, "reader_controls_after_submit")
+    await frame.click("#reading-vocab-header-btn")
+    await frame.locator("#vocab-questions-content .vocab-question-group").first.wait_for(state="attached")
+    require(await frame.locator("#vocab-manual-input").is_enabled(), "submitted_readonly_disabled_reader_input")
+    require(await frame.locator("#vocab-questions-content input, #vocab-questions-content textarea, #vocab-questions-content select").count() == 0, "reader_question_controls_after_submit")
+    after_answers = await frame.evaluate("() => window.__IELTS_UNIFIED_READING_PAGE_TEST__.collectAnswers()")
+    require(after_answers == before_answers, "reader_after_submit_changed_answers")
+    await frame.click("#vocab-reader-back-btn")
     await page.close()
-    return {"examId": "p2-low-08", "entryAvailable": False, "submittedAnswer": "A"}
+    return {"examId": "p2-low-08", "entryAvailable": True, "submittedAnswer": "A", "readerInputSurvivesPracticeLocks": True}
 
 
 async def run() -> Dict[str, Any]:
@@ -401,7 +417,7 @@ async def run() -> Dict[str, Any]:
         context = await browser.new_context(viewport={"width": 1440, "height": 1000})
         await context.add_init_script(script="window.__IELTS_READING_PAGE_TEST_HOOKS__ = true;")
         try:
-            vocab_entry_gate = await run_vocab_entry_gate_scenario(context)
+            vocab_entry_isolation = await run_vocab_entry_isolation_scenario(context)
             ack_and_nack = await run_ack_and_nack_scenario(context)
             timeout = await run_timeout_scenario(context)
         finally:
@@ -410,7 +426,7 @@ async def run() -> Dict[str, Any]:
     return {
         "status": "pass",
         "detail": "unified reliable submit acknowledgement regression passed",
-        "data": {"vocabEntryGate": vocab_entry_gate, "ackAndNack": ack_and_nack, "timeout": timeout},
+        "data": {"vocabEntryIsolation": vocab_entry_isolation, "ackAndNack": ack_and_nack, "timeout": timeout},
     }
 
 

--- a/developer/tests/js/readingInteractionRegression.test.js
+++ b/developer/tests/js/readingInteractionRegression.test.js
@@ -64,14 +64,15 @@ async function testBrowserInteractions() {
                 <header><div class="header-right"></div></header>
                 <div id="highlight-root">alpha <span class="hl" data-note-id="note-1">repeat</span><span class="hl" data-note-id="note-2" data-hl-level="secondary">repeat</span> omega</div>
                 <div id="inline-highlight-root"><span class="hl" data-hl-level="secondary"><em>AB</em>C<strong>DE</strong></span></div>
-                <input type="checkbox" name="q8-9" value="A">
-                <input type="checkbox" name="q8-9" value="B">
-                <input type="checkbox" name="q8-9" value="C">
-                <input type="checkbox" name="q12_40" value="A">
-                <input type="checkbox" name="q12_40" value="B">
-                <input type="checkbox" name="q12_40" value="C">
-                <input type="radio" name="q1" value="A" checked>
-                <div class="shell"><div id="left"></div><div id="divider"></div><div id="right"><div id="question-groups"></div></div></div>
+                <div class="shell"><div id="left"></div><div id="divider"></div><div id="right"><div id="question-groups">
+                    <input type="checkbox" name="q8-9" value="A">
+                    <input type="checkbox" name="q8-9" value="B">
+                    <input type="checkbox" name="q8-9" value="C">
+                    <input type="checkbox" name="q12_40" value="A">
+                    <input type="checkbox" name="q12_40" value="B">
+                    <input type="checkbox" name="q12_40" value="C">
+                    <input type="radio" name="q1" value="A" checked>
+                </div></div></div>
                 <div id="results"></div>
                 <div id="question-nav"></div>
                 <button id="submit-btn" type="button">Submit</button>
@@ -285,6 +286,40 @@ async function testBrowserInteractions() {
         assert.deepEqual(replayChecks.split, [true, false, true]);
         assert.deepEqual(replayChecks.single, [true, false, true]);
 
+        await page.evaluate(() => {
+            window.__READING_EXAM_DATA__ = {
+                register(_examId, dataset) { window.__PASSAGE_DROPZONE_FIXTURE__ = dataset; }
+            };
+        });
+        await page.addScriptTag({ content: read('assets/generated/reading-exams/p1-high-01.js') });
+        const passageAnswerChecks = await page.evaluate(() => {
+            const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+            const dataset = window.__PASSAGE_DROPZONE_FIXTURE__;
+            document.getElementById('left').innerHTML = dataset.passage.blocks.map((block) => block.html).join('');
+            document.getElementById('question-groups').innerHTML = dataset.questionGroups.map((group) => group.bodyHtml).join('');
+            hooks.setTestState({ dataset });
+            const foreign = document.createElement('div');
+            foreign.innerHTML = '<div class="paragraph-dropzone" data-question="q1" data-answer-value="foreign"></div>';
+            document.body.prepend(foreign);
+            hooks.applyReplayAnswersToDom({ q1: 'iv', q9: 'B' });
+            const answers = hooks.collectAnswers();
+            const result = {
+                passageAnswer: answers.q1.toLowerCase(),
+                questionAnswer: answers.q9,
+                renderedPassageAnswer: document.querySelector('#left [data-question="q1"]').dataset.answerValue.toLowerCase(),
+                foreignAnswer: foreign.firstElementChild.dataset.answerValue
+            };
+            foreign.remove();
+            document.getElementById('left').innerHTML = '';
+            return result;
+        });
+        assert.deepEqual(passageAnswerChecks, {
+            passageAnswer: 'iv',
+            questionAnswer: 'B',
+            renderedPassageAnswer: 'iv',
+            foreignAnswer: 'foreign'
+        }, 'production matching-headings answers in the passage pane must collect and replay without using foreign dropzones');
+
         const cardPoolChecks = await page.evaluate(() => {
             const groups = document.getElementById('question-groups');
             groups.innerHTML = `
@@ -360,6 +395,7 @@ async function testBrowserInteractions() {
 
         const unknownPresentation = await page.evaluate(() => {
             const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+            document.getElementById('question-groups').innerHTML = '<input type="radio" name="q1" value="A" checked>';
             hooks.captureDom();
             hooks.setTestState({
                 dataset: {

--- a/developer/tests/js/readingVocabQuestionIsolation.test.js
+++ b/developer/tests/js/readingVocabQuestionIsolation.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const readerSource = fs.readFileSync(new URL('../../../js/components/readingVocabReader.js', import.meta.url), 'utf8');
+const registryPath = fileURLToPath(new URL('../../../js/runtime/readingExamRegistry.js', import.meta.url));
+
+test('reader questions are selectable text with isolated identities and no answering behavior', async () => {
+    const browser = await chromium.launch({ headless: true,
+        ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}) });
+    try {
+        const page = await browser.newPage();
+        await page.route('https://reader.test/**', route => route.fulfill({ contentType: 'text/html', body: `
+            <button id="launch">Open reader</button><div id="practice">
+              <input type="radio" id="choice-a" name="q1" value="A" checked>
+              <input type="radio" name="q1" value="B">
+              <input type="text" id="answer" name="q2" value="original">
+              <p id="description">Practice description</p>
+            </div>` }));
+        await page.goto('https://reader.test/');
+        await page.addScriptTag({ path: registryPath });
+        await page.evaluate(() => {
+            window.__READING_EXPLANATION_MANIFEST__ = {};
+            window.ReadingBookshelfStore = { recordExamUsed() {} };
+            __READING_EXAM_DATA__.register('isolation', {
+                meta: { title: 'Isolation fixture' },
+                passage: { blocks: [{ html: '<p>A sufficiently long article for selectable reading content.</p>' }] },
+                questionGroups: [{ bodyHtml: `
+                    <form id="practice" onsubmit="window.__submitted=true">
+                      <p id="description">Read the <em>question</em> and choose a response.</p>
+                      <label for="choice-a"><input type="radio" id="choice-a" name="q1" value="B" checked> B Alternative</label>
+                      <label for="answer">Answer</label><input id="answer" name="q2" value="reader" aria-describedby="description outside">
+                      <input type="checkbox" name="q3" checked><textarea name="q4">preset</textarea>
+                      <select name="q5"><option>Choose</option><option value="A">A Alpha</option><option value="B">B Beta</option></select>
+                      <input type="hidden" name="q6" value="hidden"><button type="submit">Submit</button>
+                      <a href="#answer" onclick="window.__clicked=true">Reference</a>
+                      <div id="answer" class="match-dropzone" data-question="q7" tabindex="0" contenteditable="true"></div>
+                      <div class="drag-item" draggable="true" data-option="A" onmousedown="window.__dragged=true">A Selectable option</div>
+                      <div class="drop-target-summary" data-question="q8"></div>
+                      <div class="options-pool pool-items"><span class="draggable-word">summary option</span></div>
+                      <div class="cardpool"><div class="card">card option</div></div>
+                    </form>` }, { bodyHtml: '<p id="answer">Repeated source identity</p>' }]
+            });
+        });
+        await page.addScriptTag({ content: readerSource });
+        await page.evaluate(() => ReadingVocabReader.open('isolation', { fromPractice: true }));
+        const state = await page.evaluate(() => {
+            const questions = document.getElementById('vocab-questions-content');
+            const identities = [...document.querySelectorAll('[id]')].map(node => node.id);
+            const range = document.createRange();
+            range.selectNodeContents(questions.querySelector('em'));
+            getSelection().removeAllRanges();
+            getSelection().addRange(range);
+            const selected = getSelection().toString();
+            questions.querySelector('em').click();
+            questions.querySelector('.vocab-question-options').click();
+            return {
+                selected, text: questions.textContent,
+                controls: questions.querySelectorAll('input, textarea, select, button, form, label, [name], [for], [href], [contenteditable], [draggable], [tabindex], [onclick], [onmousedown], .drag-item, .match-dropzone, .drop-target-summary, .draggable-word, .card, .pool-items, .options-pool, .cardpool, [data-question]').length,
+                duplicateIds: identities.filter((id, index) => identities.indexOf(id) !== index),
+                answer: document.getElementById('answer').value,
+                checked: document.getElementById('choice-a').checked,
+                action: !!(window.__clicked || window.__submitted || window.__dragged)
+            };
+        });
+        assert.equal(state.selected, 'question');
+        assert.equal(state.controls, 0);
+        assert.deepEqual(state.duplicateIds, []);
+        assert.equal(state.answer, 'original');
+        assert.equal(state.checked, true, 'checked reader radios must be inert before insertion');
+        assert.equal(state.action, false);
+        for (const text of ['B Alternative', 'A Alpha / B Beta', 'A Selectable option', '________']) assert.ok(state.text.includes(text), text);
+        await page.evaluate(() => ReadingVocabReader.close());
+        assert.equal(await page.locator('#vocab-questions-content input, #vocab-questions-content select').count(), 0);
+    } finally { await browser.close(); }
+});

--- a/developer/tests/js/readingVocabReaderLifecycle.test.js
+++ b/developer/tests/js/readingVocabReaderLifecycle.test.js
@@ -1,0 +1,239 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const source = fs.readFileSync(path.join(root, 'js/components/readingVocabReader.js'), 'utf8');
+const css = fs.readFileSync(path.join(root, 'css/vocab-reader.css'), 'utf8');
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
+async function createPage(browser) {
+    const page = await browser.newPage();
+    await page.route('https://reader-lifecycle.test/**', route => route.fulfill({
+        contentType: 'text/html',
+        body: '<!doctype html><html><head></head><body><button id="entry">Open reader</button></body></html>'
+    }));
+    await page.goto('https://reader-lifecycle.test/');
+    await page.addStyleTag({ content: css });
+    await page.evaluate(() => {
+        const payloads = new Map(['a', 'b'].map(id => [id, {
+            meta: { title: `Article ${id}` },
+            passage: { blocks: [{ html: `<p><strong>A</strong> A sufficiently long <em>${id}</em> passage for independent reading.</p>` }] },
+            questionGroups: [{ bodyHtml: `<p>Questions for ${id}</p>` }]
+        }]));
+        window.__READING_EXAM_DATA__ = { get: id => payloads.get(id), register: (id, data) => payloads.set(id, data) };
+        window.__READING_EXPLANATION_MANIFEST__ = {};
+        window.__visits = [];
+        window.ReadingBookshelfStore = { recordExamUsed: id => __visits.push(id) };
+        window.__listeners = [];
+        const add = EventTarget.prototype.addEventListener;
+        const remove = EventTarget.prototype.removeEventListener;
+        EventTarget.prototype.addEventListener = function(type, callback, options) {
+            const capture = typeof options === 'boolean' ? options : !!options?.capture;
+            if (!__listeners.some(item => item.target === this && item.type === type && item.callback === callback && item.capture === capture)) {
+                __listeners.push({ target: this, type, callback, capture });
+            }
+            return add.call(this, type, callback, options);
+        };
+        EventTarget.prototype.removeEventListener = function(type, callback, options) {
+            const capture = typeof options === 'boolean' ? options : !!options?.capture;
+            window.__listeners = __listeners.filter(item => !(item.target === this && item.type === type && item.callback === callback && item.capture === capture));
+            return remove.call(this, type, callback, options);
+        };
+        window.__activeReaderListeners = () => __listeners.filter(({ target, type }) =>
+            (target === window && type === 'keydown') || target.closest?.('#reading-vocab-reader-overlay')
+        ).length;
+    });
+    await page.addScriptTag({ content: source });
+    return page;
+}
+
+test('reader lifecycle restores its initiating view and releases reader interactions', async t => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    try {
+        await t.test('repeated Questions/close/reopen resets content and removes listeners, including nested Escape focus', async () => {
+            const page = await createPage(browser);
+            try {
+                const states = await page.evaluate(async () => {
+                    const result = [];
+                    const entry = document.getElementById('entry');
+                    for (let iteration = 0; iteration < 5; iteration += 1) {
+                        entry.focus();
+                        await openReadingVocabReader('a', { fromPractice: true });
+                        const overlay = document.getElementById('reading-vocab-reader-overlay');
+                        const activeCount = __activeReaderListeners();
+                        const reopened = {
+                            activeTab: ReadingVocabReader.activeTab,
+                            selectedTab: overlay.querySelector('.vocab-tab-btn.active').dataset.para,
+                            passageVisible: getComputedStyle(document.getElementById('vocab-passage-section')).display !== 'none',
+                            questionsVisible: getComputedStyle(document.getElementById('vocab-questions-section')).display !== 'none',
+                            focus: document.activeElement.id
+                        };
+                        overlay.querySelector('[data-para="questions"]').click();
+                        const questionsOnly = getComputedStyle(document.getElementById('vocab-passage-section')).display === 'none';
+                        const fab = document.getElementById('vocab-fab');
+                        fab.focus();
+                        fab.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+                        const modalFocus = document.activeElement.id;
+                        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+                        const modalClosed = !ReadingVocabReader.modalOpen && document.activeElement === fab;
+                        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+                        result.push({
+                            reopened, questionsOnly, modalFocus, modalClosed, activeCount,
+                            closedCount: __activeReaderListeners(),
+                            returnedFocus: document.activeElement === entry,
+                            hidden: getComputedStyle(overlay).display === 'none',
+                            ariaHidden: overlay.getAttribute('aria-hidden'),
+                            bodyUnlocked: !document.body.classList.contains('vocab-reader-open')
+                        });
+                    }
+                    return result;
+                });
+                const activeCount = states[0].activeCount;
+                assert.ok(activeCount > 0);
+                for (const state of states) {
+                    assert.deepEqual(state, {
+                        reopened: { activeTab: 'all', selectedTab: 'all', passageVisible: true, questionsVisible: true, focus: 'vocab-reader-back-btn' },
+                        questionsOnly: true, modalFocus: 'vocab-manual-input', modalClosed: true,
+                        activeCount, closedCount: 0, returnedFocus: true, hidden: true,
+                        ariaHidden: 'true', bodyUnlocked: true
+                    });
+                }
+            } finally { await page.close(); }
+        });
+
+        await t.test('old tabs, vocabulary controls and retries cannot act on a later article', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    await ReadingVocabReader.open('missing');
+                    const retry = document.querySelector('.vocab-error-state button');
+                    ReadingVocabReader.close();
+                    const failedCloseCount = __activeReaderListeners();
+                    await ReadingVocabReader.open('a');
+                    const oldTab = document.querySelector('[data-para="questions"]');
+                    ReadingVocabStore.add('preserved', 'a', 'Article a');
+                    ReadingVocabReader.openModal();
+                    const oldDelete = document.querySelector('.vocab-delete-btn');
+                    ReadingVocabReader.close();
+                    // Closed reader controls must not reopen the modal or delete words.
+                    document.getElementById('vocab-fab').click();
+                    oldDelete.click();
+                    const closedInert = !ReadingVocabReader.modalOpen && ReadingVocabStore.getAll().length === 1;
+                    await ReadingVocabReader.open('b');
+                    ReadingVocabReader.openModal();
+                    ReadingVocabReader.closeModal();
+                    oldTab.click();
+                    oldDelete.click();
+                    retry.click();
+                    await Promise.resolve();
+                    return {
+                        closedInert, failedCloseCount, current: ReadingVocabReader.currentExamId,
+                        tab: ReadingVocabReader.activeTab, title: document.getElementById('vocab-reader-title').textContent,
+                        words: ReadingVocabStore.getAll().map(item => item.word), visits: __visits
+                    };
+                });
+                assert.deepEqual(state, {
+                    closedInert: true, failedCloseCount: 0, current: 'b', tab: 'all', title: 'Article b',
+                    words: ['preserved'], visits: ['a', 'a', 'b']
+                });
+            } finally { await page.close(); }
+        });
+
+        await t.test('vocabulary collected after a late A-to-B race belongs only to the latest article', async () => {
+            const page = await createPage(browser);
+            try {
+                await page.evaluate(async () => {
+                    window.__READING_EXAM_MANIFEST__ = {
+                        'race-a': { examId: 'race-a', script: 'race-a.js' },
+                        'race-b': { examId: 'race-b', script: 'race-b.js' }
+                    };
+                    const pending = new Map();
+                    const append = document.head.appendChild.bind(document.head);
+                    document.head.appendChild = node => {
+                        if (node.tagName === 'SCRIPT' && node.src) {
+                            pending.set(node.src.split('/').pop(), node);
+                            return node;
+                        }
+                        return append(node);
+                    };
+                    const finish = (id, title) => {
+                        __READING_EXAM_DATA__.register(id, {
+                            meta: { title },
+                            passage: { blocks: [{ html: `<p><strong>A</strong> This sufficiently long passage belongs to ${title}.</p>` }] },
+                            questionGroups: [{ bodyHtml: `<p>Questions for ${title}</p>` }]
+                        });
+                        pending.get(`${id}.js`).onload();
+                    };
+                    const openA = ReadingVocabReader.open('race-a');
+                    const openB = ReadingVocabReader.open('race-b');
+                    finish('race-b', 'Latest race article');
+                    await openB;
+                    finish('race-a', 'Stale race article');
+                    await openA;
+                    document.head.appendChild = append;
+                });
+                await page.locator('#vocab-fab').click();
+                await page.locator('#vocab-manual-input').fill('chrysoprase');
+                await page.locator('#vocab-manual-add-btn').click();
+                const state = await page.evaluate(() => ({
+                    current: ReadingVocabReader.currentExamId,
+                    title: document.getElementById('vocab-reader-title').textContent,
+                    words: ReadingVocabStore.getAll().map(({ word, examId, examTitle }) => ({ word, examId, examTitle })),
+                    visits: __visits
+                }));
+                assert.deepEqual(state, {
+                    current: 'race-b', title: 'Latest race article',
+                    words: [{ word: 'chrysoprase', examId: 'race-b', examTitle: 'Latest race article' }],
+                    visits: ['race-b', 'race-b']
+                });
+            } finally { await page.close(); }
+        });
+
+        await t.test('closing cancels deferred vocabulary work and a later open preserves the original focus target', async () => {
+            const page = await createPage(browser);
+            try {
+                const state = await page.evaluate(async () => {
+                    document.getElementById('entry').focus();
+                    await ReadingVocabReader.open('a');
+                    const scheduled = new Map();
+                    const callbacks = [];
+                    const setTimer = window.setTimeout;
+                    const clearTimer = window.clearTimeout;
+                    window.setTimeout = callback => {
+                        callbacks.push(callback);
+                        scheduled.set(callbacks.length, callback);
+                        return callbacks.length;
+                    };
+                    window.clearTimeout = id => scheduled.delete(id);
+                    const range = document.createRange();
+                    range.selectNodeContents(document.querySelector('#vocab-passage-content em'));
+                    window.getSelection().removeAllRanges();
+                    window.getSelection().addRange(range);
+                    document.getElementById('vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
+                    ReadingVocabReader.showToast('pending');
+                    const pendingBefore = scheduled.size;
+                    await ReadingVocabReader.open('b');
+                    const pendingAfterOpen = scheduled.size;
+                    ReadingVocabReader.close();
+                    callbacks.forEach(callback => callback());
+                    window.setTimeout = setTimer;
+                    window.clearTimeout = clearTimer;
+                    return {
+                        pendingBefore, pendingAfterOpen, pendingAfterClose: scheduled.size,
+                        toast: document.getElementById('vocab-toast').textContent,
+                        selection: window.getSelection().toString(),
+                        words: ReadingVocabStore.getAll(), focus: document.activeElement.id
+                    };
+                });
+                assert.deepEqual(state, {
+                    pendingBefore: 2, pendingAfterOpen: 0, pendingAfterClose: 0,
+                    toast: '', selection: '', words: [], focus: 'entry'
+                });
+            } finally { await page.close(); }
+        });
+    } finally { await browser.close(); }
+});

--- a/developer/tests/js/unifiedReadingAnswerIsolation.test.js
+++ b/developer/tests/js/unifiedReadingAnswerIsolation.test.js
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+
+const runtimeSource = fs.readFileSync(new URL('../../../js/runtime/unifiedReadingPage.js', import.meta.url), 'utf8');
+
+function control(tagName, attributes, value = '', checked = false) {
+    return {
+        tagName,
+        type: tagName === 'INPUT' ? (attributes.type || 'text') : undefined,
+        name: attributes.name || '',
+        id: attributes.id || '',
+        value,
+        checked,
+        dataset: {},
+        getAttribute(name) { return attributes[name] ?? null; }
+    };
+}
+
+function queryControls(controls, selector) {
+    return controls.filter((field) => selector.split(', ').some((part) => {
+        const tag = part.match(/^[a-z]+/i)?.[0];
+        if (tag && field.tagName.toLowerCase() !== tag.toLowerCase()) return false;
+        if (/^[.#]/.test(part)) return false;
+        const attributes = [...part.matchAll(/\[([^=\]]+)(?:="([^"]*)")?\]/g)];
+        if (!attributes.length) return false;
+        return attributes.every(([, name, value]) => value === undefined
+            ? field.getAttribute(name) !== null
+            : field.getAttribute(name) === value);
+    }));
+}
+
+function createHarness() {
+    const practice = [
+        control('INPUT', { type: 'radio', name: 'q1' }, 'A', true),
+        control('INPUT', { type: 'radio', name: 'q1' }, 'B'),
+        control('INPUT', { type: 'checkbox', name: 'q2-3' }, 'C', true),
+        control('INPUT', { type: 'checkbox', name: 'q2-3' }, 'A', true),
+        control('INPUT', { type: 'checkbox', name: 'q2-3' }, 'D'),
+        control('INPUT', { name: 'q4' }, ' practice text '),
+        control('INPUT', { name: 'q4', type: 'hidden' }, 'hidden shadow'),
+        control('SELECT', { name: 'q5' }, 'E'),
+        control('TEXTAREA', { name: 'q6' }, 'practice note answer'),
+        control('INPUT', { id: 'q7_input' }, 'id fallback'),
+        control('INPUT', { name: 'q8', type: 'hidden' }, 'must stay unanswered'),
+        control('INPUT', { id: 'q8_input', type: 'hidden' }, 'hidden id fallback'),
+        control('INPUT', { name: 'q999', type: 'checkbox' }, 'outside dataset', true)
+    ];
+    const reader = [
+        control('INPUT', { name: 'q1', type: 'radio' }, 'B', true),
+        control('INPUT', { name: 'q2-3', type: 'checkbox' }, 'D', true),
+        control('INPUT', { name: 'q4' }, 'reader text'),
+        control('SELECT', { name: 'q5' }, 'reader select'),
+        control('TEXTAREA', { name: 'q6' }, 'reader textarea'),
+        control('INPUT', { id: 'q7_input' }, 'reader fallback'),
+        control('INPUT', { name: 'q10', type: 'checkbox' }, 'reader-only answer', true)
+    ];
+    const practiceDropzone = { dataset: { answerValue: 'G' } };
+    const passageDropzone = { dataset: { answerValue: 'I' } };
+    const readerDropzone = { dataset: { answerValue: 'reader dropzone' } };
+    const left = {
+        querySelector(selector) {
+            return selector.includes('.match-dropzone[data-question="q11"]') ? passageDropzone : null;
+        }
+    };
+    const root = {
+        querySelectorAll(selector) { return queryControls(practice, selector); },
+        querySelector(selector) {
+            if (selector.includes('.match-dropzone[data-question="q9"]')) return practiceDropzone;
+            return this.querySelectorAll(selector)[0] || null;
+        }
+    };
+    let rootAvailable = true;
+    let readerOpen = false;
+    const document = {
+        referrer: '',
+        body: { dataset: {} },
+        getElementById(id) {
+            if (id === 'question-groups') return rootAvailable ? root : null;
+            if (id === 'left') return rootAvailable ? left : null;
+            return (readerOpen ? [...reader, ...practice] : practice).find((field) => field.id === id) || null;
+        },
+        querySelectorAll(selector) {
+            return queryControls(readerOpen ? [...reader, ...practice] : practice, selector);
+        },
+        querySelector(selector) {
+            if (selector === '#notes-panel textarea') return { value: 'existing practice note' };
+            if (selector.includes('.match-dropzone[data-question="q9"]')) {
+                return readerOpen ? readerDropzone : practiceDropzone;
+            }
+            return this.querySelectorAll(selector)[0] || null;
+        },
+        addEventListener() {}
+    };
+    const window = {
+        document,
+        location: { href: 'http://localhost/practice.html' },
+        __IELTS_READING_PAGE_TEST_HOOKS__: true,
+        CSS: { escape: (value) => String(value) },
+        scrollY: 77
+    };
+    window.parent = window;
+    vm.runInNewContext(runtimeSource, { window, document, URL, console });
+    const hooks = window.__IELTS_UNIFIED_READING_PAGE_TEST__;
+    hooks.setTestState({
+        examId: 'practice-exam',
+        sessionId: 'existing-session',
+        dataset: {
+            questionOrder: Array.from({ length: 11 }, (_, index) => `q${index + 1}`),
+            answerKey: {},
+            questionGroups: []
+        }
+    });
+    return {
+        hooks,
+        practice,
+        reader,
+        setReaderOpen(value) { readerOpen = value; },
+        removeRoot() { rootAvailable = false; }
+    };
+}
+
+function plain(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+test('answer and draft payloads ignore controls outside the practice root for every supported question type', () => {
+    const harness = createHarness();
+    const expected = {
+        q1: 'A', q2: ['A', 'C'], q3: ['A', 'C'], q4: 'practice text',
+        q5: 'E', q6: 'practice note answer', q7: 'id fallback', q8: '', q9: 'G', q10: '', q11: 'I'
+    };
+    const before = plain(harness.hooks.collectCurrentDraft());
+    assert.deepEqual(before.answers, expected);
+    harness.setReaderOpen(true);
+    assert.deepEqual(plain(harness.hooks.collectAnswers()), expected);
+    const during = plain(harness.hooks.collectCurrentDraft());
+    delete before.updatedAt;
+    delete during.updatedAt;
+    assert.deepEqual(during, before, 'reader controls must not change answers, notes, marks, or draft scroll position');
+    harness.setReaderOpen(false);
+    assert.deepEqual(plain(harness.hooks.collectAnswers()), expected);
+    assert.equal(harness.hooks.getTestState().sessionId, 'existing-session');
+});
+
+test('missing practice root cannot collect document-level answers', () => {
+    const harness = createHarness();
+    harness.setReaderOpen(true);
+    harness.removeRoot();
+    assert.deepEqual(plain(harness.hooks.collectAnswers()), Object.fromEntries(
+        Array.from({ length: 11 }, (_, index) => [`q${index + 1}`, ''])
+    ));
+});
+
+test('answer replay updates practice controls without changing reader fields or hidden inputs', () => {
+    const harness = createHarness();
+    harness.setReaderOpen(true);
+    const readerBefore = harness.reader.map(({ value, checked }) => ({ value, checked }));
+    harness.hooks.applyAnswersToDom({ q1: 'B', q2: ['A', 'D'], q3: ['A', 'D'], q4: 'restored', q8: 'ignored' });
+    assert.deepEqual(harness.reader.map(({ value, checked }) => ({ value, checked })), readerBefore);
+    assert.equal(harness.practice[0].checked, false);
+    assert.equal(harness.practice[1].checked, true);
+    assert.equal(harness.practice[4].checked, true);
+    assert.equal(harness.practice[5].value, 'restored');
+    assert.equal(harness.practice[6].value, 'hidden shadow');
+    assert.equal(harness.practice[10].value, 'must stay unanswered');
+});

--- a/developer/tests/js/unifiedReadingCoreRegression.test.js
+++ b/developer/tests/js/unifiedReadingCoreRegression.test.js
@@ -81,6 +81,9 @@ function createContext() {
             return [];
         },
         getElementById(id) {
+            if (id === 'question-groups') {
+                return document;
+            }
             if (id === 'timer') {
                 return timer;
             }

--- a/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
+++ b/developer/tests/js/unifiedReadingPageInlineSuiteRegression.test.js
@@ -75,6 +75,9 @@ function createDocumentStub() {
             return [];
         },
         getElementById(id) {
+            if (id === 'question-groups') {
+                return this;
+            }
             return id === 'timer' ? timer : null;
         },
         addEventListener() {},

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -16239,6 +16239,94 @@ if (typeof module !== 'undefined' && module.exports) {
     }
 
     // ============================================================================
+    // Parse in an inert template: even a pre-checked radio must never join a
+    // live practice answer group while the reader content is being prepared.
+    function createReadOnlyQuestionContent(html, namespace) {
+        const template = document.createElement('template');
+        template.innerHTML = html || '';
+        const content = template.content;
+        content.querySelectorAll('script, style, link, iframe, object, embed, template').forEach(node => node.remove());
+
+        const identities = new Map();
+        content.querySelectorAll('[id]').forEach((node, index) => {
+            const originalId = node.id;
+            node.id = `${namespace}-content-${index + 1}`;
+            if (!identities.has(originalId)) identities.set(originalId, node.id);
+        });
+
+        content.querySelectorAll('*').forEach(node => {
+            for (const attribute of [...node.attributes]) {
+                const name = attribute.name.toLowerCase();
+                if (name.startsWith('on') || name.startsWith('data-') || [
+                    'name', 'form', 'for', 'list', 'href', 'xlink:href', 'action', 'formaction',
+                    'contenteditable', 'draggable', 'tabindex', 'autofocus', 'accesskey', 'role',
+                    'aria-controls', 'aria-activedescendant', 'aria-checked', 'aria-selected'
+                ].includes(name)) {
+                    node.removeAttribute(attribute.name);
+                }
+            }
+            ['aria-labelledby', 'aria-describedby', 'headers'].forEach(name => {
+                if (!node.hasAttribute(name)) return;
+                const references = node.getAttribute(name).split(/\s+/).map(id => identities.get(id)).filter(Boolean);
+                if (references.length) node.setAttribute(name, references.join(' '));
+                else node.removeAttribute(name);
+            });
+            // Drop practice drag/drop hooks but retain the surrounding layout.
+            ['dropzone', 'match-dropzone', 'paragraph-dropzone', 'drop-target-summary'].forEach(className => {
+                if (!node.classList.contains(className)) return;
+                node.classList.remove(className);
+                if (!node.textContent.trim()) {
+                    node.textContent = '________';
+                    node.classList.add('vocab-answer-blank');
+                }
+            });
+            ['drag-item', 'draggable-word', 'card'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-option');
+                }
+            });
+            ['pool-items', 'options-pool', 'option-pool', 'cardpool', 'headings-pool', 'pool'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-pool');
+                }
+            });
+        });
+
+        content.querySelectorAll('input, textarea, select, button').forEach(control => {
+            const type = (control.getAttribute('type') || '').toLowerCase();
+            if (['hidden', 'submit', 'reset', 'image'].includes(type) ||
+                (control.tagName === 'BUTTON' && (!type || type === 'submit'))) {
+                control.remove();
+                return;
+            }
+            const replacement = document.createElement('span');
+            if (control.id) replacement.id = control.id;
+            replacement.className = 'vocab-answer-blank';
+            if (control.tagName === 'SELECT') {
+                replacement.className = 'vocab-question-options';
+                replacement.textContent = [...control.options].map(option => option.textContent.trim()).filter(Boolean).join(' / ');
+            } else if (control.tagName === 'BUTTON') {
+                replacement.textContent = control.textContent;
+            } else if (type === 'radio' || type === 'checkbox') {
+                replacement.textContent = type === 'radio' ? '○' : '□';
+                replacement.setAttribute('aria-hidden', 'true');
+            } else {
+                replacement.textContent = '________';
+                replacement.setAttribute('aria-label', 'Answer blank');
+            }
+            control.replaceWith(replacement);
+        });
+        content.querySelectorAll('label, form, fieldset, legend, a').forEach(node => {
+            const replacement = document.createElement(['FORM', 'FIELDSET'].includes(node.tagName) ? 'div' : 'span');
+            for (const attribute of [...node.attributes]) replacement.setAttribute(attribute.name, attribute.value);
+            replacement.append(...node.childNodes);
+            node.replaceWith(replacement);
+        });
+        return content;
+    }
+
     // 阅读器主控制器 (ReadingVocabReader)
     // ============================================================================
     const ReadingVocabReader = {
@@ -16252,6 +16340,40 @@ if (typeof module !== 'undefined' && module.exports) {
         modalOpen: false,
         toastTimer: null,
         _openRequestId: 0,
+        _eventOverlay: null,
+        _eventCleanups: [],
+        _pendingTimers: new Set(),
+        _returnFocus: null,
+        _modalReturnFocus: null,
+
+        clearPendingWork(overlay) {
+            this._pendingTimers.forEach(timer => clearTimeout(timer));
+            this._pendingTimers.clear();
+            this.toastTimer = null;
+            const toast = overlay?.querySelector('#vocab-toast');
+            if (toast) {
+                toast.classList.remove('show');
+                toast.textContent = '';
+            }
+            overlay?.querySelectorAll('.vocab-highlight--pulse').forEach(mark => mark.classList.remove('vocab-highlight--pulse'));
+            const selection = window.getSelection();
+            if (selection && overlay?.contains(selection.anchorNode)) selection.removeAllRanges();
+        },
+
+        defer(callback, delay) {
+            const requestId = this._openRequestId;
+            const timer = setTimeout(() => {
+                if (!this._pendingTimers.delete(timer) || requestId !== this._openRequestId) return;
+                callback();
+            }, delay);
+            this._pendingTimers.add(timer);
+            return timer;
+        },
+
+        unbindEvents() {
+            this._eventCleanups.splice(0).forEach(cleanup => cleanup());
+            this._eventOverlay = null;
+        },
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -16264,6 +16386,7 @@ if (typeof module !== 'undefined' && module.exports) {
             overlay.className = 'vocab-reader-overlay is-hidden';
             overlay.setAttribute('role', 'dialog');
             overlay.setAttribute('aria-label', '阅读生词本');
+            overlay.setAttribute('aria-hidden', 'true');
 
             overlay.innerHTML = `
                 <div class="vocab-reader-container">
@@ -16381,30 +16504,43 @@ if (typeof module !== 'undefined' && module.exports) {
         },
 
         bindEvents(overlay) {
+            if (this._eventOverlay === overlay) return;
+            this.unbindEvents();
+            this._eventOverlay = overlay;
+            const on = (element, type, callback, options) => {
+                element.addEventListener(type, callback, options);
+                this._eventCleanups.push(() => element.removeEventListener(type, callback, options));
+            };
             // 返回按钮
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
             if (backBtn) {
-                backBtn.addEventListener('click', () => this.close());
+                on(backBtn, 'click', () => this.close());
             }
 
             // 开启生词本弹窗
             const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
             const fab = overlay.querySelector('#vocab-fab');
             if (openModalBtn) {
-                openModalBtn.addEventListener('click', () => this.openModal());
+                on(openModalBtn, 'click', () => this.openModal());
             }
             if (fab) {
-                fab.addEventListener('click', () => this.openModal());
+                on(fab, 'click', () => this.openModal());
+                on(fab, 'keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        this.openModal();
+                    }
+                });
             }
 
             // 关闭生词本弹窗
             const closeModalBtn = overlay.querySelector('#vocab-modal-close');
             const modal = overlay.querySelector('#vocab-modal');
             if (closeModalBtn) {
-                closeModalBtn.addEventListener('click', () => this.closeModal());
+                on(closeModalBtn, 'click', () => this.closeModal());
             }
             if (modal) {
-                modal.addEventListener('click', (e) => {
+                on(modal, 'click', (e) => {
                     if (e.target === modal) {
                         this.closeModal();
                     }
@@ -16414,7 +16550,7 @@ if (typeof module !== 'undefined' && module.exports) {
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                bookshelfBtn.addEventListener('click', () => {
+                on(bookshelfBtn, 'click', () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
@@ -16448,7 +16584,7 @@ if (typeof module !== 'undefined' && module.exports) {
             const tabCurrent = overlay.querySelector('#v-tab-current');
             const tabAll = overlay.querySelector('#v-tab-all');
             if (tabCurrent) {
-                tabCurrent.addEventListener('click', () => {
+                on(tabCurrent, 'click', () => {
                     this.modalTab = 'current';
                     tabCurrent.classList.add('active');
                     tabAll.classList.remove('active');
@@ -16456,11 +16592,41 @@ if (typeof module !== 'undefined' && module.exports) {
                 });
             }
             if (tabAll) {
-                tabAll.addEventListener('click', () => {
+                on(tabAll, 'click', () => {
                     this.modalTab = 'all';
                     tabAll.classList.add('active');
                     tabCurrent.classList.remove('active');
                     this.renderVocabList();
+                });
+            }
+
+            const readerTabs = overlay.querySelector('#vocab-reader-tabs');
+            if (readerTabs) {
+                on(readerTabs, 'click', event => {
+                    const button = event.target.closest('.vocab-tab-btn');
+                    if (button && readerTabs.contains(button)) this.switchViewTab(button.dataset.para);
+                });
+            }
+
+            const vocabList = overlay.querySelector('#vocab-list');
+            if (vocabList) {
+                on(vocabList, 'click', event => {
+                    const speakButton = event.target.closest('.vocab-speak-btn');
+                    const deleteButton = event.target.closest('.vocab-delete-btn');
+                    if (speakButton && vocabList.contains(speakButton)) {
+                        event.stopPropagation();
+                        speakWord(speakButton.dataset.speakWord);
+                    } else if (deleteButton && vocabList.contains(deleteButton)) {
+                        event.stopPropagation();
+                        const id = deleteButton.dataset.delId;
+                        const item = ReadingVocabStore.getAll().find(word => word.id === id);
+                        const word = item?.word;
+                        ReadingVocabStore.remove(id);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) this.removeVocabHighlightForWord(word);
+                        this.showToast('已从生词本删除');
+                    }
                 });
             }
 
@@ -16486,10 +16652,10 @@ if (typeof module !== 'undefined' && module.exports) {
                 }
             };
             if (manualAddBtn) {
-                manualAddBtn.addEventListener('click', handleManualAdd);
+                on(manualAddBtn, 'click', handleManualAdd);
             }
             if (manualInput) {
-                manualInput.addEventListener('keydown', (e) => {
+                on(manualInput, 'keydown', (e) => {
                     if (e.key === 'Enter') {
                         e.preventDefault();
                         handleManualAdd();
@@ -16500,7 +16666,7 @@ if (typeof module !== 'undefined' && module.exports) {
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                exportBtn.addEventListener('click', () => {
+                on(exportBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
 
@@ -16526,7 +16692,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                on(clearBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
@@ -16554,7 +16720,7 @@ if (typeof module !== 'undefined' && module.exports) {
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
+                    this.defer(() => {
                         if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
@@ -16666,11 +16832,11 @@ if (typeof module !== 'undefined' && module.exports) {
                     }, 20);
                 };
 
-                readerBody.addEventListener('mouseup', handleSelectionCapture);
-                readerBody.addEventListener('touchend', handleSelectionCapture);
+                on(readerBody, 'mouseup', handleSelectionCapture);
+                on(readerBody, 'touchend', handleSelectionCapture);
 
                 // 点击黄色高亮生词：朗读发音并轻量提示
-                readerBody.addEventListener('click', (e) => {
+                on(readerBody, 'click', (e) => {
                     const mark = e.target.closest('mark.vocab-highlight');
                     if (mark) {
                         const selection = window.getSelection();
@@ -16687,15 +16853,17 @@ if (typeof module !== 'undefined' && module.exports) {
             }
 
             // ESC 键监听
-            window.addEventListener('keydown', (e) => {
-                if (e.key === 'Escape') {
+            on(window, 'keydown', (e) => {
+                if (e.key === 'Escape' && !overlay.classList.contains('is-hidden')) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     if (this.modalOpen) {
                         this.closeModal();
                     } else if (overlay && !overlay.classList.contains('is-hidden')) {
                         this.close();
                     }
                 }
-            });
+            }, true);
         },
 
         async open(examId, options = {}) {
@@ -16703,11 +16871,21 @@ if (typeof module !== 'undefined' && module.exports) {
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            const initiatingElement = options.returnFocus || document.activeElement;
+            if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
+            this.unbindEvents();
+            this.bindEvents(overlay);
+            this.clearPendingWork(overlay);
             this.currentExamId = examId;
             this.currentExam = null;
             this.currentPayload = null;
             this.currentExplanation = null;
-            this.closeModal();
+            this.closeModal(false);
+            this.modalTab = 'current';
+            overlay.querySelector('#v-tab-current')?.classList.add('active');
+            overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            if (manualInput) manualInput.value = '';
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -16722,7 +16900,9 @@ if (typeof module !== 'undefined' && module.exports) {
 
             // 显示加载状态
             overlay.classList.remove('is-hidden');
+            overlay.setAttribute('aria-hidden', 'false');
             document.body.classList.add('vocab-reader-open');
+            backBtn?.focus({ preventScroll: true });
 
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -16780,7 +16960,13 @@ if (typeof module !== 'undefined' && module.exports) {
                     retry.type = 'button';
                     retry.className = 'btn btn-primary';
                     retry.textContent = '重试';
-                    retry.addEventListener('click', () => this.open(examId, options));
+                    const handleRetry = () => {
+                        if (requestId === this._openRequestId && retry.isConnected && !overlay.classList.contains('is-hidden')) {
+                            this.open(examId, options);
+                        }
+                    };
+                    retry.addEventListener('click', handleRetry);
+                    this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
                     passageContent.replaceChildren(errorState);
                 }
@@ -16850,16 +17036,6 @@ if (typeof module !== 'undefined' && module.exports) {
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
-
-                // 绑定 Tab 点击事件
-                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
-                        btn.classList.add('active');
-                        const target = btn.dataset.para;
-                        this.switchViewTab(target);
-                    });
-                });
             }
 
             // 渲染文章段落
@@ -16893,15 +17069,15 @@ if (typeof module !== 'undefined' && module.exports) {
             if (questionsContent) {
                 const questionGroups = payload?.questionGroups || [];
                 if (questionGroups.length > 0) {
-                    let qHtml = '';
+                    const groups = document.createDocumentFragment();
                     questionGroups.forEach((g, idx) => {
-                        qHtml += `
-                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
-                                ${g.bodyHtml || ''}
-                            </div>
-                        `;
+                        const group = document.createElement('div');
+                        group.className = 'vocab-question-group';
+                        group.id = `vocab-qgroup-${idx + 1}`;
+                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        groups.appendChild(group);
                     });
-                    questionsContent.innerHTML = qHtml;
+                    questionsContent.replaceChildren(groups);
                 } else {
                     questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
                 }
@@ -17015,7 +17191,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 }
             }
 
-            setTimeout(() => {
+            this.defer(() => {
                 mark.classList.remove('vocab-highlight--pulse');
             }, 1500);
 
@@ -17284,6 +17460,12 @@ if (typeof module !== 'undefined' && module.exports) {
 
         switchViewTab(target) {
             const overlay = this.ensureOverlay();
+            this.activeTab = target;
+            overlay.querySelectorAll('.vocab-tab-btn').forEach(button => {
+                const active = button.dataset.para === target;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-selected', String(active));
+            });
             const passageSection = overlay.querySelector('#vocab-passage-section');
             const questionsSection = overlay.querySelector('#vocab-questions-section');
             const cards = overlay.querySelectorAll('.vocab-paragraph-card');
@@ -17376,53 +17558,36 @@ if (typeof module !== 'undefined' && module.exports) {
             });
 
             listEl.innerHTML = html;
-
-            // 绑定发音与删除
-            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    speakWord(btn.dataset.speakWord);
-                });
-            });
-
-            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const id = btn.dataset.delId;
-                    const allItems = ReadingVocabStore.getAll();
-                    const item = allItems.find(w => w.id === id);
-                    const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
-                    }
-                    this.showToast('已从生词本删除');
-                });
-            });
         },
 
         openModal() {
             const overlay = this.ensureOverlay();
+            this.bindEvents(overlay);
             const modal = overlay.querySelector('#vocab-modal');
             if (modal) {
+                if (!this.modalOpen) this._modalReturnFocus = document.activeElement;
                 this.modalOpen = true;
                 this.updateCounts();
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
+                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
             }
         },
 
-        closeModal() {
-            const overlay = this.ensureOverlay();
-            const modal = overlay.querySelector('#vocab-modal');
+        closeModal(restoreFocus = true) {
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            const modal = overlay?.querySelector('#vocab-modal');
+            const wasOpen = this.modalOpen;
+            this.modalOpen = false;
             if (modal) {
-                this.modalOpen = false;
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+            if (wasOpen && restoreFocus && this._modalReturnFocus?.isConnected) {
+                this._modalReturnFocus.focus({ preventScroll: true });
+            }
+            this._modalReturnFocus = null;
         },
 
         showToast(msg) {
@@ -17434,19 +17599,25 @@ if (typeof module !== 'undefined' && module.exports) {
             toast.classList.add('show');
 
             clearTimeout(this.toastTimer);
-            this.toastTimer = setTimeout(() => {
+            this._pendingTimers.delete(this.toastTimer);
+            this.toastTimer = this.defer(() => {
                 toast.classList.remove('show');
             }, 2000);
         },
 
         close() {
             ++this._openRequestId;
-            const overlay = this.ensureOverlay();
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            this.clearPendingWork(overlay);
+            this.closeModal(false);
+            this.unbindEvents();
             if (overlay) {
                 overlay.classList.add('is-hidden');
+                overlay.setAttribute('aria-hidden', 'true');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.closeModal();
+            if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            this._returnFocus = null;
         }
     };
 
@@ -17465,7 +17636,7 @@ if (typeof module !== 'undefined' && module.exports) {
     global.ReadingVocabStore = ReadingVocabStore;
     global.ReadingVocabReader = ReadingVocabReader;
     global.openReadingVocabReader = function(examId, options = {}) {
-        ReadingVocabReader.open(examId, options);
+        return ReadingVocabReader.open(examId, options);
     };
 
     // 启动数据同步初始化

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -7859,6 +7859,94 @@
     }
 
     // ============================================================================
+    // Parse in an inert template: even a pre-checked radio must never join a
+    // live practice answer group while the reader content is being prepared.
+    function createReadOnlyQuestionContent(html, namespace) {
+        const template = document.createElement('template');
+        template.innerHTML = html || '';
+        const content = template.content;
+        content.querySelectorAll('script, style, link, iframe, object, embed, template').forEach(node => node.remove());
+
+        const identities = new Map();
+        content.querySelectorAll('[id]').forEach((node, index) => {
+            const originalId = node.id;
+            node.id = `${namespace}-content-${index + 1}`;
+            if (!identities.has(originalId)) identities.set(originalId, node.id);
+        });
+
+        content.querySelectorAll('*').forEach(node => {
+            for (const attribute of [...node.attributes]) {
+                const name = attribute.name.toLowerCase();
+                if (name.startsWith('on') || name.startsWith('data-') || [
+                    'name', 'form', 'for', 'list', 'href', 'xlink:href', 'action', 'formaction',
+                    'contenteditable', 'draggable', 'tabindex', 'autofocus', 'accesskey', 'role',
+                    'aria-controls', 'aria-activedescendant', 'aria-checked', 'aria-selected'
+                ].includes(name)) {
+                    node.removeAttribute(attribute.name);
+                }
+            }
+            ['aria-labelledby', 'aria-describedby', 'headers'].forEach(name => {
+                if (!node.hasAttribute(name)) return;
+                const references = node.getAttribute(name).split(/\s+/).map(id => identities.get(id)).filter(Boolean);
+                if (references.length) node.setAttribute(name, references.join(' '));
+                else node.removeAttribute(name);
+            });
+            // Drop practice drag/drop hooks but retain the surrounding layout.
+            ['dropzone', 'match-dropzone', 'paragraph-dropzone', 'drop-target-summary'].forEach(className => {
+                if (!node.classList.contains(className)) return;
+                node.classList.remove(className);
+                if (!node.textContent.trim()) {
+                    node.textContent = '________';
+                    node.classList.add('vocab-answer-blank');
+                }
+            });
+            ['drag-item', 'draggable-word', 'card'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-option');
+                }
+            });
+            ['pool-items', 'options-pool', 'option-pool', 'cardpool', 'headings-pool', 'pool'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-pool');
+                }
+            });
+        });
+
+        content.querySelectorAll('input, textarea, select, button').forEach(control => {
+            const type = (control.getAttribute('type') || '').toLowerCase();
+            if (['hidden', 'submit', 'reset', 'image'].includes(type) ||
+                (control.tagName === 'BUTTON' && (!type || type === 'submit'))) {
+                control.remove();
+                return;
+            }
+            const replacement = document.createElement('span');
+            if (control.id) replacement.id = control.id;
+            replacement.className = 'vocab-answer-blank';
+            if (control.tagName === 'SELECT') {
+                replacement.className = 'vocab-question-options';
+                replacement.textContent = [...control.options].map(option => option.textContent.trim()).filter(Boolean).join(' / ');
+            } else if (control.tagName === 'BUTTON') {
+                replacement.textContent = control.textContent;
+            } else if (type === 'radio' || type === 'checkbox') {
+                replacement.textContent = type === 'radio' ? '○' : '□';
+                replacement.setAttribute('aria-hidden', 'true');
+            } else {
+                replacement.textContent = '________';
+                replacement.setAttribute('aria-label', 'Answer blank');
+            }
+            control.replaceWith(replacement);
+        });
+        content.querySelectorAll('label, form, fieldset, legend, a').forEach(node => {
+            const replacement = document.createElement(['FORM', 'FIELDSET'].includes(node.tagName) ? 'div' : 'span');
+            for (const attribute of [...node.attributes]) replacement.setAttribute(attribute.name, attribute.value);
+            replacement.append(...node.childNodes);
+            node.replaceWith(replacement);
+        });
+        return content;
+    }
+
     // 阅读器主控制器 (ReadingVocabReader)
     // ============================================================================
     const ReadingVocabReader = {
@@ -7872,6 +7960,40 @@
         modalOpen: false,
         toastTimer: null,
         _openRequestId: 0,
+        _eventOverlay: null,
+        _eventCleanups: [],
+        _pendingTimers: new Set(),
+        _returnFocus: null,
+        _modalReturnFocus: null,
+
+        clearPendingWork(overlay) {
+            this._pendingTimers.forEach(timer => clearTimeout(timer));
+            this._pendingTimers.clear();
+            this.toastTimer = null;
+            const toast = overlay?.querySelector('#vocab-toast');
+            if (toast) {
+                toast.classList.remove('show');
+                toast.textContent = '';
+            }
+            overlay?.querySelectorAll('.vocab-highlight--pulse').forEach(mark => mark.classList.remove('vocab-highlight--pulse'));
+            const selection = window.getSelection();
+            if (selection && overlay?.contains(selection.anchorNode)) selection.removeAllRanges();
+        },
+
+        defer(callback, delay) {
+            const requestId = this._openRequestId;
+            const timer = setTimeout(() => {
+                if (!this._pendingTimers.delete(timer) || requestId !== this._openRequestId) return;
+                callback();
+            }, delay);
+            this._pendingTimers.add(timer);
+            return timer;
+        },
+
+        unbindEvents() {
+            this._eventCleanups.splice(0).forEach(cleanup => cleanup());
+            this._eventOverlay = null;
+        },
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -7884,6 +8006,7 @@
             overlay.className = 'vocab-reader-overlay is-hidden';
             overlay.setAttribute('role', 'dialog');
             overlay.setAttribute('aria-label', '阅读生词本');
+            overlay.setAttribute('aria-hidden', 'true');
 
             overlay.innerHTML = `
                 <div class="vocab-reader-container">
@@ -8001,30 +8124,43 @@
         },
 
         bindEvents(overlay) {
+            if (this._eventOverlay === overlay) return;
+            this.unbindEvents();
+            this._eventOverlay = overlay;
+            const on = (element, type, callback, options) => {
+                element.addEventListener(type, callback, options);
+                this._eventCleanups.push(() => element.removeEventListener(type, callback, options));
+            };
             // 返回按钮
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
             if (backBtn) {
-                backBtn.addEventListener('click', () => this.close());
+                on(backBtn, 'click', () => this.close());
             }
 
             // 开启生词本弹窗
             const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
             const fab = overlay.querySelector('#vocab-fab');
             if (openModalBtn) {
-                openModalBtn.addEventListener('click', () => this.openModal());
+                on(openModalBtn, 'click', () => this.openModal());
             }
             if (fab) {
-                fab.addEventListener('click', () => this.openModal());
+                on(fab, 'click', () => this.openModal());
+                on(fab, 'keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        this.openModal();
+                    }
+                });
             }
 
             // 关闭生词本弹窗
             const closeModalBtn = overlay.querySelector('#vocab-modal-close');
             const modal = overlay.querySelector('#vocab-modal');
             if (closeModalBtn) {
-                closeModalBtn.addEventListener('click', () => this.closeModal());
+                on(closeModalBtn, 'click', () => this.closeModal());
             }
             if (modal) {
-                modal.addEventListener('click', (e) => {
+                on(modal, 'click', (e) => {
                     if (e.target === modal) {
                         this.closeModal();
                     }
@@ -8034,7 +8170,7 @@
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                bookshelfBtn.addEventListener('click', () => {
+                on(bookshelfBtn, 'click', () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
@@ -8068,7 +8204,7 @@
             const tabCurrent = overlay.querySelector('#v-tab-current');
             const tabAll = overlay.querySelector('#v-tab-all');
             if (tabCurrent) {
-                tabCurrent.addEventListener('click', () => {
+                on(tabCurrent, 'click', () => {
                     this.modalTab = 'current';
                     tabCurrent.classList.add('active');
                     tabAll.classList.remove('active');
@@ -8076,11 +8212,41 @@
                 });
             }
             if (tabAll) {
-                tabAll.addEventListener('click', () => {
+                on(tabAll, 'click', () => {
                     this.modalTab = 'all';
                     tabAll.classList.add('active');
                     tabCurrent.classList.remove('active');
                     this.renderVocabList();
+                });
+            }
+
+            const readerTabs = overlay.querySelector('#vocab-reader-tabs');
+            if (readerTabs) {
+                on(readerTabs, 'click', event => {
+                    const button = event.target.closest('.vocab-tab-btn');
+                    if (button && readerTabs.contains(button)) this.switchViewTab(button.dataset.para);
+                });
+            }
+
+            const vocabList = overlay.querySelector('#vocab-list');
+            if (vocabList) {
+                on(vocabList, 'click', event => {
+                    const speakButton = event.target.closest('.vocab-speak-btn');
+                    const deleteButton = event.target.closest('.vocab-delete-btn');
+                    if (speakButton && vocabList.contains(speakButton)) {
+                        event.stopPropagation();
+                        speakWord(speakButton.dataset.speakWord);
+                    } else if (deleteButton && vocabList.contains(deleteButton)) {
+                        event.stopPropagation();
+                        const id = deleteButton.dataset.delId;
+                        const item = ReadingVocabStore.getAll().find(word => word.id === id);
+                        const word = item?.word;
+                        ReadingVocabStore.remove(id);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) this.removeVocabHighlightForWord(word);
+                        this.showToast('已从生词本删除');
+                    }
                 });
             }
 
@@ -8106,10 +8272,10 @@
                 }
             };
             if (manualAddBtn) {
-                manualAddBtn.addEventListener('click', handleManualAdd);
+                on(manualAddBtn, 'click', handleManualAdd);
             }
             if (manualInput) {
-                manualInput.addEventListener('keydown', (e) => {
+                on(manualInput, 'keydown', (e) => {
                     if (e.key === 'Enter') {
                         e.preventDefault();
                         handleManualAdd();
@@ -8120,7 +8286,7 @@
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                exportBtn.addEventListener('click', () => {
+                on(exportBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
 
@@ -8146,7 +8312,7 @@
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                on(clearBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
@@ -8174,7 +8340,7 @@
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
+                    this.defer(() => {
                         if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
@@ -8286,11 +8452,11 @@
                     }, 20);
                 };
 
-                readerBody.addEventListener('mouseup', handleSelectionCapture);
-                readerBody.addEventListener('touchend', handleSelectionCapture);
+                on(readerBody, 'mouseup', handleSelectionCapture);
+                on(readerBody, 'touchend', handleSelectionCapture);
 
                 // 点击黄色高亮生词：朗读发音并轻量提示
-                readerBody.addEventListener('click', (e) => {
+                on(readerBody, 'click', (e) => {
                     const mark = e.target.closest('mark.vocab-highlight');
                     if (mark) {
                         const selection = window.getSelection();
@@ -8307,15 +8473,17 @@
             }
 
             // ESC 键监听
-            window.addEventListener('keydown', (e) => {
-                if (e.key === 'Escape') {
+            on(window, 'keydown', (e) => {
+                if (e.key === 'Escape' && !overlay.classList.contains('is-hidden')) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     if (this.modalOpen) {
                         this.closeModal();
                     } else if (overlay && !overlay.classList.contains('is-hidden')) {
                         this.close();
                     }
                 }
-            });
+            }, true);
         },
 
         async open(examId, options = {}) {
@@ -8323,11 +8491,21 @@
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            const initiatingElement = options.returnFocus || document.activeElement;
+            if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
+            this.unbindEvents();
+            this.bindEvents(overlay);
+            this.clearPendingWork(overlay);
             this.currentExamId = examId;
             this.currentExam = null;
             this.currentPayload = null;
             this.currentExplanation = null;
-            this.closeModal();
+            this.closeModal(false);
+            this.modalTab = 'current';
+            overlay.querySelector('#v-tab-current')?.classList.add('active');
+            overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            if (manualInput) manualInput.value = '';
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -8342,7 +8520,9 @@
 
             // 显示加载状态
             overlay.classList.remove('is-hidden');
+            overlay.setAttribute('aria-hidden', 'false');
             document.body.classList.add('vocab-reader-open');
+            backBtn?.focus({ preventScroll: true });
 
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -8400,7 +8580,13 @@
                     retry.type = 'button';
                     retry.className = 'btn btn-primary';
                     retry.textContent = '重试';
-                    retry.addEventListener('click', () => this.open(examId, options));
+                    const handleRetry = () => {
+                        if (requestId === this._openRequestId && retry.isConnected && !overlay.classList.contains('is-hidden')) {
+                            this.open(examId, options);
+                        }
+                    };
+                    retry.addEventListener('click', handleRetry);
+                    this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
                     passageContent.replaceChildren(errorState);
                 }
@@ -8470,16 +8656,6 @@
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
-
-                // 绑定 Tab 点击事件
-                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
-                        btn.classList.add('active');
-                        const target = btn.dataset.para;
-                        this.switchViewTab(target);
-                    });
-                });
             }
 
             // 渲染文章段落
@@ -8513,15 +8689,15 @@
             if (questionsContent) {
                 const questionGroups = payload?.questionGroups || [];
                 if (questionGroups.length > 0) {
-                    let qHtml = '';
+                    const groups = document.createDocumentFragment();
                     questionGroups.forEach((g, idx) => {
-                        qHtml += `
-                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
-                                ${g.bodyHtml || ''}
-                            </div>
-                        `;
+                        const group = document.createElement('div');
+                        group.className = 'vocab-question-group';
+                        group.id = `vocab-qgroup-${idx + 1}`;
+                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        groups.appendChild(group);
                     });
-                    questionsContent.innerHTML = qHtml;
+                    questionsContent.replaceChildren(groups);
                 } else {
                     questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
                 }
@@ -8635,7 +8811,7 @@
                 }
             }
 
-            setTimeout(() => {
+            this.defer(() => {
                 mark.classList.remove('vocab-highlight--pulse');
             }, 1500);
 
@@ -8904,6 +9080,12 @@
 
         switchViewTab(target) {
             const overlay = this.ensureOverlay();
+            this.activeTab = target;
+            overlay.querySelectorAll('.vocab-tab-btn').forEach(button => {
+                const active = button.dataset.para === target;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-selected', String(active));
+            });
             const passageSection = overlay.querySelector('#vocab-passage-section');
             const questionsSection = overlay.querySelector('#vocab-questions-section');
             const cards = overlay.querySelectorAll('.vocab-paragraph-card');
@@ -8996,53 +9178,36 @@
             });
 
             listEl.innerHTML = html;
-
-            // 绑定发音与删除
-            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    speakWord(btn.dataset.speakWord);
-                });
-            });
-
-            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const id = btn.dataset.delId;
-                    const allItems = ReadingVocabStore.getAll();
-                    const item = allItems.find(w => w.id === id);
-                    const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
-                    }
-                    this.showToast('已从生词本删除');
-                });
-            });
         },
 
         openModal() {
             const overlay = this.ensureOverlay();
+            this.bindEvents(overlay);
             const modal = overlay.querySelector('#vocab-modal');
             if (modal) {
+                if (!this.modalOpen) this._modalReturnFocus = document.activeElement;
                 this.modalOpen = true;
                 this.updateCounts();
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
+                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
             }
         },
 
-        closeModal() {
-            const overlay = this.ensureOverlay();
-            const modal = overlay.querySelector('#vocab-modal');
+        closeModal(restoreFocus = true) {
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            const modal = overlay?.querySelector('#vocab-modal');
+            const wasOpen = this.modalOpen;
+            this.modalOpen = false;
             if (modal) {
-                this.modalOpen = false;
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+            if (wasOpen && restoreFocus && this._modalReturnFocus?.isConnected) {
+                this._modalReturnFocus.focus({ preventScroll: true });
+            }
+            this._modalReturnFocus = null;
         },
 
         showToast(msg) {
@@ -9054,19 +9219,25 @@
             toast.classList.add('show');
 
             clearTimeout(this.toastTimer);
-            this.toastTimer = setTimeout(() => {
+            this._pendingTimers.delete(this.toastTimer);
+            this.toastTimer = this.defer(() => {
                 toast.classList.remove('show');
             }, 2000);
         },
 
         close() {
             ++this._openRequestId;
-            const overlay = this.ensureOverlay();
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            this.clearPendingWork(overlay);
+            this.closeModal(false);
+            this.unbindEvents();
             if (overlay) {
                 overlay.classList.add('is-hidden');
+                overlay.setAttribute('aria-hidden', 'true');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.closeModal();
+            if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            this._returnFocus = null;
         }
     };
 
@@ -9085,7 +9256,7 @@
     global.ReadingVocabStore = ReadingVocabStore;
     global.ReadingVocabReader = ReadingVocabReader;
     global.openReadingVocabReader = function(examId, options = {}) {
-        ReadingVocabReader.open(examId, options);
+        return ReadingVocabReader.open(examId, options);
     };
 
     // 启动数据同步初始化
@@ -9491,7 +9662,7 @@
         const locked = Boolean(enabled);
         state.timerLocked = locked;
         document.body.classList.toggle('timer-locked-mode', locked);
-        document.querySelectorAll('input, textarea, select').forEach((control) => {
+        getPracticeFormControls().forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 control.disabled = locked || state.readOnly;
             }
@@ -11358,12 +11529,7 @@
         }
     }
 
-    // Keep the practice entry unavailable until #157 isolates the reader's
-    // question controls from practice radio groups and answer collection.
-    const PRACTICE_VOCAB_READER_ENABLED = false;
-
     function openVocabReaderForCurrentExam() {
-        if (!PRACTICE_VOCAB_READER_ENABLED) return;
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
@@ -11381,7 +11547,6 @@
     }
 
     function ensureReadingVocabButton() {
-        if (!PRACTICE_VOCAB_READER_ENABLED) return null;
         let button = document.getElementById('reading-vocab-header-btn');
         if (button) return button;
         const headerRight = document.querySelector('.header-right');
@@ -14160,9 +14325,35 @@
         });
     }
 
+    function getPracticeAnswerRoot() {
+        // The reader and note editor share this document, but only the rendered
+        // practice questions own answer controls. Never fall back to document.
+        return dom.groups || document.getElementById('question-groups');
+    }
+
+    function getPracticeFormControls() {
+        const roots = [
+            getPracticeAnswerRoot(),
+            dom.left || document.getElementById('left'),
+            document.getElementById('notes-panel'),
+            document.getElementById('reading-note-editor'),
+            document.getElementById('reading-note-drawer')
+        ].filter(Boolean);
+        return Array.from(new Set(roots.flatMap((root) => Array.from(root.querySelectorAll('input, textarea, select')))));
+    }
+
+    function isTextualAnswerControl(field) {
+        const tagName = String(field?.tagName || '').toUpperCase();
+        return tagName === 'SELECT'
+            || tagName === 'TEXTAREA'
+            || (tagName === 'INPUT' && String(field.type || 'text').toLowerCase() === 'text');
+    }
+
     function getCheckboxAnswers() {
         const grouped = new Map();
-        document.querySelectorAll('input[type="checkbox"][name]').forEach((input) => {
+        const root = getPracticeAnswerRoot();
+        if (!root) return grouped;
+        root.querySelectorAll('input[type="checkbox"][name]').forEach((input) => {
             const name = input.name;
             if (!grouped.has(name)) {
                 grouped.set(name, []);
@@ -14196,11 +14387,13 @@
     }
 
     function getTextualAnswer(questionId) {
+        const root = getPracticeAnswerRoot();
+        if (!root) return '';
         const aliases = resolveAnswerAliases(questionId);
         const fieldMap = new Map();
         aliases.forEach((alias) => {
-            document.querySelectorAll(`[name="${alias}"]`).forEach((field) => {
-                if (!fieldMap.has(field)) {
+            root.querySelectorAll(`[name="${escapeSelector(alias)}"]`).forEach((field) => {
+                if (isTextualAnswerControl(field) && !fieldMap.has(field)) {
                     fieldMap.set(field, true);
                 }
             });
@@ -14208,14 +14401,6 @@
         const fields = Array.from(fieldMap.keys());
         const values = [];
         for (const field of fields) {
-            if (field.type === 'radio') continue;
-            if (field.tagName === 'SELECT') {
-                const value = String(field.value || '').trim();
-                if (value) {
-                    values.push(value);
-                }
-                continue;
-            }
             const value = String(field.value || '').trim();
             if (value) {
                 values.push(value);
@@ -14223,8 +14408,8 @@
         }
         if (!values.length) {
             aliases.forEach((alias) => {
-                const inputById = document.getElementById(`${alias}_input`);
-                if (!inputById || !('value' in inputById)) {
+                const inputById = root.querySelector(`[id="${escapeSelector(`${alias}_input`)}"]`);
+                if (!isTextualAnswerControl(inputById)) {
                     return;
                 }
                 const value = String(inputById.value || '').trim();
@@ -14360,6 +14545,9 @@
     }
 
     function findDropzoneByQuestionId(questionId) {
+        // Matching headings can live beside passage paragraphs in the left pane.
+        const roots = [getPracticeAnswerRoot(), dom.left || document.getElementById('left')].filter(Boolean);
+        if (!roots.length) return null;
         const aliases = resolveAnswerAliases(questionId);
         for (let index = 0; index < aliases.length; index += 1) {
             const alias = aliases[index];
@@ -14377,19 +14565,21 @@
                 `#${escaped}-dropzone`,
                 `#${escaped}-target`
             ].join(', ');
-            let direct = null;
-            try {
-                direct = document.querySelector(selector);
-            } catch (_) {
-                direct = null;
-            }
-            if (direct) {
-                return direct;
-            }
-            const anchor = document.getElementById(`${alias}-anchor`);
-            const paragraphZone = anchor?.parentElement?.querySelector?.('.paragraph-dropzone');
-            if (paragraphZone) {
-                return paragraphZone;
+            for (const root of roots) {
+                let direct = null;
+                try {
+                    direct = root.querySelector(selector);
+                } catch (_) {
+                    direct = null;
+                }
+                if (direct) {
+                    return direct;
+                }
+                const anchor = root.querySelector(`[id="${escapeSelector(`${alias}-anchor`)}"]`);
+                const paragraphZone = anchor?.parentElement?.querySelector?.('.paragraph-dropzone');
+                if (paragraphZone) {
+                    return paragraphZone;
+                }
             }
         }
         return null;
@@ -14445,11 +14635,13 @@
 
     function collectAnswers() {
         const order = Array.isArray(state.dataset?.questionOrder) ? state.dataset.questionOrder : [];
+        const questionIdsInDataset = new Set(order);
+        const root = getPracticeAnswerRoot();
         const answers = {};
         const checkboxGroups = getCheckboxAnswers();
 
         checkboxGroups.forEach((values, name) => {
-            const questionIds = resolveCheckboxQuestionIds(name);
+            const questionIds = resolveCheckboxQuestionIds(name).filter((questionId) => questionIdsInDataset.has(questionId));
             if (!questionIds.length) {
                 return;
             }
@@ -14467,7 +14659,7 @@
             if (Object.prototype.hasOwnProperty.call(answers, questionId)) {
                 return;
             }
-            const radios = document.querySelectorAll(`input[type="radio"][name="${questionId}"]`);
+            const radios = root?.querySelectorAll(`input[type="radio"][name="${escapeSelector(questionId)}"]`) || [];
             if (radios.length) {
                 const checked = Array.from(radios).find((input) => input.checked);
                 answers[questionId] = checked ? String(checked.value).trim() : '';
@@ -15109,15 +15301,17 @@
     }
 
     function collectChoiceInputsForQuestion(questionId) {
+        const root = getPracticeAnswerRoot();
+        if (!root) return [];
         const normalizedTarget = normalizeQuestionId(questionId);
         // 直接匹配
-        let inputs = document.querySelectorAll(`input[type="checkbox"][name="${escapeSelector(questionId)}"], input[type="radio"][name="${escapeSelector(questionId)}"]`);
+        let inputs = root.querySelectorAll(`input[type="checkbox"][name="${escapeSelector(questionId)}"], input[type="radio"][name="${escapeSelector(questionId)}"]`);
         if (inputs.length) {
             return Array.from(inputs);
         }
         // 扫描所有 checkbox/radio 组，匹配 name 展开后的题目序列
         const matched = [];
-        document.querySelectorAll('input[type="checkbox"][name], input[type="radio"][name]').forEach((input) => {
+        root.querySelectorAll('input[type="checkbox"][name], input[type="radio"][name]').forEach((input) => {
             const name = input.name || '';
             const ids = expandQuestionSequence(name);
             if (ids.some((id) => normalizeQuestionId(id) === normalizedTarget)) {
@@ -15308,10 +15502,12 @@
         if (!answers || typeof answers !== 'object') {
             return;
         }
+        const root = getPracticeAnswerRoot();
+        if (!root) return;
 
         const groupedHandledQuestionIds = new Set();
         const groupedChoiceInputs = new Map();
-        document.querySelectorAll('input[type="radio"][name], input[type="checkbox"][name]').forEach((input) => {
+        root.querySelectorAll('input[type="radio"][name], input[type="checkbox"][name]').forEach((input) => {
             const groupName = String(input.getAttribute('name') || '').trim();
             if (!groupName) return;
             const expandedQuestionIds = expandQuestionSequence(groupName);
@@ -15367,10 +15563,10 @@
             const selectFields = new Set();
             aliases.forEach((alias) => {
                 const escapedAlias = escapeSelector(alias);
-                document.querySelectorAll(
+                root.querySelectorAll(
                     `input[type="radio"][name="${escapedAlias}"], input[type="checkbox"][name="${escapedAlias}"]`
                 ).forEach((field) => choiceFields.add(field));
-                document.querySelectorAll([
+                root.querySelectorAll([
                     `input[name="${escapedAlias}"]`,
                     `textarea[name="${escapedAlias}"]`,
                     `input[id="${escapedAlias}"]`,
@@ -15378,11 +15574,11 @@
                     `input[data-question-id="${escapedAlias}"]`,
                     `textarea[data-question-id="${escapedAlias}"]`
                 ].join(', ')).forEach((field) => {
-                    if (field.type !== 'radio' && field.type !== 'checkbox') {
+                    if (isTextualAnswerControl(field)) {
                         textFields.add(field);
                     }
                 });
-                document.querySelectorAll([
+                root.querySelectorAll([
                     `select[name="${escapedAlias}"]`,
                     `select[id="${escapedAlias}"]`,
                     `select[data-question-id="${escapedAlias}"]`
@@ -15447,7 +15643,7 @@
         if (dom.resetBtn) {
             dom.resetBtn.disabled = state.readOnly;
         }
-        const controls = document.querySelectorAll('input, textarea, select');
+        const controls = getPracticeFormControls();
         controls.forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 // review、普通进行中练习、以及已回传 recordId 的结果页允许编辑笔记；
@@ -15675,6 +15871,10 @@
                 initializeInlineSimulationSuite,
                 activateSuiteSlot,
                 buildResultsFromAnswers,
+                collectAnswers,
+                collectCurrentDraft,
+                setTimerLockMode,
+                setReadOnlyMode,
                 applyAnswersToDom,
                 applyReplayAnswersToDom,
                 captureDom,
@@ -16023,7 +16223,7 @@
             }
         });
         enhanceReviewHighlights();
-        document.querySelectorAll('input, textarea, select').forEach((control) => {
+        getPracticeFormControls().forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 control.disabled = false;
             }
@@ -16909,15 +17109,15 @@
     }
 
     function clearCurrentAnswers() {
-        document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach((input) => {
-            input.checked = false;
-        });
-        document.querySelectorAll('input[type="text"], textarea').forEach((input) => {
+        getPracticeFormControls().forEach((input) => {
             if (input.closest('#notes-panel, #reading-note-editor, #reading-note-drawer')) return;
-            input.value = '';
-        });
-        document.querySelectorAll('select').forEach((select) => {
-            select.selectedIndex = 0;
+            if (input.type === 'radio' || input.type === 'checkbox') {
+                input.checked = false;
+            } else if (input.tagName === 'SELECT') {
+                input.selectedIndex = 0;
+            } else if (isTextualAnswerControl(input)) {
+                input.value = '';
+            }
         });
         getDropzones().forEach((dropzone) => {
             clearDropzone(dropzone);

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -692,6 +692,94 @@
     }
 
     // ============================================================================
+    // Parse in an inert template: even a pre-checked radio must never join a
+    // live practice answer group while the reader content is being prepared.
+    function createReadOnlyQuestionContent(html, namespace) {
+        const template = document.createElement('template');
+        template.innerHTML = html || '';
+        const content = template.content;
+        content.querySelectorAll('script, style, link, iframe, object, embed, template').forEach(node => node.remove());
+
+        const identities = new Map();
+        content.querySelectorAll('[id]').forEach((node, index) => {
+            const originalId = node.id;
+            node.id = `${namespace}-content-${index + 1}`;
+            if (!identities.has(originalId)) identities.set(originalId, node.id);
+        });
+
+        content.querySelectorAll('*').forEach(node => {
+            for (const attribute of [...node.attributes]) {
+                const name = attribute.name.toLowerCase();
+                if (name.startsWith('on') || name.startsWith('data-') || [
+                    'name', 'form', 'for', 'list', 'href', 'xlink:href', 'action', 'formaction',
+                    'contenteditable', 'draggable', 'tabindex', 'autofocus', 'accesskey', 'role',
+                    'aria-controls', 'aria-activedescendant', 'aria-checked', 'aria-selected'
+                ].includes(name)) {
+                    node.removeAttribute(attribute.name);
+                }
+            }
+            ['aria-labelledby', 'aria-describedby', 'headers'].forEach(name => {
+                if (!node.hasAttribute(name)) return;
+                const references = node.getAttribute(name).split(/\s+/).map(id => identities.get(id)).filter(Boolean);
+                if (references.length) node.setAttribute(name, references.join(' '));
+                else node.removeAttribute(name);
+            });
+            // Drop practice drag/drop hooks but retain the surrounding layout.
+            ['dropzone', 'match-dropzone', 'paragraph-dropzone', 'drop-target-summary'].forEach(className => {
+                if (!node.classList.contains(className)) return;
+                node.classList.remove(className);
+                if (!node.textContent.trim()) {
+                    node.textContent = '________';
+                    node.classList.add('vocab-answer-blank');
+                }
+            });
+            ['drag-item', 'draggable-word', 'card'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-option');
+                }
+            });
+            ['pool-items', 'options-pool', 'option-pool', 'cardpool', 'headings-pool', 'pool'].forEach(className => {
+                if (node.classList.contains(className)) {
+                    node.classList.remove(className);
+                    node.classList.add('vocab-question-pool');
+                }
+            });
+        });
+
+        content.querySelectorAll('input, textarea, select, button').forEach(control => {
+            const type = (control.getAttribute('type') || '').toLowerCase();
+            if (['hidden', 'submit', 'reset', 'image'].includes(type) ||
+                (control.tagName === 'BUTTON' && (!type || type === 'submit'))) {
+                control.remove();
+                return;
+            }
+            const replacement = document.createElement('span');
+            if (control.id) replacement.id = control.id;
+            replacement.className = 'vocab-answer-blank';
+            if (control.tagName === 'SELECT') {
+                replacement.className = 'vocab-question-options';
+                replacement.textContent = [...control.options].map(option => option.textContent.trim()).filter(Boolean).join(' / ');
+            } else if (control.tagName === 'BUTTON') {
+                replacement.textContent = control.textContent;
+            } else if (type === 'radio' || type === 'checkbox') {
+                replacement.textContent = type === 'radio' ? '○' : '□';
+                replacement.setAttribute('aria-hidden', 'true');
+            } else {
+                replacement.textContent = '________';
+                replacement.setAttribute('aria-label', 'Answer blank');
+            }
+            control.replaceWith(replacement);
+        });
+        content.querySelectorAll('label, form, fieldset, legend, a').forEach(node => {
+            const replacement = document.createElement(['FORM', 'FIELDSET'].includes(node.tagName) ? 'div' : 'span');
+            for (const attribute of [...node.attributes]) replacement.setAttribute(attribute.name, attribute.value);
+            replacement.append(...node.childNodes);
+            node.replaceWith(replacement);
+        });
+        return content;
+    }
+
     // 阅读器主控制器 (ReadingVocabReader)
     // ============================================================================
     const ReadingVocabReader = {
@@ -705,6 +793,40 @@
         modalOpen: false,
         toastTimer: null,
         _openRequestId: 0,
+        _eventOverlay: null,
+        _eventCleanups: [],
+        _pendingTimers: new Set(),
+        _returnFocus: null,
+        _modalReturnFocus: null,
+
+        clearPendingWork(overlay) {
+            this._pendingTimers.forEach(timer => clearTimeout(timer));
+            this._pendingTimers.clear();
+            this.toastTimer = null;
+            const toast = overlay?.querySelector('#vocab-toast');
+            if (toast) {
+                toast.classList.remove('show');
+                toast.textContent = '';
+            }
+            overlay?.querySelectorAll('.vocab-highlight--pulse').forEach(mark => mark.classList.remove('vocab-highlight--pulse'));
+            const selection = window.getSelection();
+            if (selection && overlay?.contains(selection.anchorNode)) selection.removeAllRanges();
+        },
+
+        defer(callback, delay) {
+            const requestId = this._openRequestId;
+            const timer = setTimeout(() => {
+                if (!this._pendingTimers.delete(timer) || requestId !== this._openRequestId) return;
+                callback();
+            }, delay);
+            this._pendingTimers.add(timer);
+            return timer;
+        },
+
+        unbindEvents() {
+            this._eventCleanups.splice(0).forEach(cleanup => cleanup());
+            this._eventOverlay = null;
+        },
 
         ensureOverlay() {
             let overlay = document.getElementById('reading-vocab-reader-overlay');
@@ -717,6 +839,7 @@
             overlay.className = 'vocab-reader-overlay is-hidden';
             overlay.setAttribute('role', 'dialog');
             overlay.setAttribute('aria-label', '阅读生词本');
+            overlay.setAttribute('aria-hidden', 'true');
 
             overlay.innerHTML = `
                 <div class="vocab-reader-container">
@@ -834,30 +957,43 @@
         },
 
         bindEvents(overlay) {
+            if (this._eventOverlay === overlay) return;
+            this.unbindEvents();
+            this._eventOverlay = overlay;
+            const on = (element, type, callback, options) => {
+                element.addEventListener(type, callback, options);
+                this._eventCleanups.push(() => element.removeEventListener(type, callback, options));
+            };
             // 返回按钮
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
             if (backBtn) {
-                backBtn.addEventListener('click', () => this.close());
+                on(backBtn, 'click', () => this.close());
             }
 
             // 开启生词本弹窗
             const openModalBtn = overlay.querySelector('#vocab-open-modal-btn');
             const fab = overlay.querySelector('#vocab-fab');
             if (openModalBtn) {
-                openModalBtn.addEventListener('click', () => this.openModal());
+                on(openModalBtn, 'click', () => this.openModal());
             }
             if (fab) {
-                fab.addEventListener('click', () => this.openModal());
+                on(fab, 'click', () => this.openModal());
+                on(fab, 'keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        this.openModal();
+                    }
+                });
             }
 
             // 关闭生词本弹窗
             const closeModalBtn = overlay.querySelector('#vocab-modal-close');
             const modal = overlay.querySelector('#vocab-modal');
             if (closeModalBtn) {
-                closeModalBtn.addEventListener('click', () => this.closeModal());
+                on(closeModalBtn, 'click', () => this.closeModal());
             }
             if (modal) {
-                modal.addEventListener('click', (e) => {
+                on(modal, 'click', (e) => {
                     if (e.target === modal) {
                         this.closeModal();
                     }
@@ -867,7 +1003,7 @@
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                bookshelfBtn.addEventListener('click', () => {
+                on(bookshelfBtn, 'click', () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
@@ -901,7 +1037,7 @@
             const tabCurrent = overlay.querySelector('#v-tab-current');
             const tabAll = overlay.querySelector('#v-tab-all');
             if (tabCurrent) {
-                tabCurrent.addEventListener('click', () => {
+                on(tabCurrent, 'click', () => {
                     this.modalTab = 'current';
                     tabCurrent.classList.add('active');
                     tabAll.classList.remove('active');
@@ -909,11 +1045,41 @@
                 });
             }
             if (tabAll) {
-                tabAll.addEventListener('click', () => {
+                on(tabAll, 'click', () => {
                     this.modalTab = 'all';
                     tabAll.classList.add('active');
                     tabCurrent.classList.remove('active');
                     this.renderVocabList();
+                });
+            }
+
+            const readerTabs = overlay.querySelector('#vocab-reader-tabs');
+            if (readerTabs) {
+                on(readerTabs, 'click', event => {
+                    const button = event.target.closest('.vocab-tab-btn');
+                    if (button && readerTabs.contains(button)) this.switchViewTab(button.dataset.para);
+                });
+            }
+
+            const vocabList = overlay.querySelector('#vocab-list');
+            if (vocabList) {
+                on(vocabList, 'click', event => {
+                    const speakButton = event.target.closest('.vocab-speak-btn');
+                    const deleteButton = event.target.closest('.vocab-delete-btn');
+                    if (speakButton && vocabList.contains(speakButton)) {
+                        event.stopPropagation();
+                        speakWord(speakButton.dataset.speakWord);
+                    } else if (deleteButton && vocabList.contains(deleteButton)) {
+                        event.stopPropagation();
+                        const id = deleteButton.dataset.delId;
+                        const item = ReadingVocabStore.getAll().find(word => word.id === id);
+                        const word = item?.word;
+                        ReadingVocabStore.remove(id);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) this.removeVocabHighlightForWord(word);
+                        this.showToast('已从生词本删除');
+                    }
                 });
             }
 
@@ -939,10 +1105,10 @@
                 }
             };
             if (manualAddBtn) {
-                manualAddBtn.addEventListener('click', handleManualAdd);
+                on(manualAddBtn, 'click', handleManualAdd);
             }
             if (manualInput) {
-                manualInput.addEventListener('keydown', (e) => {
+                on(manualInput, 'keydown', (e) => {
                     if (e.key === 'Enter') {
                         e.preventDefault();
                         handleManualAdd();
@@ -953,7 +1119,7 @@
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                exportBtn.addEventListener('click', () => {
+                on(exportBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
 
@@ -979,7 +1145,7 @@
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                on(clearBtn, 'click', () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
@@ -1007,7 +1173,7 @@
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
+                    this.defer(() => {
                         if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
@@ -1119,11 +1285,11 @@
                     }, 20);
                 };
 
-                readerBody.addEventListener('mouseup', handleSelectionCapture);
-                readerBody.addEventListener('touchend', handleSelectionCapture);
+                on(readerBody, 'mouseup', handleSelectionCapture);
+                on(readerBody, 'touchend', handleSelectionCapture);
 
                 // 点击黄色高亮生词：朗读发音并轻量提示
-                readerBody.addEventListener('click', (e) => {
+                on(readerBody, 'click', (e) => {
                     const mark = e.target.closest('mark.vocab-highlight');
                     if (mark) {
                         const selection = window.getSelection();
@@ -1140,15 +1306,17 @@
             }
 
             // ESC 键监听
-            window.addEventListener('keydown', (e) => {
-                if (e.key === 'Escape') {
+            on(window, 'keydown', (e) => {
+                if (e.key === 'Escape' && !overlay.classList.contains('is-hidden')) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     if (this.modalOpen) {
                         this.closeModal();
                     } else if (overlay && !overlay.classList.contains('is-hidden')) {
                         this.close();
                     }
                 }
-            });
+            }, true);
         },
 
         async open(examId, options = {}) {
@@ -1156,11 +1324,21 @@
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            const initiatingElement = options.returnFocus || document.activeElement;
+            if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
+            this.unbindEvents();
+            this.bindEvents(overlay);
+            this.clearPendingWork(overlay);
             this.currentExamId = examId;
             this.currentExam = null;
             this.currentPayload = null;
             this.currentExplanation = null;
-            this.closeModal();
+            this.closeModal(false);
+            this.modalTab = 'current';
+            overlay.querySelector('#v-tab-current')?.classList.add('active');
+            overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            const manualInput = overlay.querySelector('#vocab-manual-input');
+            if (manualInput) manualInput.value = '';
 
             // 根据来源动态调整返回按钮提示
             const backBtn = overlay.querySelector('#vocab-reader-back-btn');
@@ -1175,7 +1353,9 @@
 
             // 显示加载状态
             overlay.classList.remove('is-hidden');
+            overlay.setAttribute('aria-hidden', 'false');
             document.body.classList.add('vocab-reader-open');
+            backBtn?.focus({ preventScroll: true });
 
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -1233,7 +1413,13 @@
                     retry.type = 'button';
                     retry.className = 'btn btn-primary';
                     retry.textContent = '重试';
-                    retry.addEventListener('click', () => this.open(examId, options));
+                    const handleRetry = () => {
+                        if (requestId === this._openRequestId && retry.isConnected && !overlay.classList.contains('is-hidden')) {
+                            this.open(examId, options);
+                        }
+                    };
+                    retry.addEventListener('click', handleRetry);
+                    this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
                     passageContent.replaceChildren(errorState);
                 }
@@ -1303,16 +1489,6 @@
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
-
-                // 绑定 Tab 点击事件
-                tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        tabsContainer.querySelectorAll('.vocab-tab-btn').forEach(b => b.classList.remove('active'));
-                        btn.classList.add('active');
-                        const target = btn.dataset.para;
-                        this.switchViewTab(target);
-                    });
-                });
             }
 
             // 渲染文章段落
@@ -1346,15 +1522,15 @@
             if (questionsContent) {
                 const questionGroups = payload?.questionGroups || [];
                 if (questionGroups.length > 0) {
-                    let qHtml = '';
+                    const groups = document.createDocumentFragment();
                     questionGroups.forEach((g, idx) => {
-                        qHtml += `
-                            <div class="vocab-question-group" id="vocab-qgroup-${idx + 1}">
-                                ${g.bodyHtml || ''}
-                            </div>
-                        `;
+                        const group = document.createElement('div');
+                        group.className = 'vocab-question-group';
+                        group.id = `vocab-qgroup-${idx + 1}`;
+                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        groups.appendChild(group);
                     });
-                    questionsContent.innerHTML = qHtml;
+                    questionsContent.replaceChildren(groups);
                 } else {
                     questionsContent.innerHTML = '<p class="vocab-empty-tip">本篇无额外题目数据</p>';
                 }
@@ -1468,7 +1644,7 @@
                 }
             }
 
-            setTimeout(() => {
+            this.defer(() => {
                 mark.classList.remove('vocab-highlight--pulse');
             }, 1500);
 
@@ -1737,6 +1913,12 @@
 
         switchViewTab(target) {
             const overlay = this.ensureOverlay();
+            this.activeTab = target;
+            overlay.querySelectorAll('.vocab-tab-btn').forEach(button => {
+                const active = button.dataset.para === target;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-selected', String(active));
+            });
             const passageSection = overlay.querySelector('#vocab-passage-section');
             const questionsSection = overlay.querySelector('#vocab-questions-section');
             const cards = overlay.querySelectorAll('.vocab-paragraph-card');
@@ -1829,53 +2011,36 @@
             });
 
             listEl.innerHTML = html;
-
-            // 绑定发音与删除
-            listEl.querySelectorAll('.vocab-speak-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    speakWord(btn.dataset.speakWord);
-                });
-            });
-
-            listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const id = btn.dataset.delId;
-                    const allItems = ReadingVocabStore.getAll();
-                    const item = allItems.find(w => w.id === id);
-                    const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
-                    }
-                    this.showToast('已从生词本删除');
-                });
-            });
         },
 
         openModal() {
             const overlay = this.ensureOverlay();
+            this.bindEvents(overlay);
             const modal = overlay.querySelector('#vocab-modal');
             if (modal) {
+                if (!this.modalOpen) this._modalReturnFocus = document.activeElement;
                 this.modalOpen = true;
                 this.updateCounts();
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
+                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
             }
         },
 
-        closeModal() {
-            const overlay = this.ensureOverlay();
-            const modal = overlay.querySelector('#vocab-modal');
+        closeModal(restoreFocus = true) {
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            const modal = overlay?.querySelector('#vocab-modal');
+            const wasOpen = this.modalOpen;
+            this.modalOpen = false;
             if (modal) {
-                this.modalOpen = false;
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+            if (wasOpen && restoreFocus && this._modalReturnFocus?.isConnected) {
+                this._modalReturnFocus.focus({ preventScroll: true });
+            }
+            this._modalReturnFocus = null;
         },
 
         showToast(msg) {
@@ -1887,19 +2052,25 @@
             toast.classList.add('show');
 
             clearTimeout(this.toastTimer);
-            this.toastTimer = setTimeout(() => {
+            this._pendingTimers.delete(this.toastTimer);
+            this.toastTimer = this.defer(() => {
                 toast.classList.remove('show');
             }, 2000);
         },
 
         close() {
             ++this._openRequestId;
-            const overlay = this.ensureOverlay();
+            const overlay = document.getElementById('reading-vocab-reader-overlay');
+            this.clearPendingWork(overlay);
+            this.closeModal(false);
+            this.unbindEvents();
             if (overlay) {
                 overlay.classList.add('is-hidden');
+                overlay.setAttribute('aria-hidden', 'true');
             }
             document.body.classList.remove('vocab-reader-open');
-            this.closeModal();
+            if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            this._returnFocus = null;
         }
     };
 
@@ -1918,7 +2089,7 @@
     global.ReadingVocabStore = ReadingVocabStore;
     global.ReadingVocabReader = ReadingVocabReader;
     global.openReadingVocabReader = function(examId, options = {}) {
-        ReadingVocabReader.open(examId, options);
+        return ReadingVocabReader.open(examId, options);
     };
 
     // 启动数据同步初始化

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -394,7 +394,7 @@
         const locked = Boolean(enabled);
         state.timerLocked = locked;
         document.body.classList.toggle('timer-locked-mode', locked);
-        document.querySelectorAll('input, textarea, select').forEach((control) => {
+        getPracticeFormControls().forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 control.disabled = locked || state.readOnly;
             }
@@ -2261,12 +2261,7 @@
         }
     }
 
-    // Keep the practice entry unavailable until #157 isolates the reader's
-    // question controls from practice radio groups and answer collection.
-    const PRACTICE_VOCAB_READER_ENABLED = false;
-
     function openVocabReaderForCurrentExam() {
-        if (!PRACTICE_VOCAB_READER_ENABLED) return;
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
@@ -2284,7 +2279,6 @@
     }
 
     function ensureReadingVocabButton() {
-        if (!PRACTICE_VOCAB_READER_ENABLED) return null;
         let button = document.getElementById('reading-vocab-header-btn');
         if (button) return button;
         const headerRight = document.querySelector('.header-right');
@@ -5063,9 +5057,35 @@
         });
     }
 
+    function getPracticeAnswerRoot() {
+        // The reader and note editor share this document, but only the rendered
+        // practice questions own answer controls. Never fall back to document.
+        return dom.groups || document.getElementById('question-groups');
+    }
+
+    function getPracticeFormControls() {
+        const roots = [
+            getPracticeAnswerRoot(),
+            dom.left || document.getElementById('left'),
+            document.getElementById('notes-panel'),
+            document.getElementById('reading-note-editor'),
+            document.getElementById('reading-note-drawer')
+        ].filter(Boolean);
+        return Array.from(new Set(roots.flatMap((root) => Array.from(root.querySelectorAll('input, textarea, select')))));
+    }
+
+    function isTextualAnswerControl(field) {
+        const tagName = String(field?.tagName || '').toUpperCase();
+        return tagName === 'SELECT'
+            || tagName === 'TEXTAREA'
+            || (tagName === 'INPUT' && String(field.type || 'text').toLowerCase() === 'text');
+    }
+
     function getCheckboxAnswers() {
         const grouped = new Map();
-        document.querySelectorAll('input[type="checkbox"][name]').forEach((input) => {
+        const root = getPracticeAnswerRoot();
+        if (!root) return grouped;
+        root.querySelectorAll('input[type="checkbox"][name]').forEach((input) => {
             const name = input.name;
             if (!grouped.has(name)) {
                 grouped.set(name, []);
@@ -5099,11 +5119,13 @@
     }
 
     function getTextualAnswer(questionId) {
+        const root = getPracticeAnswerRoot();
+        if (!root) return '';
         const aliases = resolveAnswerAliases(questionId);
         const fieldMap = new Map();
         aliases.forEach((alias) => {
-            document.querySelectorAll(`[name="${alias}"]`).forEach((field) => {
-                if (!fieldMap.has(field)) {
+            root.querySelectorAll(`[name="${escapeSelector(alias)}"]`).forEach((field) => {
+                if (isTextualAnswerControl(field) && !fieldMap.has(field)) {
                     fieldMap.set(field, true);
                 }
             });
@@ -5111,14 +5133,6 @@
         const fields = Array.from(fieldMap.keys());
         const values = [];
         for (const field of fields) {
-            if (field.type === 'radio') continue;
-            if (field.tagName === 'SELECT') {
-                const value = String(field.value || '').trim();
-                if (value) {
-                    values.push(value);
-                }
-                continue;
-            }
             const value = String(field.value || '').trim();
             if (value) {
                 values.push(value);
@@ -5126,8 +5140,8 @@
         }
         if (!values.length) {
             aliases.forEach((alias) => {
-                const inputById = document.getElementById(`${alias}_input`);
-                if (!inputById || !('value' in inputById)) {
+                const inputById = root.querySelector(`[id="${escapeSelector(`${alias}_input`)}"]`);
+                if (!isTextualAnswerControl(inputById)) {
                     return;
                 }
                 const value = String(inputById.value || '').trim();
@@ -5263,6 +5277,9 @@
     }
 
     function findDropzoneByQuestionId(questionId) {
+        // Matching headings can live beside passage paragraphs in the left pane.
+        const roots = [getPracticeAnswerRoot(), dom.left || document.getElementById('left')].filter(Boolean);
+        if (!roots.length) return null;
         const aliases = resolveAnswerAliases(questionId);
         for (let index = 0; index < aliases.length; index += 1) {
             const alias = aliases[index];
@@ -5280,19 +5297,21 @@
                 `#${escaped}-dropzone`,
                 `#${escaped}-target`
             ].join(', ');
-            let direct = null;
-            try {
-                direct = document.querySelector(selector);
-            } catch (_) {
-                direct = null;
-            }
-            if (direct) {
-                return direct;
-            }
-            const anchor = document.getElementById(`${alias}-anchor`);
-            const paragraphZone = anchor?.parentElement?.querySelector?.('.paragraph-dropzone');
-            if (paragraphZone) {
-                return paragraphZone;
+            for (const root of roots) {
+                let direct = null;
+                try {
+                    direct = root.querySelector(selector);
+                } catch (_) {
+                    direct = null;
+                }
+                if (direct) {
+                    return direct;
+                }
+                const anchor = root.querySelector(`[id="${escapeSelector(`${alias}-anchor`)}"]`);
+                const paragraphZone = anchor?.parentElement?.querySelector?.('.paragraph-dropzone');
+                if (paragraphZone) {
+                    return paragraphZone;
+                }
             }
         }
         return null;
@@ -5348,11 +5367,13 @@
 
     function collectAnswers() {
         const order = Array.isArray(state.dataset?.questionOrder) ? state.dataset.questionOrder : [];
+        const questionIdsInDataset = new Set(order);
+        const root = getPracticeAnswerRoot();
         const answers = {};
         const checkboxGroups = getCheckboxAnswers();
 
         checkboxGroups.forEach((values, name) => {
-            const questionIds = resolveCheckboxQuestionIds(name);
+            const questionIds = resolveCheckboxQuestionIds(name).filter((questionId) => questionIdsInDataset.has(questionId));
             if (!questionIds.length) {
                 return;
             }
@@ -5370,7 +5391,7 @@
             if (Object.prototype.hasOwnProperty.call(answers, questionId)) {
                 return;
             }
-            const radios = document.querySelectorAll(`input[type="radio"][name="${questionId}"]`);
+            const radios = root?.querySelectorAll(`input[type="radio"][name="${escapeSelector(questionId)}"]`) || [];
             if (radios.length) {
                 const checked = Array.from(radios).find((input) => input.checked);
                 answers[questionId] = checked ? String(checked.value).trim() : '';
@@ -6012,15 +6033,17 @@
     }
 
     function collectChoiceInputsForQuestion(questionId) {
+        const root = getPracticeAnswerRoot();
+        if (!root) return [];
         const normalizedTarget = normalizeQuestionId(questionId);
         // 直接匹配
-        let inputs = document.querySelectorAll(`input[type="checkbox"][name="${escapeSelector(questionId)}"], input[type="radio"][name="${escapeSelector(questionId)}"]`);
+        let inputs = root.querySelectorAll(`input[type="checkbox"][name="${escapeSelector(questionId)}"], input[type="radio"][name="${escapeSelector(questionId)}"]`);
         if (inputs.length) {
             return Array.from(inputs);
         }
         // 扫描所有 checkbox/radio 组，匹配 name 展开后的题目序列
         const matched = [];
-        document.querySelectorAll('input[type="checkbox"][name], input[type="radio"][name]').forEach((input) => {
+        root.querySelectorAll('input[type="checkbox"][name], input[type="radio"][name]').forEach((input) => {
             const name = input.name || '';
             const ids = expandQuestionSequence(name);
             if (ids.some((id) => normalizeQuestionId(id) === normalizedTarget)) {
@@ -6211,10 +6234,12 @@
         if (!answers || typeof answers !== 'object') {
             return;
         }
+        const root = getPracticeAnswerRoot();
+        if (!root) return;
 
         const groupedHandledQuestionIds = new Set();
         const groupedChoiceInputs = new Map();
-        document.querySelectorAll('input[type="radio"][name], input[type="checkbox"][name]').forEach((input) => {
+        root.querySelectorAll('input[type="radio"][name], input[type="checkbox"][name]').forEach((input) => {
             const groupName = String(input.getAttribute('name') || '').trim();
             if (!groupName) return;
             const expandedQuestionIds = expandQuestionSequence(groupName);
@@ -6270,10 +6295,10 @@
             const selectFields = new Set();
             aliases.forEach((alias) => {
                 const escapedAlias = escapeSelector(alias);
-                document.querySelectorAll(
+                root.querySelectorAll(
                     `input[type="radio"][name="${escapedAlias}"], input[type="checkbox"][name="${escapedAlias}"]`
                 ).forEach((field) => choiceFields.add(field));
-                document.querySelectorAll([
+                root.querySelectorAll([
                     `input[name="${escapedAlias}"]`,
                     `textarea[name="${escapedAlias}"]`,
                     `input[id="${escapedAlias}"]`,
@@ -6281,11 +6306,11 @@
                     `input[data-question-id="${escapedAlias}"]`,
                     `textarea[data-question-id="${escapedAlias}"]`
                 ].join(', ')).forEach((field) => {
-                    if (field.type !== 'radio' && field.type !== 'checkbox') {
+                    if (isTextualAnswerControl(field)) {
                         textFields.add(field);
                     }
                 });
-                document.querySelectorAll([
+                root.querySelectorAll([
                     `select[name="${escapedAlias}"]`,
                     `select[id="${escapedAlias}"]`,
                     `select[data-question-id="${escapedAlias}"]`
@@ -6350,7 +6375,7 @@
         if (dom.resetBtn) {
             dom.resetBtn.disabled = state.readOnly;
         }
-        const controls = document.querySelectorAll('input, textarea, select');
+        const controls = getPracticeFormControls();
         controls.forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 // review、普通进行中练习、以及已回传 recordId 的结果页允许编辑笔记；
@@ -6578,6 +6603,10 @@
                 initializeInlineSimulationSuite,
                 activateSuiteSlot,
                 buildResultsFromAnswers,
+                collectAnswers,
+                collectCurrentDraft,
+                setTimerLockMode,
+                setReadOnlyMode,
                 applyAnswersToDom,
                 applyReplayAnswersToDom,
                 captureDom,
@@ -6926,7 +6955,7 @@
             }
         });
         enhanceReviewHighlights();
-        document.querySelectorAll('input, textarea, select').forEach((control) => {
+        getPracticeFormControls().forEach((control) => {
             if (control instanceof HTMLInputElement || control instanceof HTMLTextAreaElement || control instanceof HTMLSelectElement) {
                 control.disabled = false;
             }
@@ -7812,15 +7841,15 @@
     }
 
     function clearCurrentAnswers() {
-        document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach((input) => {
-            input.checked = false;
-        });
-        document.querySelectorAll('input[type="text"], textarea').forEach((input) => {
+        getPracticeFormControls().forEach((input) => {
             if (input.closest('#notes-panel, #reading-note-editor, #reading-note-drawer')) return;
-            input.value = '';
-        });
-        document.querySelectorAll('select').forEach((select) => {
-            select.selectedIndex = 0;
+            if (input.type === 'radio' || input.type === 'checkbox') {
+                input.checked = false;
+            } else if (input.tagName === 'SELECT') {
+                input.selectedIndex = 0;
+            } else if (isTextualAnswerControl(input)) {
+                input.value = '';
+            }
         });
         getDropzones().forEach((dropzone) => {
             clearDropzone(dropzone);


### PR DESCRIPTION
Opening the intensive reader during practice could replace the learner's selected answer: on `p2-low-08`, selecting A in practice and B in the reader left A unchecked and made answer collection return the hidden B. Reader questions now render as selectable, non-answering content, and practice collection/replay stays within its own question and passage containers. The practice reader entry is enabled.

The reader remaps source identities and removes form, label, and drag/drop behavior before inserting content. Close/reopen restores the selected tab's visibility and initiating focus, removes active listeners and deferred work, and rejects stale article/explanation results. Practice timer locks, submission locks, and answer resets preserve independent reader controls.

## Validation

- [GitHub CI](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34214249345) passed for implementation head `50f7600b81545f75f6674c6633ca5b9cdabc2466`; GitGuardian checks passed and GitHub verified the commit signature.
- `npm test --prefix developer`: 184 tests passed.
- `python -m unittest discover -s developer/tests/py -p "test_*.py"`: 26 tests passed.
- `python developer/tests/ci/check_reading_data_integrity.py`: 238 files checked, no blocking issues.
- `node scripts/build-bundles.mjs --check`: all 14 bundles current.
- `python developer/tests/e2e/e2e_runner.py`: 10/10 cases passed.
- Real Edge 143.0.3650.96, local HTTP and `file://`: original radio, checkbox, text/select answers, collected/recovery payloads, scoring results, session identity, timer continuity, history, notes, and highlights preserved. Actual Browse and Bookshelf reader-only actions create no practice session/history. Repeated Questions/close/reopen preserves visibility and focus without listener growth. Practice annotation and dictionary UI interaction remain covered; the dictionary test uses a deterministic provider.
- Browser lifecycle tests cover late A→B completion, vocabulary/visit attribution to B only, stale controls, and timer/submission locking. Production `p1-high-01` passage dropzones remain collected and replayed.

The pre-fix collision was reproduced against the baseline bundle: `originalA=false`, `hiddenB=true`, `collected=B`. To reproduce it locally, run `node developer/tests/e2e/reading_reader_isolation.node.js --baseline-only`; run without that flag for the fixed HTTP/file regression. The new regression is included in the formal E2E runner. The suite navigation test now waits for a nonempty replacement exam ID, avoiding a transient blank document being mistaken for completed navigation.

## Revisions and scope

- Upstream base (`opensource`): `0d6833dda6a28cf1ea7f4d92a060f3625b512505`.
- Reviewed implementation head: `50f7600b81545f75f6674c6633ca5b9cdabc2466`.

Closes #157.
Refs #149. Canonical vocabulary/persistence, passage normalization/occurrences, remaining entrypoint qualification, and combined release acceptance remain with their dedicated follow-up issues.
