### PR TITLE
feat(reading): make vocabulary persistence atomic and backup-safe

### DIFF
--- a/developer/doc/Intensive-Reading-Persistence.md
+++ b/developer/doc/Intensive-Reading-Persistence.md
@@ -1,0 +1,148 @@
+# Intensive Reading Persistence
+
+This is the acknowledged persistence contract for [#156](https://github.com/sallowayma-git/IELTS-practice/issues/156).
+The [vocabulary model contract](Intensive-Reading-Vocabulary-Contract.md) defines
+the canonical owners, source identities, relationships and selected occurrences.
+Parent [#149](https://github.com/sallowayma-git/IELTS-practice/issues/149) remains
+the combined feature acceptance gate.
+
+## Authority and operations
+
+`AppData.vocab.getReadingSnapshot()` resolves to
+`{snapshot: {words, lists, reading}, revision, generation}`.
+Use that snapshot for queries and retain its revision and generation with the
+user's intent. A snapshot is not a writable cache.
+
+```js
+const observed = await AppData.vocab.getReadingSnapshot();
+const receipt = await AppData.vocab.mutateReading('collect', {
+    source: { kind: 'builtin', id: 'default' },
+    article: { examId: 'p1-example', title: 'An example article' },
+    word: { word: 'apple', meaning: 'A fruit' },
+    occurrence: {
+        scopeId: 'passage:1/paragraph:2', contentVersion: 'revision-1',
+        startOffset: 10, endOffset: 15, quote: 'apple',
+        before: 'An ', after: ' grows here.'
+    }
+}, {
+    observedRevision: observed.revision,
+    observedGeneration: observed.generation
+});
+if (receipt.saved === true) {
+    // The transaction is acknowledged; update the visible collection.
+}
+```
+
+`mutateReading(type, command, options)` returns the kernel receipt plus
+`{saved: true, snapshot, revision, generation, added, changed}`. It rejects on
+validation, stale deletion/replace conflicts, quota errors and failed
+transactions. `added` identifies a collect operation; it does not mean a new
+distinct term was created. Stable term and occurrence IDs prevent duplicates.
+An optional `operationId` can identify a retry of exactly the same command.
+
+| Operation | Command and effect |
+| --- | --- |
+| `collect` | Model collection command; commits the canonical owner, relationship, optional occurrence and article visit together. Omit occurrence for manual membership. |
+| `recordVisit` | `{source, article}`; visits an article even when it has zero words. |
+| `removeOccurrence` | `{occurrenceId}`; applies the model's final-occurrence/manual-membership rules. |
+| `removeArticleTerm` | `{articleId, termId}`; removes that article's membership and occurrences. |
+| `clearArticle` | `{articleId}`; preserves the visit, canonical words, review progress and other articles. |
+| `removeTermAssociations` | `{termId}`; removes reading membership across articles, preserving canonical vocabulary. |
+| `clearReading` | `{}`; clears reading memberships and occurrences, preserving vocabulary and visits. |
+| `removeArticle` | `{articleId, clearWords}`; removes the visit and, only when `clearWords: true`, the article's vocabulary. |
+| `deleteCanonicalTerm` | `{termId}`; explicit global canonical deletion, including matching owners and all reading links. |
+
+Every operation reads fresh IndexedDB state and checks revisions of
+`vocab.words`, `vocab.lists`, `vocab.readingState` and the two legacy projection
+documents in one kernel transaction. A write conflict reruns the transformation
+against fresh state. Readers bracket their reads with the reading-state revision
+to avoid exposing owners from a different committed state.
+
+The old `saveReadingWords` and `saveReadingBookshelfExams` array APIs are
+compatibility entry points only. They require `expectedRevision` from the
+corresponding `list…({withMeta: true})` result; a stale array is rejected rather
+than retried with a newer revision. Production reading and bookshelf consumers
+use operation commands.
+
+## Conflict and deletion precedence
+
+`vocab.readingState` is a version 1 persistence envelope containing the model's
+`reading` document, `generation`, `clockAt`, the default-vocabulary seed policy,
+and deletion markers. The marker domains are `articles`, `visits`, `terms`,
+`canonicalTerms`, `associations`, `occurrences`, and the global `all` membership
+marker. Each marker stores `{at, revision}`.
+
+Independent additions commute through fresh-state retry. A deletion wins against
+an addition or visit that observed an older relevant deletion revision. Replacing
+or importing reading data invalidates older generations. The rejected action
+does not commit; reload the snapshot before a new, deliberate retry.
+
+The operation clock advances beyond all stored activity and deletion clocks and
+is at least the supplied timestamp at the write boundary. A fresh recollection therefore sorts after an earlier
+deletion even if its caller's timestamp is old. Backup conflicts compare these
+timestamps, with deletion winning a tie. Visit deletion has its own marker:
+clearing vocabulary cannot delete a zero-word visit during a later merge.
+Global vocabulary deletion has a separate marker from reading-only removal.
+Portable deletion revisions are rebased to the receiving document's revision;
+revision numbers from separate databases are not comparable.
+
+## Migration and recovery
+
+On first startup, AppData recognizes the prototype reading word/bookshelf arrays
+in their existing documents or the two `ielts_reading_*_v1` localStorage keys.
+Existing durable documents take precedence, including intentional empty arrays.
+Legacy source descriptors are retained; entries without a source use
+`{kind: 'builtin', id: 'default'}`. Legacy memberships are retained as manual
+because the prototype did not distinguish their origin. Valid exact anchors also
+become occurrences; removing their final occurrence retains that recovered manual membership.
+
+Migration commits the model, canonical owners, projection documents and
+`system.migrations.readingVocabularyV1` together. The marker is version 1 and
+contains `completed`, `completedAt` and `recoverable`: original localStorage
+bytes, original legacy documents, and rejected entries with reasons.
+Unrecognized payloads are retained instead of discarded. These recovery records
+remain local system data; they are not part of the portable vocabulary backup.
+An interrupted transaction leaves no completed marker or partial model and can
+be retried after the backend is available.
+
+After the marker commits, startup, lazy-loaded components and backup export do
+not import localStorage again. Full/vocabulary export and destructive recovery
+require successful initial migration. An unrelated settings-only import/export
+does not depend on reading migration.
+
+## Backup and visible state
+
+Native backup merge unions sources, articles, terms, manual memberships, selected
+occurrences and zero-word visits by stable identities. Existing canonical owners
+and their definitions/review progress take precedence. Conflicting incoming word
+IDs are remapped without replacing an unrelated existing owner. Article titles
+retain their separate title clock. Deletion markers filter both inputs before
+union and the result afterward, so old backups cannot revive removed records or
+undo a fresh recollection. Reimporting the same backup is idempotent.
+
+Replace installs the requested state authoritatively, including empty data, and
+changes the generation. Lazy vocabulary initialization cannot seed default words
+over an authoritative empty replacement. The established AppData commit channel
+invalidates reading, bookshelf and canonical vocabulary caches in other pages.
+Import retains the existing preview revision and safety-backup protections.
+
+UI consumers show success only after acknowledgement. Pending selection marks
+are removed on failure; manual text and deletion controls remain available for
+retry. Quota/conflict failures support retry in the same page. A latched
+`BACKEND_UNAVAILABLE` failure requires refreshing the page before retry, as in
+the existing DataKernel contract.
+
+The current full-text reader loads the built-in generated registry. It rejects
+other source namespaces before recording visits or collections, avoiding an
+association between imported identities and built-in passage content. Existing
+imported-source data remains queryable and exportable in the bookshelf; source
+navigation and content rendering continue under the later reader work items.
+
+## Validation
+
+`npm test --prefix developer` includes production model/AppData regressions,
+real IndexedDB transaction faults, and two real Playwright pages sharing storage.
+`npm run test:reading-persistence --prefix developer` runs the focused persistence
+and backup suites. UI tests exercise pending, acknowledged, failed and retried
+actions separately. Rebuild generated bundles with
+`node scripts/build-bundles.mjs` and verify with `--check`.

--- a/developer/doc/Intensive-Reading-Vocabulary-Contract.md
+++ b/developer/doc/Intensive-Reading-Vocabulary-Contract.md
@@ -4,6 +4,9 @@ This document records the schema and relationship semantics implemented for
 [#155](https://github.com/sallowayma-git/IELTS-practice/issues/155), part of
 [#149](https://github.com/sallowayma-git/IELTS-practice/issues/149).
 
+The subsequent [persistence contract](Intensive-Reading-Persistence.md) documents
+the acknowledged AppData operations, migration and backup implementation from #156.
+
 The production model is exposed as `ReadingVocabularyModel` and through
 `AppData.vocab.readingModel`. Its operations are synchronous, pure transformations
 of a snapshot containing the existing vocabulary records and the reading

--- a/developer/package.json
+++ b/developer/package.json
@@ -10,6 +10,6 @@
   "scripts": {
     "test": "node --test --test-concurrency=1 \"tests/js/**/*.test.js\"",
     "test:unit": "node --test --test-concurrency=1 \"tests/js/**/*.test.js\"",
-    "test:reading-persistence": "node --test tests/js/readingVocabularyPersistence.test.js tests/js/readingDataBackupAuthority.test.js"
+    "test:reading-persistence": "node --test tests/js/readingVocabularyPersistence.test.js tests/js/readingDataBackupAuthority.test.js tests/js/readingVocabularyBackupMembership.test.js tests/js/readingLegacyRecovery.test.js tests/js/vocabDefaultRepairPersistence.test.js"
   }
 }

--- a/developer/package.json
+++ b/developer/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "node --test --test-concurrency=1 \"tests/js/**/*.test.js\"",
-    "test:unit": "node --test --test-concurrency=1 \"tests/js/**/*.test.js\""
+    "test:unit": "node --test --test-concurrency=1 \"tests/js/**/*.test.js\"",
+    "test:reading-persistence": "node --test tests/js/readingVocabularyPersistence.test.js tests/js/readingDataBackupAuthority.test.js"
   }
 }

--- a/developer/tests/e2e/suite_practice_flow.py
+++ b/developer/tests/e2e/suite_practice_flow.py
@@ -871,7 +871,8 @@ async def run() -> bool:
                 "() => {\n"
                 "  const params = new URLSearchParams(window.location.search || '');\n"
                 "  const examId = params.get('dataKey') || params.get('examId') || '';\n"
-                "  const manifest = window.__READING_EXPLANATION_MANIFEST__ || {};\n"
+                "  const manifest = window.__READING_EXPLANATION_MANIFEST__;\n"
+                "  if (!manifest) return false;\n"
                 "  if (!examId || !manifest[examId]) return true;\n"
                 "  return document.querySelectorAll('.reading-explanation-card, .reading-question-explanation-list').length > 0;\n"
                 "}",

--- a/developer/tests/js/appDataV2.test.js
+++ b/developer/tests/js/appDataV2.test.js
@@ -154,16 +154,23 @@ async function testReadingModelUsesLiveVocabularyOwners() {
 async function testReadingCollectionPresenceMetadata() {
     const fixture = harness();
     await fixture.app.ready;
+    const migration = fixture.shared.docs.get('system.migrations').data.readingVocabularyV1;
+    assert.strictEqual(migration.version, 1);
+    assert.strictEqual(migration.completed, true, 'startup commits the reading migration marker with authoritative empty data');
     const readingCollections = [
         ['vocab.readingVocabWords', fixture.app.vocab.listReadingWords, fixture.app.vocab.saveReadingWords],
         ['vocab.readingBookshelfExams', fixture.app.vocab.listReadingBookshelfExams, fixture.app.vocab.saveReadingBookshelfExams]
     ];
+    for (const [logicalKey] of readingCollections) {
+        assert.strictEqual(fixture.shared.docs.get(logicalKey).operationId, fixture.shared.docs.get('system.migrations').operationId,
+            'the initial empty collections and migration marker share a durable commit');
+    }
     for (const [logicalKey, list, save] of readingCollections) {
         assert.deepStrictEqual(await list(), [], 'default reading list callers retain the array API');
-        const absent = await list({ withMeta: true });
-        assert.deepStrictEqual(absent.data, []);
-        assert.strictEqual(absent.envelope, null, 'metadata distinguishes an unmigrated default from an authoritative empty array');
-        await save([]);
+        const migrated = await list({ withMeta: true });
+        assert.deepStrictEqual(migrated.data, []);
+        assert.strictEqual(migrated.envelope.state, 'present', 'migration establishes an authoritative empty collection');
+        await save([], { expectedRevision: migrated.envelope.revision });
         const empty = await list({ withMeta: true });
         assert.deepStrictEqual(empty.data, []);
         assert.strictEqual(empty.envelope.state, 'present');
@@ -173,6 +180,53 @@ async function testReadingCollectionPresenceMetadata() {
         assert.deepStrictEqual(cleared.data, []);
         assert.strictEqual(cleared.envelope.state, 'cleared', 'cleared collections retain their canonical presence');
     }
+}
+
+async function testReadingMergeRetainsOwnersAndRelationships() {
+    const local = harness(); const remote = harness();
+    await Promise.all([local.app.ready, remote.app.ready]);
+    const owner = { id: 'retained-review-owner', word: 'Apple', meaning: 'My definition',
+        repetitions: 9, interval: 45, easeFactor: 2.4,
+        reviewHistory: [{ at: '2026-09-01T00:00:00.000Z', grade: 4 }] };
+    await local.app.vocab.saveWords([owner]);
+    const command = (libraryId) => ({
+        source: { kind: 'imported', id: libraryId }, article: { examId: 'same-exam', title: libraryId },
+        word: { word: 'apple', meaning: 'Imported definition' }, at: '2026-09-08T00:00:00.000Z',
+        occurrence: { scopeId: 'passage', contentVersion: 'original', startOffset: 0, endOffset: 5,
+            quote: 'apple', before: '', after: ' grows here' }
+    });
+    await local.app.vocab.mutateReading('collect', command('library-a'));
+    await remote.app.vocab.mutateReading('collect', command('library-b'));
+    await remote.app.vocab.mutateReading('recordVisit', {
+        source: { kind: 'builtin', id: 'default' }, article: { examId: 'zero-words' },
+        at: '2026-09-08T01:00:00.000Z'
+    });
+    const portable = await remote.app.backups.export({ domains: ['vocab'] });
+    const merge = async () => {
+        const plan = await local.app.backups.previewImport(portable, { practiceMode: 'merge' });
+        const receipt = await local.app.backups.commitImport(plan.id);
+        assert.strictEqual(receipt.committed, true);
+        return (await local.app.vocab.getReadingSnapshot()).snapshot;
+    };
+    const first = await merge();
+    assert.deepStrictEqual(first.words, [owner], 'backup merge preserves the complete existing canonical review record');
+    assert.strictEqual(first.reading.terms.length, 1);
+    assert.deepStrictEqual(first.reading.terms[0].wordRef, { listId: 'default', wordId: owner.id });
+    assert.strictEqual(first.reading.associations.length, 2, 'source-qualified A/B associations survive same-term merge');
+    assert.strictEqual(first.reading.occurrences.length, 2, 'both selected occurrences survive');
+    assert.strictEqual(first.reading.visits.length, 3, 'zero-word bookshelf visits also survive');
+    assert.deepStrictEqual(await merge(), first, 'repeated import is idempotent for vocabulary and reading data');
+
+    const model = local.app.vocab.readingModel;
+    const colliding = model.collect(model.createSnapshot({ words: [
+        { id: owner.id, word: 'banana', meaning: 'A different term' }
+    ] }), { ...command('library-c'), word: { word: 'banana' },
+        occurrence: { scopeId: 'passage', contentVersion: 'original', startOffset: 0, endOffset: 6, quote: 'banana' } });
+    const joined = model.merge(first, colliding);
+    assert.strictEqual(joined.words.length, 2);
+    assert.notStrictEqual(joined.words[0].id, joined.words[1].id, 'an unrelated imported ID collision gets a distinct canonical owner');
+    assert.strictEqual(model.query(joined).terms.find((row) => row.term.normalizedTerm === 'banana').word.meaning, 'A different term');
+    assert.deepStrictEqual(clone(model.merge(joined, colliding)), clone(joined), 'owner collision remapping remains idempotent');
 }
 
 async function testVocabPhoneticMutationProtection() {
@@ -328,7 +382,9 @@ async function testAtomicVocabPhoneticBackfill() {
     }, { operationId: 'phonetic-backfill-atomic' });
     assert.strictEqual(receipt.committed, true);
     assert.strictEqual(receipt.updatedCount, 3, 'every stored duplicate with a missing phonetic must be filled');
-    assert.deepStrictEqual(Object.keys(receipt.revisions), ['vocab.words'], 'the backfill must commit as one list-document mutation');
+    assert.deepStrictEqual(Object.keys(receipt.revisions), ['vocab.words', 'vocab.readingState'],
+        'backfill atomically commits the list with the reading owner consistency fence');
+    assert.strictEqual(fixture.shared.docs.get('vocab.readingState').operationId, 'phonetic-backfill-atomic');
     assert.strictEqual(
         fixture.shared.docs.get('vocab.words').revision,
         revisionBefore + 1,
@@ -487,7 +543,9 @@ async function testV2MergeImportPhoneticProtection() {
     snapshot.checksum = checksum({ envelopes: snapshot.envelopes, entities: snapshot.entities });
 
     const plan = await fixture.app.backups.previewImport(snapshot, { practiceMode: 'merge' });
-    assert.deepStrictEqual(new Set(plan.keys), new Set(['vocab.words', 'vocab.lists']));
+    assert.deepStrictEqual(new Set(plan.keys), new Set([
+        'vocab.words', 'vocab.lists', 'vocab.readingState', 'vocab.readingVocabWords', 'vocab.readingBookshelfExams'
+    ]), 'vocabulary import includes its reading references and compatibility projections in the same commit');
     assert.strictEqual(plan.destructive, false);
     await fixture.app.backups.commitImport(plan.id);
 
@@ -1537,6 +1595,7 @@ async function testRecoveryThirtyDayTtlBoundary() {
 async function run() {
     await testReadingModelUsesLiveVocabularyOwners();
     await testReadingCollectionPresenceMetadata();
+    await testReadingMergeRetainsOwnersAndRelationships();
     await testClearInterruptedRecoveryIsolation();
     await testRecoveryThirtyDayTtlBoundary();
     await testVocabPhoneticMutationProtection();
@@ -2087,6 +2146,6 @@ async function run() {
     assert.strictEqual(await app.practice.get('legacy-1'), null);
     assert.strictEqual((await app.practice.get('snake-1')).answers[1], 'yes');
 
-    console.log(JSON.stringify({ status: 'pass', tests: 56 }));
+    console.log(JSON.stringify({ status: 'pass', tests: 57 }));
 }
 run().catch((error) => { console.error(error.stack || error); process.exitCode = 1; });

--- a/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
+++ b/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
@@ -3,176 +3,245 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import vm from 'node:vm';
 
-test('Bookshelf delete button and vocab isolation test', async () => {
-    const bookshelfPath = new URL('../../../js/components/bookshelfView.js', import.meta.url);
-    const bookshelfCode = fs.readFileSync(bookshelfPath, 'utf8');
+const bookshelfCode = fs.readFileSync(new URL('../../../js/components/bookshelfView.js', import.meta.url), 'utf8');
+const modelCode = fs.readFileSync(new URL('../../../js/data/v2/readingVocabularyModel.js', import.meta.url), 'utf8');
+const sourceA = { kind: 'builtin', id: 'default' };
+const sourceB = { kind: 'imported', id: 'library-b' };
+const at = '2026-09-08T00:00:00.000Z';
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const deferred = () => {
+    let resolve, reject;
+    const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+    return { promise, resolve, reject };
+};
 
-    // 1. 静态断言：确认已移除脆弱的 window.confirm，使用安全的 openConfirmDialog
-    assert.ok(!bookshelfCode.includes('if (confirm('), '应当不再依赖沙箱 iframe 中易被拦截的 window.confirm');
-    assert.ok(bookshelfCode.includes('openConfirmDialog'), '应当具有 openConfirmDialog 自定义模态确认');
-    assert.ok(bookshelfCode.includes('bookshelf-confirm-dialog'), '应当包含 bookshelf-confirm-dialog 确认对话框');
-
-    // 2. 模拟运行环境测试 ReadingBookshelfStore.removeExam
-    const mockStorage = new Map();
-    const localStorageShim = {
-        getItem: (k) => mockStorage.get(k) || null,
-        setItem: (k, v) => mockStorage.set(k, String(v)),
-        removeItem: (k) => mockStorage.delete(k)
-    };
-
-    let readingVocabStoreClearedExamId = null;
-    const mockReadingVocabStore = {
-        clear: (eid) => {
-            readingVocabStoreClearedExamId = eid;
-        }
-    };
-
-    let appDataSavedWords = null;
-    const mockAppData = {
-        vocab: {
-            saveReadingWords: async (words) => {
-                appDataSavedWords = words;
-            }
-        },
-        // 练习做题记录（严格隔离，绝不允许被删除）
-        practice: {
-            records: [
-                { id: 'rec_1', examId: 'cambridge-18-test-1-p1', score: 11, total: 13, timeSpent: 1200 },
-                { id: 'rec_2', examId: 'cambridge-18-test-1-p2', score: 9, total: 13, timeSpent: 1100 }
-            ]
-        }
-    };
-
+function fixture() {
+    const events = [];
+    const commitListeners = [];
     const sandbox = {
-        console,
-        localStorage: localStorageShim,
-        CustomEvent: class { constructor(type, detail) { this.type = type; this.detail = detail; } },
-        setTimeout,
-        clearTimeout,
-        Date,
-        JSON,
-        Set,
-        Map,
-        Array,
-        String,
-        Math,
-        ReadingVocabStore: mockReadingVocabStore,
-        AppData: mockAppData
+        console: { warn() {} }, setTimeout, clearTimeout,
+        localStorage: {
+            getItem() { throw new Error('A display consumer must not read legacy storage'); },
+            setItem() { throw new Error('A display consumer must not write legacy storage'); }
+        },
+        CustomEvent: class { constructor(type, options) { this.type = type; this.detail = options.detail; } },
+        addEventListener() {}, dispatchEvent(event) { events.push(event); },
+        document: { querySelector() { return null; }, getElementById() { return null; } }
     };
     sandbox.window = sandbox;
-    sandbox.global = sandbox;
-    sandbox.document = {
-        getElementById: () => null,
-        createElement: () => ({ setAttribute: () => {}, querySelector: () => null }),
-        querySelector: () => null,
-        body: { appendChild: () => {} }
-    };
-    sandbox.addEventListener = () => {};
-    sandbox.dispatchEvent = () => {};
-
     vm.createContext(sandbox);
+    vm.runInContext(modelCode, sandbox);
+    const model = sandbox.ReadingVocabularyModel;
+    let snapshot = model.createSnapshot();
+    for (const [source, word] of [[sourceA, 'apple'], [sourceB, 'banana']]) {
+        const command = { source, article: { examId: 'same-exam', title: source.id }, word: { word, meaning: word }, at };
+        snapshot = model.recordVisit(model.collect(snapshot, command), command);
+    }
+    let canonical = { snapshot, revision: 1, generation: 'original' };
+    let failure = null;
+    let gate = null;
+    const calls = [];
+    const practice = [{ id: 'practice-1', examId: 'same-exam', score: 11 }];
+    sandbox.AppData = {
+        ready: Promise.resolve(),
+        backups: { onDataCommitted(listener) { commitListeners.push(listener); } },
+        library: { async getActive() { return null; } },
+        practice: { records: practice },
+        vocab: {
+            readingModel: model,
+            async getReadingSnapshot() {
+                if (failure) throw failure;
+                return clone(canonical);
+            },
+            async mutateReading(type, command, options) {
+                calls.push({ type, command: clone(command), options: clone(options) });
+                if (gate) await gate.promise;
+                if (failure) throw failure;
+                let next = clone(canonical.snapshot);
+                if (type === 'removeArticle') {
+                    if (command.clearWords) next = model.clearArticle(next, command);
+                    next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                } else if (type === 'recordVisit') {
+                    next = model.recordVisit(next, { ...command, at });
+                } else throw new Error('Unexpected operation');
+                canonical = { ...canonical, snapshot: next, revision: canonical.revision + 1 };
+                return { ...clone(canonical), saved: true };
+            }
+        }
+    };
     vm.runInContext(bookshelfCode, sandbox);
+    return {
+        sandbox, model, events, calls, practice,
+        store: sandbox.ReadingBookshelfStore,
+        get canonical() { return canonical; },
+        setCanonical(value) { canonical = value; },
+        setFailure(value) { failure = value; },
+        setGate(value) { gate = value; },
+        async commit() {
+            commitListeners.forEach((listener) => listener({ targets: [{ logicalKey: 'vocab.readingState' }] }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+    };
+}
 
-    const store = sandbox.ReadingBookshelfStore;
-    assert.ok(store, 'ReadingBookshelfStore 必须正常导出到全局');
-
-    // 初始化测试数据：
-    // - 篇目 1: cambridge-18-test-1-p1 (有书架记录 + 2个生词)
-    // - 篇目 2: cambridge-18-test-1-p2 (有书架记录 + 1个生词)
-    const initialBookshelf = [
-        { examId: 'cambridge-18-test-1-p1', examTitle: 'Reading Passage 1', firstUsedAt: 1000, lastOpenedAt: 2000 },
-        { examId: 'cambridge-18-test-1-p2', examTitle: 'Reading Passage 2', firstUsedAt: 1000, lastOpenedAt: 3000 }
-    ];
-    const initialVocab = [
-        { id: 'w1', examId: 'cambridge-18-test-1-p1', word: 'urbanisation', createdAt: 2000 },
-        { id: 'w2', examId: 'cambridge-18-test-1-p1', word: 'infrastructure', createdAt: 2100 },
-        { id: 'w3', examId: 'cambridge-18-test-1-p2', word: 'biodiversity', createdAt: 3000 }
-    ];
-
-    mockStorage.set('ielts_reading_bookshelf_exams_v1', JSON.stringify(initialBookshelf));
-    mockStorage.set('ielts_reading_vocab_words_v1', JSON.stringify(initialVocab));
-
-    // 检查删除前书架列表
-    const beforeExams = store.getBookshelfExams();
-    assert.equal(beforeExams.length, 2, '初始书架应当包含2篇');
-    const p1Before = beforeExams.find(e => e.examId === 'cambridge-18-test-1-p1');
-    assert.ok(p1Before);
-    assert.equal(p1Before.wordCount, 2);
-
-    // 记录做题练习数据基线（必须严格保持一致）
-    const initialPracticeSnapshot = JSON.stringify(mockAppData.practice.records);
-
-    // 执行从书架移除 cambridge-18-test-1-p1
-    const res = store.removeExam('cambridge-18-test-1-p1', true);
-    assert.ok(res, 'removeExam 执行应当成功');
-
-    // 检查删除后的书架列表
-    const afterExams = store.getBookshelfExams();
-    assert.equal(afterExams.length, 1, '删除后书架应仅剩 1 篇');
-    assert.equal(afterExams[0].examId, 'cambridge-18-test-1-p2', '剩余篇目应为 p2');
-
-    // 检查生词本数据：p1 的词汇已被清除，p2 的词汇完整保留
-    const currentVocabRaw = mockStorage.get('ielts_reading_vocab_words_v1');
-    const currentVocab = JSON.parse(currentVocabRaw || '[]');
-    assert.equal(currentVocab.length, 1, '生词本中只保留非删除篇目的词');
-    assert.equal(currentVocab[0].word, 'biodiversity');
-
-    // 检查 ReadingVocabStore.clear 调用
-    assert.equal(readingVocabStoreClearedExamId, 'cambridge-18-test-1-p1');
-
-    // 核心断言：做题练习记录严格隔离，分毫未动！
-    const finalPracticeSnapshot = JSON.stringify(mockAppData.practice.records);
-    assert.equal(
-        finalPracticeSnapshot,
-        initialPracticeSnapshot,
-        '做题练习记录与答题历史必须完好无损，严格与生词本/书架删除隔离'
-    );
-
-    console.log('✅ 书架删除生词本记录且严格隔离做题练习记录测试全部通过！');
+test('Bookshelf removal waits for one source-scoped durable operation and preserves practice records', async () => {
+    const f = fixture();
+    await f.store.init();
+    const beforePractice = clone(f.practice);
+    const before = clone(f.store.getBookshelfExams());
+    assert.equal(before.length, 2, 'identical exam IDs from different libraries stay separate');
+    assert.deepEqual(before.map((row) => row.sampleWords), [['apple'], ['banana']]);
+    assert.equal(before[0].wordCount, 1);
+    const gate = deferred();
+    f.setGate(gate);
+    const pending = f.store.removeExam('same-exam', true, sourceA);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(clone(f.store.getBookshelfExams()), before, 'pending removal must retain visible records');
+    assert.equal(f.calls.length, 1, 'removal is one atomic operation');
+    assert.equal(f.calls[0].command.articleId, f.model.articleId(sourceA, 'same-exam'));
+    assert.equal(f.calls[0].options.observedRevision, 1);
+    gate.resolve();
+    assert.equal((await pending).saved, true);
+    const after = clone(f.store.getBookshelfExams());
+    assert.equal(after.length, 1);
+    assert.deepEqual(after[0].source, sourceB);
+    assert.deepEqual(after[0].sampleWords, ['banana']);
+    assert.deepEqual(f.practice, beforePractice, 'practice history is independent from reading removal');
+    assert.equal(f.canonical.snapshot.lists['reading-highlights'].words.length, 2, 'article removal preserves canonical review words');
 });
 
-test('Bookshelf initialization adopts empty and smaller canonical collections without reimporting stale mirrors', async () => {
-    const bookshelfCode = fs.readFileSync(new URL('../../../js/components/bookshelfView.js', import.meta.url), 'utf8');
-    const key = 'ielts_reading_bookshelf_exams_v1';
-    const stale = [{ examId: 'keep', lastOpenedAt: 999 }, { examId: 'removed' }];
-    const storage = new Map([[key, JSON.stringify(stale)]]);
-    let canonical = { data: [], envelope: { state: 'present' } };
-    let saves = 0;
-    const sandbox = {
-        console,
-        localStorage: {
-            getItem: (name) => storage.get(name) || null,
-            setItem: (name, value) => storage.set(name, String(value))
-        },
-        AppData: {
-            ready: Promise.resolve(),
-            vocab: {
-                listReadingBookshelfExams: async (options) => {
-                    assert.equal(options.withMeta, true);
-                    return canonical;
-                },
-                saveReadingBookshelfExams: async () => { saves += 1; }
-            }
-        },
-        addEventListener() {}
-    };
-    sandbox.window = sandbox;
-    vm.runInNewContext(bookshelfCode, sandbox);
-    await sandbox.ReadingBookshelfStore.init();
-    assert.deepEqual(JSON.parse(storage.get(key)), [], 'an empty canonical bookshelf clears the stale mirror');
+test('Failed bookshelf writes retain the committed cache and retry without duplicate visits', async () => {
+    const f = fixture();
+    await f.store.init();
+    const before = clone(f.store.getBookshelfExams());
+    f.setFailure(new Error('quota'));
+    await assert.rejects(f.store.removeExam('same-exam', true, sourceA), /quota/);
+    assert.deepEqual(clone(f.store.getBookshelfExams()), before);
+    await assert.rejects(f.store.recordExamUsed('new-exam', 'New', '', sourceA), /quota/);
+    assert.deepEqual(clone(f.store.getBookshelfExams()), before);
+    f.setFailure(null);
+    assert.equal((await f.store.recordExamUsed('new-exam', 'New', '', sourceA)).saved, true);
+    assert.equal((await f.store.recordExamUsed('new-exam', 'New', '', sourceA)).saved, true);
+    assert.equal(f.store.getBookshelfExams().filter((row) => row.examId === 'new-exam').length, 1);
+    assert.equal(f.store.getBookshelfExams().find((row) => row.examId === 'new-exam').wordCount, 0);
+});
 
-    canonical = { data: [{ examId: 'keep', lastOpenedAt: 100 }], envelope: { state: 'present' } };
-    storage.set(key, JSON.stringify(stale));
-    await sandbox.ReadingBookshelfStore.init();
-    assert.deepEqual(JSON.parse(storage.get(key)), canonical.data,
-        'the restored metadata and membership must replace stale local records');
-    canonical = { data: [], envelope: null };
-    storage.set(key, JSON.stringify(stale));
-    await sandbox.ReadingBookshelfStore.init();
-    assert.deepEqual(JSON.parse(storage.get(key)), stale,
-        'an absent canonical envelope must preserve the only local copy if migration failed');
-    canonical = { data: [], envelope: { state: 'cleared' } };
-    await sandbox.ReadingBookshelfStore.init();
-    assert.deepEqual(JSON.parse(storage.get(key)), [], 'a cleared envelope remains authoritative');
-    assert.equal(saves, 0, 'loading a canonical bookshelf must never save the old mirror back to AppData');
+test('Bookshelf refresh adopts authoritative empty replacement and rejects stale same-generation snapshots', async () => {
+    const f = fixture();
+    await f.store.init();
+    f.setFailure(new Error('read failed'));
+    await assert.rejects(f.store.init(), /read failed/);
+    assert.equal(f.store.getBookshelfExams().length, 2, 'failed loads retain the last committed view');
+    f.setFailure(null);
+    const stale = clone(f.canonical);
+    f.setCanonical({ snapshot: f.model.createSnapshot(), revision: 2, generation: 'original' });
+    await f.commit();
+    assert.equal(f.store.getBookshelfExams().length, 0);
+    f.store._adopt(stale);
+    assert.equal(f.store.getBookshelfExams().length, 0, 'a slower stale response cannot restore removed cards');
+    await f.store.init();
+    assert.equal(f.store.getBookshelfExams().length, 0);
+    assert.equal(f.calls.length, 0, 'reload and lazy initialization perform no writes');
+});
+
+test('Bookshelf retries reload the current generation after a missed replacement notification', async () => {
+    const f = fixture();
+    await f.store.init();
+    const gate = deferred();
+    f.setGate(gate);
+    const pending = f.store.recordExamUsed('new-exam', 'New', '', sourceA);
+    const rejection = assert.rejects(pending, /replaced/);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    f.setCanonical({ snapshot: f.model.createSnapshot(), revision: 2, generation: 'replacement' });
+    gate.reject(new Error('Reading data was replaced'));
+    await rejection;
+    assert.equal(f.store.getBookshelfExams().length, 0);
+    f.setGate(null);
+    assert.equal((await f.store.recordExamUsed('new-exam', 'New', '', sourceA)).saved, true);
+    assert.equal(f.calls[1].options.observedGeneration, 'replacement');
+    assert.equal(f.calls[1].options.observedRevision, 2);
+});
+
+test('Bookshelf confirmation shows pending, retains a retry after failure, and reports success only after acknowledgement', async () => {
+    const f = fixture();
+    await f.store.init();
+    const elements = new Map([
+        ['#bookshelf-confirm-text', { textContent: '' }],
+        ['#bookshelf-confirm-ok', { textContent: '', disabled: false }],
+        ['#bookshelf-confirm-cancel', { disabled: false }]
+    ]);
+    const classes = new Set(['is-hidden']);
+    const overlay = {
+        querySelector: (selector) => elements.get(selector),
+        classList: { add: (name) => classes.add(name), remove: (name) => classes.delete(name) }
+    };
+    f.sandbox.document.getElementById = (id) => id === 'bookshelf-confirm-dialog' ? overlay : null;
+    const view = f.sandbox.BookshelfView;
+    const toasts = [];
+    view.showToast = (message) => toasts.push(message);
+    view.render = () => {};
+    view.openConfirmDialog('same-exam', 'Article A', sourceA);
+    const ok = elements.get('#bookshelf-confirm-ok');
+    const gate = deferred();
+    f.setGate(gate);
+    f.setFailure(new Error('quota'));
+    const pending = ok.onclick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ok.disabled, true);
+    assert.equal(classes.has('is-hidden'), false);
+    assert.deepEqual(toasts, []);
+    gate.resolve();
+    await pending;
+    assert.equal(ok.disabled, false);
+    assert.match(ok.textContent, /重试/);
+    assert.equal(classes.has('is-hidden'), false);
+    assert.deepEqual(toasts, []);
+    assert.equal(f.store.getBookshelfExams().length, 2);
+    f.setFailure(null);
+    await ok.onclick();
+    assert.equal(classes.has('is-hidden'), true);
+    assert.equal(toasts.length, 1);
+    assert.match(toasts[0], /已从书架移除/);
+    assert.equal(f.store.getBookshelfExams().length, 1);
+});
+
+test('Bookshelf backend failure offers page reload instead of retrying a latched connection', async () => {
+    const f = fixture();
+    await f.store.init();
+    const elements = new Map([
+        ['#bookshelf-confirm-text', { textContent: '' }],
+        ['#bookshelf-confirm-ok', { textContent: '', disabled: false }],
+        ['#bookshelf-confirm-cancel', { disabled: false }]
+    ]);
+    const classes = new Set(['is-hidden']);
+    const overlay = {
+        querySelector: (selector) => elements.get(selector),
+        classList: { add: (name) => classes.add(name), remove: (name) => classes.delete(name) }
+    };
+    f.sandbox.document.getElementById = (id) => id === 'bookshelf-confirm-dialog' ? overlay : null;
+    let reloads = 0;
+    f.sandbox.location = { reload() { reloads += 1; } };
+    const view = f.sandbox.BookshelfView;
+    const toasts = [];
+    view.showToast = (message) => toasts.push(message);
+    view.openConfirmDialog('same-exam', 'Article A', sourceA);
+    f.setFailure(Object.assign(new Error('Connection aborted'), { code: 'BACKEND_UNAVAILABLE' }));
+    const ok = elements.get('#bookshelf-confirm-ok');
+    await ok.onclick();
+    assert.equal(ok.textContent, '刷新页面');
+    assert.match(elements.get('#bookshelf-confirm-text').textContent, /刷新页面后重试/);
+    assert.equal(classes.has('is-hidden'), false);
+    assert.equal(f.store.getBookshelfExams().length, 2);
+    assert.deepEqual(toasts, []);
+    const attempts = f.calls.length;
+    await ok.onclick();
+    assert.equal(reloads, 1);
+    assert.equal(f.calls.length, attempts, 'the recovery action does not repeat the doomed mutation');
+
+    const root = { innerHTML: '' };
+    f.sandbox.document.querySelector = () => root;
+    view.bindCardEvents = () => {};
+    view.render();
+    assert.match(root.innerHTML, /data-action="reload-page"/);
+    assert.doesNotMatch(root.innerHTML, /data-action="retry-load"/);
 });

--- a/developer/tests/js/helpers/readingVocabReaderHarness.js
+++ b/developer/tests/js/helpers/readingVocabReaderHarness.js
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+
+const source = name => fs.readFileSync(new URL(`../../../../js/${name}`, import.meta.url), 'utf8');
+const modelSource = source('data/v2/readingVocabularyModel.js');
+const readerSource = source('components/readingVocabReader.js');
+
+// Only persistence acknowledgement is mocked. Relationship updates, projection,
+// range capture and DOM rendering all execute the production implementations.
+export async function createPage(browser, { localWords = [], canonicalWords = [], authority = 'ready' } = {}) {
+    const page = await browser.newPage();
+    await page.route('https://reader.test/**', route => route.fulfill({
+        contentType: 'text/html', body: '<!doctype html><html><head></head><body></body></html>'
+    }));
+    await page.goto('https://reader.test/');
+    await page.addScriptTag({ content: modelSource });
+    await page.evaluate(({ localWords, canonicalWords, authority }) => {
+        localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify(localWords));
+        const model = window.ReadingVocabularyModel;
+        let snapshot = model.createSnapshot();
+        for (const item of canonicalWords) {
+            snapshot = model.collect(snapshot, {
+                source: item.source || { kind: 'builtin', id: 'default' },
+                article: { examId: item.examId || 'exam-a', title: item.examTitle || '' },
+                word: { ...(item.id ? { id: item.id } : {}), word: item.word, meaning: 'Fixture definition', example: item.context || '' },
+                at: '2026-09-08T01:00:00.000Z'
+            });
+        }
+        const state = window.__readingAuthority = {
+            snapshot, revision: 1, generation: 1, calls: [], reads: 0,
+            fault: null, defer: false, pending: []
+        };
+        const result = () => structuredClone({ snapshot: state.snapshot, revision: state.revision, generation: state.generation });
+        if (authority !== 'missing') {
+            window.AppData = {
+                ready: Promise.resolve(),
+                library: { getActive: async () => null },
+                vocab: {
+                    readingModel: model,
+                    getReadingSnapshot: async () => {
+                        state.reads += 1;
+                        if (authority === 'failed') throw new Error('Reading authority unavailable');
+                        return result();
+                    },
+                    mutateReading: async (type, command, options) => {
+                        state.calls.push(structuredClone({ type, command, options }));
+                        if (state.defer) await new Promise((resolve, reject) => state.pending.push({ resolve, reject }));
+                        if (state.fault) throw new Error(state.fault);
+                        if (type === 'removeTermAssociations') {
+                            for (const association of state.snapshot.reading.associations.filter(row => row.termId === command.termId)) {
+                                state.snapshot = model.removeArticleTerm(state.snapshot, association);
+                            }
+                        } else if (type === 'clearReading') {
+                            for (const article of state.snapshot.reading.articles) {
+                                state.snapshot = model.clearArticle(state.snapshot, { articleId: article.id });
+                            }
+                        } else {
+                            state.snapshot = model[type](state.snapshot, command);
+                        }
+                        if (type === 'recordVisit') window.__recordedExams.push(command.article.examId);
+                        state.revision += 1;
+                        return { ...result(), saved: true, added: true };
+                    }
+                }
+            };
+        }
+        window.__recordedExams = [];
+        window.ReadingBookshelfStore = { recordExamUsed: id => window.__recordedExams.push(id) };
+        window.__spokenWords = [];
+        window.SpeechSynthesisUtterance = class { constructor(text) { this.text = text; } };
+        Object.defineProperty(window, 'speechSynthesis', {
+            value: { cancel() {}, speak: utterance => window.__spokenWords.push(utterance.text) }
+        });
+        window.__READING_EXAM_MANIFEST__ = {};
+        window.__READING_EXPLANATION_MANIFEST__ = {};
+        window.__pendingScripts = [];
+        const appendChild = document.head.appendChild.bind(document.head);
+        document.head.appendChild = node => {
+            if (node.tagName === 'SCRIPT' && node.src) {
+                window.__pendingScripts.push(node);
+                return node;
+            }
+            return appendChild(node);
+        };
+        window.__queueOpen = async (id, key = id, script = `${id}.js`, options = {}) => {
+            window.__READING_EXAM_MANIFEST__[id] = { examId: id, script };
+            window.__READING_EXPLANATION_MANIFEST__[id] = { examId: id, script: `${id}-explanation.js` };
+            window[key] = window.ReadingVocabReader.open(id, options);
+            for (let step = 0; step < 50; step += 1) {
+                if (window.__pendingScripts.some(node => node.src.endsWith(`/${script}`))) return;
+                await Promise.resolve();
+            }
+        };
+        window.__finishScript = (scriptName, id, { error = false, explanation = false, title = id } = {}) => {
+            const index = window.__pendingScripts.findIndex(script => script.src.endsWith(`/${scriptName}`));
+            if (index < 0) throw new Error(`Missing pending script: ${scriptName}`);
+            const [script] = window.__pendingScripts.splice(index, 1);
+            if (error) return script.onerror();
+            if (explanation) {
+                window.__READING_EXPLANATION_DATA__.register(id, {
+                    passageNotes: [{ label: 'Paragraph A', text: title }]
+                });
+            } else {
+                window.__READING_EXAM_DATA__.register(id, {
+                    meta: { title },
+                    passage: { blocks: [{ html: `<div class="paragraph-wrapper"><p><strong>A</strong> This is the <em>${title}</em> passage with enough text for reading.</p></div>` }] },
+                    questionGroups: [{ bodyHtml: `<p>Questions for ${title}</p>` }]
+                });
+            }
+            script.onload();
+        };
+        window.__selectText = (selector, word, occurrence = 0) => {
+            const root = document.querySelector(selector);
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            let node;
+            while ((node = walker.nextNode())) {
+                let position = -1;
+                while ((position = node.textContent.indexOf(word, position + 1)) >= 0) {
+                    if (occurrence-- > 0) continue;
+                    const range = document.createRange();
+                    range.setStart(node, position);
+                    range.setEnd(node, position + word.length);
+                    window.getSelection().removeAllRanges();
+                    window.getSelection().addRange(range);
+                    return;
+                }
+            }
+            throw new Error(`Missing selection: ${word}`);
+        };
+    }, { localWords, canonicalWords, authority });
+    await page.addScriptTag({ content: readerSource });
+    return page;
+}
+
+export async function openArticle(page, id = 'article', title = id, options = {}) {
+    await page.evaluate(async ({ id, title, options }) => {
+        await ReadingVocabStore.init();
+        await __queueOpen(id, '__open', `${id}.js`, options);
+        __finishScript(`${id}.js`, id, { title });
+        await __open;
+    }, { id, title, options });
+}

--- a/developer/tests/js/readingDataBackupAuthority.test.js
+++ b/developer/tests/js/readingDataBackupAuthority.test.js
@@ -5,126 +5,66 @@ import test from 'node:test';
 import { chromium } from 'playwright';
 
 const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
-const catalogSource = source('data/v2/dataCatalog.js');
-const kernelSource = source('data/v2/dataKernel.js');
-const recordSource = source('data/practiceRecordSource.js');
+const scripts = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js',
+    'data/practiceRecordSource.js', 'data/v2/readingVocabularyModel.js'
+].map(source);
 const appDataSource = source('data/v2/appData.js');
-const bookshelfSource = source('components/bookshelfView.js');
-const readerSource = source('components/readingVocabReader.js');
+const AT = '2026-09-08T01:00:00.000Z';
+const SOURCE = { kind: 'imported', id: 'backup-library' };
 const wordsKey = 'ielts_reading_vocab_words_v1';
 const bookshelfKey = 'ielts_reading_bookshelf_exams_v1';
-const staleWords = [{ id: 'keep', word: 'keep', examId: 'keep' }, { id: 'removed', word: 'removed', examId: 'removed' }];
-const staleBookshelf = [{ examId: 'keep', firstUsedAt: 10 }, { examId: 'removed', firstUsedAt: 20 }];
 
-async function loadAppData(page, { interceptInstall = false, failReadingMigration = false, trackReadingMigration = false } = {}) {
-    await page.addScriptTag({ content: catalogSource });
-    await page.addScriptTag({ content: kernelSource });
-    await page.addScriptTag({ content: recordSource });
-    if (trackReadingMigration) await trackReadingMigrationFault(page);
-    if (failReadingMigration) {
-        await page.evaluate(() => {
-            const put = IDBObjectStore.prototype.put;
-            IDBObjectStore.prototype.put = function (value, ...args) {
-                if (['vocab.readingVocabWords', 'vocab.readingBookshelfExams'].includes(value?.logicalKey)) {
-                    throw new DOMException('Reading migration quota regression', 'QuotaExceededError');
-                }
-                return put.call(this, value, ...args);
-            };
-        });
-    }
-    if (interceptInstall) {
-        // Only the competing-writer test intercepts this boundary. The write and
-        // snapshot installation still use the real kernel and IndexedDB.
-        await page.evaluate(() => {
-            const prototype = window.__AppDataV2Internals.DataKernel.prototype;
-            const install = prototype.installSnapshot;
-            prototype.installSnapshot = async function (snapshot, options) {
-                if (window.beforeSnapshotInstall) {
-                    const beforeInstall = window.beforeSnapshotInstall;
-                    window.beforeSnapshotInstall = null;
-                    await beforeInstall();
-                }
-                return install.call(this, snapshot, options);
-            };
-        });
-    }
-    await page.addScriptTag({ content: appDataSource });
-    await page.evaluate(() => AppData.ready);
-    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2', 'exercise the actual IndexedDB backend');
-}
-
-async function setMirrors(page, words = staleWords, bookshelf = staleBookshelf) {
-    await page.evaluate(({ wordsKey, bookshelfKey, words, bookshelf }) => {
-        localStorage.setItem(wordsKey, JSON.stringify(words));
-        localStorage.setItem(bookshelfKey, JSON.stringify(bookshelf));
-    }, { wordsKey, bookshelfKey, words, bookshelf });
-}
-
-async function readingState(page) {
-    return page.evaluate(async ({ wordsKey, bookshelfKey }) => ({
-        words: await AppData.vocab.listReadingWords(),
-        bookshelf: await AppData.vocab.listReadingBookshelfExams(),
-        localWords: JSON.parse(localStorage.getItem(wordsKey) || '[]'),
-        localBookshelf: JSON.parse(localStorage.getItem(bookshelfKey) || '[]')
-    }), { wordsKey, bookshelfKey });
-}
-
-async function trackReadingMigrationFault(page) {
+async function loadAppData(page) {
+    for (const content of scripts) await page.addScriptTag({ content });
     await page.evaluate(() => {
-        const fault = { enabled: false, logicalKey: null, migrationWrites: 0, installCalls: 0 };
-        window.readingMigrationFault = fault;
+        const prototype = window.__AppDataV2Internals.DataKernel.prototype;
+        const install = prototype.installSnapshot;
+        prototype.installSnapshot = async function (...args) {
+            if (window.beforeSnapshotInstall) {
+                const intercept = window.beforeSnapshotInstall;
+                window.beforeSnapshotInstall = null;
+                await intercept();
+            }
+            return install.apply(this, args);
+        };
         const put = IDBObjectStore.prototype.put;
         IDBObjectStore.prototype.put = function (value, ...args) {
-            // Fail only the migration: a snapshot install could still succeed
-            // and erase the local-only collection if the error is swallowed.
-            if (fault.enabled && value?.logicalKey === fault.logicalKey
-                && value.envelope?.operationId.startsWith('migrate-reading_')) {
-                fault.migrationWrites += 1;
-                throw new DOMException('Reading migration quota regression', 'QuotaExceededError');
+            if (window.failSnapshotInstall && value?.logicalKey === 'vocab.readingState') {
+                window.failedSnapshotPuts = (window.failedSnapshotPuts || 0) + 1;
+                throw new DOMException('Injected snapshot quota failure', 'QuotaExceededError');
             }
             return put.call(this, value, ...args);
         };
-        const internals = window.__AppDataV2Internals;
-        const prototype = internals.DataKernel.prototype;
-        const install = prototype.installSnapshot;
-        prototype.installSnapshot = function (...args) {
-            fault.installCalls += 1;
-            return install.apply(this, args);
-        };
-        window.makeReadingSnapshotForTest = (logicalKey, data) => {
-            const catalog = internals.catalog;
-            const snapshot = {
-                format: 'ielts-atlas-data-v2', schemaVersion: catalog.version, scope: 'partial',
-                envelopes: { [logicalKey]: internals.makeEnvelope(catalog.get(logicalKey), data) }, entities: {}
-            };
-            snapshot.checksum = internals.checksum({ envelopes: snapshot.envelopes, entities: snapshot.entities });
-            return snapshot;
-        };
     });
+    await page.addScriptTag({ content: appDataSource });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
 }
 
-async function failReadingMigration(page, logicalKey) {
-    await page.evaluate((logicalKey) => {
-        Object.assign(window.readingMigrationFault, { enabled: true, logicalKey, migrationWrites: 0, installCalls: 0 });
-    }, logicalKey);
+async function collect(page, word, article = 'article-a') {
+    return page.evaluate(({ word, article, source, at }) => AppData.vocab.mutateReading('collect', {
+        source, article: { examId: article, title: article }, word: { word, meaning: `Definition of ${word}` }, at,
+        occurrence: { scopeId: 'passage-1', contentVersion: 'backup-fixture-v1',
+            startOffset: 0, endOffset: word.length, quote: word }
+    }), { word, article, source: SOURCE, at: AT });
 }
 
-async function backupFailureState(page) {
-    return page.evaluate(async ({ wordsKey, bookshelfKey }) => ({
-        settings: await AppData.settings.getAll(),
-        backupIds: (await AppData.backups.list()).map((entry) => entry.id),
-        words: await AppData.vocab.listReadingWords({ withMeta: true }),
-        bookshelf: await AppData.vocab.listReadingBookshelfExams({ withMeta: true }),
-        rawWords: localStorage.getItem(wordsKey),
-        rawBookshelf: localStorage.getItem(bookshelfKey),
-        fault: { ...window.readingMigrationFault }
-    }), { wordsKey, bookshelfKey });
+async function readingState(page) {
+    return page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
 }
 
-test('reading collections retain canonical authority through backup workflows in IndexedDB', { timeout: 120000 }, async (t) => {
+async function staleMirrors(page) {
+    await page.evaluate(({ wordsKey, bookshelfKey }) => {
+        localStorage.setItem(wordsKey, JSON.stringify([{ id: 'stale', word: 'stale', examId: 'stale' }]));
+        localStorage.setItem(bookshelfKey, JSON.stringify([{ examId: 'stale', firstUsedAt: 1 }]));
+    }, { wordsKey, bookshelfKey });
+}
+
+test('reading backup restoration preserves canonical authority, safety backups and revision checks in IndexedDB', { timeout: 120000 }, async (t) => {
     const server = http.createServer((_request, response) => {
         response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
-        response.end('<!doctype html><title>Reading backup regression</title>');
+        response.end('<!doctype html><title>Reading backup authority integration</title>');
     });
     await new Promise((resolve, reject) => {
         server.once('error', reject);
@@ -140,366 +80,152 @@ test('reading collections retain canonical authority through backup workflows in
     const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
     browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
 
+    async function pages(t, count = 1) {
+        const context = await browser.newContext();
+        t.after(() => context.close());
+        const result = [];
+        for (let index = 0; index < count; index += 1) {
+            const page = await context.newPage();
+            await page.goto(url);
+            await loadAppData(page);
+            result.push(page);
+        }
+        return result;
+    }
+
+    // Replaces the former late-localStorage-migration fixtures: after one-time
+    // migration, mirrors are no longer new user writes and must never be imported.
     for (const workflow of ['restore', 'replace']) {
         for (const collection of ['cleared', 'empty', 'smaller']) {
-            await t.test(`${workflow} preserves ${collection} collections without a loaded reader`, async () => {
-                const context = await browser.newContext();
-                try {
-                    const page = await context.newPage();
-                    await page.goto(url);
-                    await loadAppData(page);
-                    const words = collection === 'smaller' ? staleWords.slice(0, 1) : [];
-                    const bookshelf = collection === 'smaller' ? staleBookshelf.slice(0, 1) : [];
-                    await page.evaluate(async ({ words, bookshelf, collection }) => {
-                        if (collection !== 'cleared') {
-                            await AppData.vocab.saveReadingWords(words);
-                            await AppData.vocab.saveReadingBookshelfExams(bookshelf);
-                        }
-                        window.targetSnapshot = await AppData.backups.export();
-                        await AppData.backups.create({ id: 'target' });
-                    }, { words, bookshelf, collection });
-                    await page.evaluate(async ({ staleWords, staleBookshelf }) => {
-                        await AppData.vocab.saveReadingWords(staleWords);
-                        await AppData.vocab.saveReadingBookshelfExams(staleBookshelf);
-                    }, { staleWords, staleBookshelf });
-                    await setMirrors(page);
-                    assert.equal(await page.evaluate(() => typeof ReadingVocabStore), 'undefined');
-                    await page.evaluate(async (workflow) => {
-                        if (workflow === 'restore') await AppData.backups.restore('target');
-                        else {
-                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                            await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
-                        }
-                    }, workflow);
-                    const expected = { words, bookshelf, localWords: words, localBookshelf: bookshelf };
-                    assert.deepEqual(await readingState(page), expected, 'snapshot installation refreshes both mirrors with no reader listener');
-
-                    // An old tab can leave a stale mirror again. It must not win on
-                    // a cold startup, subsequent export, or bookshelf lazy load.
-                    await setMirrors(page);
-                    await page.reload();
-                    await loadAppData(page);
-                    assert.deepEqual(await readingState(page), expected);
-                    const exported = await page.evaluate(() => AppData.backups.export());
-                    assert.deepEqual(exported.envelopes['vocab.readingVocabWords'].data || [], words);
-                    assert.deepEqual(exported.envelopes['vocab.readingBookshelfExams'].data || [], bookshelf);
-                    await setMirrors(page, words, staleBookshelf);
-                    await page.addScriptTag({ content: bookshelfSource });
-                    await page.evaluate(() => ReadingBookshelfStore.init());
-                    assert.deepEqual(await readingState(page), expected, 'bookshelf initialization adopts the canonical array without merging stale records');
-                } finally {
-                    await context.close();
+            await t.test(`${workflow} preserves ${collection} canonical collections without a loaded reader`, async (t) => {
+                const [page] = await pages(t);
+                if (collection !== 'empty') await collect(page, 'apple');
+                if (collection === 'cleared') await page.evaluate(() => AppData.vocab.mutateReading('clearReading', {}));
+                const expected = await readingState(page);
+                await page.evaluate(async () => {
+                    window.targetSnapshot = await AppData.backups.export();
+                    await AppData.backups.create({ id: 'target' });
+                });
+                await collect(page, 'apple');
+                await collect(page, 'banana', 'article-b');
+                const before = await readingState(page);
+                await staleMirrors(page);
+                assert.equal(await page.evaluate(() => typeof ReadingVocabStore), 'undefined');
+                const receipt = await page.evaluate(async (workflow) => {
+                    if (workflow === 'restore') return AppData.backups.restore('target');
+                    const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                    return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                }, workflow);
+                assert.equal(receipt.committed, true);
+                assert.deepEqual(await readingState(page), expected);
+                if (workflow === 'restore') {
+                    const safety = await page.evaluate(async (id) => (await AppData.backups.list()).find((entry) => entry.id === id), receipt.preRestoreBackupId);
+                    assert.equal(safety.type, 'pre-restore');
+                    assert.deepEqual(safety.data.envelopes['vocab.readingState'].data.reading, before.reading, 'pre-restore backup retains all preexisting relationships');
+                    assert.deepEqual(safety.data.envelopes['vocab.lists'].data, before.lists);
                 }
+                await staleMirrors(page);
+                await page.reload();
+                await loadAppData(page);
+                assert.deepEqual(await readingState(page), expected);
+                const exported = await page.evaluate(() => AppData.backups.export());
+                assert.deepEqual(exported.envelopes['vocab.readingState'].data.reading, expected.reading);
+                assert.deepEqual(exported.envelopes['vocab.lists'].data, expected.lists);
             });
         }
     }
 
-    await t.test('genuine legacy words and bookshelf migrate on the first startup and survive a reload', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            await page.goto(url);
-            await setMirrors(page);
-            await loadAppData(page);
-            const expected = {
-                words: staleWords, bookshelf: staleBookshelf,
-                localWords: staleWords, localBookshelf: staleBookshelf
-            };
-            assert.deepEqual(await readingState(page), expected, 'legacy data seeds previously absent canonical documents');
-            await page.reload();
-            await loadAppData(page);
-            assert.deepEqual(await readingState(page), expected);
-        } finally {
-            await context.close();
-        }
+    await t.test('a safety backup between replace preview and commit does not invalidate the reviewed reading revisions', async (t) => {
+        const [page] = await pages(t);
+        await collect(page, 'apple');
+        const expected = await readingState(page);
+        await page.evaluate(async () => { window.targetSnapshot = await AppData.backups.export(); });
+        await collect(page, 'banana', 'article-b');
+        const before = await readingState(page);
+        const result = await page.evaluate(async () => {
+            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+            const safety = await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+            const receipt = await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+            return { safety, receipt };
+        });
+        assert.equal(result.receipt.committed, true);
+        assert.deepEqual(result.safety.data.envelopes['vocab.readingState'].data.reading, before.reading);
+        assert.deepEqual(await readingState(page), expected);
     });
 
-    await t.test('failed initial migration preserves the only legacy copy through lazy stores and retries on reload', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            await page.goto(url);
-            await setMirrors(page);
-            await loadAppData(page, { failReadingMigration: true });
-            await page.addScriptTag({ content: bookshelfSource });
-            await page.addScriptTag({ content: readerSource });
-            await page.evaluate(async () => {
-                await ReadingBookshelfStore.init();
-                await ReadingVocabStore.init();
-            });
-            assert.deepEqual(await readingState(page), {
-                words: [], bookshelf: [], localWords: staleWords, localBookshelf: staleBookshelf
-            }, 'absent documents after a failed migration must not overwrite legacy data with defaults');
-            assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll()), staleWords);
-
-            await page.reload();
-            await loadAppData(page);
-            assert.deepEqual(await readingState(page), {
-                words: staleWords, bookshelf: staleBookshelf, localWords: staleWords, localBookshelf: staleBookshelf
-            }, 'the preserved legacy copy remains available for the next successful migration');
-        } finally {
-            await context.close();
-        }
-    });
-
-    for (const workflow of ['restore', 'replace-preview', 'replace-commit', 'replace-smaller']) {
-        for (const logicalKey of ['vocab.readingVocabWords', 'vocab.readingBookshelfExams']) {
-            await t.test(`${workflow} aborts when the only legacy copy of ${logicalKey} cannot migrate`, async () => {
-                const context = await browser.newContext();
-                try {
-                    const page = await context.newPage();
-                    await page.goto(url);
-                    await loadAppData(page, { trackReadingMigration: true });
-                    await page.evaluate(async ({ workflow, logicalKey, staleWords, staleBookshelf }) => {
-                        await AppData.settings.patch({ theme: 'original' });
-                        window.targetSnapshot = await AppData.backups.export();
-                        await AppData.backups.create({ id: 'target' });
-                        await AppData.settings.patch({ theme: 'changed' });
-                        if (workflow === 'replace-commit') {
-                            // A legacy tab can introduce local-only records after
-                            // preview, so commit must recheck migration safety.
-                            window.pendingPlan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                        }
-                        if (workflow === 'replace-smaller') {
-                            const data = logicalKey === 'vocab.readingVocabWords' ? staleWords : staleBookshelf;
-                            window.targetSnapshot = window.makeReadingSnapshotForTest(logicalKey, data.slice(0, 1));
-                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                            window.smallerPlanDestructive = plan.destructive;
-                        }
-                    }, { workflow, logicalKey, staleWords, staleBookshelf });
-                    if (workflow === 'replace-smaller') {
-                        assert.equal(await page.evaluate(() => window.smallerPlanDestructive), false,
-                            'present smaller reading arrays must be protected even when the preview is not marked destructive');
-                    }
-                    await setMirrors(page);
-                    await failReadingMigration(page, logicalKey);
-                    const before = await backupFailureState(page);
-                    const failure = await page.evaluate(async (workflow) => {
-                        try {
-                            if (workflow === 'restore') await AppData.backups.restore('target');
-                            else {
-                                const plan = workflow === 'replace-commit'
-                                    ? window.pendingPlan
-                                    : await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                                if (workflow === 'replace-preview') {
-                                    await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
-                                }
-                                await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
-                            }
-                            return null;
-                        } catch (error) {
-                            return { code: error.code, message: error.message };
-                        }
-                    }, workflow);
-                    assert.equal(failure?.code, 'QUOTA_EXCEEDED', 'destructive workflow must surface the required migration failure');
-                    const after = await backupFailureState(page);
-                    assert.ok(after.fault.migrationWrites > 0, 'exercise an actual failed IndexedDB migration write');
-                    assert.equal(after.fault.installCalls, 0, 'abort before attempting snapshot installation');
-                    assert.deepEqual(after.settings, before.settings, 'failed migration must not install target settings');
-                    assert.deepEqual(after.backupIds, before.backupIds, 'do not create a misleading safety backup without the only legacy copy');
-                    assert.equal(after.rawWords, before.rawWords, 'preserve the original words mirror byte for byte');
-                    assert.equal(after.rawBookshelf, before.rawBookshelf, 'preserve the original bookshelf mirror byte for byte');
-                    assert.equal(after[logicalKey === 'vocab.readingVocabWords' ? 'words' : 'bookshelf'].envelope, null,
-                        'failed migration leaves this collection recoverable only from its preserved mirror');
-
-                    await page.evaluate(() => { window.readingMigrationFault.enabled = false; });
-                    if (workflow === 'replace-commit') {
-                        const conflict = await page.evaluate(async () => {
-                            try {
-                                await AppData.backups.commitImport(window.pendingPlan.id, { confirmDestructive: true });
-                                return null;
-                            } catch (error) {
-                                return error.code;
-                            }
-                        });
-                        assert.equal(conflict, 'CONFLICT', 'late migration must preserve the original preview token and require a fresh preview');
-                        assert.equal((await backupFailureState(page)).settings.theme, 'changed');
-                        assert.deepEqual(await readingState(page), {
-                            words: staleWords, bookshelf: staleBookshelf, localWords: staleWords, localBookshelf: staleBookshelf
-                        }, 'successful migration after quota recovery must preserve records when the old plan conflicts');
-                    }
-                    const result = await page.evaluate(async (workflow) => {
-                        let receipt;
-                        let safety;
-                        if (workflow === 'restore') {
-                            receipt = await AppData.backups.restore('target');
-                            safety = (await AppData.backups.list()).find((entry) => entry.id === receipt.preRestoreBackupId);
-                        } else {
-                            // Re-preview after a failed commit so newly migrated
-                            // records are covered by its revision token.
-                            const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                            safety = await AppData.backups.create({ id: 'pre-import-retry', type: 'pre-import' });
-                            receipt = await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
-                        }
-                        return { receipt, safety, settings: await AppData.settings.getAll() };
-                    }, workflow);
-                    assert.equal(result.receipt.committed, true, 'retry succeeds after the migration write becomes available');
-                    assert.equal(result.settings.theme, workflow === 'replace-smaller' ? 'changed' : 'original');
-                    assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
-                    assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
-                    assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
-                    const words = workflow === 'replace-smaller'
-                        ? (logicalKey === 'vocab.readingVocabWords' ? staleWords.slice(0, 1) : staleWords) : [];
-                    const bookshelf = workflow === 'replace-smaller'
-                        ? (logicalKey === 'vocab.readingBookshelfExams' ? staleBookshelf.slice(0, 1) : staleBookshelf) : [];
-                    assert.deepEqual(await readingState(page), { words, bookshelf, localWords: words, localBookshelf: bookshelf });
-                } finally {
-                    await context.close();
-                }
-            });
-        }
-    }
-
-    await t.test('settings-only import leaves broken reading migration alone, while a safety backup requires it', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            await page.goto(url);
-            await loadAppData(page, { trackReadingMigration: true });
-            await page.evaluate(async () => {
-                await AppData.settings.patch({ theme: 'original' });
-                window.settingsSnapshot = await AppData.backups.export({ domains: ['settings'] });
-                await AppData.settings.patch({ theme: 'changed' });
-            });
-            await setMirrors(page);
-            await failReadingMigration(page, 'vocab.readingBookshelfExams');
-            const before = await backupFailureState(page);
-            const receipt = await page.evaluate(async () => {
-                const plan = await AppData.backups.previewImport(window.settingsSnapshot, { replace: true });
-                return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
-            });
-            assert.equal(receipt.committed, true);
-            const imported = await backupFailureState(page);
-            assert.equal(imported.settings.theme, 'original');
-            assert.equal(imported.fault.migrationWrites, 0, 'an unrelated partial import must not require reading migration');
-            assert.equal(imported.words.envelope, null);
-            assert.equal(imported.bookshelf.envelope, null);
-            assert.equal(imported.rawWords, before.rawWords);
-            assert.equal(imported.rawBookshelf, before.rawBookshelf);
-
-            const failure = await page.evaluate(async () => {
-                try {
-                    await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
-                    return null;
-                } catch (error) {
-                    return error.code;
-                }
-            });
-            assert.equal(failure, 'QUOTA_EXCEEDED', 'explicit safety backups must include recoverable local-only collections');
-            const failed = await backupFailureState(page);
-            assert.ok(failed.fault.migrationWrites > 0);
-            assert.equal(failed.fault.installCalls, imported.fault.installCalls);
-            assert.deepEqual(failed.settings, imported.settings);
-            assert.deepEqual(failed.backupIds, before.backupIds, 'a failed backup must not leave an incomplete safety entry');
-            assert.equal(failed.rawWords, before.rawWords);
-            assert.equal(failed.rawBookshelf, before.rawBookshelf);
-
-            const safety = await page.evaluate(async () => {
-                window.readingMigrationFault.enabled = false;
-                return AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
-            });
-            assert.deepEqual(safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
-            assert.deepEqual(safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
-        } finally {
-            await context.close();
-        }
-    });
-
-    await t.test('restore migrates late legacy mirrors before its revision token and retains its safety backup', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            await page.goto(url);
-            await loadAppData(page);
-            await page.evaluate(async () => {
-                await AppData.settings.patch({ theme: 'original' });
-                await AppData.backups.create({ id: 'target' });
-                await AppData.settings.patch({ theme: 'changed' });
-            });
-            await setMirrors(page);
-            const result = await page.evaluate(async () => {
-                const receipt = await AppData.backups.restore('target');
-                const safety = (await AppData.backups.list()).find((entry) => entry.id === receipt.preRestoreBackupId);
-                return { receipt, settings: await AppData.settings.getAll(), safety };
-            });
-            assert.equal(result.receipt.committed, true, 'restore succeeds on its first attempt without a competing writer');
-            assert.equal(result.settings.theme, 'original');
-            assert.equal(result.safety.type, 'pre-restore');
-            assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
-            assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
-            assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
-            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
-            await page.reload();
-            await loadAppData(page);
-            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'original');
-            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
-        } finally {
-            await context.close();
-        }
-    });
-
-    await t.test('replace import migrates late mirrors before preview so its safety backup does not invalidate the plan', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            await page.goto(url);
-            await loadAppData(page);
+    for (const workflow of ['restore', 'replace']) {
+        await t.test(`${workflow} detects a competing reader after its revision token and preserves its safety backup`, async (t) => {
+            const [page, writer] = await pages(t, 2);
             await page.evaluate(async () => {
                 await AppData.settings.patch({ theme: 'original' });
                 window.targetSnapshot = await AppData.backups.export();
-                await AppData.settings.patch({ theme: 'changed' });
-            });
-            await setMirrors(page);
-            const result = await page.evaluate(async () => {
-                const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
-                const safety = await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
-                const receipt = await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
-                return { receipt, safety, settings: await AppData.settings.getAll() };
-            });
-            assert.equal(result.receipt.committed, true, 'preview, safety backup, and commit succeed on the first attempt');
-            assert.equal(result.settings.theme, 'original');
-            assert.equal(result.safety.data.envelopes['settings.values'].data.theme, 'changed');
-            assert.deepEqual(result.safety.data.envelopes['vocab.readingVocabWords'].data, staleWords);
-            assert.deepEqual(result.safety.data.envelopes['vocab.readingBookshelfExams'].data, staleBookshelf);
-            await page.reload();
-            await loadAppData(page);
-            assert.deepEqual(await readingState(page), { words: [], bookshelf: [], localWords: [], localBookshelf: [] });
-            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'original');
-        } finally {
-            await context.close();
-        }
-    });
-
-    await t.test('a competing reading writer still aborts restore after the safety backup', async () => {
-        const context = await browser.newContext();
-        try {
-            const page = await context.newPage();
-            const writer = await context.newPage();
-            await page.goto(url);
-            await loadAppData(page, { interceptInstall: true });
-            await page.evaluate(async () => {
-                await AppData.settings.patch({ theme: 'original' });
                 await AppData.backups.create({ id: 'target' });
                 await AppData.settings.patch({ theme: 'changed' });
             });
-            await writer.goto(url);
-            await loadAppData(writer);
-            await page.exposeFunction('commitConcurrentReading', () => writer.evaluate(async () => {
-                await AppData.vocab.saveReadingWords([{ id: 'concurrent', word: 'concurrent' }]);
-            }));
-            const result = await page.evaluate(async () => {
+            await collect(page, 'apple');
+            await page.exposeFunction('commitConcurrentReading', () => collect(writer, 'banana', 'article-b'));
+            const result = await page.evaluate(async (workflow) => {
                 window.beforeSnapshotInstall = () => window.commitConcurrentReading();
-                try { await AppData.backups.restore('target'); } catch (error) {
-                    return { code: error.code, settings: await AppData.settings.getAll(), backups: await AppData.backups.list() };
+                try {
+                    if (workflow === 'restore') await AppData.backups.restore('target');
+                    else {
+                        const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                        await AppData.backups.create({ id: 'pre-import', type: 'pre-import' });
+                        await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                    }
+                    return null;
+                } catch (error) {
+                    return { code: error.code, committed: error.committed,
+                        settings: await AppData.settings.getAll(), backups: await AppData.backups.list() };
                 }
-                return null;
+            }, workflow);
+            assert.equal(result?.code, 'CONFLICT');
+            assert.equal(result.committed, false);
+            assert.equal(result.settings.theme, 'changed', 'failed install cannot partially change settings');
+            assert.ok(result.backups.some((entry) => entry.type === (workflow === 'restore' ? 'pre-restore' : 'pre-import')));
+            const current = await readingState(writer);
+            assert.deepEqual(current.reading.terms.map((row) => row.normalizedTerm).sort(), ['apple', 'banana']);
+            assert.equal(current.reading.associations.length, 2);
+            assert.equal(current.reading.occurrences.length, 2);
+        });
+    }
+
+    for (const workflow of ['restore', 'replace']) {
+        await t.test(`${workflow} transaction quota failure leaves the current snapshot intact and supports retry`, async (t) => {
+            const [page] = await pages(t);
+            await page.evaluate(async () => {
+                await AppData.settings.patch({ theme: 'original' });
+                window.targetSnapshot = await AppData.backups.export();
+                await AppData.backups.create({ id: 'target' });
+                await AppData.settings.patch({ theme: 'changed' });
             });
-            assert.equal(result.code, 'CONFLICT');
-            assert.equal(result.settings.theme, 'changed', 'failed restore must not partially install the target snapshot');
-            assert.ok(result.backups.some((entry) => entry.type === 'pre-restore'));
-            assert.deepEqual((await readingState(writer)).words, [{ id: 'concurrent', word: 'concurrent' }]);
-        } finally {
-            await context.close();
-        }
-    });
+            await collect(page, 'apple');
+            const before = await readingState(page);
+            const failed = await page.evaluate(async (workflow) => {
+                window.failSnapshotInstall = true;
+                try {
+                    if (workflow === 'restore') await AppData.backups.restore('target');
+                    else {
+                        const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                        await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                    }
+                    return null;
+                } catch (error) { return { code: error.code, committed: error.committed, puts: window.failedSnapshotPuts }; }
+            }, workflow);
+            assert.equal(failed?.code, 'QUOTA_EXCEEDED');
+            assert.equal(failed.committed, false);
+            assert.equal(failed.puts, 1, 'the actual IndexedDB snapshot transaction failed');
+            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'changed');
+            assert.deepEqual(await readingState(page), before, 'graph, canonical owners and visits roll back together');
+            const receipt = await page.evaluate(async (workflow) => {
+                window.failSnapshotInstall = false;
+                if (workflow === 'restore') return AppData.backups.restore('target');
+                const plan = await AppData.backups.previewImport(window.targetSnapshot, { replace: true });
+                return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+            }, workflow);
+            assert.equal(receipt.committed, true);
+            assert.equal((await readingState(page)).reading.associations.length, 0);
+            assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'original');
+        });
+    }
 });

--- a/developer/tests/js/readingLegacyRecovery.test.js
+++ b/developer/tests/js/readingLegacyRecovery.test.js
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+// Run production migration and storage code against Chromium IndexedDB. The
+// first-start fault aborts only the legacy database's actual read transaction.
+const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const scripts = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js',
+    'data/practiceRecordSource.js', 'data/v2/readingVocabularyModel.js'
+].map(source);
+const appDataSource = source('data/v2/appData.js');
+const LEGACY_WORD = {
+    id: 'legacy-reviewed-apple', word: 'apple', meaning: 'Personal apple definition', note: 'Keep my note',
+    easeFactor: 2.3, repetitions: 7, interval: 21, correctCount: 9,
+    lastReviewed: '2026-09-01T01:00:00.000Z', nextReview: '2026-09-22T01:00:00.000Z',
+    reviewHistory: [{ at: '2026-09-01T01:00:00.000Z', grade: 4 }]
+};
+const LEGACY_LISTS = {
+    'personal-list': {
+        id: 'personal-list', name: 'My reviewed vocabulary', words: [{
+            ...LEGACY_WORD, id: 'legacy-reviewed-banana', word: 'banana', meaning: 'Personal banana definition',
+            repetitions: 11, interval: 35, correctCount: 15
+        }]
+    }
+};
+
+async function seedLegacyVocabulary(page) {
+    return page.evaluate(({ words, lists }) => new Promise((resolve, reject) => {
+        const open = indexedDB.open('ExamSystemDB', 1);
+        open.onupgradeneeded = () => open.result.createObjectStore('keyValueStore', { keyPath: 'key' });
+        open.onerror = () => reject(open.error);
+        open.onsuccess = () => {
+            const database = open.result;
+            const transaction = database.transaction('keyValueStore', 'readwrite');
+            for (const [key, data] of [['exam_system_vocab_words', words], ['exam_system_vocab_lists', lists]]) {
+                transaction.objectStore('keyValueStore').put({ key,
+                    value: JSON.stringify({ data, version: '1.0.0', timestamp: 1000, compressed: false }),
+                    timestamp: 1000 });
+            }
+            transaction.oncomplete = () => { database.close(); resolve(); };
+            transaction.onerror = transaction.onabort = () => { database.close(); reject(transaction.error); };
+        };
+    }), { words: [LEGACY_WORD], lists: LEGACY_LISTS });
+}
+
+async function loadAppData(page, { failLegacyRead = false } = {}) {
+    for (const content of scripts) await page.addScriptTag({ content });
+    await page.evaluate((fail) => {
+        window.legacyRecoveryTest = { fail, abortedReads: 0, internals: window.__AppDataV2Internals };
+        const getAll = IDBObjectStore.prototype.getAll;
+        IDBObjectStore.prototype.getAll = function (...args) {
+            const request = getAll.apply(this, args);
+            if (window.legacyRecoveryTest.fail && this.transaction.db.name === 'ExamSystemDB') {
+                window.legacyRecoveryTest.abortedReads += 1;
+                this.transaction.abort();
+            }
+            return request;
+        };
+    }, failLegacyRead);
+    await page.addScriptTag({ content: appDataSource });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+
+async function durableRow(page, store, key) {
+    return page.evaluate(({ store, key }) => new Promise((resolve, reject) => {
+        const open = indexedDB.open('IELTSAtlasDataV2');
+        open.onerror = () => reject(open.error);
+        open.onsuccess = () => {
+            const database = open.result;
+            const request = database.transaction(store, 'readonly').objectStore(store).get(key);
+            request.onsuccess = () => { database.close(); resolve(request.result || null); };
+            request.onerror = () => { database.close(); reject(request.error); };
+        };
+    }), { store, key });
+}
+
+test('reading migration waits for recoverable V1 vocabulary without weakening replacement authority', { timeout: 90000 }, async (t) => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Reading legacy recovery integration</title>');
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+    });
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+
+    async function newPage(t) {
+        const context = await browser.newContext();
+        t.after(() => context.close());
+        const page = await context.newPage();
+        await page.goto(url);
+        return page;
+    }
+
+    await t.test('an aborted first V1 read recovers reviewed default and list words on a healthy reload', async (t) => {
+        const page = await newPage(t);
+        await seedLegacyVocabulary(page);
+        await loadAppData(page, { failLegacyRead: true });
+        assert.ok(await page.evaluate(() => window.legacyRecoveryTest.abortedReads) > 0,
+            'the fixture must abort the production legacy read transaction');
+        const firstMarker = (await durableRow(page, 'system', 'system.migrations'))?.envelope?.data || {};
+        assert.notEqual(firstMarker.v1ToV2?.status, 'complete', 'an unread source is still pending recovery');
+        assert.notEqual(firstMarker.readingVocabularyV1?.completed, true,
+            'reading migration must not claim completion before canonical V1 vocabulary is available');
+        for (const key of ['vocab.words', 'vocab.lists', 'vocab.readingState']) {
+            assert.equal(await durableRow(page, 'documents', key), null,
+                `${key} must not become an authoritative empty placeholder during a failed first startup`);
+        }
+        // Lazy readers, backups and canonical writes must obey the same barrier
+        // as startup; a words-only write cannot discard unrecovered list words.
+        for (const workflow of ['read', 'backup', 'saveWords', 'saveCollections']) {
+            const failure = await page.evaluate(async (workflow) => {
+                try {
+                    if (workflow === 'read') await AppData.vocab.getReadingSnapshot();
+                    if (workflow === 'backup') await AppData.backups.create({ id: 'incomplete-v1-backup' });
+                    if (workflow === 'saveWords') await AppData.vocab.saveWords([{ id: 'new-word', word: 'new', meaning: 'new' }]);
+                    if (workflow === 'saveCollections') await AppData.vocab.saveCollections({ newList: [] });
+                    return null;
+                } catch (error) { return { code: error.code, committed: error.committed }; }
+            }, workflow);
+            assert.deepEqual(failure, { code: 'BACKEND_UNAVAILABLE', committed: false },
+                `${workflow} must keep incomplete legacy vocabulary recoverable`);
+            assert.equal(await durableRow(page, 'documents', 'vocab.readingState'), null);
+        }
+
+        await page.reload();
+        await loadAppData(page);
+        const recovered = await page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+        assert.deepEqual(recovered.words, [LEGACY_WORD], 'retain default-word definitions, notes and review progress');
+        assert.deepEqual(recovered.lists, LEGACY_LISTS, 'retain list membership and every reviewed-word field');
+        const recoveredMarker = (await durableRow(page, 'system', 'system.migrations')).envelope.data;
+        assert.equal(recoveredMarker.v1ToV2.status, 'complete');
+        assert.equal(recoveredMarker.readingVocabularyV1.completed, true);
+        const backup = await page.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+        assert.deepEqual(backup.envelopes['vocab.words'].data, [LEGACY_WORD]);
+        assert.deepEqual(backup.envelopes['vocab.lists'].data, LEGACY_LISTS);
+        await page.reload();
+        await loadAppData(page);
+        assert.deepEqual(await page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot), recovered,
+            'subsequent startup is idempotent after the deferred recovery succeeds');
+    });
+
+    await t.test('a real empty backup replacement remains authoritative when a prior V1 migration is retried', async (t) => {
+        const page = await newPage(t);
+        await loadAppData(page);
+        const empty = await page.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+        await page.evaluate(({ words, lists }) => AppData.vocab.saveWords(words).then(() => AppData.vocab.saveCollections(lists)),
+            { words: [LEGACY_WORD], lists: LEGACY_LISTS });
+        const replaced = await page.evaluate(async (snapshot) => {
+            const plan = await AppData.backups.previewImport(snapshot, { replace: true });
+            return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+        }, empty);
+        assert.equal(replaced.committed, true);
+        const expected = await page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+        assert.deepEqual(expected.words, []);
+        assert.deepEqual(expected.lists, {});
+        await seedLegacyVocabulary(page);
+        // Represent a persisted state from an earlier interrupted broad
+        // migration. Preserve the actual replacement's documents and provenance.
+        await page.evaluate(async () => {
+            const kernel = new window.legacyRecoveryTest.internals.DataKernel();
+            await kernel.initialize();
+            try {
+                const migration = await kernel.read('system.migrations', { withMeta: true });
+                delete migration.data.v1ToV2;
+                await kernel.mutate([{ logicalKey: 'system.migrations', data: migration.data,
+                    expectedRevision: migration.envelope.revision }], { operationId: 'fixture-pending-v1-after-replace' });
+            } finally { kernel.close(); }
+        });
+        await page.reload();
+        await loadAppData(page);
+        assert.deepEqual(await page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot), expected,
+            'legacy recovery cannot resurrect vocabulary removed by an acknowledged replacement');
+        assert.equal((await durableRow(page, 'system', 'system.migrations')).envelope.data.v1ToV2.status, 'complete');
+    });
+});

--- a/developer/tests/js/readingVocabHighlightInstance.test.js
+++ b/developer/tests/js/readingVocabHighlightInstance.test.js
@@ -1,149 +1,86 @@
 #!/usr/bin/env node
+import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { createPage, openArticle } from './helpers/readingVocabReaderHarness.js';
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const root = path.resolve(here, '..', '..', '..');
-const vocabReaderPath = path.join(root, 'js/components/readingVocabReader.js');
-const vocabReaderSource = fs.readFileSync(vocabReaderPath, 'utf8');
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
 
-// 1. 验证 ReadingVocabStore.add 支持 highlight 存储，且能够保存选区实例位置信息
-assert.match(
-    vocabReaderSource,
-    /add\(rawWord,\s*examId,\s*examTitle,\s*context\s*=\s*'',\s*highlight\s*=\s*null\)/,
-    'ReadingVocabStore.add must accept highlight metadata parameter'
-);
+test('production range calculation and restoration preserve one selected instance', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    try {
+        const results = await page.evaluate(() => {
+            const fullText = 'Clean water is essential for life, but contaminated water causes severe diseases. Stored water must be protected.';
+            const root = document.createElement('p');
+            root.textContent = fullText;
+            document.body.append(root);
+            return [6, 52, 89].map((offset, occurrence) => {
+                const range = document.createRange();
+                range.setStart(root.firstChild, offset);
+                range.setEnd(root.firstChild, offset + 5);
+                const location = ReadingVocabReader.calculateRangeLocation(root, range, 'water');
+                const restored = ReadingVocabReader.resolveRangeForHighlight(root, { ...location, text: 'water' });
+                const fallback = ReadingVocabReader.resolveRangeForHighlight(root, { startOffset: -1, endOffset: -1, occurrence, text: 'water' });
+                return {
+                    startOffset: location.startOffset, endOffset: location.endOffset, occurrence: location.occurrence,
+                    restored: { text: restored.toString(), start: restored.startOffset, end: restored.endOffset },
+                    fallback: { text: fallback.toString(), start: fallback.startOffset, end: fallback.endOffset }
+                };
+            });
+        });
+        assert.deepEqual(results, [6, 52, 89].map((offset, occurrence) => ({
+            startOffset: offset, endOffset: offset + 5, occurrence,
+            restored: { text: 'water', start: offset, end: offset + 5 },
+            fallback: { text: 'water', start: offset, end: offset + 5 }
+        })));
+    } finally { await page.close(); await browser.close(); }
+});
 
-assert.match(
-    vocabReaderSource,
-    /highlights:\s*highlight\s*\?\s*\[highlight\]\s*:\s*\[\]/,
-    'New vocab items must initialize highlights array with highlight parameter'
-);
+test('acknowledged highlights restore only the selected instance in the active library', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    const sourceA = { kind: 'builtin', id: 'default' };
+    const sourceB = { kind: 'imported', id: 'library-b' };
+    try {
+        await openArticle(page, 'shared-exam', 'water water water', { source: sourceA });
+        await page.evaluate(() => {
+            __selectText('#vocab-passage-content em', 'water', 1);
+            document.querySelector('#vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
+        });
+        await page.waitForFunction(() => __readingAuthority.snapshot.reading.occurrences.length === 1);
+        await page.evaluate(async source => {
+            const captured = __readingAuthority.snapshot.reading.occurrences[0];
+            await ReadingVocabStore.add('water', 'shared-exam', 'An imported article', '', {
+                ...captured, text: captured.quote,
+                startOffset: captured.startOffset + 6, endOffset: captured.endOffset + 6
+            }, source);
+        }, sourceB);
+        await page.evaluate(source => ReadingVocabReader.open('shared-exam', { source }), sourceA);
+        assert.deepEqual(await page.evaluate(() => {
+            const container = document.querySelector('#vocab-passage-content em');
+            const mark = container.querySelector('mark.vocab-highlight');
+            return { count: container.querySelectorAll('mark').length, before: mark.previousSibling.textContent, after: mark.nextSibling.textContent };
+        }), { count: 1, before: 'water ', after: ' water' });
+        await page.evaluate(async source => {
+            await ReadingVocabStore.clear('shared-exam', source);
+            ReadingVocabReader.applyVocabHighlights();
+        }, sourceA);
+        assert.equal(await page.locator('mark.vocab-highlight').count(), 0);
+        assert.deepEqual(await page.evaluate(source => ({
+            terms: ReadingVocabStore.getByExam('shared-exam', source).length,
+            occurrences: __readingAuthority.snapshot.reading.occurrences.length
+        }), sourceB), { terms: 1, occurrences: 1 });
+    } finally { await page.close(); await browser.close(); }
+});
 
-assert.match(
-    vocabReaderSource,
-    /item\.highlights\.push\(highlight\)/,
-    'Existing vocab items must append new highlight instances'
-);
-
-// 2. 验证 handleSelectionCapture 仅高亮当前选中的具体单词实例，不执行全篇盲匹配
-assert.match(
-    vocabReaderSource,
-    /const locInfo = this\.calculateRangeLocation\(scopeElement,\s*trimmedRange,\s*text\);/,
-    'Must calculate exact range location within scopeElement'
-);
-
-assert.match(
-    vocabReaderSource,
-    /const wrappedMark = this\.wrapRangeWithHighlight\(trimmedRange,\s*cleanWord\);/,
-    'Must wrap ONLY the trimmedRange with highlight'
-);
-
-// 确保在划词捕获时绝不调用全局 applyVocabHighlights (这曾是全篇所有相同单词都被高亮的根本原因)
-const captureBlock = vocabReaderSource.match(/const handleSelectionCapture = \(\) => \{([\s\S]*?)\n                \};/)?.[1] || '';
-assert.ok(captureBlock.length > 0, 'handleSelectionCapture must exist');
-assert.doesNotMatch(
-    captureBlock,
-    /this\.applyVocabHighlights\(/,
-    'handleSelectionCapture must NOT trigger global applyVocabHighlights across the whole text'
-);
-
-// 3. 验证 applyVocabHighlights 是基于保存的实例元数据精确恢复单处高亮，而非全篇盲目正则
-assert.match(
-    vocabReaderSource,
-    /this\.restoreVocabHighlight\(overlay,\s*hl,\s*item\.word\)/,
-    'applyVocabHighlights must restore each highlight record individually'
-);
-
-assert.doesNotMatch(
-    vocabReaderSource,
-    /new RegExp\(`\(\$\{patternParts\.join\('\|'\)\}\)`,\s*'gi'\)/,
-    'Global regex multi-match replacement over entire document must be removed'
-);
-
-// 4. 验证删除单词时针对性清理该单词的高亮 mark
-assert.match(
-    vocabReaderSource,
-    /this\.removeVocabHighlightForWord\(word\)/,
-    'Deleting a word must specifically remove only that word marks'
-);
-
-// 5. 模拟验证实例定位算法：当文本中出现多个相同单词时，精准命中目标实例
-function simulateResolveInstance(fullText, targetWord, targetOccurrence) {
-    const lowerFull = fullText.toLowerCase();
-    const lowerWord = targetWord.toLowerCase();
-    let currentOccurrence = 0;
-    let pos = 0;
-    let matchPos = -1;
-    while ((matchPos = lowerFull.indexOf(lowerWord, pos)) !== -1) {
-        if (currentOccurrence === targetOccurrence) {
-            return { start: matchPos, end: matchPos + targetWord.length };
-        }
-        currentOccurrence += 1;
-        pos = matchPos + 1;
-    }
-    return null;
-}
-
-const sampleArticle = "Clean water is essential for life, but contaminated water causes severe diseases. Stored water must be protected.";
-// 文中有 3 个 "water":
-// 0: offset 6..11 ("Clean water")
-// 1: offset 52..57 ("contaminated water")
-// 2: offset 87..92 ("Stored water")
-const hit0 = simulateResolveInstance(sampleArticle, "water", 0);
-const hit1 = simulateResolveInstance(sampleArticle, "water", 1);
-const hit2 = simulateResolveInstance(sampleArticle, "water", 2);
-
-assert.strictEqual(hit0.start, 6);
-assert.strictEqual(hit0.end, 11);
-assert.strictEqual(hit1.start, 52);
-assert.strictEqual(hit1.end, 57);
-assert.strictEqual(hit2.start, 89);
-assert.strictEqual(hit2.end, 94);
-
-// 验证命中第 1 个（第二个出现）时，只定位第 1 个，而不影响第 0 和第 2 个
-assert.notStrictEqual(hit1.start, hit0.start);
-assert.notStrictEqual(hit1.start, hit2.start);
-
-// 6. 验证 header 右侧的生词本按钮已被移除，保留右下角悬浮 FAB 按钮
-assert.doesNotMatch(
-    vocabReaderSource,
-    /id="vocab-open-modal-btn"/,
-    'Right header vocab-open-modal-btn must be removed'
-);
-
-assert.match(
-    vocabReaderSource,
-    /id="vocab-fab"/,
-    'Floating vocab FAB must be preserved'
-);
-
-// 7. 验证段落切换 Tab 生成文案为 "Para ${b.letter}"，并完全陈列展开
-assert.match(
-    vocabReaderSource,
-    /Para \$\{b\.letter\}/,
-    'Tab button text must use English abbreviation Para ${b.letter}'
-);
-
-const vocabCssPath = path.join(root, 'css/vocab-reader.css');
-const vocabCssSource = fs.readFileSync(vocabCssPath, 'utf8');
-
-// 8. 验证 CSS 中 tabs 样式已移除滑动限制并支持 flex-wrap 陈列
-assert.match(
-    vocabCssSource,
-    /\.vocab-reader-tabs\s*\{[\s\S]*?flex-wrap:\s*wrap;/m,
-    'Tabs must use flex-wrap: wrap for complete expansion without horizontal scrolling'
-);
-
-assert.doesNotMatch(
-    vocabCssSource,
-    /\.vocab-reader-tabs\s*\{[\s\S]*?overflow-x:\s*auto;/m,
-    'Tabs must NOT use overflow-x: auto'
-);
-
-console.log(JSON.stringify({
-    status: 'pass',
-    detail: 'Reading vocab highlight and layout customization verified'
-}));
+test('reader preserves the floating vocabulary entry and expanded paragraph navigation', () => {
+    const reader = fs.readFileSync(new URL('../../../js/components/readingVocabReader.js', import.meta.url), 'utf8');
+    const css = fs.readFileSync(new URL('../../../css/vocab-reader.css', import.meta.url), 'utf8');
+    assert.doesNotMatch(reader, /id="vocab-open-modal-btn"/, 'The redundant header button must remain removed');
+    assert.match(reader, /id="vocab-fab"/, 'The floating vocabulary button remains available');
+    assert.match(reader, /Para \$\{b\.letter\}/, 'Paragraph tabs retain their compact labels');
+    assert.match(css, /\.vocab-reader-tabs\s*\{[^}]*flex-wrap:\s*wrap;/m, 'Paragraph tabs wrap to show every option');
+    assert.doesNotMatch(css, /\.vocab-reader-tabs\s*\{[^}]*overflow-x:\s*auto;/m, 'Paragraph tabs do not require horizontal scrolling');
+});

--- a/developer/tests/js/readingVocabReaderSafety.test.js
+++ b/developer/tests/js/readingVocabReaderSafety.test.js
@@ -1,81 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { createPage, openArticle } from './helpers/readingVocabReaderHarness.js';
 import { chromium } from 'playwright';
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const readerSource = fs.readFileSync(path.join(repoRoot, 'js/components/readingVocabReader.js'), 'utf8');
 const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
-
-async function createPage(browser, { localWords = [], canonicalWords, canonicalResult } = {}) {
-    const page = await browser.newPage();
-    await page.route('https://reader.test/**', route => route.fulfill({
-        contentType: 'text/html', body: '<!doctype html><html><head></head><body></body></html>'
-    }));
-    await page.goto('https://reader.test/');
-    await page.evaluate(({ localWords, canonicalWords, canonicalResult }) => {
-        localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify(localWords));
-        window.__savedWords = [];
-        if (canonicalWords !== undefined || canonicalResult !== undefined) {
-            window.AppData = {
-                ready: Promise.resolve(),
-                vocab: {
-                    listReadingWords: async options => options?.withMeta && canonicalResult !== undefined
-                        ? canonicalResult : (canonicalWords ?? canonicalResult.data),
-                    saveReadingWords: async words => window.__savedWords.push(words)
-                }
-            };
-        }
-        window.__recordedExams = [];
-        window.ReadingBookshelfStore = { recordExamUsed: id => window.__recordedExams.push(id) };
-        window.__spokenWords = [];
-        window.SpeechSynthesisUtterance = class { constructor(text) { this.text = text; } };
-        Object.defineProperty(window, 'speechSynthesis', {
-            value: { cancel() {}, speak: utterance => window.__spokenWords.push(utterance.text) }
-        });
-        window.__READING_EXAM_MANIFEST__ = {};
-        window.__READING_EXPLANATION_MANIFEST__ = {};
-        window.__pendingScripts = [];
-        const appendChild = document.head.appendChild.bind(document.head);
-        document.head.appendChild = node => {
-            if (node.tagName === 'SCRIPT' && node.src) {
-                window.__pendingScripts.push(node);
-                return node;
-            }
-            return appendChild(node);
-        };
-        window.__queueOpen = (id, key = id, script = `${id}.js`, options = {}) => {
-            window.__READING_EXAM_MANIFEST__[id] = { examId: id, script };
-            window.__READING_EXPLANATION_MANIFEST__[id] = { examId: id, script: `${id}-explanation.js` };
-            window[key] = window.ReadingVocabReader.open(id, options);
-        };
-        window.__finishScript = (scriptName, id, { error = false, explanation = false, title = id } = {}) => {
-            const index = window.__pendingScripts.findIndex(script => script.src.endsWith(`/${scriptName}`));
-            if (index < 0) throw new Error(`Missing pending script: ${scriptName}`);
-            const [script] = window.__pendingScripts.splice(index, 1);
-            if (error) {
-                script.onerror();
-                return;
-            }
-            if (explanation) {
-                window.__READING_EXPLANATION_DATA__.register(id, {
-                    passageNotes: [{ label: 'Paragraph A', text: title }]
-                });
-            } else {
-                window.__READING_EXAM_DATA__.register(id, {
-                    meta: { title },
-                    passage: { blocks: [{ html: `<div class="paragraph-wrapper"><p><strong>A</strong> This is the <em>${title}</em> passage with enough text for reading.</p></div>` }] },
-                    questionGroups: [{ bodyHtml: `<p>Questions for ${title}</p>` }]
-                });
-            }
-            script.onload();
-        };
-    }, { localWords, canonicalWords, canonicalResult });
-    await page.addScriptTag({ content: readerSource });
-    return page;
-}
 
 test('reading vocab reader preserves text boundaries and the active reading session', async t => {
     const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
@@ -89,14 +17,13 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                 examId: 'exam-a'
             }, {
                 id: 'ordinary-id', word: 'research & development', context: 'A "quoted" context',
-                examTitle: 'Ordinary exam', examId: 'exam-a'
+                examTitle: 'Ordinary exam', examId: 'exam-b'
             }, {
                 id: "alternate-'\"-id", word: '&lt;svg onload=alert(1)&gt;',
-                context: '&#34; & < >', examTitle: 'Title &amp; literal', examId: 'exam-a'
+                context: '&#34; & < >', examTitle: 'Title &amp; literal', examId: 'exam-c'
             }];
-            for (const source of ['local', 'canonical']) {
-                const page = await createPage(browser, source === 'local'
-                    ? { localWords: attacks } : { canonicalWords: attacks });
+            {
+                const page = await createPage(browser, { canonicalWords: attacks });
                 try {
                     const state = await page.evaluate(async () => {
                         await ReadingVocabStore.init();
@@ -104,6 +31,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                         ReadingVocabReader.openModal();
                         const list = document.getElementById('vocab-list');
                         return {
+                            ids: ReadingVocabStore.getAll().map(item => item.id),
                             unsafeNodes: list.querySelectorAll('img, svg, iframe, script, [onclick], [onload], [onerror], [data-extra]').length,
                             rows: [...list.querySelectorAll('.vocab-item')].map(row => ({
                                 id: row.dataset.wordId, word: row.querySelector('.vocab-item__word').textContent,
@@ -114,43 +42,189 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                             }))
                         };
                     });
-                    assert.equal(state.unsafeNodes, 0, `${source} vocabulary must remain inert text`);
-                    assert.deepEqual(state.rows, attacks.map(item => ({
-                        id: item.id, word: item.word, speak: item.word, deleteId: item.id,
+                    assert.equal(state.unsafeNodes, 0, 'Canonical vocabulary must remain inert text');
+                    assert.deepEqual(state.rows, attacks.map((item, index) => ({
+                        id: state.ids[index], word: item.word, speak: item.word, deleteId: state.ids[index],
                         context: `"${item.context}"`, title: item.examTitle
                     })));
                     await page.locator('.vocab-speak-btn').first().click();
                     assert.deepEqual(await page.evaluate(() => window.__spokenWords), [attacks[0].word]);
                     await page.locator('.vocab-delete-btn').first().click();
-                    assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll().map(item => item.id)), attacks.slice(1).map(item => item.id));
+                    await page.waitForFunction(() => ReadingVocabStore.getAll().length === 2);
+                    assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll().map(item => item.id)), state.ids.slice(1));
                     assert.equal(await page.evaluate(() => !!window.__injected), false);
                 } finally { await page.close(); }
             }
         });
 
-        await t.test('canonical empty and smaller vocab lists replace stale local mirrors without saving them back', async () => {
+        await t.test('canonical snapshots replace stale mirrors without touching local vocabulary storage', async () => {
             const localWords = [{ id: 'old', word: 'stale' }, { id: 'new', word: 'current' }];
             for (const canonicalWords of [[], [localWords[1]]]) {
-                const page = await createPage(browser, { localWords, canonicalResult: { data: canonicalWords, envelope: { revision: 2 } } });
+                const page = await createPage(browser, { localWords, canonicalWords });
                 try {
                     const state = await page.evaluate(async () => {
+                        const reads = [], writes = [];
+                        const get = Storage.prototype.getItem;
+                        const set = Storage.prototype.setItem;
+                        Storage.prototype.getItem = function (key) { reads.push(key); return get.call(this, key); };
+                        Storage.prototype.setItem = function (key, value) { writes.push(key); return set.call(this, key, value); };
                         await ReadingVocabStore.init();
-                        return { words: ReadingVocabStore.getAll(), local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: window.__savedWords };
+                        const words = ReadingVocabStore.getAll().map(item => item.word);
+                        Storage.prototype.getItem = get;
+                        Storage.prototype.setItem = set;
+                        return { words, reads, writes, local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: __readingAuthority.calls };
                     });
-                    assert.deepEqual(state, { words: canonicalWords, local: canonicalWords, saves: [] });
+                    assert.deepEqual(state, { words: canonicalWords.map(item => item.word), reads: [], writes: [], local: localWords, saves: [] });
                 } finally { await page.close(); }
             }
         });
 
-        await t.test('absent canonical metadata preserves the only local copy when migration has failed', async () => {
+        await t.test('missing or failed canonical authority rejects initialization and never adopts the legacy mirror', async () => {
             const localWords = [{ id: 'legacy', word: 'preserved' }];
-            const page = await createPage(browser, { localWords, canonicalResult: { data: [], envelope: null } });
+            for (const authority of ['missing', 'failed']) {
+                const page = await createPage(browser, { localWords, authority });
+                try {
+                    const state = await page.evaluate(async () => {
+                        let rejected = false;
+                        try { await ReadingVocabStore.init(); } catch (_) { rejected = true; }
+                        return { rejected, words: ReadingVocabStore.getAll(), local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: __readingAuthority.calls };
+                    });
+                    assert.deepEqual(state, { rejected: true, words: [], local: localWords, saves: [] });
+                } finally { await page.close(); }
+            }
+        });
+
+        await t.test('manual collection waits for acknowledgement and failed retries preserve the entered word', async () => {
+            const page = await createPage(browser);
+            try {
+                await openArticle(page);
+                await page.evaluate(() => {
+                    ReadingVocabReader.openModal();
+                    __readingAuthority.defer = true;
+                });
+                await page.locator('#vocab-manual-input').fill('acknowledged');
+                await page.locator('#vocab-manual-add-btn').click();
+                await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+                assert.equal(await page.locator('#vocab-manual-input').inputValue(), 'acknowledged');
+                assert.equal(await page.evaluate(() => ReadingVocabStore.getAll().length), 0);
+                await page.evaluate(() => __readingAuthority.pending.shift().reject(new Error('Injected quota failure')));
+                await page.waitForFunction(() => document.querySelector('#vocab-toast')?.textContent.includes('失败'));
+                assert.equal(await page.locator('#vocab-manual-input').inputValue(), 'acknowledged');
+                assert.equal(await page.evaluate(() => ReadingVocabStore.getAll().length), 0);
+                await page.locator('#vocab-manual-add-btn').click();
+                await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+                await page.evaluate(() => __readingAuthority.pending.shift().resolve());
+                await page.waitForFunction(() => document.querySelector('#vocab-manual-input').value === '');
+                assert.deepEqual(await page.evaluate(() => ({
+                    words: ReadingVocabStore.getAll().map(item => item.word),
+                    anchors: __readingAuthority.snapshot.reading.occurrences.length,
+                    manual: __readingAuthority.snapshot.reading.associations[0].manual,
+                    optimisticMarks: document.querySelectorAll('mark.vocab-highlight').length
+                })), { words: ['acknowledged'], anchors: 0, manual: true, optimisticMarks: 0 });
+            } finally { await page.close(); }
+        });
+
+        await t.test('selection failure removes the temporary mark and retry acknowledges one exact occurrence', async () => {
+            const page = await createPage(browser);
+            try {
+                await openArticle(page, 'article', 'water water water');
+                await page.evaluate(() => {
+                    __readingAuthority.defer = true;
+                    __selectText('#vocab-passage-content em', 'water', 1);
+                    document.querySelector('#vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
+                });
+                await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+                assert.equal(await page.evaluate(() => ReadingVocabStore.getAll().length), 0);
+                await page.evaluate(() => __readingAuthority.pending.shift().reject(new Error('Injected transaction abort')));
+                await page.waitForFunction(() => document.querySelector('#vocab-toast')?.textContent.includes('失败'));
+                assert.equal(await page.locator('mark.vocab-highlight').count(), 0);
+                assert.equal(await page.evaluate(() => __readingAuthority.snapshot.reading.occurrences.length), 0);
+                assert.match(await page.locator('#vocab-toast').textContent(), /重新|重试/);
+                await page.evaluate(() => {
+                    __selectText('#vocab-passage-content em', 'water', 1);
+                    document.querySelector('#vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
+                });
+                await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+                await page.evaluate(() => __readingAuthority.pending.shift().resolve());
+                await page.waitForFunction(() => ReadingVocabStore.getAll().length === 1);
+                assert.equal(await page.locator('mark.vocab-highlight').count(), 1);
+                const saved = await page.evaluate(() => __readingAuthority.snapshot.reading.occurrences[0]);
+                assert.equal(saved.quote, 'water');
+                assert.equal(saved.endOffset - saved.startOffset, 5);
+                assert.equal(await page.evaluate(() => __readingAuthority.snapshot.reading.occurrences.length), 1);
+                await page.evaluate(() => ReadingVocabReader.applyVocabHighlights());
+                assert.equal(await page.locator('mark.vocab-highlight').count(), 1);
+                assert.deepEqual(await page.evaluate(() => {
+                    const mark = document.querySelector('#vocab-passage-content em mark');
+                    return { text: mark.textContent, before: mark.previousSibling.textContent, after: mark.nextSibling.textContent };
+                }), { text: 'water', before: 'water ', after: ' water' });
+            } finally { await page.close(); }
+        });
+
+        await t.test('failed delete and clear preserve the visible collection until a durable retry succeeds', async () => {
+            const page = await createPage(browser);
+            try {
+                await openArticle(page);
+                await page.evaluate(async () => {
+                    await ReadingVocabStore.add('retained', 'article', 'article');
+                    ReadingVocabReader.openModal();
+                    __readingAuthority.fault = 'Injected storage failure';
+                });
+                for (const button of ['.vocab-delete-btn', '#vocab-clear-btn']) {
+                    await page.locator(button).click();
+                    await page.waitForFunction(() => document.querySelector('#vocab-toast')?.textContent.includes('失败'));
+                    assert.equal(await page.locator('.vocab-item').count(), 1);
+                    assert.deepEqual(await page.evaluate(() => ReadingVocabStore.getAll().map(item => item.word)), ['retained']);
+                }
+                await page.evaluate(() => { __readingAuthority.fault = null; });
+                await page.locator('#vocab-clear-btn').click();
+                await page.waitForFunction(() => ReadingVocabStore.getAll().length === 0);
+                assert.equal(await page.locator('.vocab-item').count(), 0);
+            } finally { await page.close(); }
+        });
+
+        await t.test('identical exam IDs stay isolated by library and current-article clear preserves the other library', async () => {
+            const page = await createPage(browser);
             try {
                 const state = await page.evaluate(async () => {
+                    const a = { kind: 'imported', id: 'library-a' };
+                    const b = { kind: 'imported', id: 'library-b' };
                     await ReadingVocabStore.init();
-                    return { words: ReadingVocabStore.getAll(), local: JSON.parse(localStorage.getItem('ielts_reading_vocab_words_v1')), saves: window.__savedWords };
+                    await ReadingVocabStore.add('apple', 'same-exam', 'Library A', '', null, a);
+                    await ReadingVocabStore.add('apple', 'same-exam', 'Library B', '', null, b);
+                    const before = {
+                        all: ReadingVocabStore.getAll().length,
+                        a: ReadingVocabStore.getByExam('same-exam', a).length,
+                        b: ReadingVocabStore.getByExam('same-exam', b).length,
+                        builtin: ReadingVocabStore.getByExam('same-exam').length
+                    };
+                    await ReadingVocabStore.clear('same-exam', a);
+                    return { before, a: ReadingVocabStore.getByExam('same-exam', a).length, b: ReadingVocabStore.getByExam('same-exam', b).length };
                 });
-                assert.deepEqual(state, { words: localWords, local: localWords, saves: [] });
+                assert.deepEqual(state, { before: { all: 1, a: 1, b: 1, builtin: 0 }, a: 0, b: 1 });
+            } finally { await page.close(); }
+        });
+
+        await t.test('unsupported imported source cannot record a visit or collect builtin passage content', async () => {
+            const page = await createPage(browser);
+            try {
+                await openArticle(page);
+                await page.evaluate(async () => {
+                    await ReadingVocabStore.add('retained', 'article', 'Builtin article');
+                    window.__beforeUnsupported = __readingAuthority.calls.length;
+                    await ReadingVocabReader.open('article', { source: { kind: 'imported', id: 'missing-library' } });
+                    ReadingVocabReader.openModal();
+                });
+                await page.locator('#vocab-manual-input').fill('not-collected');
+                await page.locator('#vocab-manual-add-btn').click();
+                const state = await page.evaluate(() => ({
+                    words: ReadingVocabStore.getAll().map(item => item.word),
+                    payload: ReadingVocabReader.currentPayload,
+                    writes: __readingAuthority.calls.length - __beforeUnsupported,
+                    error: !!document.querySelector('.vocab-error-state'),
+                    retainedInput: document.querySelector('#vocab-manual-input').value
+                }));
+                assert.deepEqual(state, { words: ['retained'], payload: null, writes: 0, error: true, retainedInput: 'not-collected' });
             } finally { await page.close(); }
         });
 
@@ -158,7 +232,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
             const page = await createPage(browser);
             try {
                 const state = await page.evaluate(async () => {
-                    __queueOpen('metadata', '__openMetadata');
+                    await __queueOpen('metadata', '__openMetadata');
                     __READING_EXAM_DATA__.register('metadata', {
                         meta: { title: 'Ordinary article', category: '<img src=x onerror="window.__injected=true">', frequency: '&lt;svg&gt; & "quoted"' },
                         passage: { blocks: [{ html: '<p><strong>A</strong> A sufficiently long <em>formatted</em> passage for reading.</p>' }] }
@@ -181,8 +255,8 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                 const page = await createPage(browser);
                 try {
                     const state = await page.evaluate(async error => {
-                        __queueOpen('a', '__openA');
-                        __queueOpen('b', '__openB');
+                        await __queueOpen('a', '__openA');
+                        await __queueOpen('b', '__openB');
                         __finishScript('b.js', 'b');
                         await __openB;
                         __finishScript('a.js', 'a', { error });
@@ -204,11 +278,11 @@ test('reading vocab reader preserves text boundaries and the active reading sess
             const page = await createPage(browser);
             try {
                 const state = await page.evaluate(async () => {
-                    __queueOpen('a', '__openA');
+                    await __queueOpen('a', '__openA');
                     __finishScript('a.js', 'a');
                     await __openA;
                     ReadingVocabReader.currentExplanation = { passageNotes: [{ label: 'Paragraph A', text: 'old cached translation' }] };
-                    __queueOpen('b', '__openB');
+                    await __queueOpen('b', '__openB');
                     const cleared = ReadingVocabReader.currentPayload === null && ReadingVocabReader.currentExam === null && ReadingVocabReader.currentExplanation === null;
                     __finishScript('b.js', 'b');
                     await __openB;
@@ -229,7 +303,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
             const page = await createPage(browser);
             try {
                 const state = await page.evaluate(async () => {
-                    __queueOpen('a', '__openA');
+                    await __queueOpen('a', '__openA');
                     __finishScript('a.js', 'a');
                     await __openA;
                     ReadingVocabReader.switchViewTab('questions');
@@ -245,14 +319,14 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     const queueCapture = () => document.getElementById('vocab-reader-body').dispatchEvent(new MouseEvent('mouseup'));
                     select('#vocab-passage-content em');
                     queueCapture();
-                    __queueOpen('b', '__openB');
+                    await __queueOpen('b', '__openB');
                     __finishScript('b.js', 'b');
                     await __openB;
                     select('#vocab-passage-content em');
                     callbacks.shift()();
                     const staleCount = ReadingVocabStore.getAll().length;
                     queueCapture();
-                    callbacks.shift()();
+                    await callbacks.shift()();
                     const currentWords = ReadingVocabStore.getAll().map(item => ({ word: item.word, examId: item.examId }));
                     select('#vocab-passage-content strong');
                     queueCapture();
@@ -274,7 +348,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                 const page = await createPage(browser);
                 try {
                     const state = await page.evaluate(async error => {
-                        __queueOpen('a', '__openA');
+                        await __queueOpen('a', '__openA');
                         ReadingVocabReader.openModal();
                         ReadingVocabReader.close();
                         const before = document.getElementById('vocab-passage-content').innerHTML;
@@ -294,7 +368,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
             const page = await createPage(browser);
             try {
                 const state = await page.evaluate(async () => {
-                    __queueOpen('a', '__openA');
+                    await __queueOpen('a', '__openA');
                     __finishScript('a.js', 'a');
                     await __openA;
                     ReadingVocabReader.close();
@@ -304,9 +378,9 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     await Promise.resolve();
                     const closedUnchanged = before === document.getElementById('vocab-trans-text-A').textContent;
                     __READING_EXAM_DATA__.clear();
-                    __queueOpen('a', '__oldOpen', 'old-a.js');
+                    await __queueOpen('a', '__oldOpen', 'old-a.js');
                     ReadingVocabReader.close();
-                    __queueOpen('a', '__newOpen', 'new-a.js');
+                    await __queueOpen('a', '__newOpen', 'new-a.js');
                     __finishScript('new-a.js', 'a', { title: 'new article' });
                     await __newOpen;
                     __finishScript('old-a.js', 'a', { title: 'stale article' });
@@ -323,7 +397,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                 const state = await page.evaluate(async () => {
                     const id = "exam');window.__injected=true;//";
                     const scriptName = 'missing-<img src=x onerror=alert(1)>.js';
-                    __queueOpen(id, '__failed', scriptName, { fromPractice: true });
+                    await __queueOpen(id, '__failed', scriptName, { fromPractice: true });
                     const script = __pendingScripts.shift();
                     // Preserve the raw malicious manifest text in the loader's error message.
                     script.onerror();

--- a/developer/tests/js/readingVocabularyBackupMembership.test.js
+++ b/developer/tests/js/readingVocabularyBackupMembership.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+// Exercise full backup import through production AppData and actual IndexedDB.
+const scripts = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js', 'data/practiceRecordSource.js',
+    'data/v2/readingVocabularyModel.js', 'data/v2/appData.js'
+].map((name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8'));
+const AT = '2026-09-08T01:00:00.000Z';
+const SOURCE = { kind: 'imported', id: 'membership-backup-library' };
+const word = (id, repetitions, grade) => ({
+    id, word: 'apple', meaning: `Definition for ${id}`, note: `Progress ${repetitions}`,
+    easeFactor: 2.3, interval: repetitions * 3, repetitions, correctCount: repetitions + 1,
+    lastReviewed: AT, nextReview: '2026-09-29T01:00:00.000Z',
+    reviewHistory: [{ at: AT, grade }]
+});
+const incomingWords = [word('shared-apple-id', 2, 2)];
+const incomingLists = {
+    custom: { id: 'custom', name: 'Personal words', words: [word('shared-apple-id', 4, 3)] },
+    'spelling-errors': { id: 'spelling-errors', name: 'Spelling errors', words: [word('spelling-apple', 6, 4)] }
+};
+
+async function loadAppData(page) {
+    for (const content of scripts) await page.addScriptTag({ content });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+
+async function snapshot(page) {
+    return page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+}
+
+async function seed(page, words, lists, owner, examId) {
+    await page.evaluate(async ({ words, lists, owner, examId, source, at }) => {
+        await AppData.vocab.saveWords(words);
+        await AppData.vocab.saveCollections(lists);
+        await AppData.vocab.mutateReading('collect', {
+            source, article: { examId, title: examId }, word: { word: 'apple' }, wordRef: owner, at,
+            occurrence: { scopeId: 'passage-1', contentVersion: 'membership-fixture-v1',
+                startOffset: 0, endOffset: 5, quote: 'apple' }
+        });
+    }, { words, lists, owner, examId, source: SOURCE, at: AT });
+}
+
+async function mergeBackup(page, backup) {
+    const receipt = await page.evaluate(async (backup) => {
+        const plan = await AppData.backups.previewImport(backup);
+        return AppData.backups.commitImport(plan.id);
+    }, backup);
+    assert.equal(receipt.committed, true);
+}
+
+test('full backup merge preserves same-term list memberships and per-list review history in IndexedDB', { timeout: 60000 }, async (t) => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Vocabulary backup membership integration</title>');
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+    });
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+    async function pageFor(t) {
+        const context = await browser.newContext();
+        t.after(() => context.close());
+        const page = await context.newPage();
+        await page.goto(url);
+        await loadAppData(page);
+        return page;
+    }
+
+    const exporter = await pageFor(t);
+    await seed(exporter, incomingWords, incomingLists,
+        { listId: 'spelling-errors', wordId: 'spelling-apple' }, 'imported-article');
+    const backup = await exporter.evaluate(() => AppData.backups.export());
+    assert.equal(backup.scope, 'full');
+
+    for (const hasLocalProgress of [false, true]) {
+        await t.test(hasLocalProgress ? 'existing list progress and explicit local owner survive'
+            : 'an empty installation retains all incoming lists and its explicit owner', async (t) => {
+            const page = await pageFor(t);
+            const localWords = [word('shared-apple-id', 12, 5)];
+            const localLists = { custom: { id: 'custom', name: 'Local personal words',
+                words: [word('shared-apple-id', 14, 5)] } };
+            if (hasLocalProgress) {
+                await seed(page, localWords, localLists,
+                    { listId: 'custom', wordId: 'shared-apple-id' }, 'local-article');
+            }
+            await mergeBackup(page, backup);
+            const merged = await snapshot(page);
+            assert.deepEqual(merged.words, hasLocalProgress ? localWords : incomingWords);
+            assert.deepEqual(merged.lists.custom, hasLocalProgress ? localLists.custom : incomingLists.custom);
+            assert.deepEqual(merged.lists['spelling-errors'], incomingLists['spelling-errors']);
+            assert.equal(merged.reading.terms.length, 1);
+            assert.equal(merged.reading.associations.length, hasLocalProgress ? 2 : 1);
+            assert.equal(merged.reading.occurrences.length, hasLocalProgress ? 2 : 1);
+            assert.deepEqual(merged.reading.terms[0].wordRef, hasLocalProgress
+                ? { listId: 'custom', wordId: 'shared-apple-id' }
+                : { listId: 'spelling-errors', wordId: 'spelling-apple' });
+
+            await mergeBackup(page, backup);
+            assert.deepEqual(await snapshot(page), merged, 'repeated merge preserves records and progress exactly');
+
+            // Independently reviewing an imported non-default membership must
+            // remain authoritative when the original backup is imported again.
+            await page.evaluate(async () => {
+                await AppData.vocab.patchWord({ listId: 'spelling-errors', wordId: 'spelling-apple', patch: {
+                    repetitions: 20, interval: 60, reviewHistory: [{ at: '2026-09-08T02:00:00.000Z', grade: 5 }]
+                } });
+            });
+            const reviewed = await snapshot(page);
+            assert.equal(reviewed.lists['spelling-errors'].words[0].repetitions, 20);
+            await mergeBackup(page, backup);
+            assert.deepEqual(await snapshot(page), reviewed, 'backup cannot roll back a separately reviewed membership');
+
+            await page.reload();
+            await loadAppData(page);
+            assert.deepEqual(await snapshot(page), reviewed, 'all memberships persist after reopening IndexedDB');
+            const exported = await page.evaluate(() => AppData.backups.export());
+            assert.deepEqual(exported.envelopes['vocab.words'].data, reviewed.words);
+            assert.deepEqual(exported.envelopes['vocab.lists'].data, reviewed.lists);
+        });
+    }
+});

--- a/developer/tests/js/readingVocabularyModel.test.js
+++ b/developer/tests/js/readingVocabularyModel.test.js
@@ -399,6 +399,74 @@ test('legacy array-shaped lists remain valid canonical owners through serializat
     assert.equal(query(snapshot).distinctTermCount, 0);
 });
 
+test('backup merge preserves independent same-term vocabulary memberships and the incoming explicit reader owner', () => {
+    const customApple = { ...APPLE, meaning: 'Personal definition', repetitions: 2,
+        reviewHistory: [{ at: AT, grade: 2 }] };
+    const spellingApple = { ...APPLE, id: 'spelling-apple', word: 'APPLE', repetitions: 4,
+        reviewHistory: [{ at: AT, grade: 3 }] };
+    const anotherCustomApple = { ...APPLE, id: 'another-custom-apple', note: 'Independent record in the same list' };
+    const incoming = mutate('collect', model.createSnapshot({
+        words: [APPLE],
+        lists: {
+            custom: [customApple, anotherCustomApple],
+            'spelling-errors': { id: 'spelling-errors', name: 'Spelling errors', words: [spellingApple] }
+        }
+    }), command({ wordRef: { listId: 'spelling-errors', wordId: spellingApple.id } }));
+    const merged = mutate('merge', model.createSnapshot(), incoming);
+    assert.deepEqual(plain(merged.words), [APPLE]);
+    assert.deepEqual(plain(merged.lists), plain(incoming.lists));
+    assert.deepEqual(plain(query(merged).terms[0].wordRef), { listId: 'spelling-errors', wordId: spellingApple.id });
+    assert.deepEqual(plain(query(merged).terms[0].word.reviewHistory), spellingApple.reviewHistory);
+    assert.deepEqual(plain(mutate('merge', merged, incoming)), plain(merged), 'repeated merge retains every record exactly once');
+});
+
+test('backup merge keeps local per-list progress and reader ownership while importing other same-term records', () => {
+    const localCustom = { ...APPLE, id: 'custom-apple', meaning: 'Local custom definition', repetitions: 12,
+        reviewHistory: [{ at: LATER, grade: 5 }] };
+    const existing = mutate('collect', model.createSnapshot({
+        words: [APPLE], lists: { custom: { id: 'custom', name: 'Local list', words: [localCustom] } }
+    }), command({ wordRef: { listId: 'custom', wordId: localCustom.id } }));
+    const importedDefault = { ...APPLE, repetitions: 0, reviewHistory: [] };
+    const importedCustom = { ...localCustom, repetitions: 0, reviewHistory: [] };
+    const importedSpelling = { ...APPLE, id: 'spelling-apple', repetitions: 3,
+        reviewHistory: [{ at: AT, grade: 1 }] };
+    const incoming = mutate('collect', model.createSnapshot({
+        words: [importedDefault], lists: {
+            custom: { id: 'custom', words: [importedCustom] },
+            'spelling-errors': { id: 'spelling-errors', words: [importedSpelling] }
+        }
+    }), command({ source: SOURCE_B }));
+    const merged = mutate('merge', existing, incoming);
+    assert.deepEqual(plain(merged.words), [APPLE]);
+    assert.deepEqual(plain(merged.lists.custom), plain(existing.lists.custom));
+    assert.deepEqual(plain(merged.lists['spelling-errors'].words), [importedSpelling]);
+    assert.deepEqual(plain(query(merged).terms[0].wordRef), { listId: 'custom', wordId: localCustom.id });
+    assert.equal(merged.reading.terms.length, 1);
+    assert.equal(merged.reading.associations.length, 2);
+    assert.deepEqual(plain(mutate('merge', merged, incoming)), plain(merged));
+});
+
+test('backup merge remaps list-scoped ID collisions and reuses the same imported owner after review and retry', () => {
+    const collisionId = 'shared-record-id';
+    const existing = model.createSnapshot({ lists: { custom: [{ ...APPLE, id: collisionId }] } });
+    const incomingPear = { ...APPLE, id: collisionId, word: 'pear', meaning: 'Another fruit' };
+    const incoming = mutate('collect', model.createSnapshot({ lists: { custom: [incomingPear] } }), command({
+        word: { word: 'pear' }, occurrence: undefined, wordRef: { listId: 'custom', wordId: collisionId }
+    }));
+    const merged = mutate('merge', existing, incoming);
+    assert.equal(merged.lists.custom.length, 2);
+    assert.deepEqual(plain(merged.lists.custom[0]), plain(existing.lists.custom[0]));
+    const importedRef = query(merged).terms[0].wordRef;
+    assert.equal(importedRef.listId, 'custom');
+    assert.notEqual(importedRef.wordId, collisionId);
+    assert.equal(query(merged).terms[0].word.word, 'pear');
+    const reviewed = plain(merged);
+    reviewed.lists.custom[1].repetitions = 10;
+    reviewed.lists.custom[1].reviewHistory.push({ at: LATER, grade: 5 });
+    assert.deepEqual(plain(mutate('merge', reviewed, incoming)), reviewed,
+        'retry must resolve the original collision to the existing renamed record without replacing progress');
+});
+
 test('explicit global deletion cascades all reader relationships and same-term vocabulary rows, preserving other terms and visits', () => {
     const pear = { id: 'pear', word: 'pear', meaning: 'Another fruit', interval: 12 };
     let snapshot = twoArticles({

--- a/developer/tests/js/readingVocabularyPersistence.test.js
+++ b/developer/tests/js/readingVocabularyPersistence.test.js
@@ -222,6 +222,48 @@ test('reading vocabulary operations are durable, atomic and backup-safe in real 
         });
     }
 
+    for (const removal of ['removeOccurrence', 'removeArticleTerm', 'clearArticle', 'deleteCanonicalTerm',
+        'removeTermAssociations', 'clearReading', 'removeArticle']) {
+        await t.test(`${removal} rejects an old generation and a pending deletion across replacement`, async (t) => {
+            const [stale, writer] = await pages(t, 2);
+            const [donor] = await pages(t);
+            await collect(writer, command('apple'));
+            await collect(donor, command('apple'));
+            await collect(donor, command('banana'));
+            const restored = await snapshot(donor);
+            const backup = await donor.evaluate(() => AppData.backups.export());
+            const observed = await stale.evaluate(() => AppData.vocab.getReadingSnapshot());
+            const input = {
+                articleId: observed.snapshot.reading.articles[0].id,
+                termId: observed.snapshot.reading.terms[0].id,
+                occurrenceId: observed.snapshot.reading.occurrences[0].id,
+                clearWords: true, at: AT
+            };
+            await startPausedOperation(stale, removal, { ...input, operationId: `pending-delete-${removal}` });
+            assert.equal((await importSnapshot(writer, backup, true)).committed, true);
+            const pending = await releaseCollect(stale);
+            assert.equal(pending.error?.code, 'CONFLICT', 'a pending deletion must not replay against restored data');
+            assert.equal(pending.error?.committed, false);
+            assert.deepEqual(await snapshot(writer), restored);
+
+            const oldGeneration = await stale.evaluate(async ({ removal, input, observed }) => {
+                try {
+                    return { receipt: await AppData.vocab.mutateReading(removal, input, {
+                        observedRevision: observed.revision, observedGeneration: observed.generation
+                    }) };
+                } catch (error) { return { code: error.code, committed: error.committed }; }
+            }, { removal, input, observed });
+            assert.deepEqual(oldGeneration, { code: 'CONFLICT', committed: false });
+            assert.deepEqual(await snapshot(writer), restored, 'explicit stale observation cannot remove any restored records');
+            await stale.reload();
+            await loadAppData(stale);
+            assert.deepEqual(await snapshot(stale), restored, 'rejected commands leave durable data intact');
+            const fresh = await stale.evaluate(({ removal, input }) => AppData.vocab.mutateReading(removal, input), { removal, input });
+            assert.equal(fresh.committed, true, 'a refreshed deletion can still be acknowledged');
+            assert.notDeepEqual(await snapshot(writer), restored);
+        });
+    }
+
     await t.test('removing an article and its vocabulary commits together and fences an already pending bookshelf visit', async (t) => {
         const [stale, writer] = await pages(t, 2);
         await collect(writer, command('apple', SOURCE_A));

--- a/developer/tests/js/readingVocabularyPersistence.test.js
+++ b/developer/tests/js/readingVocabularyPersistence.test.js
@@ -1,0 +1,612 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+// Production AppData and DataKernel execute in Chromium against actual IndexedDB.
+// Faults intercept only a transaction boundary; there is no in-memory kernel.
+const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const scripts = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js',
+    'data/practiceRecordSource.js', 'data/v2/readingVocabularyModel.js'
+].map(source);
+const appDataSource = source('data/v2/appData.js');
+const AT = '2026-09-08T01:00:00.000Z';
+const SOURCE_A = { kind: 'imported', id: 'library-a' };
+const SOURCE_B = { kind: 'imported', id: 'library-b' };
+const ARTICLE = { examId: 'shared-exam', title: 'The same exam in independent libraries' };
+const REVIEWED_APPLE = {
+    id: 'reviewed-apple', word: 'apple', meaning: 'My definition', note: 'My note',
+    phonetic: 'æpəl', easeFactor: 2.3, repetitions: 7, interval: 21,
+    correctCount: 9, lastReviewed: '2026-09-01T01:00:00.000Z',
+    nextReview: '2026-09-22T01:00:00.000Z',
+    reviewHistory: [{ at: '2026-09-01T01:00:00.000Z', grade: 4 }]
+};
+const command = (word, sourceIdentity = SOURCE_A, extra = {}) => ({
+    source: sourceIdentity, article: ARTICLE, word: { word, meaning: `Definition of ${word}` }, at: AT,
+    occurrence: {
+        scopeId: 'passage-1', contentVersion: 'sha256:fixture-v1',
+        startOffset: 10, endOffset: 10 + word.length, quote: word,
+        before: 'A ', after: ' grows here.'
+    }, ...extra
+});
+
+async function loadAppData(page, { fault = null, seedBackup = null } = {}) {
+    for (const content of scripts) await page.addScriptTag({ content });
+    await page.evaluate((fault) => {
+        const internals = window.__AppDataV2Internals;
+        window.readingTest = { internals, fault, writes: [], attempts: 0, blocked: false, installCalls: 0 };
+        const prototype = internals.DataKernel.prototype;
+        const mutate = prototype.mutate;
+        prototype.mutate = async function (changes, options = {}) {
+            const control = window.readingTest;
+            if (control.pauseOperation === options.operationId) {
+                control.attempts += 1;
+                if (!control.blocked) {
+                    control.blocked = true;
+                    await new Promise((resolve) => { control.release = resolve; });
+                }
+            }
+            return mutate.call(this, changes, options);
+        };
+        const install = prototype.installSnapshot;
+        prototype.installSnapshot = function (...args) {
+            window.readingTest.installCalls += 1;
+            return install.apply(this, args);
+        };
+        const put = IDBObjectStore.prototype.put;
+        IDBObjectStore.prototype.put = function (value, ...args) {
+            const control = window.readingTest;
+            const matches = control.fault && (value?.envelope?.operationId === control.fault.operationId
+                || (control.fault.operationPrefix && value?.envelope?.operationId?.startsWith(control.fault.operationPrefix)));
+            if (matches) {
+                control.writes.push(value.logicalKey);
+                if (value.logicalKey === control.fault.failKey || control.writes.length === control.fault.afterWrites) {
+                    if (control.fault.kind === 'abort') {
+                        this.transaction.abort();
+                        throw new DOMException('Injected transaction abort', 'AbortError');
+                    }
+                    throw new DOMException('Injected storage quota failure', 'QuotaExceededError');
+                }
+            }
+            return put.call(this, value, ...args);
+        };
+    }, fault);
+    if (seedBackup) await page.evaluate(async (backup) => {
+        const kernel = new window.readingTest.internals.DataKernel();
+        await kernel.initialize();
+        await kernel.mutate([{ logicalKey: 'backups.entries', data: [backup] }], { operationId: 'seed-existing-backup' });
+        kernel.close();
+    }, seedBackup);
+    await page.addScriptTag({ content: appDataSource });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+
+async function collect(page, input) {
+    return page.evaluate(({ operationId, ...input }) => AppData.vocab.mutateReading('collect', input, { operationId }), input);
+}
+
+async function snapshot(page) {
+    return page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+}
+
+async function importSnapshot(page, data, replace = false) {
+    return page.evaluate(async ({ data, replace }) => {
+        const plan = await AppData.backups.previewImport(data, { replace });
+        return AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+    }, { data, replace });
+}
+
+async function startPausedCollect(page, input) {
+    return startPausedOperation(page, 'collect', input);
+}
+
+async function startPausedOperation(page, type, input) {
+    await page.evaluate(({ type, input: { operationId, ...input } }) => {
+        window.readingTest.pauseOperation = operationId;
+        window.pendingReadingOperation = AppData.vocab.mutateReading(type, input, { operationId }).then(
+            (receipt) => { window.readingTest.finished = true; return { receipt }; },
+            (error) => { window.readingTest.finished = true; return { error: { code: error.code, committed: error.committed, message: error.message } }; }
+        );
+    }, { type, input });
+    await page.waitForFunction(() => window.readingTest.blocked || window.readingTest.finished);
+    if (!await page.evaluate(() => window.readingTest.blocked)) {
+        assert.fail(`The intended transaction boundary was never reached: ${JSON.stringify(await page.evaluate(() => window.pendingReadingOperation))}`);
+    }
+}
+
+async function releaseCollect(page) {
+    return page.evaluate(async () => {
+        window.readingTest.release();
+        return window.pendingReadingOperation;
+    });
+}
+
+async function durableRow(page, store, key) {
+    return page.evaluate(({ store, key }) => new Promise((resolve, reject) => {
+        const open = indexedDB.open('IELTSAtlasDataV2');
+        open.onerror = () => reject(open.error);
+        open.onsuccess = () => {
+            const database = open.result;
+            const get = database.transaction(store, 'readonly').objectStore(store).get(key);
+            get.onsuccess = () => { database.close(); resolve(get.result || null); };
+            get.onerror = () => { database.close(); reject(get.error); };
+        };
+    }), { store, key });
+}
+
+test('reading vocabulary operations are durable, atomic and backup-safe in real browser pages', { timeout: 180000 }, async (t) => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Reading vocabulary persistence integration</title>');
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+    });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+
+    async function pages(t, count = 1, options = {}) {
+        const context = await browser.newContext();
+        t.after(() => context.close());
+        const result = [];
+        for (let index = 0; index < count; index += 1) {
+            const page = await context.newPage();
+            await page.goto(url);
+            if (options.legacy) await page.evaluate((legacy) => {
+                for (const [key, value] of Object.entries(legacy)) localStorage.setItem(key, value);
+            }, options.legacy);
+            await loadAppData(page, options);
+            result.push(page);
+        }
+        return result;
+    }
+
+    await t.test('two stale readers keep apple and banana with both source associations after a real conflict', async (t) => {
+        const [stale, writer] = await pages(t, 2);
+        assert.deepEqual(await snapshot(stale), await snapshot(writer));
+        await startPausedCollect(stale, command('apple', SOURCE_A, { operationId: 'stale-apple' }));
+        const banana = await collect(writer, command('banana', SOURCE_B, { operationId: 'fresh-banana' }));
+        assert.equal(banana.committed, true);
+        const apple = await releaseCollect(stale);
+        assert.equal(apple.receipt?.committed, true, apple.error?.message);
+        assert.ok(await stale.evaluate(() => window.readingTest.attempts) >= 2, 'the stale snapshot encountered a real revision conflict');
+        const actual = await snapshot(writer);
+        assert.deepEqual(actual.reading.terms.map((row) => row.normalizedTerm).sort(), ['apple', 'banana']);
+        assert.equal(actual.reading.associations.length, 2);
+        assert.equal(actual.reading.occurrences.length, 2);
+        assert.deepEqual(actual.reading.sources.map((row) => row.libraryId).sort(), ['library-a', 'library-b']);
+        assert.equal(actual.reading.visits.length, 2, 'collect and required bookshelf visit commit together');
+        await stale.reload();
+        await loadAppData(stale);
+        assert.deepEqual(await snapshot(stale), actual, 'a cold page reads both committed commands');
+    });
+
+    for (const removal of ['removeArticleTerm', 'clearArticle', 'clearReading']) {
+        await t.test(`${removal} wins over an already pending collection, while a fresh collection can be acknowledged`, async (t) => {
+            const [stale, writer] = await pages(t, 2);
+            await collect(writer, command('apple', SOURCE_A, { operationId: `seed-${removal}` }));
+            await collect(writer, command('apple', SOURCE_B, { operationId: `other-${removal}` }));
+            await startPausedCollect(stale, command('apple', SOURCE_A, {
+                operationId: `delayed-${removal}`,
+                occurrence: { ...command('apple').occurrence, startOffset: 30, endOffset: 35 }
+            }));
+            const removed = await writer.evaluate(async ({ removal, source, examId }) => {
+                const model = AppData.vocab.readingModel;
+                return AppData.vocab.mutateReading(removal, {
+                    articleId: model.articleId(source, examId), termId: model.termId('apple')
+                }, { operationId: `remove-${removal}` });
+            }, { removal, source: SOURCE_A, examId: ARTICLE.examId });
+            assert.equal(removed.committed, true);
+            const result = await releaseCollect(stale);
+            assert.equal(result.error?.code, 'CONFLICT', 'stale collect must require an explicit refreshed intent');
+            assert.equal(result.error?.committed, false);
+            const after = await snapshot(writer);
+            const articleA = after.reading.articles.find((row) => row.sourceId === after.reading.sources.find((row) => row.libraryId === SOURCE_A.id)?.id);
+            assert.equal(after.reading.associations.filter((row) => row.articleId === articleA?.id).length, 0);
+            assert.equal(after.reading.associations.length, removal === 'clearReading' ? 0 : 1, 'article deletion leaves the other source independent');
+            assert.equal(after.reading.visits.length, 2, 'clearing vocabulary retains visits');
+            const fresh = await collect(stale, command('apple', SOURCE_A, { operationId: `fresh-${removal}` }));
+            assert.equal(fresh.committed, true);
+            assert.equal((await snapshot(writer)).reading.associations.length, removal === 'clearReading' ? 1 : 2);
+        });
+    }
+
+    await t.test('removing an article and its vocabulary commits together and fences an already pending bookshelf visit', async (t) => {
+        const [stale, writer] = await pages(t, 2);
+        await collect(writer, command('apple', SOURCE_A));
+        await collect(writer, command('apple', SOURCE_B));
+        await startPausedOperation(stale, 'recordVisit', {
+            source: SOURCE_A, article: ARTICLE, at: AT, operationId: 'delayed-visit'
+        });
+        const removal = await writer.evaluate(({ source, examId }) => AppData.vocab.mutateReading('removeArticle', {
+            articleId: AppData.vocab.readingModel.articleId(source, examId), clearWords: true
+        }), { source: SOURCE_A, examId: ARTICLE.examId });
+        assert.equal(removal.committed, true);
+        const result = await releaseCollect(stale);
+        assert.equal(result.error?.code, 'CONFLICT');
+        const after = await snapshot(writer);
+        assert.equal(after.reading.visits.length, 1);
+        assert.equal(after.reading.associations.length, 1);
+        assert.equal(after.reading.occurrences.length, 1);
+        const remaining = after.reading.articles.find((row) => row.id === after.reading.visits[0].articleId);
+        assert.equal(after.reading.sources.find((row) => row.id === remaining.sourceId).libraryId, SOURCE_B.id);
+        assert.equal((await stale.evaluate(({ source, article, at }) => AppData.vocab.mutateReading('recordVisit', {
+            source, article, at
+        }), { source: SOURCE_A, article: ARTICLE, at: AT })).committed, true);
+        const revisited = await snapshot(writer);
+        assert.equal(revisited.reading.visits.length, 2, 'a newly acknowledged visit restores the zero-word bookshelf entry');
+        assert.equal(revisited.reading.associations.length, 1, 'visiting alone does not resurrect removed vocabulary');
+    });
+
+    await t.test('same-term A/B backup merge retains associations and occurrences, local review progress and retry idempotence', async (t) => {
+        const [articleA] = await pages(t);
+        const [articleB] = await pages(t);
+        await articleA.evaluate((word) => AppData.vocab.saveWords([word]), REVIEWED_APPLE);
+        await collect(articleA, command('apple', SOURCE_A, { operationId: 'backup-article-a' }));
+        await collect(articleB, command('apple', SOURCE_B, { operationId: 'backup-article-b' }));
+        const backupB = await articleB.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+        assert.equal((await importSnapshot(articleA, backupB)).committed, true);
+        const merged = await snapshot(articleA);
+        assert.equal(merged.reading.terms.length, 1, 'same normalized term retains one canonical owner');
+        assert.equal(merged.reading.associations.length, 2);
+        assert.equal(merged.reading.occurrences.length, 2);
+        assert.equal(merged.reading.visits.length, 2);
+        assert.deepEqual(merged.words, [REVIEWED_APPLE], 'an imported definition and schedule cannot replace local review history');
+        assert.equal(merged.reading.terms[0].wordRef.wordId, REVIEWED_APPLE.id);
+        assert.equal((await importSnapshot(articleA, backupB)).committed, true);
+        assert.deepEqual(await snapshot(articleA), merged, 'repeated merge does not duplicate or change reading data');
+        await articleA.reload();
+        await loadAppData(articleA);
+        assert.deepEqual(await snapshot(articleA), merged);
+    });
+
+    for (const removal of ['deleteCanonicalTerm', 'clearArticle', 'removeArticle']) {
+        await t.test(`${removal} remains effective when an older backup is merged, without deleting unrelated visits or associations`, async (t) => {
+            const [page] = await pages(t);
+            const oldClock = removal === 'deleteCanonicalTerm' ? { at: '2099-01-01T00:00:00.000Z' } : {};
+            const initialCollection = command('apple', SOURCE_A, { ...oldClock, operationId: `initial-${removal}` });
+            await collect(page, initialCollection);
+            await collect(page, command('apple', SOURCE_B, oldClock));
+            const oldBackup = await page.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+            await page.evaluate(({ removal, source, examId }) => AppData.vocab.mutateReading(removal, {
+                articleId: AppData.vocab.readingModel.articleId(source, examId),
+                termId: AppData.vocab.readingModel.termId('apple'), clearWords: false
+            }), { removal, source: SOURCE_A, examId: ARTICLE.examId });
+            if (removal === 'deleteCanonicalTerm') {
+                const replay = await page.evaluate(async ({ operationId, ...input }) => {
+                    try { return { receipt: await AppData.vocab.mutateReading('collect', input, { operationId }) }; }
+                    catch (error) { return { code: error.code, committed: error.committed }; }
+                }, initialCollection);
+                assert.deepEqual(replay, { code: 'CONFLICT', committed: false }, 'an old acknowledged operation cannot report saved after its association was deleted');
+            }
+            assert.equal((await importSnapshot(page, oldBackup)).committed, true);
+            const merged = await snapshot(page);
+            const owners = merged.words.concat(...Object.values(merged.lists).map((list) => Array.isArray(list) ? list : list.words || []));
+            if (removal === 'deleteCanonicalTerm') {
+                assert.equal(merged.reading.terms.length, 0);
+                assert.equal(owners.filter((row) => row.word.toLowerCase() === 'apple').length, 0, 'stale backup cannot resurrect a deleted review owner');
+                assert.equal(merged.reading.associations.length, 0);
+                assert.equal(merged.reading.occurrences.length, 0);
+                assert.equal(merged.reading.visits.length, 2, 'global vocabulary deletion retains both visits');
+            } else if (removal === 'clearArticle') {
+                assert.equal(merged.reading.associations.length, 1);
+                assert.equal(merged.reading.occurrences.length, 1);
+                assert.equal(merged.reading.visits.length, 2, 'clearing a vocabulary article does not remove its bookshelf visit');
+            } else {
+                assert.equal(merged.reading.associations.length, 2, 'removing a visit with clearWords=false retains both article collections');
+                assert.equal(merged.reading.occurrences.length, 2);
+                assert.equal(merged.reading.visits.length, 1, 'an old backup cannot resurrect the removed visit');
+            }
+            await importSnapshot(page, oldBackup);
+            assert.deepEqual(await snapshot(page), merged, 'deletion precedence is idempotent across repeated merges');
+            await collect(page, command('apple', SOURCE_A));
+            if (removal === 'deleteCanonicalTerm') await page.evaluate(async () => {
+                const current = (await AppData.vocab.getReadingSnapshot()).snapshot;
+                const owner = current.lists['reading-highlights'].words[0];
+                await AppData.vocab.upsertCollectionWord('reading-highlights', {
+                    ...owner, note: 'Reviewed after explicit recollection', repetitions: 9, interval: 17,
+                    correctCount: 12, reviewHistory: [{ at: '2099-01-02T00:00:00.000Z', grade: 4 }]
+                });
+            });
+            const recollected = await snapshot(page);
+            assert.equal(recollected.reading.associations.length, removal === 'deleteCanonicalTerm' ? 1 : 2);
+            assert.equal(recollected.reading.visits.length, 2);
+            if (removal === 'deleteCanonicalTerm') {
+                await importSnapshot(page, oldBackup);
+                assert.deepEqual(await snapshot(page), recollected, 'old future-dated backup rows cannot erase or replace a fresh recollection and review');
+            }
+            const newBackup = await page.evaluate(() => AppData.backups.export());
+            const [restored] = await pages(t);
+            await importSnapshot(restored, newBackup, true);
+            assert.deepEqual(await snapshot(restored), recollected, 'an explicitly fresh collection survives a full backup roundtrip after prior deletion');
+        });
+    }
+
+    for (const collection of ['words', 'bookshelf']) {
+        await t.test(`legacy ${collection} snapshots require explicit revision and cannot overwrite newer reading operations`, async (t) => {
+            const [stale, writer] = await pages(t, 2);
+            await collect(writer, command('apple'));
+            const observed = await stale.evaluate((collection) => collection === 'words'
+                ? AppData.vocab.listReadingWords({ withMeta: true })
+                : AppData.vocab.listReadingBookshelfExams({ withMeta: true }), collection);
+            await collect(writer, command('banana', SOURCE_B));
+            const before = await snapshot(writer);
+            const result = await stale.evaluate(async ({ collection, observed }) => {
+                const save = collection === 'words' ? AppData.vocab.saveReadingWords : AppData.vocab.saveReadingBookshelfExams;
+                const failure = async (options) => {
+                    try { return { receipt: await save(observed.data, options) }; }
+                    catch (error) { return { code: error.code, committed: error.committed }; }
+                };
+                return { unversioned: await failure({}), stale: await failure({ expectedRevision: observed.envelope.revision }) };
+            }, { collection, observed });
+            assert.equal(result.unversioned.code, 'VALIDATION');
+            assert.equal(result.stale.code, 'CONFLICT');
+            assert.equal(result.stale.committed, false);
+            assert.deepEqual(await snapshot(writer), before);
+        });
+    }
+
+    await t.test('backup roundtrip preserves source identity, manual associations, exact occurrences and zero-word visits', async (t) => {
+        const [page] = await pages(t);
+        const [restored] = await pages(t);
+        await collect(page, command('apple', SOURCE_A, { operationId: 'roundtrip-selected' }));
+        const manual = command('banana', SOURCE_B, { manual: true, operationId: 'roundtrip-manual' });
+        delete manual.occurrence;
+        await collect(page, manual);
+        await page.evaluate(({ source, at }) => AppData.vocab.mutateReading('recordVisit', {
+            source, article: { examId: 'zero-words', title: 'Visited without collecting' }, at
+        }, { operationId: 'roundtrip-visit' }), { source: SOURCE_A, at: AT });
+        const before = await snapshot(page);
+        assert.equal(before.reading.visits.length, 3);
+        assert.equal(before.reading.associations.filter((row) => row.manual).length, 1);
+        const exported = await page.evaluate(() => AppData.backups.export());
+        assert.ok(exported.envelopes['vocab.readingState'], 'the canonical relationship state is a backup domain');
+        assert.equal((await importSnapshot(restored, exported, true)).committed, true);
+        assert.deepEqual(await snapshot(restored), before);
+        await restored.reload();
+        await loadAppData(restored);
+        assert.deepEqual(await snapshot(restored), before);
+        const reexported = await restored.evaluate(() => AppData.backups.export());
+        assert.deepEqual(reexported.envelopes['vocab.readingState'].data.reading, exported.envelopes['vocab.readingState'].data.reading);
+    });
+
+    await t.test('empty replace stays authoritative across stale mirrors, lazy reader/bookshelf initialization, reload and export', async (t) => {
+        const [page, stale] = await pages(t, 2);
+        const empty = await page.evaluate(() => AppData.backups.export());
+        await collect(page, command('apple', SOURCE_A, { operationId: 'before-empty' }));
+        const staleBefore = await stale.evaluate(() => AppData.vocab.getReadingSnapshot());
+        await importSnapshot(page, empty, true);
+        const writeStaleMirrors = async () => stale.evaluate(() => {
+            localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify([{ id: 'stale', word: 'apple', examId: 'shared-exam' }]));
+            localStorage.setItem('ielts_reading_bookshelf_exams_v1', JSON.stringify([{ examId: 'shared-exam', firstUsedAt: 1 }]));
+        });
+        await writeStaleMirrors();
+        const staleResult = await stale.evaluate(async ({ before, input }) => {
+            try {
+                await AppData.vocab.mutateReading('collect', input, {
+                    operationId: 'collect-from-before-empty', observedRevision: before.revision, observedGeneration: before.generation
+                });
+                return null;
+            } catch (error) { return { code: error.code, committed: error.committed }; }
+        }, { before: staleBefore, input: command('apple') });
+        assert.deepEqual(staleResult, { code: 'CONFLICT', committed: false }, 'replace invalidates pre-import readers even if an old revision number recurs');
+        await page.addScriptTag({ content: source('components/readingVocabReader.js') });
+        await page.addScriptTag({ content: source('components/bookshelfView.js') });
+        await page.evaluate(async () => {
+            await ReadingVocabStore.init();
+            await ReadingBookshelfStore.init();
+        });
+        let actual = await snapshot(page);
+        assert.equal(actual.reading.associations.length, 0);
+        assert.equal(actual.reading.occurrences.length, 0);
+        assert.equal(actual.reading.visits.length, 0);
+        await writeStaleMirrors();
+        await page.reload();
+        await loadAppData(page);
+        actual = await snapshot(page);
+        assert.equal(actual.reading.associations.length, 0);
+        assert.equal(actual.reading.visits.length, 0);
+        const exported = await page.evaluate(() => AppData.backups.export());
+        assert.equal(exported.envelopes['vocab.readingState'].data.reading.associations.length, 0);
+        assert.equal(exported.envelopes['vocab.readingState'].data.reading.visits.length, 0);
+    });
+
+    await t.test('loaded reader and bookshelf caches adopt a remote replace through production commit notifications', async (t) => {
+        const [writer, observer] = await pages(t, 2);
+        const empty = await writer.evaluate(() => AppData.backups.export());
+        await collect(writer, command('apple'));
+        await observer.addScriptTag({ content: source('components/readingVocabReader.js') });
+        await observer.addScriptTag({ content: source('components/bookshelfView.js') });
+        await observer.evaluate(async () => {
+            await ReadingVocabStore.init();
+            await ReadingBookshelfStore.init();
+        });
+        assert.deepEqual(await observer.evaluate(() => ({
+            words: ReadingVocabStore.getAll().length, visits: ReadingBookshelfStore.getBookshelfExams().length
+        })), { words: 1, visits: 1 });
+        await importSnapshot(writer, empty, true);
+        // These are synchronous cached projections: no explicit init, AppData
+        // refresh, or new page navigation can conceal a missing notification.
+        await observer.waitForFunction(() => ReadingVocabStore.getAll().length === 0
+            && ReadingBookshelfStore.getBookshelfExams().length === 0);
+    });
+
+    await t.test('a deletion imported from a lower-revision device fences stale local readers but allows freshly observed collection', async (t) => {
+        const [writer, stale] = await pages(t, 2);
+        const [remote] = await pages(t);
+        await collect(writer, command('apple'));
+        await collect(remote, command('apple'));
+        await writer.evaluate(async ({ source, article, at }) => {
+            for (let index = 0; index < 12; index += 1) {
+                await AppData.vocab.mutateReading('recordVisit', { source, article, at }, { operationId: `advance-local-${index}` });
+            }
+        }, { source: SOURCE_A, article: ARTICLE, at: AT });
+        const observed = await stale.evaluate(() => AppData.vocab.getReadingSnapshot());
+        await remote.evaluate(() => AppData.vocab.mutateReading('deleteCanonicalTerm', {
+            termId: AppData.vocab.readingModel.termId('apple')
+        }));
+        const remoteState = await remote.evaluate(() => AppData.vocab.getReadingSnapshot());
+        assert.ok(observed.revision > remoteState.revision, 'exercise different device-local revision ranges');
+        const backup = await remote.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+        await importSnapshot(writer, backup);
+        assert.equal((await snapshot(writer)).reading.associations.length, 0);
+        const rejected = await stale.evaluate(async ({ observed, input }) => {
+            try {
+                await AppData.vocab.mutateReading('collect', input, {
+                    observedRevision: observed.revision, observedGeneration: observed.generation
+                });
+                return null;
+            } catch (error) { return { code: error.code, committed: error.committed }; }
+        }, { observed, input: command('apple') });
+        assert.deepEqual(rejected, { code: 'CONFLICT', committed: false });
+        assert.equal((await collect(stale, command('apple'))).committed, true, 'foreign revision numbers do not permanently block a refreshed local intent');
+        assert.equal((await snapshot(writer)).reading.associations.length, 1);
+    });
+
+    for (const kind of ['quota', 'abort']) {
+        await t.test(`${kind} failure rolls back every written document and retries without duplicate vocabulary or occurrences`, async (t) => {
+            const operationId = `${kind}-retry`;
+            const [page, observer] = await pages(t, 2, { fault: { operationId, kind, afterWrites: 2 } });
+            const before = await snapshot(observer);
+            await observer.evaluate(() => {
+                window.readingCommits = [];
+                AppData.backups.onDataCommitted((event) => window.readingCommits.push(event.operationId));
+            });
+            const failed = await page.evaluate(async ({ operationId, input }) => {
+                try { return { receipt: await AppData.vocab.mutateReading('collect', input, { operationId }) }; }
+                catch (error) { return { code: error.code, committed: error.committed, writes: window.readingTest.writes }; }
+            }, { operationId, input: command('apple') });
+            assert.equal(failed.receipt, undefined, 'failed persistence cannot return saved/added success');
+            assert.equal(failed.committed, false);
+            assert.equal(failed.code, kind === 'quota' ? 'QUOTA_EXCEEDED' : 'BACKEND_UNAVAILABLE');
+            assert.equal(failed.writes.length, 2, 'failure follows a prior write inside a real transaction');
+            assert.deepEqual(await snapshot(observer), before, 'the preceding put was rolled back atomically');
+            assert.equal(await observer.evaluate((id) => window.readingCommits.includes(id), operationId), false, 'failed transaction emits no commit notification');
+            if (kind === 'abort') {
+                await page.reload();
+                await loadAppData(page);
+            } else await page.evaluate(() => { window.readingTest.fault = null; });
+            const receipt = await collect(page, command('apple', SOURCE_A, { operationId }));
+            assert.equal(receipt.committed, true);
+            assert.equal(receipt.saved, true);
+            await observer.waitForFunction((id) => window.readingCommits.includes(id), operationId);
+            const after = await snapshot(observer);
+            assert.equal(after.reading.terms.length, 1);
+            assert.equal(after.reading.associations.length, 1);
+            assert.equal(after.reading.occurrences.length, 1);
+            assert.equal(after.reading.visits.length, 1);
+            assert.equal((await collect(page, command('apple', SOURCE_A, { operationId }))).committed, true);
+            assert.deepEqual(await snapshot(observer), after, 'retrying the acknowledged operation is also idempotent');
+        });
+    }
+
+    await t.test('interrupted one-time migration retains original bytes, retries atomically and cannot reimport later stale mirrors', async (t) => {
+        const words = [{
+            id: 'legacy-apple', word: 'apple', examId: 'legacy-exam', examTitle: 'Legacy article',
+            source: SOURCE_A, createdAt: AT, note: 'Retain this note',
+            highlights: [{ examId: 'legacy-exam', text: 'apple', scope: 'passage-1', startOffset: 2, endOffset: 7 }]
+        }];
+        const visits = [{ examId: 'legacy-zero', source: SOURCE_B, firstUsedAt: 1000, lastOpenedAt: 2000 }];
+        const legacy = {
+            ielts_reading_vocab_words_v1: JSON.stringify(words),
+            ielts_reading_bookshelf_exams_v1: JSON.stringify(visits)
+        };
+        const [page] = await pages(t, 1, { legacy, fault: {
+            kind: 'quota', operationPrefix: 'migrate-reading_', failKey: 'system.migrations'
+        } });
+        assert.equal(await durableRow(page, 'documents', 'vocab.readingState'), null, 'failed marker put rolls back the new model document');
+        const initialMarker = await durableRow(page, 'system', 'system.migrations');
+        assert.equal(initialMarker?.envelope?.data?.readingVocabularyV1, undefined, 'interrupted migration must not be marked complete');
+        assert.deepEqual(await page.evaluate((keys) => Object.fromEntries(keys.map((key) => [key, localStorage.getItem(key)])), Object.keys(legacy)), legacy);
+        assert.ok(await page.evaluate(() => window.readingTest.writes.includes('vocab.readingState')), 'exercise rollback after a real canonical state write');
+        await page.reload();
+        await loadAppData(page);
+        const migrated = await snapshot(page);
+        assert.equal(migrated.reading.terms.length, 1);
+        assert.equal(migrated.reading.associations.length, 1);
+        assert.equal(migrated.reading.occurrences.length, 1);
+        assert.equal(migrated.reading.visits.length, 2);
+        const marker = (await durableRow(page, 'system', 'system.migrations')).envelope.data.readingVocabularyV1;
+        assert.equal(marker.version, 1);
+        assert.equal(marker.completed, true);
+        assert.deepEqual(marker.recoverable.localStorage, legacy, 'original bytes remain durably recoverable after conversion');
+        await page.evaluate(() => {
+            localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify([{ word: 'banana', examId: 'stale-late' }]));
+        });
+        await page.reload();
+        await loadAppData(page);
+        await page.evaluate(() => AppData.backups.export());
+        assert.deepEqual(await snapshot(page), migrated, 'startup and export do not repeat a completed migration');
+        assert.deepEqual((await durableRow(page, 'system', 'system.migrations')).envelope.data.readingVocabularyV1, marker);
+    });
+
+    await t.test('unrecognized prototype payloads stay recoverable with explicit migration diagnostics', async (t) => {
+        const legacy = {
+            ielts_reading_vocab_words_v1: JSON.stringify({ vendorVersion: 'unknown', terms: [{ term: 'apple' }] }),
+            ielts_reading_bookshelf_exams_v1: '{broken json'
+        };
+        const [page] = await pages(t, 1, { legacy });
+        const actual = await snapshot(page);
+        assert.equal(actual.reading.associations.length, 0);
+        assert.equal(actual.reading.visits.length, 0);
+        const marker = (await durableRow(page, 'system', 'system.migrations')).envelope.data.readingVocabularyV1;
+        assert.equal(marker.completed, true);
+        assert.deepEqual(marker.recoverable.localStorage, legacy);
+        for (const key of Object.keys(legacy)) assert.ok(marker.recoverable.rejected.some((entry) => entry.key === key), `record rejection diagnostics for ${key}`);
+        await page.evaluate(() => AppData.backups.export());
+        await page.reload();
+        await loadAppData(page);
+        assert.deepEqual(await page.evaluate((keys) => Object.fromEntries(keys.map((key) => [key, localStorage.getItem(key)])), Object.keys(legacy)), legacy, 'unrecognized original payloads are not silently overwritten with empty mirrors');
+        assert.deepEqual((await durableRow(page, 'system', 'system.migrations')).envelope.data.readingVocabularyV1, marker);
+    });
+
+    await t.test('settings-only import is independent of interrupted reading migration, while reading backups require recovery first', async (t) => {
+        const [donor] = await pages(t);
+        await donor.evaluate(() => AppData.settings.patch({ theme: 'imported' }));
+        const settings = await donor.evaluate(() => AppData.backups.export({ domains: ['settings'] }));
+        const seedBackup = await donor.evaluate(() => AppData.backups.create({ id: 'migration-target' }));
+        const legacy = {
+            ielts_reading_vocab_words_v1: JSON.stringify([{ id: 'legacy', word: 'apple', examId: 'legacy' }]),
+            ielts_reading_bookshelf_exams_v1: JSON.stringify([{ examId: 'legacy-zero', firstUsedAt: 1 }])
+        };
+        const [page] = await pages(t, 1, { legacy, seedBackup,
+            fault: { kind: 'quota', operationPrefix: 'migrate-reading_', failKey: 'system.migrations' } });
+        await page.evaluate(() => AppData.settings.patch({ theme: 'changed' }));
+        assert.equal((await importSnapshot(page, settings, true)).committed, true, 'an unrelated settings import does not require reading migration');
+        assert.equal(await page.evaluate(async () => (await AppData.settings.getAll()).theme), 'imported');
+        const beforeIds = await page.evaluate(async () => (await AppData.backups.list()).map((entry) => entry.id));
+        const beforeInstalls = await page.evaluate(() => window.readingTest.installCalls);
+        for (const workflow of ['export', 'create', 'preview', 'restore']) {
+            const failure = await page.evaluate(async ({ workflow, snapshot }) => {
+                try {
+                    if (workflow === 'export') await AppData.backups.export();
+                    if (workflow === 'create') await AppData.backups.create({ id: 'unsafe-safety', type: 'pre-import' });
+                    if (workflow === 'preview') await AppData.backups.previewImport(snapshot, { replace: true });
+                    if (workflow === 'restore') await AppData.backups.restore('migration-target');
+                    return null;
+                } catch (error) { return { code: error.code, committed: error.committed }; }
+            }, { workflow, snapshot: seedBackup.data });
+            assert.deepEqual(failure, { code: 'QUOTA_EXCEEDED', committed: false }, `${workflow} must not silently omit unmigrated reading data`);
+            assert.equal(await page.evaluate(() => window.readingTest.installCalls), beforeInstalls, `${workflow} aborts before snapshot installation`);
+            assert.deepEqual(await page.evaluate(async () => (await AppData.backups.list()).map((entry) => entry.id)), beforeIds, 'do not leave a misleading partial safety backup');
+            assert.equal(await durableRow(page, 'documents', 'vocab.readingState'), null);
+            assert.deepEqual(await page.evaluate((keys) => Object.fromEntries(keys.map((key) => [key, localStorage.getItem(key)])), Object.keys(legacy)), legacy);
+        }
+        await page.evaluate(() => { window.readingTest.fault = null; });
+        const safety = await page.evaluate(() => AppData.backups.create({ id: 'recovered-safety', type: 'pre-import' }));
+        assert.equal(safety.data.envelopes['vocab.readingState'].data.reading.associations.length, 1);
+        assert.equal(safety.data.envelopes['vocab.readingState'].data.reading.visits.length, 2);
+        assert.equal(safety.data.envelopes['settings.values'].data.theme, 'imported');
+    });
+});

--- a/developer/tests/js/reviewHighlightDictionaryProtocol.test.js
+++ b/developer/tests/js/reviewHighlightDictionaryProtocol.test.js
@@ -2,11 +2,13 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import vm from 'vm';
+import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '../../..');
+const readingModel = createRequire(import.meta.url)(path.join(repoRoot, 'js/data/v2/readingVocabularyModel.js'));
 const sourcePath = path.join(repoRoot, 'js/runtime/reviewHighlightDictionary.js');
 const source = fs.readFileSync(sourcePath, 'utf8');
 const instrumentedSource = source.replace(
@@ -85,13 +87,14 @@ async function run() {
     assert.strictEqual(posted.length, 1);
     assert.strictEqual(posted[0].type, 'VOCAB_HIGHLIGHT_SAVE');
     assert.strictEqual(posted[0].payload.requestId, 'vocab-highlight-request-1');
-    assert.strictEqual(failedButton.textContent, '加入生词', 'bare postMessage delivery must not show success');
+    assert.strictEqual(failedButton.textContent, '保存中…', 'bare postMessage delivery must remain pending');
+    assert.strictEqual(failedButton.disabled, true);
     assert.strictEqual(
         dictionary.handleSaveOutcome({ requestId: 'unknown-request' }, true),
         false,
         'unknown ACK must not settle another request'
     );
-    assert.strictEqual(failedButton.textContent, '加入生词');
+    assert.strictEqual(failedButton.textContent, '保存中…');
     assert.strictEqual(
         dictionary.handleSaveOutcome({ requestId: posted[0].payload.requestId }, false),
         true,
@@ -127,28 +130,34 @@ async function run() {
     harness.AppData = {
         ready: Promise.resolve(),
         vocab: {
-            async mergeListWords(command) {
+            async getReadingSnapshot() {
+                return { revision: 3, generation: 0 };
+            },
+            async mutateReading(operation, command, options) {
+                assert.strictEqual(operation, 'collect');
+                assert.strictEqual(options.observedRevision, 3);
                 directWrites.push(command);
-                const incoming = command.words[0];
-                existingDirectWord.meaning = incoming.meaning;
-                if (incoming.example) existingDirectWord.example = incoming.example;
-                if (typeof incoming.phonetic === 'string' && incoming.phonetic.trim()) {
-                    existingDirectWord.phonetic = incoming.phonetic.trim().replace(/^\/(.*)\/$/, '$1').trim();
-                }
+                const snapshot = readingModel.collect(readingModel.createSnapshot({ words: [existingDirectWord] }), JSON.parse(JSON.stringify(command)));
+                assert.strictEqual(snapshot.reading.associations.length, 1);
+                assert.strictEqual(snapshot.reading.terms[0].wordRef.listId, 'default');
+                assert.deepStrictEqual(snapshot.words[0], existingDirectWord);
+                return { saved: true, snapshot };
             }
         }
     };
     hooks.configure({
         postMessage() {
             return false;
-        }
+        },
+        getContext() { return { examId: 'article-a', libraryConfigurationId: 'library-a' }; }
     });
     hooks.setActiveLookup({ term: 'durable', zh: '持久的', phonetic: '/ˈdjʊərəbəl/' }, 'durable');
     const directButton = new HTMLButtonElement();
     await hooks.saveActiveLookup(directButton);
     assert.strictEqual(directWrites.length, 1, 'unavailable host route must commit through direct AppData');
-    assert.strictEqual(directWrites[0].listId, 'reading-highlights');
-    const incomingDirectWord = directWrites[0].words[0];
+    assert.strictEqual(directWrites[0].source.id, 'library-a');
+    assert.strictEqual(directWrites[0].article.examId, 'article-a');
+    const incomingDirectWord = directWrites[0].word;
     ['easeFactor', 'interval', 'repetitions', 'intraCycles', 'correctCount', 'lastReviewed', 'nextReview'].forEach((field) => {
         assert.ok(
             !Object.prototype.hasOwnProperty.call(incomingDirectWord, field),
@@ -168,8 +177,8 @@ async function run() {
         !incomingDirectWord.note.includes('ˈdjʊərəbəl'),
         'phonetic must not be duplicated into the free-form note'
     );
-    assert.strictEqual(existingDirectWord.meaning, '持久的');
-    assert.strictEqual(existingDirectWord.phonetic, 'ˈdjʊərəbəl');
+    assert.strictEqual(existingDirectWord.meaning, '旧释义');
+    assert.strictEqual(existingDirectWord.phonetic, 'old-phonetic');
     assert.strictEqual(existingDirectWord.note, '用户笔记');
     assert.strictEqual(existingDirectWord.correctCount, 5);
     assert.strictEqual(existingDirectWord.interval, 10);
@@ -180,14 +189,14 @@ async function run() {
     const blankPhoneticButton = new HTMLButtonElement();
     await hooks.saveActiveLookup(blankPhoneticButton);
     assert.strictEqual(directWrites.length, 2);
-    const blankPhoneticWord = directWrites[1].words[0];
+    const blankPhoneticWord = directWrites[1].word;
     assert.ok(
         !Object.prototype.hasOwnProperty.call(blankPhoneticWord, 'phonetic'),
         'blank lookup phonetic must be omitted from the merge patch'
     );
     assert.strictEqual(
         existingDirectWord.phonetic,
-        'ˈdjʊərəbəl',
+        'old-phonetic',
         'omitted phonetic must not erase the existing stored value'
     );
     assert.ok(
@@ -197,9 +206,41 @@ async function run() {
     assert.strictEqual(blankPhoneticButton.textContent, '已加入');
     assert.strictEqual(blankPhoneticButton.disabled, true);
 
+    hooks.configure({ postMessage(type, payload) { posted.push({ type, payload }); return true; } });
+    const rejectedHostButton = new HTMLButtonElement();
+    const rejectedHostSave = hooks.saveActiveLookup(rejectedHostButton);
+    dictionary.handleSaveOutcome({ requestId: posted[posted.length - 1].payload.requestId }, false);
+    await rejectedHostSave;
+    assert.strictEqual(directWrites.length, 2, 'a rejected host operation must remain failed until an explicit retry');
+    assert.strictEqual(rejectedHostButton.textContent, '保存失败');
+    assert.strictEqual(rejectedHostButton.disabled, false);
+
+    const unavailableHostButton = new HTMLButtonElement();
+    const unavailableHostSave = hooks.saveActiveLookup(unavailableHostButton);
+    dictionary.handleSaveOutcome({
+        requestId: posted[posted.length - 1].payload.requestId,
+        errorCode: 'BACKEND_UNAVAILABLE'
+    }, false);
+    await unavailableHostSave;
+    assert.strictEqual(unavailableHostButton.textContent, '请刷新主页并重开阅读页后重试');
+    assert.strictEqual(unavailableHostButton.disabled, false);
+
+    hooks.configure({ postMessage() { return false; } });
+    harness.AppData.vocab.mutateReading = async () => { throw Object.assign(new Error('unavailable'), { code: 'BACKEND_UNAVAILABLE' }); };
+    const unavailableDirectButton = new HTMLButtonElement();
+    await hooks.saveActiveLookup(unavailableDirectButton);
+    assert.strictEqual(unavailableDirectButton.textContent, '请刷新页面后重试');
+    assert.strictEqual(unavailableDirectButton.disabled, false);
+
+    harness.AppData.vocab.mutateReading = async () => { throw Object.assign(new Error('quota exceeded'), { code: 'QUOTA' }); };
+    const quotaButton = new HTMLButtonElement();
+    await hooks.saveActiveLookup(quotaButton);
+    assert.strictEqual(quotaButton.textContent, '保存失败');
+    assert.strictEqual(quotaButton.disabled, false);
+
     console.log(JSON.stringify({
         status: 'pass',
-        detail: 'vocab requestId ACK/FAILED, direct-commit phonetic merge, and UI checks passed'
+        detail: 'vocab requestId ACK/FAILED, canonical reading collection, and explicit retry checks passed'
     }));
 }
 

--- a/developer/tests/js/vocabDefaultRepairPersistence.test.js
+++ b/developer/tests/js/vocabDefaultRepairPersistence.test.js
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const scripts = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js',
+    'data/practiceRecordSource.js', 'data/v2/readingVocabularyModel.js'
+].map(source);
+const appDataSource = source('data/v2/appData.js');
+const vocabStoreSource = source('core/vocabStore.js');
+const POLLUTED = [{ id: 'polluted-garden', word: 'garden', meaning: '你曾拼写为: gardon' }];
+const BUNDLED = [{ id: 'default-apple', word: 'apple', meaning: 'Apple' }];
+
+async function loadAppData(page, seedWords) {
+    for (const content of scripts) await page.addScriptTag({ content });
+    await page.evaluate(async (seedWords) => {
+        const prototype = window.__AppDataV2Internals.DataKernel.prototype;
+        window.vocabTest = { repairAttempts: 0, failedWrites: 0 };
+        const mutate = prototype.mutate;
+        prototype.mutate = async function (changes, options = {}) {
+            if (options.operationId?.startsWith('vocab-default-repair')) {
+                window.vocabTest.repairAttempts += 1;
+                if (window.vocabTest.pauseRepair && !window.vocabTest.blocked) {
+                    window.vocabTest.blocked = true;
+                    await new Promise((resolve) => { window.vocabTest.release = resolve; });
+                }
+            }
+            return mutate.call(this, changes, options);
+        };
+        const put = IDBObjectStore.prototype.put;
+        IDBObjectStore.prototype.put = function (value, ...args) {
+            if (window.vocabTest.failRepair && value?.envelope?.operationId?.startsWith('vocab-default-repair')
+                && (!window.vocabTest.failKey || value.logicalKey === window.vocabTest.failKey)) {
+                window.vocabTest.failedWrites += 1;
+                throw new DOMException('Injected default repair quota failure', 'QuotaExceededError');
+            }
+            return put.call(this, value, ...args);
+        };
+        if (seedWords !== undefined) {
+            const kernel = new window.__AppDataV2Internals.DataKernel();
+            await kernel.initialize();
+            await kernel.mutate([{ logicalKey: 'vocab.words', data: seedWords }], { operationId: 'seed-persisted-default' });
+            kernel.close();
+        }
+    }, seedWords);
+    await page.addScriptTag({ content: appDataSource });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+
+async function loadVocabStore(page, bundledWords = BUNDLED) {
+    await page.evaluate((words) => { window.__EMBEDDED_WORDLISTS__ = { ielts_core: words }; }, bundledWords);
+    await page.addScriptTag({ content: vocabStoreSource });
+}
+
+test('default vocabulary pollution repair is acknowledged and preserves empty authority in IndexedDB', { timeout: 90000 }, async (t) => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Default vocabulary repair integration</title>');
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+    });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+
+    async function pageWithWords(t, words) {
+        const context = await browser.newContext();
+        t.after(() => context.close());
+        const page = await context.newPage();
+        await page.goto(url);
+        await loadAppData(page, words);
+        await loadVocabStore(page);
+        return page;
+    }
+
+    await t.test('a migrated polluted default envelope is durably repaired and remains repaired after reload', async (t) => {
+        const page = await pageWithWords(t, POLLUTED);
+        assert.equal(await page.evaluate(() => AppData.vocab.shouldInitializeDefaultWords()), false);
+        await page.evaluate(() => VocabStore.init());
+        const words = await page.evaluate(() => AppData.vocab.listWords());
+        assert.deepEqual(words.map((word) => word.word), ['apple']);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords()), words);
+        assert.equal(await page.evaluate(() => window.vocabTest.repairAttempts), 1);
+
+        await page.reload();
+        await loadAppData(page);
+        await loadVocabStore(page);
+        await page.evaluate(() => VocabStore.init());
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords()), words);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords()), words);
+        assert.equal(await page.evaluate(() => window.vocabTest.repairAttempts), 0);
+    });
+
+    await t.test('an acknowledged empty default list is never seeded or repaired', async (t) => {
+        const page = await pageWithWords(t, []);
+        assert.equal(await page.evaluate(() => AppData.vocab.shouldInitializeDefaultWords()), false);
+        await page.evaluate(() => VocabStore.init());
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords()), []);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords()), []);
+        assert.equal(await page.evaluate(() => window.vocabTest.repairAttempts), 0);
+    });
+
+    await t.test('a failed IndexedDB repair keeps acknowledged words and retries after reload', async (t) => {
+        const page = await pageWithWords(t, POLLUTED);
+        const failed = await page.evaluate(async () => {
+            window.vocabTest.failRepair = true;
+            try { await VocabStore.init(); return { resolved: true }; }
+            catch (error) { return { code: error.code, ready: VocabStore.state.ready }; }
+        });
+        assert.equal(failed.ready, false);
+        assert.ok(failed.code, 'initialization must propagate the durable storage failure');
+        assert.equal(await page.evaluate(() => window.vocabTest.failedWrites), 1);
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords()), POLLUTED);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords().map((word) => word.word)), ['garden']);
+
+        await page.reload();
+        await loadAppData(page);
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords()), POLLUTED);
+        await loadVocabStore(page);
+        await page.evaluate(() => VocabStore.init());
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords().then((words) => words.map((word) => word.word))), ['apple']);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords().map((word) => word.word)), ['apple']);
+    });
+
+    for (const includesGarden of [true, false]) {
+        await t.test(`repair retains reading owners when the bundle ${includesGarden ? 'changes their IDs' : 'omits their terms'}`, async (t) => {
+            const owner = {
+                ...POLLUTED[0], note: 'My garden note', phonetic: 'gɑːdən',
+                correctCount: 9, interval: 21, repetitions: 7, easeFactor: 2.3,
+                lastReviewed: '2026-09-01T01:00:00.000Z', nextReview: '2026-09-22T01:00:00.000Z',
+                reviewHistory: [{ at: '2026-09-01T01:00:00.000Z', grade: 4 }]
+            };
+            const bundled = includesGarden ? [{ id: 'default-garden', word: 'garden', meaning: 'A cultivated plot' }] : BUNDLED;
+            const page = await pageWithWords(t, [owner]);
+            const baseId = JSON.stringify(['default-repair', owner.id]);
+            const collisions = [
+                { id: baseId, word: 'other', meaning: 'Existing row', correctCount: 3 },
+                { id: `${baseId}-1`, word: 'another', meaning: 'Another row', correctCount: 5 }
+            ];
+            const existingCollection = includesGarden
+                ? { id: 'reading-highlights', name: 'My reading words', words: collisions }
+                : collisions;
+            await page.evaluate(async ({ collection, bundled }) => {
+                window.__EMBEDDED_WORDLISTS__.ielts_core = bundled;
+                await AppData.vocab.saveCollection('reading-highlights', collection);
+                await AppData.vocab.mutateReading('collect', {
+                    source: { kind: 'imported', id: 'garden-library' },
+                    article: { examId: 'garden-article', title: 'Garden article' },
+                    word: { word: 'garden', meaning: 'Keep acknowledged owner' }, at: '2026-09-08T01:00:00.000Z',
+                    occurrence: { scopeId: 'passage-1', contentVersion: 'garden-v1', startOffset: 0, endOffset: 6, quote: 'garden' }
+                });
+            }, { collection: existingCollection, bundled });
+            const before = await page.evaluate(() => AppData.vocab.getReadingSnapshot().then((result) => result.snapshot));
+            assert.deepEqual(before.reading.terms[0].wordRef, { listId: 'default', wordId: owner.id });
+
+            const failed = await page.evaluate(async () => {
+                window.vocabTest.failRepair = true;
+                window.vocabTest.failKey = 'vocab.readingState';
+                try { await VocabStore.init(); return { resolved: true }; }
+                catch (error) { return { code: error.code, ready: VocabStore.state.ready }; }
+            });
+            assert.equal(failed.ready, false);
+            assert.ok(failed.code);
+            assert.equal(await page.evaluate(() => window.vocabTest.failedWrites), 1);
+            assert.deepEqual(await page.evaluate(() => AppData.vocab.getReadingSnapshot().then((result) => result.snapshot)), before,
+                'a failure after owner writes must roll back both owner relocation and the graph');
+
+            await page.evaluate(async () => { window.vocabTest.failRepair = false; await VocabStore.init(); });
+            const after = await page.evaluate(() => AppData.vocab.getReadingSnapshot().then((result) => result.snapshot));
+            assert.deepEqual(after.words.map((word) => ({ id: word.id, word: word.word, meaning: word.meaning })), bundled);
+            const collection = after.lists['reading-highlights'];
+            const retainedWords = Array.isArray(collection) ? collection : collection.words;
+            const retainedId = `${baseId}-2`;
+            assert.equal(Array.isArray(collection), !includesGarden);
+            if (includesGarden) assert.equal(collection.name, existingCollection.name);
+            assert.deepEqual(retainedWords, [...collisions, { ...owner, id: retainedId }], 'preserve all acknowledged fields and avoid occupied IDs');
+            const expectedReading = structuredClone(before.reading);
+            expectedReading.terms[0].wordRef = { listId: 'reading-highlights', wordId: retainedId };
+            assert.deepEqual(after.reading, expectedReading, 'only the canonical reference changes; every relationship remains intact');
+
+            const replay = await page.evaluate((words) => AppData.vocab.repairDefaultWords({ words }), bundled);
+            assert.equal(replay.committed, false);
+            assert.deepEqual(await page.evaluate(() => AppData.vocab.getReadingSnapshot().then((result) => result.snapshot)), after,
+                'retrying an acknowledged repair must not duplicate retained owners');
+            await page.reload();
+            await loadAppData(page);
+            await loadVocabStore(page, bundled);
+            await page.evaluate(() => VocabStore.init());
+            assert.deepEqual(await page.evaluate(() => AppData.vocab.getReadingSnapshot().then((result) => result.snapshot)), after);
+            assert.equal(await page.evaluate(() => window.vocabTest.repairAttempts), 0);
+        });
+    }
+
+    await t.test('a concurrent empty replacement wins when the repair retries a stale transaction', async (t) => {
+        const page = await pageWithWords(t, POLLUTED);
+        const other = await page.context().newPage();
+        await other.goto(url);
+        await loadAppData(other);
+        await page.evaluate(() => {
+            window.vocabTest.pauseRepair = true;
+            window.pendingInit = VocabStore.init().then(
+                () => ({ ready: VocabStore.state.ready }),
+                (error) => ({ error: error.message })
+            );
+        });
+        await page.waitForFunction(() => window.vocabTest.blocked);
+        await other.evaluate(() => AppData.vocab.saveWords([]));
+        const result = await page.evaluate(async () => {
+            window.vocabTest.release();
+            return window.pendingInit;
+        });
+        assert.deepEqual(result, { ready: true });
+        assert.deepEqual(await page.evaluate(() => AppData.vocab.listWords()), []);
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords()), []);
+        assert.deepEqual(await page.evaluate(() => VocabStore.loadList('default').then((list) => list.words)), []);
+        assert.equal(await page.evaluate(() => window.vocabTest.repairAttempts), 1, 'the retry must stop before another write after rereading empty authority');
+
+        await page.reload();
+        await loadAppData(page);
+        await loadVocabStore(page);
+        await page.evaluate(() => VocabStore.init());
+        assert.deepEqual(await page.evaluate(() => VocabStore.getWords()), []);
+    });
+});

--- a/developer/tests/js/vocabStore.test.js
+++ b/developer/tests/js/vocabStore.test.js
@@ -26,6 +26,7 @@ function createVocabFacade(seed = {}) {
         replaceListWordsCalls: [],
         backfillListWordPhoneticsCalls: [],
         backfillListWordPhoneticsWrites: 0,
+        repairDefaultWordsCalls: [],
         replaceProgressCalls: []
     };
     const state = {
@@ -45,6 +46,20 @@ function createVocabFacade(seed = {}) {
                 state.allowDefaultWordSeed = false;
             }
             if (!await this.shouldInitializeDefaultWords()) return { committed: false, words: clone(state.words) };
+            await this.replaceListWords({ listId: 'default', words });
+            state.allowDefaultWordSeed = false;
+            return { committed: true, words: clone(state.words) };
+        },
+        async repairDefaultWords({ words }) {
+            metrics.repairDefaultWordsCalls.push({ words: clone(words) });
+            if (seed.replaceBeforeRepair) {
+                state.words = [];
+                state.allowDefaultWordSeed = false;
+            }
+            const pollutedCount = state.words.filter((word) => String(word.meaning || '').trim().startsWith('你曾拼写为:')).length;
+            if (!state.words.length || pollutedCount / state.words.length < 0.6) {
+                return { committed: false, words: clone(state.words) };
+            }
             await this.replaceListWords({ listId: 'default', words });
             state.allowDefaultWordSeed = false;
             return { committed: true, words: clone(state.words) };
@@ -951,12 +966,51 @@ async function testDefaultBootstrapPreservesAuthoritativeEmptyReplace() {
     assert.deepStrictEqual(restored.__appDataState.words, []);
     assert.strictEqual(restored.getWords().length, 0);
     assert.strictEqual(restored.__appDataMetrics.replaceListWordsCalls.length, 0);
+    assert.strictEqual(restored.__appDataMetrics.repairDefaultWordsCalls.length, 0);
 
     const racing = loadVocabStore({ embeddedWords, dataSeed: { replaceBeforeSeed: true } });
     await racing.init();
     assert.deepStrictEqual(racing.__appDataState.words, []);
     assert.strictEqual(racing.getWords().length, 0, 'the committed empty receipt must supersede the bundled snapshot');
     assert.strictEqual(racing.__appDataMetrics.replaceListWordsCalls.length, 0);
+}
+
+async function testDefaultBootstrapRepairsPollutedSnapshotAndRetriesFailedWrite() {
+    const embeddedWords = [{ id: 'default-apple', word: 'apple', meaning: 'Apple' }];
+    const dataSeed = {
+        words: [{ id: 'polluted-garden', word: 'garden', meaning: '你曾拼写为: gardon' }],
+        failReplace: true
+    };
+    const vocabStore = loadVocabStore({ embeddedWords, dataSeed });
+    await assert.rejects(vocabStore.init(), /backend write failed/);
+    assert.strictEqual(vocabStore.state.ready, false);
+    assert.deepStrictEqual(vocabStore.__appDataState.words, dataSeed.words, 'failed repair must leave the acknowledged words untouched');
+    assert.strictEqual(vocabStore.getWords()[0].word, 'garden', 'uncommitted bundled words must not reach runtime state');
+
+    dataSeed.failReplace = false;
+    await vocabStore.init();
+    assert.strictEqual(vocabStore.state.ready, true);
+    assert.strictEqual(vocabStore.__appDataState.words[0].word, 'apple');
+    assert.strictEqual(vocabStore.getWords()[0].word, 'apple');
+    assert.strictEqual((await vocabStore.loadList('default')).words[0].word, 'apple');
+    assert.strictEqual(vocabStore.__appDataMetrics.repairDefaultWordsCalls.length, 2);
+    assert.strictEqual(vocabStore.__appDataMetrics.replaceListWordsCalls.length, 1);
+}
+
+async function testDefaultRepairUsesConcurrentAuthoritativeEmptyReceipt() {
+    const vocabStore = loadVocabStore({
+        embeddedWords: [{ id: 'default-apple', word: 'apple', meaning: 'Apple' }],
+        dataSeed: {
+            words: [{ id: 'polluted-garden', word: 'garden', meaning: '你曾拼写为: gardon' }],
+            replaceBeforeRepair: true
+        }
+    });
+    await vocabStore.init();
+    assert.deepStrictEqual(vocabStore.__appDataState.words, []);
+    assert.strictEqual(vocabStore.getWords().length, 0);
+    assert.strictEqual((await vocabStore.loadList('default')).words.length, 0);
+    assert.strictEqual(vocabStore.__appDataMetrics.repairDefaultWordsCalls.length, 1);
+    assert.strictEqual(vocabStore.__appDataMetrics.replaceListWordsCalls.length, 0);
 }
 
 async function testReadingHighlightLegacyNoteProjectsPhoneticWithoutMutation() {
@@ -1153,6 +1207,10 @@ async function main() {
         results.push({ name: '阅读高亮复用默认规范词条并拒绝未持久化的成功', status: 'pass' });
         await testDefaultBootstrapPreservesAuthoritativeEmptyReplace();
         results.push({ name: '默认词库初始化保留权威空替换及并发替换结果', status: 'pass' });
+        await testDefaultBootstrapRepairsPollutedSnapshotAndRetriesFailedWrite();
+        results.push({ name: '默认词库污染修复须持久化成功且失败可重试', status: 'pass' });
+        await testDefaultRepairUsesConcurrentAuthoritativeEmptyReceipt();
+        results.push({ name: '污染修复采用并发权威空替换的回执', status: 'pass' });
         await testReadingHighlightLegacyNoteProjectsPhoneticWithoutMutation();
         results.push({ name: '阅读高亮旧 note 音标只投影且显式字段优先', status: 'pass' });
         await testExternalListCommitInvalidatesCacheAndRefreshesActiveList();

--- a/developer/tests/js/vocabStore.test.js
+++ b/developer/tests/js/vocabStore.test.js
@@ -3,11 +3,13 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import vm from 'vm';
+import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const readingModel = createRequire(import.meta.url)(path.join(repoRoot, 'js/data/v2/readingVocabularyModel.js'));
 
 function clone(value) {
     return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
@@ -29,9 +31,36 @@ function createVocabFacade(seed = {}) {
     const state = {
         words: clone(seed.words || []),
         collections: clone(seed.collections || {}),
+        reading: readingModel.createSnapshot().reading,
+        allowDefaultWordSeed: seed.authoritativeEmpty !== true,
         config: { activeListId: 'default', ...(clone(seed.config) || {}) }
     };
     const vocab = {
+        async shouldInitializeDefaultWords() {
+            return state.allowDefaultWordSeed && state.words.length === 0;
+        },
+        async initializeDefaultWords({ words }) {
+            if (seed.replaceBeforeSeed) {
+                state.words = [];
+                state.allowDefaultWordSeed = false;
+            }
+            if (!await this.shouldInitializeDefaultWords()) return { committed: false, words: clone(state.words) };
+            await this.replaceListWords({ listId: 'default', words });
+            state.allowDefaultWordSeed = false;
+            return { committed: true, words: clone(state.words) };
+        },
+        async getReadingSnapshot() {
+            return { snapshot: readingModel.createSnapshot({ words: state.words, lists: state.collections, reading: state.reading }), revision: 0, generation: 0 };
+        },
+        async mutateReading(operation, command) {
+            if (seed.failReadingWrite) throw new Error('backend reading write failed');
+            const current = (await this.getReadingSnapshot()).snapshot;
+            const snapshot = readingModel[operation](current, clone(command));
+            state.words = snapshot.words;
+            state.collections = snapshot.lists;
+            state.reading = snapshot.reading;
+            return { saved: true, snapshot: clone(snapshot), revision: 1, generation: 0 };
+        },
         async getConfig() {
             return clone(state.config);
         },
@@ -858,15 +887,16 @@ async function testReadingHighlightUpsertPreservesStudyProgress() {
         meaning: '新释义',
         phonetic: '  /njuː/  ',
         example: 'New example',
-        sourceLabel: 'Reading passage'
+        sourceLabel: 'Reading passage',
+        context: { examId: 'reading-a', libraryConfigurationId: 'library-a' }
     });
     let [stored] = vocabStore.__appDataState.collections['reading-highlights'].words;
 
-    assert.strictEqual(saved.meaning, '新释义');
-    assert.strictEqual(saved.phonetic, 'njuː', '非空音标应写入结构化 phonetic 字段并移除外围斜杠');
-    assert.strictEqual(saved.example, 'New example');
+    assert.strictEqual(saved.meaning, '旧释义', 'collection must preserve the canonical definition');
+    assert.strictEqual(saved.phonetic, 'old-phonetic');
+    assert.strictEqual(saved.example, 'Old example');
     assert.strictEqual(saved.note, '用户记忆笔记');
-    assert.strictEqual(stored.phonetic, 'njuː');
+    assert.strictEqual(stored.phonetic, 'old-phonetic');
     assert.strictEqual(stored.note.includes('音标:'), false, '音标不应再编码进 note 文本');
     assert.strictEqual(stored.easeFactor, 2.2);
     assert.strictEqual(stored.interval, 10);
@@ -881,11 +911,12 @@ async function testReadingHighlightUpsertPreservesStudyProgress() {
         meaning: '再次更新释义',
         phonetic: '   ',
         example: 'Latest example',
-        sourceLabel: 'Another reading passage'
+        sourceLabel: 'Another reading passage',
+        context: { examId: 'reading-b', libraryConfigurationId: 'library-b' }
     });
     [stored] = vocabStore.__appDataState.collections['reading-highlights'].words;
-    assert.strictEqual(savedWithBlankPhonetic.phonetic, 'njuː', '空音标更新必须保留已有结构化音标');
-    assert.strictEqual(stored.phonetic, 'njuː');
+    assert.strictEqual(savedWithBlankPhonetic.phonetic, 'old-phonetic', 'collection preserves the canonical phonetic');
+    assert.strictEqual(stored.phonetic, 'old-phonetic');
     assert.strictEqual(stored.note, '用户记忆笔记', '空音标更新不得破坏用户笔记');
     assert.strictEqual(stored.easeFactor, 2.2);
     assert.strictEqual(stored.interval, 10);
@@ -894,6 +925,38 @@ async function testReadingHighlightUpsertPreservesStudyProgress() {
     assert.strictEqual(stored.lastReviewed, '2026-08-01T00:00:00.000Z');
     assert.strictEqual(stored.nextReview, '2026-08-11T00:00:00.000Z');
     assert.strictEqual(stored.createdAt, '2026-07-01T00:00:00.000Z');
+    assert.strictEqual(vocabStore.__appDataState.reading.associations.length, 2);
+    assert.strictEqual(vocabStore.__appDataState.collections['reading-highlights'].words.length, 1);
+}
+
+async function testReadingCollectionUsesDefaultOwnerAndRejectsFailedWrites() {
+    const seed = { words: [{ id: 'default-apple', word: 'apple', meaning: 'Canonical definition', correctCount: 8 }] };
+    const vocabStore = loadVocabStore({ embeddedWords: [], dataSeed: seed });
+    const payload = { word: 'APPLE', meaning: 'Ignored', context: { examId: 'article-a', libraryConfigurationId: null } };
+    const saved = await vocabStore.upsertReadingHighlightWord(payload);
+    assert.strictEqual(saved.id, 'default-apple');
+    assert.strictEqual(saved.meaning, 'Canonical definition');
+    assert.strictEqual(saved.correctCount, 8);
+    assert.strictEqual(vocabStore.__appDataState.collections['reading-highlights'], undefined);
+    const failed = loadVocabStore({ embeddedWords: [], dataSeed: { ...seed, failReadingWrite: true } });
+    await assert.rejects(failed.upsertReadingHighlightWord(payload), /backend reading write failed/);
+    assert.strictEqual(failed.__appDataState.reading.associations.length, 0);
+    assert.strictEqual(failed.__appDataState.collections['reading-highlights'], undefined);
+}
+
+async function testDefaultBootstrapPreservesAuthoritativeEmptyReplace() {
+    const embeddedWords = [{ id: 'default-apple', word: 'apple', meaning: 'Apple' }];
+    const restored = loadVocabStore({ embeddedWords, dataSeed: { authoritativeEmpty: true } });
+    await restored.init();
+    assert.deepStrictEqual(restored.__appDataState.words, []);
+    assert.strictEqual(restored.getWords().length, 0);
+    assert.strictEqual(restored.__appDataMetrics.replaceListWordsCalls.length, 0);
+
+    const racing = loadVocabStore({ embeddedWords, dataSeed: { replaceBeforeSeed: true } });
+    await racing.init();
+    assert.deepStrictEqual(racing.__appDataState.words, []);
+    assert.strictEqual(racing.getWords().length, 0, 'the committed empty receipt must supersede the bundled snapshot');
+    assert.strictEqual(racing.__appDataMetrics.replaceListWordsCalls.length, 0);
 }
 
 async function testReadingHighlightLegacyNoteProjectsPhoneticWithoutMutation() {
@@ -1085,7 +1148,11 @@ async function main() {
         await testProgressRestorePreservesExistingExplicitPhonetics();
         results.push({ name: '进度恢复保留存量显式音标并采用提交结果', status: 'pass' });
         await testReadingHighlightUpsertPreservesStudyProgress();
-        results.push({ name: '阅读高亮结构化音标更新并保留学习进度', status: 'pass' });
+        results.push({ name: '阅读高亮保留规范词条与两篇文章的关联', status: 'pass' });
+        await testReadingCollectionUsesDefaultOwnerAndRejectsFailedWrites();
+        results.push({ name: '阅读高亮复用默认规范词条并拒绝未持久化的成功', status: 'pass' });
+        await testDefaultBootstrapPreservesAuthoritativeEmptyReplace();
+        results.push({ name: '默认词库初始化保留权威空替换及并发替换结果', status: 'pass' });
         await testReadingHighlightLegacyNoteProjectsPhoneticWithoutMutation();
         results.push({ name: '阅读高亮旧 note 音标只投影且显式字段优先', status: 'pass' });
         await testExternalListCommitInvalidatesCacheAndRefreshesActiveList();

--- a/js/app/examSessionMixin.js
+++ b/js/app/examSessionMixin.js
@@ -2908,8 +2908,16 @@
                             break;
                         }
                         try {
+                            const savePayload = Object.assign({}, data, {
+                                context: Object.assign({}, data.context || {}, {
+                                    examId,
+                                    libraryConfigurationId: Object.prototype.hasOwnProperty.call(windowInfo, 'libraryConfigurationId')
+                                        ? windowInfo.libraryConfigurationId
+                                        : this._readLaunchLibraryConfigurationId(examId)
+                                })
+                            });
                             const saved = typeof window.saveReadingHighlightVocab === 'function'
-                                ? await window.saveReadingHighlightVocab(data)
+                                ? await window.saveReadingHighlightVocab(savePayload)
                                 : null;
                             this._announceVocabHighlightOutcome(
                                 examId,
@@ -2925,7 +2933,7 @@
                                 data,
                                 sourceWindow || expectedWindow,
                                 false,
-                                'save_failed'
+                                saveError && saveError.code || 'save_failed'
                             );
                         }
                         break;

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -10490,8 +10490,16 @@
                             break;
                         }
                         try {
+                            const savePayload = Object.assign({}, data, {
+                                context: Object.assign({}, data.context || {}, {
+                                    examId,
+                                    libraryConfigurationId: Object.prototype.hasOwnProperty.call(windowInfo, 'libraryConfigurationId')
+                                        ? windowInfo.libraryConfigurationId
+                                        : this._readLaunchLibraryConfigurationId(examId)
+                                })
+                            });
                             const saved = typeof window.saveReadingHighlightVocab === 'function'
-                                ? await window.saveReadingHighlightVocab(data)
+                                ? await window.saveReadingHighlightVocab(savePayload)
                                 : null;
                             this._announceVocabHighlightOutcome(
                                 examId,
@@ -10507,7 +10515,7 @@
                                 data,
                                 sourceWindow || expectedWindow,
                                 false,
-                                'save_failed'
+                                saveError && saveError.code || 'save_failed'
                             );
                         }
                         break;
@@ -15548,8 +15556,7 @@ if (typeof module !== 'undefined' && module.exports) {
 (function initReadingVocabReader(global) {
     'use strict';
 
-    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
-    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+    const DEFAULT_SOURCE = { kind: 'builtin', id: 'default' };
 
     function escapeHtml(value) {
         return String(value == null ? '' : value)
@@ -15560,174 +15567,134 @@ if (typeof module !== 'undefined' && module.exports) {
             .replace(/'/g, '&#39;');
     }
 
-    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
         if (!examId) return;
-        try {
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
-                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
-                return;
-            }
-            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
-            const records = raw ? JSON.parse(raw) : [];
-            const idx = records.findIndex(r => String(r.examId) === String(examId));
-            const now = Date.now();
-            if (idx !== -1) {
-                records[idx].lastOpenedAt = now;
-                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
-                if (category && !records[idx].category) records[idx].category = category;
-            } else {
-                records.unshift({
-                    examId: String(examId),
-                    examTitle: examTitle || '',
-                    category: category || '',
-                    firstUsedAt: now,
-                    lastOpenedAt: now
-                });
-            }
-            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
-                global.ReadingBookshelfStore.syncToAppData(records);
-            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
-                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
-            }
-        } catch (e) {
-            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
-        }
+        return ReadingVocabStore.mutate('recordVisit', {
+            source, article: { examId: String(examId), title: examTitle },
+            at: new Date().toISOString()
+        });
     }
 
-    // ============================================================================
-    // 生词本数据管理 (Store)
-    // ============================================================================
+    // This cache is a view of acknowledged AppData state, never a storage authority.
     const ReadingVocabStore = {
-        _cache: null,
+        _state: null,
         _commitBound: false,
+        _loadSequence: 0,
 
-        getAll() {
-            if (this._cache) {
-                return this._cache;
+        async resolveSource(options = {}) {
+            if (options.source) return { ...options.source };
+            const id = Object.prototype.hasOwnProperty.call(options, 'libraryConfigurationId')
+                ? options.libraryConfigurationId
+                : await global.AppData.library.getActive();
+            return id == null || id === '' ? { ...DEFAULT_SOURCE } : { kind: 'imported', id: String(id) };
+        },
+
+        getAll() { return this.project(); },
+
+        project(articleId = null) {
+            if (!this._state) return [];
+            const snapshot = this._state.snapshot;
+            const model = global.AppData.vocab.readingModel;
+            return model.query(snapshot, articleId ? { articleId } : {}).terms.map(entry => {
+                const associations = entry.associations;
+                const article = snapshot.reading.articles.find(row => row.id === associations[0]?.articleId);
+                return {
+                    ...entry.word, id: entry.term.id, word: entry.word.word,
+                    examId: article?.examId || '', examTitle: article?.title || '',
+                    context: entry.word.example || entry.word.context || '',
+                    associations, occurrences: entry.occurrences,
+                    highlights: entry.occurrences.map(occurrence => {
+                        const relation = associations.find(row => row.id === occurrence.associationId);
+                        const owner = snapshot.reading.articles.find(row => row.id === relation?.articleId);
+                        return { ...occurrence, examId: owner?.examId, scope: occurrence.scopeId, text: occurrence.quote };
+                    })
+                };
+            });
+        },
+
+        getByExam(examId, source = DEFAULT_SOURCE) {
+            if (!examId || !this._state) return [];
+            return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
+        },
+
+        adopt(state) {
+            if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
+            this._state = state;
+            if (typeof global.dispatchEvent === 'function') {
+                global.dispatchEvent(new CustomEvent('reading-vocab-store-updated'));
             }
+        },
+
+        async reload() {
+            const sequence = ++this._loadSequence;
+            await global.AppData.ready;
+            const state = await global.AppData.vocab.getReadingSnapshot();
+            if (sequence === this._loadSequence) this.adopt(state);
+            return state;
+        },
+
+        async mutate(type, command) {
+            if (!this._state) await this.init();
+            const observed = this._state;
+            let result;
             try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (raw) {
-                    const parsed = JSON.parse(raw);
-                    if (Array.isArray(parsed)) {
-                        this._cache = parsed;
-                        return this._cache;
-                    }
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 读取失败:', err);
+                result = await global.AppData.vocab.mutateReading(type, command, {
+                    observedRevision: observed.revision, observedGeneration: observed.generation
+                });
+            } catch (error) {
+                // The next explicit retry must use the new deletion/replace fence.
+                await this.reload().catch(() => {});
+                throw error;
             }
-            this._cache = [];
-            return this._cache;
+            if (!result || result.saved !== true) throw new Error('Reading save was not acknowledged');
+            ++this._loadSequence;
+            this.adopt(result);
+            return result;
         },
 
-        _save() {
-            try {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 保存失败:', err);
-            }
-            this.syncToAppData();
-        },
+        // Compatibility flush methods only read authoritative state.
+        async syncToAppData() { return this.reload(); },
+        async flushToAppData() { return this.reload(); },
 
-        async syncToAppData() {
-            try {
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
-                    await global.AppData.vocab.saveReadingWords(this._cache || []);
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
-            }
-        },
-
-        async flushToAppData() {
-            return this.syncToAppData();
-        },
-
-        getByExam(examId) {
-            if (!examId) return [];
-            const all = this.getAll();
-            return all.filter(item => String(item.examId) === String(examId));
-        },
-
-        add(rawWord, examId, examTitle, context = '', highlight = null) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
             const word = this.cleanWord(rawWord);
-            if (!word || word.length > 50) {
-                return { added: false, reason: 'invalid_word' };
-            }
-
-            const all = this.getAll();
-            const lowerWord = word.toLowerCase();
-
-            // 检查当前文章或全局是否存在
-            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
-            if (existingIndex !== -1) {
-                const item = all[existingIndex];
-                item.updatedAt = Date.now();
-                if (examId && !item.examId) {
-                    item.examId = examId;
-                    item.examTitle = examTitle || '';
-                }
-                if (highlight) {
-                    if (!Array.isArray(item.highlights)) {
-                        item.highlights = [];
-                    }
-                    const isDup = item.highlights.some(h =>
-                        String(h.examId) === String(highlight.examId) &&
-                        String(h.scope) === String(highlight.scope) &&
-                        h.startOffset === highlight.startOffset
-                    );
-                    if (!isDup) {
-                        item.highlights.push(highlight);
-                    }
-                }
-                this._save();
-                return { added: true, item: item, isDuplicate: true };
-            }
-
-            const newItem = {
-                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                word: word,
-                examId: examId || '',
-                examTitle: examTitle || '',
-                context: context ? String(context).trim().slice(0, 150) : '',
-                createdAt: Date.now(),
-                highlights: highlight ? [highlight] : []
-            };
-
-            all.unshift(newItem);
-            this._save();
-
-            if (examId) {
-                recordBookshelfExamDirect(examId, examTitle);
-            }
-
-            return { added: true, item: newItem, isDuplicate: false };
+            if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
+            if (!this._state) await this.init();
+            const duplicate = this.getByExam(examId, source).some(item => item.word.toLowerCase() === word.toLowerCase());
+            const occurrence = highlight ? {
+                scopeId: highlight.scopeId || highlight.scope,
+                contentVersion: highlight.contentVersion || 'legacy-reader-v1',
+                startOffset: highlight.startOffset, endOffset: highlight.endOffset,
+                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+            } : undefined;
+            const result = await this.mutate('collect', {
+                source, article: { examId: String(examId), title: examTitle || '' },
+                word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
+                ...(occurrence ? { occurrence } : { manual: true }),
+                at: new Date().toISOString()
+            });
+            return { ...result, added: result.added !== false, isDuplicate: duplicate,
+                item: this.getByExam(examId, source).find(item => item.word.toLowerCase() === word.toLowerCase()) };
         },
 
-        remove(wordOrId) {
-            const all = this.getAll();
+        async remove(wordOrId, examId = null, source = DEFAULT_SOURCE) {
+            if (!this._state) await this.init();
             const target = String(wordOrId).trim().toLowerCase();
-            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
-            if (index !== -1) {
-                all.splice(index, 1);
-                this._save();
-                return true;
-            }
-            return false;
-        },
-
-        clear(examId = null) {
-            if (!examId) {
-                this._cache = [];
-                this._save();
-                return true;
-            }
-            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
-            this._save();
+            const item = this.getAll().find(row => row.id === wordOrId || row.word.toLowerCase() === target);
+            if (!item) return false;
+            await this.mutate(examId ? 'removeArticleTerm' : 'removeTermAssociations', {
+                termId: item.id,
+                ...(examId ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {})
+            });
             return true;
         },
+
+        async clear(examId = null, source = DEFAULT_SOURCE) {
+            await this.mutate(examId ? 'clearArticle' : 'clearReading', examId
+                ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {});
+            return true;
+        },
+
 
         cleanWord(str) {
             if (!str) return '';
@@ -15736,8 +15703,8 @@ if (typeof module !== 'undefined' && module.exports) {
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
-            const list = examId ? this.getByExam(examId) : this.getAll();
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            const list = examId ? this.getByExam(examId, source) : this.getAll();
             if (!list || list.length === 0) {
                 return false;
             }
@@ -15786,49 +15753,21 @@ if (typeof module !== 'undefined' && module.exports) {
 
         async init() {
             this.bindCommitListener();
-            try {
-                if (global.AppData && global.AppData.ready) {
-                    await global.AppData.ready;
-                }
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
-                    const appDataWords = Array.isArray(result)
-                        ? result
-                        : (result && result.envelope ? result.data : null);
-                    if (Array.isArray(appDataWords)) {
-                        // An existing AppData document owns restores, including empty lists.
-                        // An absent document may mean migration failed; preserve the local copy.
-                        this._cache = appDataWords;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
-                    }
-                }
-            } catch (e) {
-                console.warn('[ReadingVocabStore] init failed:', e);
-            }
+            return this.reload();
         },
 
         bindCommitListener() {
-            if (this._commitBound) return;
-            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
-                this._commitBound = true;
-                global.AppData.backups.onDataCommitted(async (event) => {
-                    const targets = event && event.targets;
-                    if (!Array.isArray(targets)) return;
-                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
-                    if (hasVocab) {
-                        try {
-                            const updated = await global.AppData.vocab.listReadingWords();
-                            if (Array.isArray(updated)) {
-                                this._cache = updated;
-                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
-                            }
-                        } catch (err) {
-                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
-                        }
+            if (this._commitBound || !global.AppData?.backups?.onDataCommitted) return;
+            this._commitBound = true;
+            global.AppData.backups.onDataCommitted(event => {
+                if (!event?.targets?.some(target => target.logicalKey?.startsWith('vocab.'))) return;
+                this.reload().catch(error => {
+                    console.warn('[ReadingVocabStore] Unable to refresh committed data:', error);
+                    if (global.ReadingVocabReader?.currentExamId) {
+                        global.ReadingVocabReader.showToast('数据刷新失败，请重新打开生词本重试');
                     }
                 });
-            }
+            });
         }
     };
 
@@ -16243,6 +16182,7 @@ if (typeof module !== 'undefined' && module.exports) {
     // ============================================================================
     const ReadingVocabReader = {
         currentExamId: null,
+        currentSource: DEFAULT_SOURCE,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -16467,22 +16407,33 @@ if (typeof module !== 'undefined' && module.exports) {
             // 手动收录
             const manualInput = overlay.querySelector('#vocab-manual-input');
             const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
-            const handleManualAdd = () => {
-                if (!manualInput) return;
+            const handleManualAdd = async () => {
+                if (!manualInput || manualAddBtn?.disabled || !this.currentPayload) return;
                 const val = manualInput.value.trim();
                 if (!val) return;
-                const result = ReadingVocabStore.add(
-                    val,
-                    this.currentExamId,
-                    this.currentExam?.title || '',
-                    ''
-                );
-                if (result.added) {
-                    manualInput.value = '';
-                    this.updateCounts();
-                    this.renderVocabList();
-                    this.applyVocabHighlights(val);
-                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                const requestId = this._openRequestId;
+                if (manualAddBtn) manualAddBtn.disabled = true;
+                this.showToast('正在保存…');
+                try {
+                    const result = await ReadingVocabStore.add(
+                        val,
+                        this.currentExamId,
+                        this.currentExam?.title || '',
+                        '', null, this.currentSource
+                    );
+                    if (requestId !== this._openRequestId) return;
+                    if (result.added) {
+                        manualInput.value = '';
+                        this.updateCounts();
+                        this.renderVocabList();
+                        this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录`);
+                    } else {
+                        this.showToast('未保存，请检查输入后重试');
+                    }
+                } catch (error) {
+                    this.showSaveError(error, '保存失败，请再次点击收录重试');
+                } finally {
+                    if (manualAddBtn) manualAddBtn.disabled = false;
                 }
             };
             if (manualAddBtn) {
@@ -16515,7 +16466,7 @@ if (typeof module !== 'undefined' && module.exports) {
                     const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
                     const filename = `${dateStr}_${safeArticleName}.txt`;
 
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
                     if (success) {
                         this.showToast(`✅ 已导出：${filename}`);
                     } else {
@@ -16526,11 +16477,11 @@ if (typeof module !== 'undefined' && module.exports) {
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                clearBtn.addEventListener('click', async () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
-                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).length
                         : ReadingVocabStore.getAll().length;
 
                     if (count === 0) {
@@ -16538,14 +16489,22 @@ if (typeof module !== 'undefined' && module.exports) {
                         return;
                     }
 
-                    ReadingVocabStore.clear(examId);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    const passageContent = overlay.querySelector('#vocab-passage-content');
-                    const questionsContent = overlay.querySelector('#vocab-questions-content');
-                    this.removeVocabHighlights(passageContent);
-                    this.removeVocabHighlights(questionsContent);
-                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    clearBtn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.clear(examId, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        this.removeVocabHighlights(passageContent);
+                        this.removeVocabHighlights(questionsContent);
+                        this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    } catch (error) {
+                        this.showSaveError(error, '清空失败，请再次点击清空重试');
+                    } finally {
+                        clearBtn.disabled = false;
+                    }
                 });
             }
 
@@ -16554,8 +16513,8 @@ if (typeof module !== 'undefined' && module.exports) {
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
+                    setTimeout(async () => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -16647,21 +16606,35 @@ if (typeof module !== 'undefined' && module.exports) {
                             text: cleanWord
                         };
 
-                        const result = ReadingVocabStore.add(
-                            cleanWord,
-                            this.currentExamId,
-                            this.currentExam?.title || '',
-                            contextSentence,
-                            highlightRecord
-                        );
+                        this.showToast('正在保存…');
+                        try {
+                            const result = await ReadingVocabStore.add(
+                                cleanWord,
+                                this.currentExamId,
+                                this.currentExam?.title || '',
+                                contextSentence,
+                                highlightRecord, this.currentSource
+                            );
 
-                        if (result.added) {
-                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                            this.updateCounts();
-                            if (this.modalOpen) {
-                                this.renderVocabList();
+                            if (requestId !== this._openRequestId) return;
+                            if (result.added) {
+                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                                this.updateCounts();
+                                if (this.modalOpen) {
+                                    this.renderVocabList();
+                                }
+                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                            } else {
+                                throw new Error('Selection was not saved');
                             }
-                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        } catch (error) {
+                            if (wrappedMark.parentNode) {
+                                const parent = wrappedMark.parentNode;
+                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
+                                wrappedMark.remove();
+                                parent.normalize();
+                            }
+                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
                         }
                     }, 20);
                 };
@@ -16741,12 +16714,20 @@ if (typeof module !== 'undefined' && module.exports) {
 
             try {
                 // 加载试卷数据
-                const payload = await loadReadingExamPayload(examId);
+                const [payload, source] = await Promise.all([
+                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
+                ]);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
+                // The current payload registry contains only built-in generated
+                // content. Never attach that content to a different library.
+                if (source.kind !== 'builtin' || source.id !== 'default') {
+                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
+                }
                 this.currentPayload = payload;
+                this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
@@ -16763,11 +16744,20 @@ if (typeof module !== 'undefined' && module.exports) {
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
-                recordBookshelfExamDirect(examId, examTitle, examCategory);
+                let saveError = null;
+                try {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                } catch (error) {
+                    saveError = error;
+                }
+                if (requestId !== this._openRequestId) return;
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
@@ -17034,7 +17024,7 @@ if (typeof module !== 'undefined' && module.exports) {
             if (!this.currentExamId) return;
 
             // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
             if (!examItems || examItems.length === 0) return;
 
             examItems.forEach(item => {
@@ -17044,9 +17034,6 @@ if (typeof module !== 'undefined' && module.exports) {
                             this.restoreVocabHighlight(overlay, hl, item.word);
                         }
                     });
-                } else if (item.context && item.word) {
-                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
-                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
                 }
             });
         },
@@ -17322,7 +17309,7 @@ if (typeof module !== 'undefined' && module.exports) {
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId);
+            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -17344,7 +17331,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId)
+                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -17386,19 +17373,27 @@ if (typeof module !== 'undefined' && module.exports) {
             });
 
             listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
+                btn.addEventListener('click', async (e) => {
                     e.stopPropagation();
                     const id = btn.dataset.delId;
                     const allItems = ReadingVocabStore.getAll();
                     const item = allItems.find(w => w.id === id);
                     const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
+                    btn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.remove(id, isCurrent ? this.currentExamId : null, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) {
+                            this.removeVocabHighlightForWord(word);
+                        }
+                        this.showToast('已从生词本删除');
+                    } catch (error) {
+                        this.showSaveError(error, '删除失败，请再次点击删除重试');
+                    } finally {
+                        btn.disabled = false;
                     }
-                    this.showToast('已从生词本删除');
                 });
             });
         },
@@ -17423,6 +17418,11 @@ if (typeof module !== 'undefined' && module.exports) {
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+        },
+
+        showSaveError(error, retryMessage) {
+            this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                ? '存储暂不可用，请刷新页面后重试' : retryMessage);
         },
 
         showToast(msg) {
@@ -17453,8 +17453,8 @@ if (typeof module !== 'undefined' && module.exports) {
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.modalOpen) {
-                ReadingVocabReader.renderVocabList();
+            if (ReadingVocabReader.currentExamId) {
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
             }
@@ -17469,7 +17469,7 @@ if (typeof module !== 'undefined' && module.exports) {
     };
 
     // 启动数据同步初始化
-    ReadingVocabStore.init();
+    ReadingVocabStore.init().catch(error => console.warn('[ReadingVocabStore] Initialization failed:', error));
 
 })(typeof window !== 'undefined' ? window : globalThis);
 
@@ -21155,9 +21155,11 @@ async function saveReadingHighlightVocab(payload) {
     } catch (error) {
         console.warn('[VocabStore] 阅读高亮生词保存失败:', error);
         if (typeof showMessage === 'function') {
-            showMessage('高亮生词已在阅读页本地缓存，主词表稍后同步', 'warning');
+            showMessage(error && error.code === 'BACKEND_UNAVAILABLE'
+                ? '高亮生词保存失败，请刷新主页并重新打开阅读页后重试'
+                : '高亮生词保存失败，请在阅读页重试', 'warning');
         }
-        return null;
+        throw error;
     }
 }
 
@@ -21330,11 +21332,19 @@ function setupMessageListener() {
             const payload = data.data && typeof data.data === 'object' ? data.data : data;
             const requestId = payload && payload.requestId != null ? String(payload.requestId).trim() : '';
             if (!requestId) return;
-            saveReadingHighlightVocab(payload).then((saved) => {
+            const launchContext = matched.rec.initPayload || matched.rec;
+            const savePayload = Object.assign({}, payload, {
+                context: Object.assign({}, payload.context || {}, {
+                    examId: matched.rec.examId,
+                    libraryConfigurationId: launchContext.libraryConfigurationId == null
+                        ? null : launchContext.libraryConfigurationId
+                })
+            });
+            saveReadingHighlightVocab(savePayload).then((saved) => {
                 sendFallbackVocabOutcome(matched.rec, payload, Boolean(saved), saved ? '' : 'save_failed');
             }).catch((error) => {
                 console.warn('[VocabStore] 阅读高亮生词保存异常:', error);
-                sendFallbackVocabOutcome(matched.rec, payload, false, 'save_failed');
+                sendFallbackVocabOutcome(matched.rec, payload, false, error && error.code || 'save_failed');
             });
         } else if (type === 'PRACTICE_COMPLETE' || type === 'practice_completed') {
             const payload = extractCompletionPayload(data) || {};

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -674,6 +674,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'
@@ -3007,6 +3012,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -3038,7 +3178,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -4762,7 +4902,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -4804,6 +4944,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -4897,28 +5039,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -4927,7 +5143,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -4976,7 +5196,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -5097,17 +5320,391 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5120,7 +5717,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5133,7 +5730,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5149,7 +5746,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5164,7 +5761,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5196,7 +5793,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5214,7 +5811,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5287,7 +5884,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5346,7 +5943,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5388,7 +5985,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -5425,35 +6022,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -5713,6 +6292,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -5921,7 +6505,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -3056,7 +3056,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -3075,34 +3075,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;
@@ -5105,6 +5129,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -5529,10 +5560,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -5637,6 +5668,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -5711,6 +5743,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -343,6 +343,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'
@@ -2676,6 +2681,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -2707,7 +2847,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -4431,7 +4571,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -4473,6 +4613,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -4566,28 +4708,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -4596,7 +4812,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -4645,7 +4865,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4766,17 +4989,391 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4789,7 +5386,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4802,7 +5399,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4818,7 +5415,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4833,7 +5430,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4865,7 +5462,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4883,7 +5480,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4956,7 +5553,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5015,7 +5612,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5057,7 +5654,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -5094,35 +5691,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -5382,6 +5961,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -5590,7 +6174,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -2725,7 +2725,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -2744,34 +2744,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;
@@ -4774,6 +4798,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -5198,10 +5229,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -5306,6 +5337,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -5380,6 +5412,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -343,6 +343,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'
@@ -2676,6 +2681,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -2707,7 +2847,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -4431,7 +4571,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -4473,6 +4613,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -4566,28 +4708,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -4596,7 +4812,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -4645,7 +4865,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4766,17 +4989,391 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4789,7 +5386,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4802,7 +5399,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4818,7 +5415,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4833,7 +5430,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4865,7 +5462,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4883,7 +5480,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4956,7 +5553,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5015,7 +5612,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5057,7 +5654,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -5094,35 +5691,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -5382,6 +5961,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -5590,7 +6174,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -2725,7 +2725,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -2744,34 +2744,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;
@@ -4774,6 +4798,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -5198,10 +5229,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -5306,6 +5337,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -5380,6 +5412,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -1480,7 +1480,7 @@
                 return backfilled;
             }
             const vocab = await requireVocabData();
-            if (!await vocab.shouldInitializeDefaultWords()) {
+            if (!pollutedBySpellingList && !await vocab.shouldInitializeDefaultWords()) {
                 if (state.activeListId === DEFAULT_LIST_ID) setWordsInternal(normalizedStored);
                 return normalizedStored;
             }
@@ -1490,7 +1490,9 @@
                 console.warn('[VocabStore] 默认词库为空');
                 return [];
             }
-            const receipt = await vocab.initializeDefaultWords({ words: normalized });
+            const receipt = pollutedBySpellingList
+                ? await vocab.repairDefaultWords({ words: normalized })
+                : await vocab.initializeDefaultWords({ words: normalized });
             normalized = normalizeStoredListWords(receipt.words, DEFAULT_LIST_ID);
             if (state.activeListId === DEFAULT_LIST_ID) {
                 setWordsInternal(normalized);

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -1152,13 +1152,6 @@
         return Object.prototype.hasOwnProperty.call(collections, listId) ? collections[listId] : null;
     }
 
-    async function saveListData(listId, value) {
-        const vocab = await requireVocabData();
-        const words = value && typeof value === 'object' && Array.isArray(value.words) ? value.words : value;
-        await vocab.replaceListWords({ listId, words: Array.isArray(words) ? words : [] });
-        return true;
-    }
-
     async function saveConfigData(configPatch = state.config) {
         const vocab = await requireVocabData();
         await vocab.patchConfig(Object.assign({}, configPatch, { activeListId: state.activeListId }));
@@ -1486,16 +1479,19 @@
                 }
                 return backfilled;
             }
-            if (pollutedBySpellingList) {
-                console.warn('[VocabStore] 检测到默认词表被错词快照污染，正在恢复 IELTS 核心词表');
+            const vocab = await requireVocabData();
+            if (!await vocab.shouldInitializeDefaultWords()) {
+                if (state.activeListId === DEFAULT_LIST_ID) setWordsInternal(normalizedStored);
+                return normalizedStored;
             }
 
-            const normalized = await loadBundledDefaultLexicon();
+            let normalized = await loadBundledDefaultLexicon();
             if (!normalized.length) {
                 console.warn('[VocabStore] 默认词库为空');
                 return [];
             }
-            await saveListData(DEFAULT_LIST_ID, normalized);
+            const receipt = await vocab.initializeDefaultWords({ words: normalized });
+            normalized = normalizeStoredListWords(receipt.words, DEFAULT_LIST_ID);
             if (state.activeListId === DEFAULT_LIST_ID) {
                 setWordsInternal(normalized);
                 state.lastLoadSource = 'default';
@@ -1914,38 +1910,47 @@
         if (!normalized) {
             return null;
         }
-        await init();
-        const listId = 'reading-highlights';
-        const storedData = await readListData(listId);
-        const words = normalizeStoredListWords(storedData, listId);
-        const key = normalized.word.toLowerCase();
-        const existingIndex = words.findIndex((entry) => String(entry.word || '').trim().toLowerCase() === key);
-        let committedWord = normalized;
-        if (existingIndex >= 0) {
-            const existing = words[existingIndex];
-            committedWord = normalizeWordRecord({
-                ...existing,
-                ...normalized,
-                id: existing.id || normalized.id,
-                createdAt: existing.createdAt || normalized.createdAt,
-                note: existing.note || normalized.note,
-                easeFactor: existing.easeFactor,
-                interval: existing.interval,
-                repetitions: existing.repetitions,
-                intraCycles: existing.intraCycles,
-                correctCount: existing.correctCount,
-                lastReviewed: existing.lastReviewed,
-                nextReview: existing.nextReview,
-                updatedAt: getNow()
-            });
-            words.splice(existingIndex, 1, committedWord);
-        } else {
-            words.push(normalized);
+        const vocab = await requireVocabData();
+        const context = payload.context && typeof payload.context === 'object' ? payload.context : {};
+        const examId = String(context.examId || payload.examId || '').trim();
+        if (!examId) throw new Error('Reading vocabulary requires an article identity');
+        let source = context.source || (payload.source && typeof payload.source === 'object' ? payload.source : null);
+        const configurationId = Object.prototype.hasOwnProperty.call(context, 'libraryConfigurationId')
+            ? context.libraryConfigurationId
+            : payload.libraryConfigurationId;
+        if (configurationId !== undefined || !source) {
+            if (configurationId === undefined) throw new Error('Reading vocabulary requires a library identity');
+            source = configurationId == null || configurationId === ''
+                ? { kind: 'builtin', id: 'default' }
+                : { kind: 'imported', id: String(configurationId).trim() };
         }
-        await saveListData(listId, words.filter(Boolean));
+        const observed = await vocab.getReadingSnapshot();
+        const command = {
+            source,
+            article: { examId, title: String(context.title || '') },
+            word: normalized,
+            manual: !payload.occurrence,
+            at: getNow()
+        };
+        if (payload.occurrence) command.occurrence = cloneValue(payload.occurrence);
+        const receipt = await vocab.mutateReading('collect', command, {
+            observedRevision: observed.revision,
+            observedGeneration: observed.generation
+        });
+        if (!receipt || receipt.saved !== true || !receipt.snapshot) {
+            throw new Error('Reading vocabulary was not durably acknowledged');
+        }
+        const snapshot = receipt.snapshot;
+        const term = snapshot.reading.terms.find((entry) => entry.normalizedTerm === normalized.word.toLowerCase());
+        if (!term) throw new Error('Saved reading vocabulary has no canonical owner');
+        const listId = term.wordRef.listId;
+        const storedList = listId === DEFAULT_LIST_ID ? snapshot.words : snapshot.lists[listId];
+        const words = Array.isArray(storedList) ? storedList : storedList && storedList.words || [];
+        const committedWord = words.find((entry) => entry.id === term.wordRef.wordId);
+        if (!committedWord) throw new Error('Saved reading vocabulary has no canonical word');
         state.listCache.delete(listId);
         if (state.activeListId === listId) {
-            setWordsInternal(words.map((word) => resolveWordPhonetic(word)).filter(Boolean));
+            setWordsInternal(normalizeStoredListWords(storedList, listId));
         }
         return cloneValue(resolveWordPhonetic(committedWord));
     }
@@ -5185,269 +5190,186 @@
 (function initBookshelfView(global) {
     'use strict';
 
-    const BOOKSHELF_KEY = 'ielts_reading_bookshelf_exams_v1';
-    const VOCAB_KEY = 'ielts_reading_vocab_words_v1';
+    function needsPageReload(error) {
+        return error && error.code === 'BACKEND_UNAVAILABLE';
+    }
 
-    // ============================================================================
-    // 书架数据管理 (ReadingBookshelfStore)
-    // ============================================================================
+    // AppData owns persistence. This snapshot is only a view cache and is never
+    // written back as a whole collection.
     const ReadingBookshelfStore = {
+        _snapshot: null,
+        _revision: null,
+        _generation: null,
         _commitBound: false,
+        _loadSequence: 0,
+        _loadError: null,
 
         getRawRecords() {
-            try {
-                const raw = localStorage.getItem(BOOKSHELF_KEY);
-                return raw ? JSON.parse(raw) : [];
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 读取书架记录失败:', e);
-                return [];
-            }
+            return this.getBookshelfExams().map((exam) => ({
+                articleId: exam.articleId, source: exam.source, examId: exam.examId,
+                examTitle: exam.title, category: exam.category, lastOpenedAt: exam.lastActivityAt
+            }));
         },
 
-        saveRecords(records) {
-            try {
-                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(records || []));
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 保存书架记录失败:', e);
+        async resolveSource(source) {
+            if (source) return source;
+            if (global.ReadingVocabStore && typeof global.ReadingVocabStore.resolveSource === 'function') {
+                return global.ReadingVocabStore.resolveSource({});
             }
-            this.syncToAppData(records);
+            const library = global.AppData && global.AppData.library;
+            const id = library && typeof library.getActive === 'function' ? await library.getActive() : null;
+            return id ? { kind: 'imported', id } : { kind: 'builtin', id: 'default' };
         },
 
-        async syncToAppData(records) {
-            try {
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
-                    await global.AppData.vocab.saveReadingBookshelfExams(records || this.getRawRecords());
-                }
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] syncToAppData failed:', e);
-            }
+        _adopt(result) {
+            if (!result || !result.snapshot) throw new Error('Reading snapshot is unavailable');
+            if (this._revision !== null && result.revision < this._revision) return;
+            this._snapshot = result.snapshot;
+            this._revision = result.revision;
+            this._generation = result.generation;
+            this._loadError = null;
         },
 
-        async flushToAppData() {
-            return this.syncToAppData(this.getRawRecords());
+        _notify(detail = {}) {
+            global.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail }));
         },
 
         async init() {
-            this.bindCommitListener();
+            const sequence = ++this._loadSequence;
             try {
-                if (global.AppData && global.AppData.ready) {
-                    await global.AppData.ready;
+                if (global.AppData && global.AppData.ready) await global.AppData.ready;
+                this.bindCommitListener();
+                const vocab = global.AppData && global.AppData.vocab;
+                if (!vocab || typeof vocab.getReadingSnapshot !== 'function') {
+                    throw new Error('Reading persistence is unavailable');
                 }
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
-                    const result = await global.AppData.vocab.listReadingBookshelfExams({ withMeta: true });
-                    const appDataRecords = Array.isArray(result) ? result : result && result.envelope && result.data;
-                    // AppData owns legacy migration. Its restored collection,
-                    // including an empty array, replaces the local display mirror.
-                    // An absent envelope can mean migration failed; retain its
-                    // only legacy copy instead of treating the default [] as a clear.
-                    if (Array.isArray(appDataRecords)) {
-                        localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(appDataRecords));
-                    }
+                const result = await vocab.getReadingSnapshot();
+                if (sequence === this._loadSequence) {
+                    this._adopt(result);
+                    this._notify({ action: 'reload' });
                 }
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] init failed:', e);
+                return result;
+            } catch (error) {
+                if (sequence === this._loadSequence) {
+                    this._loadError = error;
+                    this._notify({ action: 'load-failed' });
+                }
+                throw error;
             }
         },
+
+        // Compatibility flush callers wait for a fresh durable snapshot.
+        async flushToAppData() { return this.init(); },
 
         bindCommitListener() {
             if (this._commitBound) return;
-            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+            const backups = global.AppData && global.AppData.backups;
+            if (backups && typeof backups.onDataCommitted === 'function') {
                 this._commitBound = true;
-                global.AppData.backups.onDataCommitted(async (event) => {
+                backups.onDataCommitted((event) => {
                     const targets = event && event.targets;
-                    if (!Array.isArray(targets)) return;
-                    const hasBookshelf = targets.some(t => t.logicalKey === 'vocab.readingBookshelfExams');
-                    if (hasBookshelf) {
-                        try {
-                            const updated = await global.AppData.vocab.listReadingBookshelfExams();
-                            if (Array.isArray(updated)) {
-                                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(updated));
-                                window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail: { records: updated } }));
-                            }
-                        } catch (err) {
-                            console.warn('[ReadingBookshelfStore] reload on committed failed:', err);
-                        }
+                    if (Array.isArray(targets) && targets.some((target) => String(target.logicalKey || '').startsWith('vocab.'))) {
+                        this.init().catch((error) => console.warn('[ReadingBookshelfStore] Reload failed:', error));
                     }
                 });
             }
         },
 
-        recordExamUsed(examId, examTitle = '', category = '') {
-            if (!examId) return;
+        async _mutate(type, command) {
+            if (!this._snapshot) await this.init();
+            let result;
             try {
-                const records = this.getRawRecords();
-                const now = Date.now();
-                const idx = records.findIndex(r => String(r.examId) === String(examId));
-                if (idx !== -1) {
-                    records[idx].lastOpenedAt = now;
-                    if (examTitle && !records[idx].examTitle) {
-                        records[idx].examTitle = examTitle;
-                    }
-                    if (category && !records[idx].category) {
-                        records[idx].category = category;
-                    }
-                } else {
-                    records.unshift({
-                        examId: String(examId),
-                        examTitle: examTitle || '',
-                        category: category || '',
-                        firstUsedAt: now,
-                        lastOpenedAt: now
-                    });
-                }
-                this.saveRecords(records);
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 记录题目失败:', e);
+                result = await global.AppData.vocab.mutateReading(type, command, {
+                    observedRevision: this._revision, observedGeneration: this._generation
+                });
+            } catch (error) {
+                // A missed cross-window notification must not leave every retry
+                // anchored to a removed association or an old import generation.
+                await this.init().catch(() => {});
+                throw error;
             }
+            if (!result || result.saved !== true) throw new Error('Reading change was not durably acknowledged');
+            // An in-flight reload may predate this acknowledgement.
+            ++this._loadSequence;
+            this._adopt(result);
+            this._notify({ action: type, articleId: command.articleId });
+            return result;
+        },
+
+        async recordExamUsed(examId, examTitle = '', category = '', source) {
+            if (!examId) return false;
+            return this._mutate('recordVisit', {
+                source: await this.resolveSource(source),
+                article: { examId: String(examId), title: examTitle || '' }
+            });
         },
 
         getBookshelfExams() {
-            // 1. 读取全部生词
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
-
-            // 统计生词数据映射
-            const vocabMap = new Map();
-            vocabWords.forEach(item => {
-                if (!item || !item.examId) return;
-                const eid = String(item.examId);
-                if (!vocabMap.has(eid)) {
-                    vocabMap.set(eid, {
-                        count: 0,
-                        words: [],
-                        latestTime: item.createdAt || 0,
-                        examTitle: item.examTitle || ''
-                    });
-                }
-                const group = vocabMap.get(eid);
-                group.count++;
-                if (group.words.length < 6 && item.word) {
-                    group.words.push(item.word);
-                }
-                if (item.createdAt && item.createdAt > group.latestTime) {
-                    group.latestTime = item.createdAt;
-                }
-                if (!group.examTitle && item.examTitle) {
-                    group.examTitle = item.examTitle;
-                }
+            const snapshot = this._snapshot;
+            if (!snapshot) return [];
+            const reading = snapshot.reading;
+            const sourceMap = new Map(reading.sources.map((source) => [source.id, source]));
+            const termMap = new Map(reading.terms.map((term) => [term.id, term]));
+            const visitMap = new Map(reading.visits.map((visit) => [visit.articleId, visit]));
+            const associations = new Map();
+            reading.associations.forEach((association) => {
+                if (!associations.has(association.articleId)) associations.set(association.articleId, []);
+                associations.get(association.articleId).push(association);
             });
-
-            // 2. 读取书架记录
-            const records = this.getRawRecords();
-            const recordMap = new Map();
-            records.forEach(r => {
-                if (r && r.examId) {
-                    recordMap.set(String(r.examId), r);
-                }
-            });
-
-            // 3. 读取全局 Manifest 题库元信息
-            const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || {};
-
-            // 4. 合并集合（记录过的题目 + 拥有生词的题目）
-            const allExamIds = new Set([...recordMap.keys(), ...vocabMap.keys()]);
-            const results = [];
-
-            allExamIds.forEach(examId => {
-                const rec = recordMap.get(examId) || {};
-                const vocab = vocabMap.get(examId) || { count: 0, words: [], latestTime: 0, examTitle: '' };
-                const meta = manifest[examId] || {};
-
-                const title = rec.examTitle || vocab.examTitle || meta.title || meta.name || examId;
-                const category = rec.category || meta.category || meta.type || '雅思阅读';
-                const lastActivity = Math.max(rec.lastOpenedAt || 0, vocab.latestTime || 0, rec.firstUsedAt || 0);
-
-                results.push({
-                    examId: examId,
-                    title: title,
-                    category: category,
-                    wordCount: vocab.count,
-                    sampleWords: vocab.words,
-                    lastActivityAt: lastActivity || Date.now(),
-                    hasPdf: Boolean(meta.pdfPath || meta.pdf)
-                });
-            });
-
-            // 默认按最后活动时间倒序排序
-            results.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
-            return results;
+            const manifest = global.__READING_EXAM_MANIFEST__ || {};
+            return reading.articles.filter((article) => visitMap.has(article.id) || associations.has(article.id)).map((article) => {
+                const sourceRow = sourceMap.get(article.sourceId);
+                const source = { kind: sourceRow.kind, id: sourceRow.libraryId };
+                const related = associations.get(article.id) || [];
+                const visit = visitMap.get(article.id);
+                const meta = source.kind === 'builtin' ? manifest[article.examId] || {} : {};
+                const words = related.map((association) => this._wordForTerm(termMap.get(association.termId))).filter(Boolean);
+                const lastActivityAt = Math.max(
+                    visit ? Date.parse(visit.lastVisitedAt) : 0,
+                    ...related.map((association) => Date.parse(association.updatedAt)),
+                    0
+                );
+                return {
+                    articleId: article.id, source, examId: article.examId,
+                    title: article.title || meta.title || meta.name || article.examId,
+                    category: meta.category || meta.type || '雅思阅读',
+                    wordCount: words.length, sampleWords: words.slice(0, 6).map((word) => word.word),
+                    lastActivityAt, hasPdf: Boolean(meta.pdfPath || meta.pdf)
+                };
+            }).sort((a, b) => b.lastActivityAt - a.lastActivityAt);
         },
 
-        removeExam(examId, alsoDeleteWords = true) {
-            try {
-                const targetExamId = String(examId).trim();
-                if (!targetExamId) return false;
-
-                // 1. 从书架记录中移除篇目
-                const records = this.getRawRecords().filter(r => String(r.examId || r.id).trim() !== targetExamId);
-                this.saveRecords(records);
-
-                // 2. 仅删除该篇目下的生词本记录（严格与做题练习记录隔离）
-                if (alsoDeleteWords) {
-                    // 若全局内存中存在 ReadingVocabStore，同步调用 clear
-                    if (global.ReadingVocabStore && typeof global.ReadingVocabStore.clear === 'function') {
-                        try {
-                            global.ReadingVocabStore.clear(targetExamId);
-                        } catch (err) {
-                            console.warn('[ReadingBookshelfStore] ReadingVocabStore.clear 失败:', err);
-                        }
-                    }
-
-                    // 持久化存储过滤生词
-                    let vocabWords = [];
-                    const raw = localStorage.getItem(VOCAB_KEY);
-                    if (raw) {
-                        try { vocabWords = JSON.parse(raw); } catch (_) {}
-                    }
-                    const filtered = vocabWords.filter(w => String(w.examId).trim() !== targetExamId);
-                    try {
-                        localStorage.setItem(VOCAB_KEY, JSON.stringify(filtered));
-                    } catch (e) {
-                        console.warn('[ReadingBookshelfStore] 保存过滤生词失败:', e);
-                    }
-
-                    // 同步到 AppData.vocab
-                    if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
-                        global.AppData.vocab.saveReadingWords(filtered).catch(err => {
-                            console.warn('[ReadingBookshelfStore] 同步生词删除至 AppData 失败:', err);
-                        });
-                    }
-
-                    // 广播生词变更事件，通知所有打开的阅读器及组件
-                    try {
-                        window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', {
-                            detail: { examId: targetExamId, action: 'clear-exam-vocab' }
-                        }));
-                    } catch (_) {}
-                }
-
-                // 3. 严格数据隔离：绝不触碰任何做题练习记录（做题历史、得分记录、错题记录等完整保留）
-
-                // 4. 广播书架更新事件
-                try {
-                    window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', {
-                        detail: { examId: targetExamId, action: 'remove-exam' }
-                    }));
-                } catch (_) {}
-
-                return true;
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 移除题目失败:', e);
-                return false;
-            }
+        _wordForTerm(term) {
+            if (!term || !this._snapshot) return null;
+            const ref = term.wordRef;
+            const list = ref.listId === 'default' ? this._snapshot.words : this._snapshot.lists[ref.listId];
+            const words = Array.isArray(list) ? list : list && list.words || [];
+            return words.find((word) => word.id === ref.wordId) || null;
         },
 
-        exportExamTxt(examId, examTitle) {
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
+        _getWords(articleId) {
+            if (!this._snapshot) return [];
+            const reading = this._snapshot.reading;
+            const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
+            return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
+        },
 
-            const examWords = vocabWords.filter(item => String(item.examId) === String(examId));
+        async _articleId(examId, source, articleId) {
+            if (articleId) return articleId;
+            const resolvedSource = await this.resolveSource(source);
+            return global.AppData.vocab.readingModel.articleId(resolvedSource, String(examId));
+        },
+
+        async removeExam(examId, alsoDeleteWords = true, source, articleId) {
+            if (!String(examId || '').trim()) return false;
+            const id = await this._articleId(examId, source, articleId);
+            return this._mutate('removeArticle', { articleId: id, clearWords: alsoDeleteWords });
+        },
+
+        async exportExamTxt(examId, examTitle, source, articleId) {
+            await this.init();
+            const id = await this._articleId(examId, source, articleId);
+            const examWords = this._getWords(id);
             if (examWords.length === 0) {
                 return false;
             }
@@ -5489,12 +5411,9 @@
             return { filename, count: words.length };
         },
 
-        exportAllBookshelfTxt() {
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
+        async exportAllBookshelfTxt() {
+            await this.init();
+            const vocabWords = this._getWords();
 
             if (vocabWords.length === 0) {
                 return false;
@@ -5567,6 +5486,7 @@
 
             this.render();
             this.bindGlobalEvents();
+            ReadingBookshelfStore.init().catch(() => {});
         },
 
         render() {
@@ -5607,6 +5527,9 @@
 
             root.innerHTML = `
                 <div class="bookshelf-layout">
+                    ${ReadingBookshelfStore._loadError ? (needsPageReload(ReadingBookshelfStore._loadError)
+                        ? '<p role="alert">书架加载失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
+                        : '<p role="alert">书架加载失败，已显示的数据保持不变。<button type="button" class="btn btn-secondary" data-action="retry-load">重试加载</button></p>') : ''}
                     <!-- 顶部标题栏与导航 -->
                     <div class="bookshelf-topbar">
                         <div class="bookshelf-topbar__left">
@@ -5690,7 +5613,7 @@
 
                     <!-- 篇目卡片网格 -->
                     <div class="bookshelf-content-area">
-                        ${filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
+                        ${!ReadingBookshelfStore._snapshot ? (ReadingBookshelfStore._loadError ? '' : '<p role="status">正在加载书架…</p>') : filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
                     </div>
                 </div>
 
@@ -5714,7 +5637,7 @@
             const wordsList = exam.sampleWords || [];
 
             return `
-                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}">
+                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}" data-article-id="${this.escapeHtml(exam.articleId)}">
                     <div class="bookshelf-card__header">
                         <div class="bookshelf-card__tags">
                             <span class="bookshelf-card__badge bookshelf-card__badge--category">${this.escapeHtml(exam.category || '雅思阅读')}</span>
@@ -5870,12 +5793,12 @@
             // 导出全部
             const exportAllBtn = root.querySelector('[data-action="export-all-bookshelf"]');
             if (exportAllBtn) {
-                exportAllBtn.addEventListener('click', () => {
-                    const res = ReadingBookshelfStore.exportAllBookshelfTxt();
-                    if (res) {
-                        this.showToast(`✅ 已导出 ${res.count} 个生词（${res.filename}）`);
-                    } else {
-                        this.showToast('⚠️ 书架暂无生词可导出');
+                exportAllBtn.addEventListener('click', async () => {
+                    try {
+                        const res = await ReadingBookshelfStore.exportAllBookshelfTxt();
+                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 书架暂无生词可导出');
+                    } catch (error) {
+                        this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }
                 });
             }
@@ -5905,12 +5828,24 @@
             }
 
             // 单个卡片事件代理
-            root.addEventListener('click', (e) => {
+            // Re-rendering replaces this delegate instead of accumulating writes.
+            root.onclick = async (e) => {
+                if (e.target.closest('[data-action="reload-page"]')) {
+                    global.location.reload();
+                    return;
+                }
+                if (e.target.closest('[data-action="retry-load"]')) {
+                    await ReadingBookshelfStore.init().catch(() => {});
+                    return;
+                }
+                const card = e.target.closest('[data-article-id]');
+                const articleId = card && card.dataset.articleId;
+                const article = ReadingBookshelfStore.getBookshelfExams().find((exam) => exam.articleId === articleId);
                 // 打开生词本精读
                 const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
                 if (openVocabTrigger) {
                     const examId = openVocabTrigger.dataset.examId;
-                    this.launchExamVocabReader(examId);
+                    await this.launchExamVocabReader(examId, article && article.source, articleId);
                     return;
                 }
 
@@ -5941,11 +5876,11 @@
                 if (exportTxtTrigger) {
                     const examId = exportTxtTrigger.dataset.examId;
                     const examTitle = exportTxtTrigger.dataset.examTitle || '';
-                    const res = ReadingBookshelfStore.exportExamTxt(examId, examTitle);
-                    if (res) {
-                        this.showToast(`✅ 已导出：${res.filename}`);
-                    } else {
-                        this.showToast('⚠️ 该篇目暂无可导出的生词');
+                    try {
+                        const res = await ReadingBookshelfStore.exportExamTxt(examId, examTitle, article && article.source, articleId);
+                        this.showToast(res ? `✅ 已导出：${res.filename}` : '⚠️ 该篇目暂无可导出的生词');
+                    } catch (error) {
+                        this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }
                     return;
                 }
@@ -5957,7 +5892,7 @@
                     e.preventDefault();
                     const examId = removeTrigger.dataset.examId;
                     const examTitle = removeTrigger.dataset.examTitle || examId;
-                    this.openConfirmDialog(examId, examTitle);
+                    this.openConfirmDialog(examId, examTitle, article && article.source, articleId);
                     return;
                 }
 
@@ -5968,14 +5903,14 @@
                     this.speakWord(word);
                     return;
                 }
-            });
+            };
         },
 
         bindGlobalEvents() {
             // 可在此处理全局监听
         },
 
-        openConfirmDialog(examId, examTitle) {
+        openConfirmDialog(examId, examTitle, source, articleId) {
             let overlay = document.getElementById('bookshelf-confirm-dialog');
             if (!overlay) {
                 overlay = document.createElement('div');
@@ -6011,17 +5946,44 @@
 
             const okBtn = overlay.querySelector('#bookshelf-confirm-ok');
             const cancelBtn = overlay.querySelector('#bookshelf-confirm-cancel');
+            let pending = false;
+            let reloadRequired = false;
+            okBtn.disabled = false;
+            cancelBtn.disabled = false;
+            okBtn.textContent = '确认移除';
 
             const closeDialog = () => {
-                overlay.classList.add('is-hidden');
+                if (!pending) overlay.classList.add('is-hidden');
             };
 
-            okBtn.onclick = () => {
-                closeDialog();
-                // 仅删除书架与生词本记录，严格保留练习做题数据
-                ReadingBookshelfStore.removeExam(examId, true);
-                this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
-                this.render();
+            okBtn.onclick = async () => {
+                if (pending) return;
+                if (reloadRequired) {
+                    global.location.reload();
+                    return;
+                }
+                pending = true;
+                okBtn.disabled = true;
+                cancelBtn.disabled = true;
+                okBtn.textContent = '正在移除…';
+                try {
+                    const result = await ReadingBookshelfStore.removeExam(examId, true, source, articleId);
+                    if (!result || result.saved !== true) throw new Error('Removal was not acknowledged');
+                    pending = false;
+                    closeDialog();
+                    this.render();
+                    this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
+                } catch (error) {
+                    reloadRequired = needsPageReload(error);
+                    if (textEl) textEl.textContent = reloadRequired
+                        ? `《${examTitle || examId}》移除失败，请刷新页面后重试。`
+                        : `《${examTitle || examId}》移除失败，原有数据已保留，请重试。`;
+                    okBtn.textContent = reloadRequired ? '刷新页面' : '重试移除';
+                } finally {
+                    pending = false;
+                    okBtn.disabled = false;
+                    cancelBtn.disabled = false;
+                }
             };
 
             cancelBtn.onclick = () => {
@@ -6037,7 +5999,7 @@
             overlay.classList.remove('is-hidden');
         },
 
-        async launchExamVocabReader(examId) {
+        async launchExamVocabReader(examId, source, articleId) {
             if (!examId) return;
 
             // 确保 ReadingVocabReader 依赖加载
@@ -6050,9 +6012,9 @@
             }
 
             if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                global.ReadingVocabReader.open(examId);
+                await global.ReadingVocabReader.open(examId, { source, articleId });
             } else if (typeof global.openReadingVocabReader === 'function') {
-                global.openReadingVocabReader(examId);
+                await global.openReadingVocabReader(examId, { source, articleId });
             } else {
                 this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
             }
@@ -6175,7 +6137,7 @@
     }
 
     global.BookshelfView = BookshelfView;
-    ReadingBookshelfStore.init();
+    ReadingBookshelfStore.init().catch((error) => console.warn('[ReadingBookshelfStore] Initialization failed:', error));
 })(window);
 
 

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -343,6 +343,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'
@@ -2676,6 +2681,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -2707,7 +2847,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -4431,7 +4571,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -4473,6 +4613,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -4566,28 +4708,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -4596,7 +4812,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -4645,7 +4865,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4766,17 +4989,391 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4789,7 +5386,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4802,7 +5399,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4818,7 +5415,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4833,7 +5430,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4865,7 +5462,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4883,7 +5480,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4956,7 +5553,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5015,7 +5612,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5057,7 +5654,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -5094,35 +5691,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -5382,6 +5961,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -5590,7 +6174,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -2725,7 +2725,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -2744,34 +2744,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;
@@ -4774,6 +4798,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -5198,10 +5229,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -5306,6 +5337,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -5380,6 +5412,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -2725,7 +2725,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -2744,34 +2744,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;
@@ -4774,6 +4798,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -5198,10 +5229,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -5306,6 +5337,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -5380,6 +5412,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -343,6 +343,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'
@@ -2676,6 +2681,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -2707,7 +2847,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -4431,7 +4571,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -4473,6 +4613,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -4566,28 +4708,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -4596,7 +4812,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -4645,7 +4865,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -4766,17 +4989,391 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4789,7 +5386,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4802,7 +5399,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4818,7 +5415,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4833,7 +5430,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4865,7 +5462,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4883,7 +5480,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -4956,7 +5553,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5015,7 +5612,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -5057,7 +5654,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -5094,35 +5691,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -5382,6 +5961,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -5590,7 +6174,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }
@@ -7394,16 +7977,21 @@
         if (payload.phonetic) {
             word.phonetic = payload.phonetic;
         }
-        if (typeof global.AppData.vocab.mergeListWords === 'function') {
-            // mergeListWords 对已有词条只更新词典字段，保留用户笔记与学习进度。
-            await global.AppData.vocab.mergeListWords({
-                listId: 'reading-highlights',
-                words: [word]
-            });
-        } else {
-            await global.AppData.vocab.upsertCollectionWord('reading-highlights', word);
-        }
-        return true;
+        const context = payload.context || {};
+        if (!context.examId || context.libraryConfigurationId === undefined) return false;
+        const configurationId = context.libraryConfigurationId;
+        const source = configurationId == null || configurationId === ''
+            ? { kind: 'builtin', id: 'default' }
+            : { kind: 'imported', id: String(configurationId).trim() };
+        const observed = await global.AppData.vocab.getReadingSnapshot();
+        const receipt = await global.AppData.vocab.mutateReading('collect', {
+            source,
+            article: { examId: String(context.examId), title: String(context.title || '') },
+            word,
+            manual: true,
+            at: now
+        }, { observedRevision: observed.revision, observedGeneration: observed.generation });
+        return Boolean(receipt && receipt.saved === true);
     }
 
     function createRequestId() {
@@ -7417,19 +8005,19 @@
         return `vocab-highlight-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     }
 
-    function settleSaveRequest(requestId, succeeded) {
+    function settleSaveRequest(requestId, succeeded, errorCode = '') {
         const id = String(requestId || '').trim();
         const pending = pendingSaveRequests.get(id);
         if (!id || !pending) return false;
         pendingSaveRequests.delete(id);
         clearTimeout(pending.timer);
-        pending.resolve(Boolean(succeeded));
+        pending.resolve({ saved: Boolean(succeeded), errorCode: String(errorCode || '') });
         return true;
     }
 
     function handleSaveOutcome(payload, succeeded) {
         const requestId = payload && payload.requestId != null ? String(payload.requestId).trim() : '';
-        return settleSaveRequest(requestId, succeeded);
+        return settleSaveRequest(requestId, succeeded, payload && payload.errorCode);
     }
 
     function postVocabPayload(payload) {
@@ -7439,7 +8027,7 @@
         const outcome = new Promise((resolve) => {
             const timer = setTimeout(() => {
                 pendingSaveRequests.delete(requestId);
-                resolve(false);
+                resolve({ saved: false, errorCode: 'timeout' });
             }, 5000);
             pendingSaveRequests.set(requestId, { resolve, timer });
         });
@@ -7461,13 +8049,26 @@
         if (!payload.word) {
             return;
         }
+        if (button instanceof HTMLButtonElement) {
+            button.textContent = '保存中…';
+            button.disabled = true;
+        }
         const hostOutcome = postVocabPayload(payload);
-        let persisted = hostOutcome ? await hostOutcome : false;
-        if (!persisted) {
-            try { persisted = await writeAppDataVocab(payload); } catch (_) { persisted = false; }
+        const hostResult = hostOutcome ? await hostOutcome : null;
+        let persisted = Boolean(hostResult && hostResult.saved);
+        let errorCode = hostResult && hostResult.errorCode || '';
+        if (!hostOutcome) {
+            try { persisted = await writeAppDataVocab(payload); } catch (error) {
+                persisted = false;
+                errorCode = error && error.code || '';
+            }
         }
         if (button instanceof HTMLButtonElement) {
-            button.textContent = persisted ? '已加入' : '保存失败';
+            const unavailable = errorCode === 'BACKEND_UNAVAILABLE';
+            button.textContent = persisted ? '已加入' : unavailable
+                ? (hostOutcome ? '请刷新主页并重开阅读页后重试' : '请刷新页面后重试')
+                : '保存失败';
+            button.title = !persisted && unavailable ? button.textContent : '';
             button.disabled = persisted;
         }
     }
@@ -7628,8 +8229,7 @@
 (function initReadingVocabReader(global) {
     'use strict';
 
-    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
-    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+    const DEFAULT_SOURCE = { kind: 'builtin', id: 'default' };
 
     function escapeHtml(value) {
         return String(value == null ? '' : value)
@@ -7640,174 +8240,134 @@
             .replace(/'/g, '&#39;');
     }
 
-    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
         if (!examId) return;
-        try {
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
-                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
-                return;
-            }
-            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
-            const records = raw ? JSON.parse(raw) : [];
-            const idx = records.findIndex(r => String(r.examId) === String(examId));
-            const now = Date.now();
-            if (idx !== -1) {
-                records[idx].lastOpenedAt = now;
-                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
-                if (category && !records[idx].category) records[idx].category = category;
-            } else {
-                records.unshift({
-                    examId: String(examId),
-                    examTitle: examTitle || '',
-                    category: category || '',
-                    firstUsedAt: now,
-                    lastOpenedAt: now
-                });
-            }
-            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
-                global.ReadingBookshelfStore.syncToAppData(records);
-            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
-                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
-            }
-        } catch (e) {
-            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
-        }
+        return ReadingVocabStore.mutate('recordVisit', {
+            source, article: { examId: String(examId), title: examTitle },
+            at: new Date().toISOString()
+        });
     }
 
-    // ============================================================================
-    // 生词本数据管理 (Store)
-    // ============================================================================
+    // This cache is a view of acknowledged AppData state, never a storage authority.
     const ReadingVocabStore = {
-        _cache: null,
+        _state: null,
         _commitBound: false,
+        _loadSequence: 0,
 
-        getAll() {
-            if (this._cache) {
-                return this._cache;
+        async resolveSource(options = {}) {
+            if (options.source) return { ...options.source };
+            const id = Object.prototype.hasOwnProperty.call(options, 'libraryConfigurationId')
+                ? options.libraryConfigurationId
+                : await global.AppData.library.getActive();
+            return id == null || id === '' ? { ...DEFAULT_SOURCE } : { kind: 'imported', id: String(id) };
+        },
+
+        getAll() { return this.project(); },
+
+        project(articleId = null) {
+            if (!this._state) return [];
+            const snapshot = this._state.snapshot;
+            const model = global.AppData.vocab.readingModel;
+            return model.query(snapshot, articleId ? { articleId } : {}).terms.map(entry => {
+                const associations = entry.associations;
+                const article = snapshot.reading.articles.find(row => row.id === associations[0]?.articleId);
+                return {
+                    ...entry.word, id: entry.term.id, word: entry.word.word,
+                    examId: article?.examId || '', examTitle: article?.title || '',
+                    context: entry.word.example || entry.word.context || '',
+                    associations, occurrences: entry.occurrences,
+                    highlights: entry.occurrences.map(occurrence => {
+                        const relation = associations.find(row => row.id === occurrence.associationId);
+                        const owner = snapshot.reading.articles.find(row => row.id === relation?.articleId);
+                        return { ...occurrence, examId: owner?.examId, scope: occurrence.scopeId, text: occurrence.quote };
+                    })
+                };
+            });
+        },
+
+        getByExam(examId, source = DEFAULT_SOURCE) {
+            if (!examId || !this._state) return [];
+            return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
+        },
+
+        adopt(state) {
+            if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
+            this._state = state;
+            if (typeof global.dispatchEvent === 'function') {
+                global.dispatchEvent(new CustomEvent('reading-vocab-store-updated'));
             }
+        },
+
+        async reload() {
+            const sequence = ++this._loadSequence;
+            await global.AppData.ready;
+            const state = await global.AppData.vocab.getReadingSnapshot();
+            if (sequence === this._loadSequence) this.adopt(state);
+            return state;
+        },
+
+        async mutate(type, command) {
+            if (!this._state) await this.init();
+            const observed = this._state;
+            let result;
             try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (raw) {
-                    const parsed = JSON.parse(raw);
-                    if (Array.isArray(parsed)) {
-                        this._cache = parsed;
-                        return this._cache;
-                    }
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 读取失败:', err);
+                result = await global.AppData.vocab.mutateReading(type, command, {
+                    observedRevision: observed.revision, observedGeneration: observed.generation
+                });
+            } catch (error) {
+                // The next explicit retry must use the new deletion/replace fence.
+                await this.reload().catch(() => {});
+                throw error;
             }
-            this._cache = [];
-            return this._cache;
+            if (!result || result.saved !== true) throw new Error('Reading save was not acknowledged');
+            ++this._loadSequence;
+            this.adopt(result);
+            return result;
         },
 
-        _save() {
-            try {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 保存失败:', err);
-            }
-            this.syncToAppData();
-        },
+        // Compatibility flush methods only read authoritative state.
+        async syncToAppData() { return this.reload(); },
+        async flushToAppData() { return this.reload(); },
 
-        async syncToAppData() {
-            try {
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
-                    await global.AppData.vocab.saveReadingWords(this._cache || []);
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
-            }
-        },
-
-        async flushToAppData() {
-            return this.syncToAppData();
-        },
-
-        getByExam(examId) {
-            if (!examId) return [];
-            const all = this.getAll();
-            return all.filter(item => String(item.examId) === String(examId));
-        },
-
-        add(rawWord, examId, examTitle, context = '', highlight = null) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
             const word = this.cleanWord(rawWord);
-            if (!word || word.length > 50) {
-                return { added: false, reason: 'invalid_word' };
-            }
-
-            const all = this.getAll();
-            const lowerWord = word.toLowerCase();
-
-            // 检查当前文章或全局是否存在
-            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
-            if (existingIndex !== -1) {
-                const item = all[existingIndex];
-                item.updatedAt = Date.now();
-                if (examId && !item.examId) {
-                    item.examId = examId;
-                    item.examTitle = examTitle || '';
-                }
-                if (highlight) {
-                    if (!Array.isArray(item.highlights)) {
-                        item.highlights = [];
-                    }
-                    const isDup = item.highlights.some(h =>
-                        String(h.examId) === String(highlight.examId) &&
-                        String(h.scope) === String(highlight.scope) &&
-                        h.startOffset === highlight.startOffset
-                    );
-                    if (!isDup) {
-                        item.highlights.push(highlight);
-                    }
-                }
-                this._save();
-                return { added: true, item: item, isDuplicate: true };
-            }
-
-            const newItem = {
-                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                word: word,
-                examId: examId || '',
-                examTitle: examTitle || '',
-                context: context ? String(context).trim().slice(0, 150) : '',
-                createdAt: Date.now(),
-                highlights: highlight ? [highlight] : []
-            };
-
-            all.unshift(newItem);
-            this._save();
-
-            if (examId) {
-                recordBookshelfExamDirect(examId, examTitle);
-            }
-
-            return { added: true, item: newItem, isDuplicate: false };
+            if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
+            if (!this._state) await this.init();
+            const duplicate = this.getByExam(examId, source).some(item => item.word.toLowerCase() === word.toLowerCase());
+            const occurrence = highlight ? {
+                scopeId: highlight.scopeId || highlight.scope,
+                contentVersion: highlight.contentVersion || 'legacy-reader-v1',
+                startOffset: highlight.startOffset, endOffset: highlight.endOffset,
+                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+            } : undefined;
+            const result = await this.mutate('collect', {
+                source, article: { examId: String(examId), title: examTitle || '' },
+                word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
+                ...(occurrence ? { occurrence } : { manual: true }),
+                at: new Date().toISOString()
+            });
+            return { ...result, added: result.added !== false, isDuplicate: duplicate,
+                item: this.getByExam(examId, source).find(item => item.word.toLowerCase() === word.toLowerCase()) };
         },
 
-        remove(wordOrId) {
-            const all = this.getAll();
+        async remove(wordOrId, examId = null, source = DEFAULT_SOURCE) {
+            if (!this._state) await this.init();
             const target = String(wordOrId).trim().toLowerCase();
-            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
-            if (index !== -1) {
-                all.splice(index, 1);
-                this._save();
-                return true;
-            }
-            return false;
-        },
-
-        clear(examId = null) {
-            if (!examId) {
-                this._cache = [];
-                this._save();
-                return true;
-            }
-            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
-            this._save();
+            const item = this.getAll().find(row => row.id === wordOrId || row.word.toLowerCase() === target);
+            if (!item) return false;
+            await this.mutate(examId ? 'removeArticleTerm' : 'removeTermAssociations', {
+                termId: item.id,
+                ...(examId ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {})
+            });
             return true;
         },
+
+        async clear(examId = null, source = DEFAULT_SOURCE) {
+            await this.mutate(examId ? 'clearArticle' : 'clearReading', examId
+                ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {});
+            return true;
+        },
+
 
         cleanWord(str) {
             if (!str) return '';
@@ -7816,8 +8376,8 @@
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
-            const list = examId ? this.getByExam(examId) : this.getAll();
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            const list = examId ? this.getByExam(examId, source) : this.getAll();
             if (!list || list.length === 0) {
                 return false;
             }
@@ -7866,49 +8426,21 @@
 
         async init() {
             this.bindCommitListener();
-            try {
-                if (global.AppData && global.AppData.ready) {
-                    await global.AppData.ready;
-                }
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
-                    const appDataWords = Array.isArray(result)
-                        ? result
-                        : (result && result.envelope ? result.data : null);
-                    if (Array.isArray(appDataWords)) {
-                        // An existing AppData document owns restores, including empty lists.
-                        // An absent document may mean migration failed; preserve the local copy.
-                        this._cache = appDataWords;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
-                    }
-                }
-            } catch (e) {
-                console.warn('[ReadingVocabStore] init failed:', e);
-            }
+            return this.reload();
         },
 
         bindCommitListener() {
-            if (this._commitBound) return;
-            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
-                this._commitBound = true;
-                global.AppData.backups.onDataCommitted(async (event) => {
-                    const targets = event && event.targets;
-                    if (!Array.isArray(targets)) return;
-                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
-                    if (hasVocab) {
-                        try {
-                            const updated = await global.AppData.vocab.listReadingWords();
-                            if (Array.isArray(updated)) {
-                                this._cache = updated;
-                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
-                            }
-                        } catch (err) {
-                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
-                        }
+            if (this._commitBound || !global.AppData?.backups?.onDataCommitted) return;
+            this._commitBound = true;
+            global.AppData.backups.onDataCommitted(event => {
+                if (!event?.targets?.some(target => target.logicalKey?.startsWith('vocab.'))) return;
+                this.reload().catch(error => {
+                    console.warn('[ReadingVocabStore] Unable to refresh committed data:', error);
+                    if (global.ReadingVocabReader?.currentExamId) {
+                        global.ReadingVocabReader.showToast('数据刷新失败，请重新打开生词本重试');
                     }
                 });
-            }
+            });
         }
     };
 
@@ -8323,6 +8855,7 @@
     // ============================================================================
     const ReadingVocabReader = {
         currentExamId: null,
+        currentSource: DEFAULT_SOURCE,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -8547,22 +9080,33 @@
             // 手动收录
             const manualInput = overlay.querySelector('#vocab-manual-input');
             const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
-            const handleManualAdd = () => {
-                if (!manualInput) return;
+            const handleManualAdd = async () => {
+                if (!manualInput || manualAddBtn?.disabled || !this.currentPayload) return;
                 const val = manualInput.value.trim();
                 if (!val) return;
-                const result = ReadingVocabStore.add(
-                    val,
-                    this.currentExamId,
-                    this.currentExam?.title || '',
-                    ''
-                );
-                if (result.added) {
-                    manualInput.value = '';
-                    this.updateCounts();
-                    this.renderVocabList();
-                    this.applyVocabHighlights(val);
-                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                const requestId = this._openRequestId;
+                if (manualAddBtn) manualAddBtn.disabled = true;
+                this.showToast('正在保存…');
+                try {
+                    const result = await ReadingVocabStore.add(
+                        val,
+                        this.currentExamId,
+                        this.currentExam?.title || '',
+                        '', null, this.currentSource
+                    );
+                    if (requestId !== this._openRequestId) return;
+                    if (result.added) {
+                        manualInput.value = '';
+                        this.updateCounts();
+                        this.renderVocabList();
+                        this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录`);
+                    } else {
+                        this.showToast('未保存，请检查输入后重试');
+                    }
+                } catch (error) {
+                    this.showSaveError(error, '保存失败，请再次点击收录重试');
+                } finally {
+                    if (manualAddBtn) manualAddBtn.disabled = false;
                 }
             };
             if (manualAddBtn) {
@@ -8595,7 +9139,7 @@
                     const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
                     const filename = `${dateStr}_${safeArticleName}.txt`;
 
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
                     if (success) {
                         this.showToast(`✅ 已导出：${filename}`);
                     } else {
@@ -8606,11 +9150,11 @@
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                clearBtn.addEventListener('click', async () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
-                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).length
                         : ReadingVocabStore.getAll().length;
 
                     if (count === 0) {
@@ -8618,14 +9162,22 @@
                         return;
                     }
 
-                    ReadingVocabStore.clear(examId);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    const passageContent = overlay.querySelector('#vocab-passage-content');
-                    const questionsContent = overlay.querySelector('#vocab-questions-content');
-                    this.removeVocabHighlights(passageContent);
-                    this.removeVocabHighlights(questionsContent);
-                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    clearBtn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.clear(examId, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        this.removeVocabHighlights(passageContent);
+                        this.removeVocabHighlights(questionsContent);
+                        this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    } catch (error) {
+                        this.showSaveError(error, '清空失败，请再次点击清空重试');
+                    } finally {
+                        clearBtn.disabled = false;
+                    }
                 });
             }
 
@@ -8634,8 +9186,8 @@
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
+                    setTimeout(async () => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -8727,21 +9279,35 @@
                             text: cleanWord
                         };
 
-                        const result = ReadingVocabStore.add(
-                            cleanWord,
-                            this.currentExamId,
-                            this.currentExam?.title || '',
-                            contextSentence,
-                            highlightRecord
-                        );
+                        this.showToast('正在保存…');
+                        try {
+                            const result = await ReadingVocabStore.add(
+                                cleanWord,
+                                this.currentExamId,
+                                this.currentExam?.title || '',
+                                contextSentence,
+                                highlightRecord, this.currentSource
+                            );
 
-                        if (result.added) {
-                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                            this.updateCounts();
-                            if (this.modalOpen) {
-                                this.renderVocabList();
+                            if (requestId !== this._openRequestId) return;
+                            if (result.added) {
+                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                                this.updateCounts();
+                                if (this.modalOpen) {
+                                    this.renderVocabList();
+                                }
+                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                            } else {
+                                throw new Error('Selection was not saved');
                             }
-                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        } catch (error) {
+                            if (wrappedMark.parentNode) {
+                                const parent = wrappedMark.parentNode;
+                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
+                                wrappedMark.remove();
+                                parent.normalize();
+                            }
+                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
                         }
                     }, 20);
                 };
@@ -8821,12 +9387,20 @@
 
             try {
                 // 加载试卷数据
-                const payload = await loadReadingExamPayload(examId);
+                const [payload, source] = await Promise.all([
+                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
+                ]);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
+                // The current payload registry contains only built-in generated
+                // content. Never attach that content to a different library.
+                if (source.kind !== 'builtin' || source.id !== 'default') {
+                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
+                }
                 this.currentPayload = payload;
+                this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
@@ -8843,11 +9417,20 @@
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
-                recordBookshelfExamDirect(examId, examTitle, examCategory);
+                let saveError = null;
+                try {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                } catch (error) {
+                    saveError = error;
+                }
+                if (requestId !== this._openRequestId) return;
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
@@ -9114,7 +9697,7 @@
             if (!this.currentExamId) return;
 
             // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
             if (!examItems || examItems.length === 0) return;
 
             examItems.forEach(item => {
@@ -9124,9 +9707,6 @@
                             this.restoreVocabHighlight(overlay, hl, item.word);
                         }
                     });
-                } else if (item.context && item.word) {
-                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
-                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
                 }
             });
         },
@@ -9402,7 +9982,7 @@
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId);
+            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -9424,7 +10004,7 @@
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId)
+                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -9466,19 +10046,27 @@
             });
 
             listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
+                btn.addEventListener('click', async (e) => {
                     e.stopPropagation();
                     const id = btn.dataset.delId;
                     const allItems = ReadingVocabStore.getAll();
                     const item = allItems.find(w => w.id === id);
                     const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
+                    btn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.remove(id, isCurrent ? this.currentExamId : null, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) {
+                            this.removeVocabHighlightForWord(word);
+                        }
+                        this.showToast('已从生词本删除');
+                    } catch (error) {
+                        this.showSaveError(error, '删除失败，请再次点击删除重试');
+                    } finally {
+                        btn.disabled = false;
                     }
-                    this.showToast('已从生词本删除');
                 });
             });
         },
@@ -9503,6 +10091,11 @@
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+        },
+
+        showSaveError(error, retryMessage) {
+            this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                ? '存储暂不可用，请刷新页面后重试' : retryMessage);
         },
 
         showToast(msg) {
@@ -9533,8 +10126,8 @@
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.modalOpen) {
-                ReadingVocabReader.renderVocabList();
+            if (ReadingVocabReader.currentExamId) {
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
             }
@@ -9549,7 +10142,7 @@
     };
 
     // 启动数据同步初始化
-    ReadingVocabStore.init();
+    ReadingVocabStore.init().catch(error => console.warn('[ReadingVocabStore] Initialization failed:', error));
 
 })(typeof window !== 'undefined' ? window : globalThis);
 
@@ -9636,6 +10229,7 @@
 
     const state = {
         examId: null,
+        libraryConfigurationId: undefined,
         dataKey: null,
         sessionId: null,
         suiteSessionId: null,
@@ -10625,6 +11219,7 @@
     function getReviewDictionaryContext() {
         return {
             examId: state.examId,
+            libraryConfigurationId: state.libraryConfigurationId,
             dataKey: state.dataKey,
             title: state.dataset?.meta?.title || '',
             category: state.dataset?.meta?.category || '',
@@ -11832,9 +12427,9 @@
         ensureVocabReaderStyles();
 
         if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-            global.ReadingVocabReader.open(examId, { fromPractice: true });
+            global.ReadingVocabReader.open(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
         } else if (typeof global.openReadingVocabReader === 'function') {
-            global.openReadingVocabReader(examId, { fromPractice: true });
+            global.openReadingVocabReader(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
         } else {
             console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
         }
@@ -17682,6 +18277,9 @@
             }
             if (data.sessionId) {
                 state.sessionId = data.sessionId;
+            }
+            if (Object.prototype.hasOwnProperty.call(data, 'libraryConfigurationId')) {
+                state.libraryConfigurationId = data.libraryConfigurationId;
             }
             if (data.suiteSessionId) {
                 state.suiteSessionId = data.suiteSessionId;

--- a/js/components/bookshelfView.js
+++ b/js/components/bookshelfView.js
@@ -1,269 +1,186 @@
 (function initBookshelfView(global) {
     'use strict';
 
-    const BOOKSHELF_KEY = 'ielts_reading_bookshelf_exams_v1';
-    const VOCAB_KEY = 'ielts_reading_vocab_words_v1';
+    function needsPageReload(error) {
+        return error && error.code === 'BACKEND_UNAVAILABLE';
+    }
 
-    // ============================================================================
-    // 书架数据管理 (ReadingBookshelfStore)
-    // ============================================================================
+    // AppData owns persistence. This snapshot is only a view cache and is never
+    // written back as a whole collection.
     const ReadingBookshelfStore = {
+        _snapshot: null,
+        _revision: null,
+        _generation: null,
         _commitBound: false,
+        _loadSequence: 0,
+        _loadError: null,
 
         getRawRecords() {
-            try {
-                const raw = localStorage.getItem(BOOKSHELF_KEY);
-                return raw ? JSON.parse(raw) : [];
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 读取书架记录失败:', e);
-                return [];
-            }
+            return this.getBookshelfExams().map((exam) => ({
+                articleId: exam.articleId, source: exam.source, examId: exam.examId,
+                examTitle: exam.title, category: exam.category, lastOpenedAt: exam.lastActivityAt
+            }));
         },
 
-        saveRecords(records) {
-            try {
-                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(records || []));
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 保存书架记录失败:', e);
+        async resolveSource(source) {
+            if (source) return source;
+            if (global.ReadingVocabStore && typeof global.ReadingVocabStore.resolveSource === 'function') {
+                return global.ReadingVocabStore.resolveSource({});
             }
-            this.syncToAppData(records);
+            const library = global.AppData && global.AppData.library;
+            const id = library && typeof library.getActive === 'function' ? await library.getActive() : null;
+            return id ? { kind: 'imported', id } : { kind: 'builtin', id: 'default' };
         },
 
-        async syncToAppData(records) {
-            try {
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
-                    await global.AppData.vocab.saveReadingBookshelfExams(records || this.getRawRecords());
-                }
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] syncToAppData failed:', e);
-            }
+        _adopt(result) {
+            if (!result || !result.snapshot) throw new Error('Reading snapshot is unavailable');
+            if (this._revision !== null && result.revision < this._revision) return;
+            this._snapshot = result.snapshot;
+            this._revision = result.revision;
+            this._generation = result.generation;
+            this._loadError = null;
         },
 
-        async flushToAppData() {
-            return this.syncToAppData(this.getRawRecords());
+        _notify(detail = {}) {
+            global.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail }));
         },
 
         async init() {
-            this.bindCommitListener();
+            const sequence = ++this._loadSequence;
             try {
-                if (global.AppData && global.AppData.ready) {
-                    await global.AppData.ready;
+                if (global.AppData && global.AppData.ready) await global.AppData.ready;
+                this.bindCommitListener();
+                const vocab = global.AppData && global.AppData.vocab;
+                if (!vocab || typeof vocab.getReadingSnapshot !== 'function') {
+                    throw new Error('Reading persistence is unavailable');
                 }
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingBookshelfExams === 'function') {
-                    const result = await global.AppData.vocab.listReadingBookshelfExams({ withMeta: true });
-                    const appDataRecords = Array.isArray(result) ? result : result && result.envelope && result.data;
-                    // AppData owns legacy migration. Its restored collection,
-                    // including an empty array, replaces the local display mirror.
-                    // An absent envelope can mean migration failed; retain its
-                    // only legacy copy instead of treating the default [] as a clear.
-                    if (Array.isArray(appDataRecords)) {
-                        localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(appDataRecords));
-                    }
+                const result = await vocab.getReadingSnapshot();
+                if (sequence === this._loadSequence) {
+                    this._adopt(result);
+                    this._notify({ action: 'reload' });
                 }
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] init failed:', e);
+                return result;
+            } catch (error) {
+                if (sequence === this._loadSequence) {
+                    this._loadError = error;
+                    this._notify({ action: 'load-failed' });
+                }
+                throw error;
             }
         },
+
+        // Compatibility flush callers wait for a fresh durable snapshot.
+        async flushToAppData() { return this.init(); },
 
         bindCommitListener() {
             if (this._commitBound) return;
-            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
+            const backups = global.AppData && global.AppData.backups;
+            if (backups && typeof backups.onDataCommitted === 'function') {
                 this._commitBound = true;
-                global.AppData.backups.onDataCommitted(async (event) => {
+                backups.onDataCommitted((event) => {
                     const targets = event && event.targets;
-                    if (!Array.isArray(targets)) return;
-                    const hasBookshelf = targets.some(t => t.logicalKey === 'vocab.readingBookshelfExams');
-                    if (hasBookshelf) {
-                        try {
-                            const updated = await global.AppData.vocab.listReadingBookshelfExams();
-                            if (Array.isArray(updated)) {
-                                localStorage.setItem(BOOKSHELF_KEY, JSON.stringify(updated));
-                                window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', { detail: { records: updated } }));
-                            }
-                        } catch (err) {
-                            console.warn('[ReadingBookshelfStore] reload on committed failed:', err);
-                        }
+                    if (Array.isArray(targets) && targets.some((target) => String(target.logicalKey || '').startsWith('vocab.'))) {
+                        this.init().catch((error) => console.warn('[ReadingBookshelfStore] Reload failed:', error));
                     }
                 });
             }
         },
 
-        recordExamUsed(examId, examTitle = '', category = '') {
-            if (!examId) return;
+        async _mutate(type, command) {
+            if (!this._snapshot) await this.init();
+            let result;
             try {
-                const records = this.getRawRecords();
-                const now = Date.now();
-                const idx = records.findIndex(r => String(r.examId) === String(examId));
-                if (idx !== -1) {
-                    records[idx].lastOpenedAt = now;
-                    if (examTitle && !records[idx].examTitle) {
-                        records[idx].examTitle = examTitle;
-                    }
-                    if (category && !records[idx].category) {
-                        records[idx].category = category;
-                    }
-                } else {
-                    records.unshift({
-                        examId: String(examId),
-                        examTitle: examTitle || '',
-                        category: category || '',
-                        firstUsedAt: now,
-                        lastOpenedAt: now
-                    });
-                }
-                this.saveRecords(records);
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 记录题目失败:', e);
+                result = await global.AppData.vocab.mutateReading(type, command, {
+                    observedRevision: this._revision, observedGeneration: this._generation
+                });
+            } catch (error) {
+                // A missed cross-window notification must not leave every retry
+                // anchored to a removed association or an old import generation.
+                await this.init().catch(() => {});
+                throw error;
             }
+            if (!result || result.saved !== true) throw new Error('Reading change was not durably acknowledged');
+            // An in-flight reload may predate this acknowledgement.
+            ++this._loadSequence;
+            this._adopt(result);
+            this._notify({ action: type, articleId: command.articleId });
+            return result;
+        },
+
+        async recordExamUsed(examId, examTitle = '', category = '', source) {
+            if (!examId) return false;
+            return this._mutate('recordVisit', {
+                source: await this.resolveSource(source),
+                article: { examId: String(examId), title: examTitle || '' }
+            });
         },
 
         getBookshelfExams() {
-            // 1. 读取全部生词
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
-
-            // 统计生词数据映射
-            const vocabMap = new Map();
-            vocabWords.forEach(item => {
-                if (!item || !item.examId) return;
-                const eid = String(item.examId);
-                if (!vocabMap.has(eid)) {
-                    vocabMap.set(eid, {
-                        count: 0,
-                        words: [],
-                        latestTime: item.createdAt || 0,
-                        examTitle: item.examTitle || ''
-                    });
-                }
-                const group = vocabMap.get(eid);
-                group.count++;
-                if (group.words.length < 6 && item.word) {
-                    group.words.push(item.word);
-                }
-                if (item.createdAt && item.createdAt > group.latestTime) {
-                    group.latestTime = item.createdAt;
-                }
-                if (!group.examTitle && item.examTitle) {
-                    group.examTitle = item.examTitle;
-                }
+            const snapshot = this._snapshot;
+            if (!snapshot) return [];
+            const reading = snapshot.reading;
+            const sourceMap = new Map(reading.sources.map((source) => [source.id, source]));
+            const termMap = new Map(reading.terms.map((term) => [term.id, term]));
+            const visitMap = new Map(reading.visits.map((visit) => [visit.articleId, visit]));
+            const associations = new Map();
+            reading.associations.forEach((association) => {
+                if (!associations.has(association.articleId)) associations.set(association.articleId, []);
+                associations.get(association.articleId).push(association);
             });
-
-            // 2. 读取书架记录
-            const records = this.getRawRecords();
-            const recordMap = new Map();
-            records.forEach(r => {
-                if (r && r.examId) {
-                    recordMap.set(String(r.examId), r);
-                }
-            });
-
-            // 3. 读取全局 Manifest 题库元信息
-            const manifest = (typeof window !== 'undefined' && window.__READING_EXAM_MANIFEST__) || {};
-
-            // 4. 合并集合（记录过的题目 + 拥有生词的题目）
-            const allExamIds = new Set([...recordMap.keys(), ...vocabMap.keys()]);
-            const results = [];
-
-            allExamIds.forEach(examId => {
-                const rec = recordMap.get(examId) || {};
-                const vocab = vocabMap.get(examId) || { count: 0, words: [], latestTime: 0, examTitle: '' };
-                const meta = manifest[examId] || {};
-
-                const title = rec.examTitle || vocab.examTitle || meta.title || meta.name || examId;
-                const category = rec.category || meta.category || meta.type || '雅思阅读';
-                const lastActivity = Math.max(rec.lastOpenedAt || 0, vocab.latestTime || 0, rec.firstUsedAt || 0);
-
-                results.push({
-                    examId: examId,
-                    title: title,
-                    category: category,
-                    wordCount: vocab.count,
-                    sampleWords: vocab.words,
-                    lastActivityAt: lastActivity || Date.now(),
-                    hasPdf: Boolean(meta.pdfPath || meta.pdf)
-                });
-            });
-
-            // 默认按最后活动时间倒序排序
-            results.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
-            return results;
+            const manifest = global.__READING_EXAM_MANIFEST__ || {};
+            return reading.articles.filter((article) => visitMap.has(article.id) || associations.has(article.id)).map((article) => {
+                const sourceRow = sourceMap.get(article.sourceId);
+                const source = { kind: sourceRow.kind, id: sourceRow.libraryId };
+                const related = associations.get(article.id) || [];
+                const visit = visitMap.get(article.id);
+                const meta = source.kind === 'builtin' ? manifest[article.examId] || {} : {};
+                const words = related.map((association) => this._wordForTerm(termMap.get(association.termId))).filter(Boolean);
+                const lastActivityAt = Math.max(
+                    visit ? Date.parse(visit.lastVisitedAt) : 0,
+                    ...related.map((association) => Date.parse(association.updatedAt)),
+                    0
+                );
+                return {
+                    articleId: article.id, source, examId: article.examId,
+                    title: article.title || meta.title || meta.name || article.examId,
+                    category: meta.category || meta.type || '雅思阅读',
+                    wordCount: words.length, sampleWords: words.slice(0, 6).map((word) => word.word),
+                    lastActivityAt, hasPdf: Boolean(meta.pdfPath || meta.pdf)
+                };
+            }).sort((a, b) => b.lastActivityAt - a.lastActivityAt);
         },
 
-        removeExam(examId, alsoDeleteWords = true) {
-            try {
-                const targetExamId = String(examId).trim();
-                if (!targetExamId) return false;
-
-                // 1. 从书架记录中移除篇目
-                const records = this.getRawRecords().filter(r => String(r.examId || r.id).trim() !== targetExamId);
-                this.saveRecords(records);
-
-                // 2. 仅删除该篇目下的生词本记录（严格与做题练习记录隔离）
-                if (alsoDeleteWords) {
-                    // 若全局内存中存在 ReadingVocabStore，同步调用 clear
-                    if (global.ReadingVocabStore && typeof global.ReadingVocabStore.clear === 'function') {
-                        try {
-                            global.ReadingVocabStore.clear(targetExamId);
-                        } catch (err) {
-                            console.warn('[ReadingBookshelfStore] ReadingVocabStore.clear 失败:', err);
-                        }
-                    }
-
-                    // 持久化存储过滤生词
-                    let vocabWords = [];
-                    const raw = localStorage.getItem(VOCAB_KEY);
-                    if (raw) {
-                        try { vocabWords = JSON.parse(raw); } catch (_) {}
-                    }
-                    const filtered = vocabWords.filter(w => String(w.examId).trim() !== targetExamId);
-                    try {
-                        localStorage.setItem(VOCAB_KEY, JSON.stringify(filtered));
-                    } catch (e) {
-                        console.warn('[ReadingBookshelfStore] 保存过滤生词失败:', e);
-                    }
-
-                    // 同步到 AppData.vocab
-                    if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
-                        global.AppData.vocab.saveReadingWords(filtered).catch(err => {
-                            console.warn('[ReadingBookshelfStore] 同步生词删除至 AppData 失败:', err);
-                        });
-                    }
-
-                    // 广播生词变更事件，通知所有打开的阅读器及组件
-                    try {
-                        window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', {
-                            detail: { examId: targetExamId, action: 'clear-exam-vocab' }
-                        }));
-                    } catch (_) {}
-                }
-
-                // 3. 严格数据隔离：绝不触碰任何做题练习记录（做题历史、得分记录、错题记录等完整保留）
-
-                // 4. 广播书架更新事件
-                try {
-                    window.dispatchEvent(new CustomEvent('reading-bookshelf-store-updated', {
-                        detail: { examId: targetExamId, action: 'remove-exam' }
-                    }));
-                } catch (_) {}
-
-                return true;
-            } catch (e) {
-                console.warn('[ReadingBookshelfStore] 移除题目失败:', e);
-                return false;
-            }
+        _wordForTerm(term) {
+            if (!term || !this._snapshot) return null;
+            const ref = term.wordRef;
+            const list = ref.listId === 'default' ? this._snapshot.words : this._snapshot.lists[ref.listId];
+            const words = Array.isArray(list) ? list : list && list.words || [];
+            return words.find((word) => word.id === ref.wordId) || null;
         },
 
-        exportExamTxt(examId, examTitle) {
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
+        _getWords(articleId) {
+            if (!this._snapshot) return [];
+            const reading = this._snapshot.reading;
+            const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
+            return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
+        },
 
-            const examWords = vocabWords.filter(item => String(item.examId) === String(examId));
+        async _articleId(examId, source, articleId) {
+            if (articleId) return articleId;
+            const resolvedSource = await this.resolveSource(source);
+            return global.AppData.vocab.readingModel.articleId(resolvedSource, String(examId));
+        },
+
+        async removeExam(examId, alsoDeleteWords = true, source, articleId) {
+            if (!String(examId || '').trim()) return false;
+            const id = await this._articleId(examId, source, articleId);
+            return this._mutate('removeArticle', { articleId: id, clearWords: alsoDeleteWords });
+        },
+
+        async exportExamTxt(examId, examTitle, source, articleId) {
+            await this.init();
+            const id = await this._articleId(examId, source, articleId);
+            const examWords = this._getWords(id);
             if (examWords.length === 0) {
                 return false;
             }
@@ -305,12 +222,9 @@
             return { filename, count: words.length };
         },
 
-        exportAllBookshelfTxt() {
-            let vocabWords = [];
-            try {
-                const raw = localStorage.getItem(VOCAB_KEY);
-                if (raw) vocabWords = JSON.parse(raw);
-            } catch (e) {}
+        async exportAllBookshelfTxt() {
+            await this.init();
+            const vocabWords = this._getWords();
 
             if (vocabWords.length === 0) {
                 return false;
@@ -383,6 +297,7 @@
 
             this.render();
             this.bindGlobalEvents();
+            ReadingBookshelfStore.init().catch(() => {});
         },
 
         render() {
@@ -423,6 +338,9 @@
 
             root.innerHTML = `
                 <div class="bookshelf-layout">
+                    ${ReadingBookshelfStore._loadError ? (needsPageReload(ReadingBookshelfStore._loadError)
+                        ? '<p role="alert">书架加载失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
+                        : '<p role="alert">书架加载失败，已显示的数据保持不变。<button type="button" class="btn btn-secondary" data-action="retry-load">重试加载</button></p>') : ''}
                     <!-- 顶部标题栏与导航 -->
                     <div class="bookshelf-topbar">
                         <div class="bookshelf-topbar__left">
@@ -506,7 +424,7 @@
 
                     <!-- 篇目卡片网格 -->
                     <div class="bookshelf-content-area">
-                        ${filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
+                        ${!ReadingBookshelfStore._snapshot ? (ReadingBookshelfStore._loadError ? '' : '<p role="status">正在加载书架…</p>') : filtered.length > 0 ? this.renderCardGrid(filtered) : this.renderEmptyState(allExams.length === 0)}
                     </div>
                 </div>
 
@@ -530,7 +448,7 @@
             const wordsList = exam.sampleWords || [];
 
             return `
-                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}">
+                <div class="bookshelf-card" data-exam-id="${this.escapeHtml(exam.examId)}" data-article-id="${this.escapeHtml(exam.articleId)}">
                     <div class="bookshelf-card__header">
                         <div class="bookshelf-card__tags">
                             <span class="bookshelf-card__badge bookshelf-card__badge--category">${this.escapeHtml(exam.category || '雅思阅读')}</span>
@@ -686,12 +604,12 @@
             // 导出全部
             const exportAllBtn = root.querySelector('[data-action="export-all-bookshelf"]');
             if (exportAllBtn) {
-                exportAllBtn.addEventListener('click', () => {
-                    const res = ReadingBookshelfStore.exportAllBookshelfTxt();
-                    if (res) {
-                        this.showToast(`✅ 已导出 ${res.count} 个生词（${res.filename}）`);
-                    } else {
-                        this.showToast('⚠️ 书架暂无生词可导出');
+                exportAllBtn.addEventListener('click', async () => {
+                    try {
+                        const res = await ReadingBookshelfStore.exportAllBookshelfTxt();
+                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 书架暂无生词可导出');
+                    } catch (error) {
+                        this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }
                 });
             }
@@ -721,12 +639,24 @@
             }
 
             // 单个卡片事件代理
-            root.addEventListener('click', (e) => {
+            // Re-rendering replaces this delegate instead of accumulating writes.
+            root.onclick = async (e) => {
+                if (e.target.closest('[data-action="reload-page"]')) {
+                    global.location.reload();
+                    return;
+                }
+                if (e.target.closest('[data-action="retry-load"]')) {
+                    await ReadingBookshelfStore.init().catch(() => {});
+                    return;
+                }
+                const card = e.target.closest('[data-article-id]');
+                const articleId = card && card.dataset.articleId;
+                const article = ReadingBookshelfStore.getBookshelfExams().find((exam) => exam.articleId === articleId);
                 // 打开生词本精读
                 const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
                 if (openVocabTrigger) {
                     const examId = openVocabTrigger.dataset.examId;
-                    this.launchExamVocabReader(examId);
+                    await this.launchExamVocabReader(examId, article && article.source, articleId);
                     return;
                 }
 
@@ -757,11 +687,11 @@
                 if (exportTxtTrigger) {
                     const examId = exportTxtTrigger.dataset.examId;
                     const examTitle = exportTxtTrigger.dataset.examTitle || '';
-                    const res = ReadingBookshelfStore.exportExamTxt(examId, examTitle);
-                    if (res) {
-                        this.showToast(`✅ 已导出：${res.filename}`);
-                    } else {
-                        this.showToast('⚠️ 该篇目暂无可导出的生词');
+                    try {
+                        const res = await ReadingBookshelfStore.exportExamTxt(examId, examTitle, article && article.source, articleId);
+                        this.showToast(res ? `✅ 已导出：${res.filename}` : '⚠️ 该篇目暂无可导出的生词');
+                    } catch (error) {
+                        this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }
                     return;
                 }
@@ -773,7 +703,7 @@
                     e.preventDefault();
                     const examId = removeTrigger.dataset.examId;
                     const examTitle = removeTrigger.dataset.examTitle || examId;
-                    this.openConfirmDialog(examId, examTitle);
+                    this.openConfirmDialog(examId, examTitle, article && article.source, articleId);
                     return;
                 }
 
@@ -784,14 +714,14 @@
                     this.speakWord(word);
                     return;
                 }
-            });
+            };
         },
 
         bindGlobalEvents() {
             // 可在此处理全局监听
         },
 
-        openConfirmDialog(examId, examTitle) {
+        openConfirmDialog(examId, examTitle, source, articleId) {
             let overlay = document.getElementById('bookshelf-confirm-dialog');
             if (!overlay) {
                 overlay = document.createElement('div');
@@ -827,17 +757,44 @@
 
             const okBtn = overlay.querySelector('#bookshelf-confirm-ok');
             const cancelBtn = overlay.querySelector('#bookshelf-confirm-cancel');
+            let pending = false;
+            let reloadRequired = false;
+            okBtn.disabled = false;
+            cancelBtn.disabled = false;
+            okBtn.textContent = '确认移除';
 
             const closeDialog = () => {
-                overlay.classList.add('is-hidden');
+                if (!pending) overlay.classList.add('is-hidden');
             };
 
-            okBtn.onclick = () => {
-                closeDialog();
-                // 仅删除书架与生词本记录，严格保留练习做题数据
-                ReadingBookshelfStore.removeExam(examId, true);
-                this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
-                this.render();
+            okBtn.onclick = async () => {
+                if (pending) return;
+                if (reloadRequired) {
+                    global.location.reload();
+                    return;
+                }
+                pending = true;
+                okBtn.disabled = true;
+                cancelBtn.disabled = true;
+                okBtn.textContent = '正在移除…';
+                try {
+                    const result = await ReadingBookshelfStore.removeExam(examId, true, source, articleId);
+                    if (!result || result.saved !== true) throw new Error('Removal was not acknowledged');
+                    pending = false;
+                    closeDialog();
+                    this.render();
+                    this.showToast(`已从书架移除《${examTitle}》（做题练习记录已保留）`);
+                } catch (error) {
+                    reloadRequired = needsPageReload(error);
+                    if (textEl) textEl.textContent = reloadRequired
+                        ? `《${examTitle || examId}》移除失败，请刷新页面后重试。`
+                        : `《${examTitle || examId}》移除失败，原有数据已保留，请重试。`;
+                    okBtn.textContent = reloadRequired ? '刷新页面' : '重试移除';
+                } finally {
+                    pending = false;
+                    okBtn.disabled = false;
+                    cancelBtn.disabled = false;
+                }
             };
 
             cancelBtn.onclick = () => {
@@ -853,7 +810,7 @@
             overlay.classList.remove('is-hidden');
         },
 
-        async launchExamVocabReader(examId) {
+        async launchExamVocabReader(examId, source, articleId) {
             if (!examId) return;
 
             // 确保 ReadingVocabReader 依赖加载
@@ -866,9 +823,9 @@
             }
 
             if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                global.ReadingVocabReader.open(examId);
+                await global.ReadingVocabReader.open(examId, { source, articleId });
             } else if (typeof global.openReadingVocabReader === 'function') {
-                global.openReadingVocabReader(examId);
+                await global.openReadingVocabReader(examId, { source, articleId });
             } else {
                 this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
             }
@@ -991,5 +948,5 @@
     }
 
     global.BookshelfView = BookshelfView;
-    ReadingBookshelfStore.init();
+    ReadingBookshelfStore.init().catch((error) => console.warn('[ReadingBookshelfStore] Initialization failed:', error));
 })(window);

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -1,8 +1,7 @@
 (function initReadingVocabReader(global) {
     'use strict';
 
-    const STORAGE_KEY = 'ielts_reading_vocab_words_v1';
-    const BOOKSHELF_STORAGE_KEY = 'ielts_reading_bookshelf_exams_v1';
+    const DEFAULT_SOURCE = { kind: 'builtin', id: 'default' };
 
     function escapeHtml(value) {
         return String(value == null ? '' : value)
@@ -13,174 +12,134 @@
             .replace(/'/g, '&#39;');
     }
 
-    function recordBookshelfExamDirect(examId, examTitle = '', category = '') {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
         if (!examId) return;
-        try {
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.recordExamUsed === 'function') {
-                global.ReadingBookshelfStore.recordExamUsed(examId, examTitle, category);
-                return;
-            }
-            const raw = localStorage.getItem(BOOKSHELF_STORAGE_KEY);
-            const records = raw ? JSON.parse(raw) : [];
-            const idx = records.findIndex(r => String(r.examId) === String(examId));
-            const now = Date.now();
-            if (idx !== -1) {
-                records[idx].lastOpenedAt = now;
-                if (examTitle && !records[idx].examTitle) records[idx].examTitle = examTitle;
-                if (category && !records[idx].category) records[idx].category = category;
-            } else {
-                records.unshift({
-                    examId: String(examId),
-                    examTitle: examTitle || '',
-                    category: category || '',
-                    firstUsedAt: now,
-                    lastOpenedAt: now
-                });
-            }
-            localStorage.setItem(BOOKSHELF_STORAGE_KEY, JSON.stringify(records));
-            if (global.ReadingBookshelfStore && typeof global.ReadingBookshelfStore.syncToAppData === 'function') {
-                global.ReadingBookshelfStore.syncToAppData(records);
-            } else if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingBookshelfExams === 'function') {
-                global.AppData.vocab.saveReadingBookshelfExams(records).catch(() => {});
-            }
-        } catch (e) {
-            console.warn('[ReadingVocabReader] recordBookshelfExamDirect error:', e);
-        }
+        return ReadingVocabStore.mutate('recordVisit', {
+            source, article: { examId: String(examId), title: examTitle },
+            at: new Date().toISOString()
+        });
     }
 
-    // ============================================================================
-    // 生词本数据管理 (Store)
-    // ============================================================================
+    // This cache is a view of acknowledged AppData state, never a storage authority.
     const ReadingVocabStore = {
-        _cache: null,
+        _state: null,
         _commitBound: false,
+        _loadSequence: 0,
 
-        getAll() {
-            if (this._cache) {
-                return this._cache;
+        async resolveSource(options = {}) {
+            if (options.source) return { ...options.source };
+            const id = Object.prototype.hasOwnProperty.call(options, 'libraryConfigurationId')
+                ? options.libraryConfigurationId
+                : await global.AppData.library.getActive();
+            return id == null || id === '' ? { ...DEFAULT_SOURCE } : { kind: 'imported', id: String(id) };
+        },
+
+        getAll() { return this.project(); },
+
+        project(articleId = null) {
+            if (!this._state) return [];
+            const snapshot = this._state.snapshot;
+            const model = global.AppData.vocab.readingModel;
+            return model.query(snapshot, articleId ? { articleId } : {}).terms.map(entry => {
+                const associations = entry.associations;
+                const article = snapshot.reading.articles.find(row => row.id === associations[0]?.articleId);
+                return {
+                    ...entry.word, id: entry.term.id, word: entry.word.word,
+                    examId: article?.examId || '', examTitle: article?.title || '',
+                    context: entry.word.example || entry.word.context || '',
+                    associations, occurrences: entry.occurrences,
+                    highlights: entry.occurrences.map(occurrence => {
+                        const relation = associations.find(row => row.id === occurrence.associationId);
+                        const owner = snapshot.reading.articles.find(row => row.id === relation?.articleId);
+                        return { ...occurrence, examId: owner?.examId, scope: occurrence.scopeId, text: occurrence.quote };
+                    })
+                };
+            });
+        },
+
+        getByExam(examId, source = DEFAULT_SOURCE) {
+            if (!examId || !this._state) return [];
+            return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
+        },
+
+        adopt(state) {
+            if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
+            this._state = state;
+            if (typeof global.dispatchEvent === 'function') {
+                global.dispatchEvent(new CustomEvent('reading-vocab-store-updated'));
             }
+        },
+
+        async reload() {
+            const sequence = ++this._loadSequence;
+            await global.AppData.ready;
+            const state = await global.AppData.vocab.getReadingSnapshot();
+            if (sequence === this._loadSequence) this.adopt(state);
+            return state;
+        },
+
+        async mutate(type, command) {
+            if (!this._state) await this.init();
+            const observed = this._state;
+            let result;
             try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (raw) {
-                    const parsed = JSON.parse(raw);
-                    if (Array.isArray(parsed)) {
-                        this._cache = parsed;
-                        return this._cache;
-                    }
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 读取失败:', err);
+                result = await global.AppData.vocab.mutateReading(type, command, {
+                    observedRevision: observed.revision, observedGeneration: observed.generation
+                });
+            } catch (error) {
+                // The next explicit retry must use the new deletion/replace fence.
+                await this.reload().catch(() => {});
+                throw error;
             }
-            this._cache = [];
-            return this._cache;
+            if (!result || result.saved !== true) throw new Error('Reading save was not acknowledged');
+            ++this._loadSequence;
+            this.adopt(result);
+            return result;
         },
 
-        _save() {
-            try {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(this._cache || []));
-            } catch (err) {
-                console.warn('[ReadingVocabStore] 保存失败:', err);
-            }
-            this.syncToAppData();
-        },
+        // Compatibility flush methods only read authoritative state.
+        async syncToAppData() { return this.reload(); },
+        async flushToAppData() { return this.reload(); },
 
-        async syncToAppData() {
-            try {
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.saveReadingWords === 'function') {
-                    await global.AppData.vocab.saveReadingWords(this._cache || []);
-                }
-            } catch (err) {
-                console.warn('[ReadingVocabStore] syncToAppData failed:', err);
-            }
-        },
-
-        async flushToAppData() {
-            return this.syncToAppData();
-        },
-
-        getByExam(examId) {
-            if (!examId) return [];
-            const all = this.getAll();
-            return all.filter(item => String(item.examId) === String(examId));
-        },
-
-        add(rawWord, examId, examTitle, context = '', highlight = null) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
             const word = this.cleanWord(rawWord);
-            if (!word || word.length > 50) {
-                return { added: false, reason: 'invalid_word' };
-            }
-
-            const all = this.getAll();
-            const lowerWord = word.toLowerCase();
-
-            // 检查当前文章或全局是否存在
-            const existingIndex = all.findIndex(item => item.word.toLowerCase() === lowerWord);
-            if (existingIndex !== -1) {
-                const item = all[existingIndex];
-                item.updatedAt = Date.now();
-                if (examId && !item.examId) {
-                    item.examId = examId;
-                    item.examTitle = examTitle || '';
-                }
-                if (highlight) {
-                    if (!Array.isArray(item.highlights)) {
-                        item.highlights = [];
-                    }
-                    const isDup = item.highlights.some(h =>
-                        String(h.examId) === String(highlight.examId) &&
-                        String(h.scope) === String(highlight.scope) &&
-                        h.startOffset === highlight.startOffset
-                    );
-                    if (!isDup) {
-                        item.highlights.push(highlight);
-                    }
-                }
-                this._save();
-                return { added: true, item: item, isDuplicate: true };
-            }
-
-            const newItem = {
-                id: 'w_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                word: word,
-                examId: examId || '',
-                examTitle: examTitle || '',
-                context: context ? String(context).trim().slice(0, 150) : '',
-                createdAt: Date.now(),
-                highlights: highlight ? [highlight] : []
-            };
-
-            all.unshift(newItem);
-            this._save();
-
-            if (examId) {
-                recordBookshelfExamDirect(examId, examTitle);
-            }
-
-            return { added: true, item: newItem, isDuplicate: false };
+            if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
+            if (!this._state) await this.init();
+            const duplicate = this.getByExam(examId, source).some(item => item.word.toLowerCase() === word.toLowerCase());
+            const occurrence = highlight ? {
+                scopeId: highlight.scopeId || highlight.scope,
+                contentVersion: highlight.contentVersion || 'legacy-reader-v1',
+                startOffset: highlight.startOffset, endOffset: highlight.endOffset,
+                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+            } : undefined;
+            const result = await this.mutate('collect', {
+                source, article: { examId: String(examId), title: examTitle || '' },
+                word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
+                ...(occurrence ? { occurrence } : { manual: true }),
+                at: new Date().toISOString()
+            });
+            return { ...result, added: result.added !== false, isDuplicate: duplicate,
+                item: this.getByExam(examId, source).find(item => item.word.toLowerCase() === word.toLowerCase()) };
         },
 
-        remove(wordOrId) {
-            const all = this.getAll();
+        async remove(wordOrId, examId = null, source = DEFAULT_SOURCE) {
+            if (!this._state) await this.init();
             const target = String(wordOrId).trim().toLowerCase();
-            const index = all.findIndex(item => item.id === wordOrId || item.word.toLowerCase() === target);
-            if (index !== -1) {
-                all.splice(index, 1);
-                this._save();
-                return true;
-            }
-            return false;
-        },
-
-        clear(examId = null) {
-            if (!examId) {
-                this._cache = [];
-                this._save();
-                return true;
-            }
-            this._cache = this.getAll().filter(item => String(item.examId) !== String(examId));
-            this._save();
+            const item = this.getAll().find(row => row.id === wordOrId || row.word.toLowerCase() === target);
+            if (!item) return false;
+            await this.mutate(examId ? 'removeArticleTerm' : 'removeTermAssociations', {
+                termId: item.id,
+                ...(examId ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {})
+            });
             return true;
         },
+
+        async clear(examId = null, source = DEFAULT_SOURCE) {
+            await this.mutate(examId ? 'clearArticle' : 'clearReading', examId
+                ? { articleId: global.AppData.vocab.readingModel.articleId(source, String(examId)) } : {});
+            return true;
+        },
+
 
         cleanWord(str) {
             if (!str) return '';
@@ -189,8 +148,8 @@
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '') {
-            const list = examId ? this.getByExam(examId) : this.getAll();
+        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            const list = examId ? this.getByExam(examId, source) : this.getAll();
             if (!list || list.length === 0) {
                 return false;
             }
@@ -239,49 +198,21 @@
 
         async init() {
             this.bindCommitListener();
-            try {
-                if (global.AppData && global.AppData.ready) {
-                    await global.AppData.ready;
-                }
-                if (global.AppData && global.AppData.vocab && typeof global.AppData.vocab.listReadingWords === 'function') {
-                    const result = await global.AppData.vocab.listReadingWords({ withMeta: true });
-                    const appDataWords = Array.isArray(result)
-                        ? result
-                        : (result && result.envelope ? result.data : null);
-                    if (Array.isArray(appDataWords)) {
-                        // An existing AppData document owns restores, including empty lists.
-                        // An absent document may mean migration failed; preserve the local copy.
-                        this._cache = appDataWords;
-                        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(appDataWords)); } catch (_) {}
-                    }
-                }
-            } catch (e) {
-                console.warn('[ReadingVocabStore] init failed:', e);
-            }
+            return this.reload();
         },
 
         bindCommitListener() {
-            if (this._commitBound) return;
-            if (global.AppData && global.AppData.backups && typeof global.AppData.backups.onDataCommitted === 'function') {
-                this._commitBound = true;
-                global.AppData.backups.onDataCommitted(async (event) => {
-                    const targets = event && event.targets;
-                    if (!Array.isArray(targets)) return;
-                    const hasVocab = targets.some(t => t.logicalKey === 'vocab.readingVocabWords');
-                    if (hasVocab) {
-                        try {
-                            const updated = await global.AppData.vocab.listReadingWords();
-                            if (Array.isArray(updated)) {
-                                this._cache = updated;
-                                localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-                                window.dispatchEvent(new CustomEvent('reading-vocab-store-updated', { detail: { words: updated } }));
-                            }
-                        } catch (err) {
-                            console.warn('[ReadingVocabStore] reload on committed failed:', err);
-                        }
+            if (this._commitBound || !global.AppData?.backups?.onDataCommitted) return;
+            this._commitBound = true;
+            global.AppData.backups.onDataCommitted(event => {
+                if (!event?.targets?.some(target => target.logicalKey?.startsWith('vocab.'))) return;
+                this.reload().catch(error => {
+                    console.warn('[ReadingVocabStore] Unable to refresh committed data:', error);
+                    if (global.ReadingVocabReader?.currentExamId) {
+                        global.ReadingVocabReader.showToast('数据刷新失败，请重新打开生词本重试');
                     }
                 });
-            }
+            });
         }
     };
 
@@ -696,6 +627,7 @@
     // ============================================================================
     const ReadingVocabReader = {
         currentExamId: null,
+        currentSource: DEFAULT_SOURCE,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -920,22 +852,33 @@
             // 手动收录
             const manualInput = overlay.querySelector('#vocab-manual-input');
             const manualAddBtn = overlay.querySelector('#vocab-manual-add-btn');
-            const handleManualAdd = () => {
-                if (!manualInput) return;
+            const handleManualAdd = async () => {
+                if (!manualInput || manualAddBtn?.disabled || !this.currentPayload) return;
                 const val = manualInput.value.trim();
                 if (!val) return;
-                const result = ReadingVocabStore.add(
-                    val,
-                    this.currentExamId,
-                    this.currentExam?.title || '',
-                    ''
-                );
-                if (result.added) {
-                    manualInput.value = '';
-                    this.updateCounts();
-                    this.renderVocabList();
-                    this.applyVocabHighlights(val);
-                    this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录并黄色高亮`);
+                const requestId = this._openRequestId;
+                if (manualAddBtn) manualAddBtn.disabled = true;
+                this.showToast('正在保存…');
+                try {
+                    const result = await ReadingVocabStore.add(
+                        val,
+                        this.currentExamId,
+                        this.currentExam?.title || '',
+                        '', null, this.currentSource
+                    );
+                    if (requestId !== this._openRequestId) return;
+                    if (result.added) {
+                        manualInput.value = '';
+                        this.updateCounts();
+                        this.renderVocabList();
+                        this.showToast(result.isDuplicate ? `"${val}" 已在生词本中` : `✅ "${val}" 已收录`);
+                    } else {
+                        this.showToast('未保存，请检查输入后重试');
+                    }
+                } catch (error) {
+                    this.showSaveError(error, '保存失败，请再次点击收录重试');
+                } finally {
+                    if (manualAddBtn) manualAddBtn.disabled = false;
                 }
             };
             if (manualAddBtn) {
@@ -968,7 +911,7 @@
                     const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
                     const filename = `${dateStr}_${safeArticleName}.txt`;
 
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName);
+                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
                     if (success) {
                         this.showToast(`✅ 已导出：${filename}`);
                     } else {
@@ -979,11 +922,11 @@
 
             const clearBtn = overlay.querySelector('#vocab-clear-btn');
             if (clearBtn) {
-                clearBtn.addEventListener('click', () => {
+                clearBtn.addEventListener('click', async () => {
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
                     const count = isCurrent
-                        ? ReadingVocabStore.getByExam(this.currentExamId).length
+                        ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).length
                         : ReadingVocabStore.getAll().length;
 
                     if (count === 0) {
@@ -991,14 +934,22 @@
                         return;
                     }
 
-                    ReadingVocabStore.clear(examId);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    const passageContent = overlay.querySelector('#vocab-passage-content');
-                    const questionsContent = overlay.querySelector('#vocab-questions-content');
-                    this.removeVocabHighlights(passageContent);
-                    this.removeVocabHighlights(questionsContent);
-                    this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    clearBtn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.clear(examId, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        const passageContent = overlay.querySelector('#vocab-passage-content');
+                        const questionsContent = overlay.querySelector('#vocab-questions-content');
+                        this.removeVocabHighlights(passageContent);
+                        this.removeVocabHighlights(questionsContent);
+                        this.showToast(isCurrent ? '✅ 本篇生词已清空' : '✅ 全部生词已清空');
+                    } catch (error) {
+                        this.showSaveError(error, '清空失败，请再次点击清空重试');
+                    } finally {
+                        clearBtn.disabled = false;
+                    }
                 });
             }
 
@@ -1007,8 +958,8 @@
             if (readerBody) {
                 const handleSelectionCapture = () => {
                     const requestId = this._openRequestId;
-                    setTimeout(() => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden')) return;
+                    setTimeout(async () => {
+                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
                         const selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
                         const rawText = selection.toString();
@@ -1100,21 +1051,35 @@
                             text: cleanWord
                         };
 
-                        const result = ReadingVocabStore.add(
-                            cleanWord,
-                            this.currentExamId,
-                            this.currentExam?.title || '',
-                            contextSentence,
-                            highlightRecord
-                        );
+                        this.showToast('正在保存…');
+                        try {
+                            const result = await ReadingVocabStore.add(
+                                cleanWord,
+                                this.currentExamId,
+                                this.currentExam?.title || '',
+                                contextSentence,
+                                highlightRecord, this.currentSource
+                            );
 
-                        if (result.added) {
-                            selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                            this.updateCounts();
-                            if (this.modalOpen) {
-                                this.renderVocabList();
+                            if (requestId !== this._openRequestId) return;
+                            if (result.added) {
+                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
+                                this.updateCounts();
+                                if (this.modalOpen) {
+                                    this.renderVocabList();
+                                }
+                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                            } else {
+                                throw new Error('Selection was not saved');
                             }
-                            this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
+                        } catch (error) {
+                            if (wrappedMark.parentNode) {
+                                const parent = wrappedMark.parentNode;
+                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
+                                wrappedMark.remove();
+                                parent.normalize();
+                            }
+                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
                         }
                     }, 20);
                 };
@@ -1194,12 +1159,20 @@
 
             try {
                 // 加载试卷数据
-                const payload = await loadReadingExamPayload(examId);
+                const [payload, source] = await Promise.all([
+                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
+                ]);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
                 }
+                // The current payload registry contains only built-in generated
+                // content. Never attach that content to a different library.
+                if (source.kind !== 'builtin' || source.id !== 'default') {
+                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
+                }
                 this.currentPayload = payload;
+                this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
                 loadReadingExplanationPayload(examId).then(exp => {
@@ -1216,11 +1189,20 @@
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
-                recordBookshelfExamDirect(examId, examTitle, examCategory);
+                let saveError = null;
+                try {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                } catch (error) {
+                    saveError = error;
+                }
+                if (requestId !== this._openRequestId) return;
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
@@ -1487,7 +1469,7 @@
             if (!this.currentExamId) return;
 
             // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId);
+            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
             if (!examItems || examItems.length === 0) return;
 
             examItems.forEach(item => {
@@ -1497,9 +1479,6 @@
                             this.restoreVocabHighlight(overlay, hl, item.word);
                         }
                     });
-                } else if (item.context && item.word) {
-                    // 兼容旧存量数据：基于 context 句子仅高亮单处实例，绝不全篇乱高亮
-                    this.restoreLegacyHighlightByContext(overlay, item.word, item.context);
                 }
             });
         },
@@ -1775,7 +1754,7 @@
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId);
+            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -1797,7 +1776,7 @@
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId)
+                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -1839,19 +1818,27 @@
             });
 
             listEl.querySelectorAll('.vocab-delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
+                btn.addEventListener('click', async (e) => {
                     e.stopPropagation();
                     const id = btn.dataset.delId;
                     const allItems = ReadingVocabStore.getAll();
                     const item = allItems.find(w => w.id === id);
                     const word = item?.word;
-                    ReadingVocabStore.remove(id);
-                    this.updateCounts();
-                    this.renderVocabList();
-                    if (word) {
-                        this.removeVocabHighlightForWord(word);
+                    btn.disabled = true;
+                    this.showToast('正在保存…');
+                    try {
+                        await ReadingVocabStore.remove(id, isCurrent ? this.currentExamId : null, this.currentSource);
+                        this.updateCounts();
+                        this.renderVocabList();
+                        if (word) {
+                            this.removeVocabHighlightForWord(word);
+                        }
+                        this.showToast('已从生词本删除');
+                    } catch (error) {
+                        this.showSaveError(error, '删除失败，请再次点击删除重试');
+                    } finally {
+                        btn.disabled = false;
                     }
-                    this.showToast('已从生词本删除');
                 });
             });
         },
@@ -1876,6 +1863,11 @@
                 modal.classList.remove('active');
                 modal.setAttribute('aria-hidden', 'true');
             }
+        },
+
+        showSaveError(error, retryMessage) {
+            this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                ? '存储暂不可用，请刷新页面后重试' : retryMessage);
         },
 
         showToast(msg) {
@@ -1906,8 +1898,8 @@
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.modalOpen) {
-                ReadingVocabReader.renderVocabList();
+            if (ReadingVocabReader.currentExamId) {
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
             }
@@ -1922,6 +1914,6 @@
     };
 
     // 启动数据同步初始化
-    ReadingVocabStore.init();
+    ReadingVocabStore.init().catch(error => console.warn('[ReadingVocabStore] Initialization failed:', error));
 
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/core/vocabStore.js
+++ b/js/core/vocabStore.js
@@ -340,13 +340,6 @@
         return Object.prototype.hasOwnProperty.call(collections, listId) ? collections[listId] : null;
     }
 
-    async function saveListData(listId, value) {
-        const vocab = await requireVocabData();
-        const words = value && typeof value === 'object' && Array.isArray(value.words) ? value.words : value;
-        await vocab.replaceListWords({ listId, words: Array.isArray(words) ? words : [] });
-        return true;
-    }
-
     async function saveConfigData(configPatch = state.config) {
         const vocab = await requireVocabData();
         await vocab.patchConfig(Object.assign({}, configPatch, { activeListId: state.activeListId }));
@@ -674,16 +667,19 @@
                 }
                 return backfilled;
             }
-            if (pollutedBySpellingList) {
-                console.warn('[VocabStore] 检测到默认词表被错词快照污染，正在恢复 IELTS 核心词表');
+            const vocab = await requireVocabData();
+            if (!await vocab.shouldInitializeDefaultWords()) {
+                if (state.activeListId === DEFAULT_LIST_ID) setWordsInternal(normalizedStored);
+                return normalizedStored;
             }
 
-            const normalized = await loadBundledDefaultLexicon();
+            let normalized = await loadBundledDefaultLexicon();
             if (!normalized.length) {
                 console.warn('[VocabStore] 默认词库为空');
                 return [];
             }
-            await saveListData(DEFAULT_LIST_ID, normalized);
+            const receipt = await vocab.initializeDefaultWords({ words: normalized });
+            normalized = normalizeStoredListWords(receipt.words, DEFAULT_LIST_ID);
             if (state.activeListId === DEFAULT_LIST_ID) {
                 setWordsInternal(normalized);
                 state.lastLoadSource = 'default';
@@ -1102,38 +1098,47 @@
         if (!normalized) {
             return null;
         }
-        await init();
-        const listId = 'reading-highlights';
-        const storedData = await readListData(listId);
-        const words = normalizeStoredListWords(storedData, listId);
-        const key = normalized.word.toLowerCase();
-        const existingIndex = words.findIndex((entry) => String(entry.word || '').trim().toLowerCase() === key);
-        let committedWord = normalized;
-        if (existingIndex >= 0) {
-            const existing = words[existingIndex];
-            committedWord = normalizeWordRecord({
-                ...existing,
-                ...normalized,
-                id: existing.id || normalized.id,
-                createdAt: existing.createdAt || normalized.createdAt,
-                note: existing.note || normalized.note,
-                easeFactor: existing.easeFactor,
-                interval: existing.interval,
-                repetitions: existing.repetitions,
-                intraCycles: existing.intraCycles,
-                correctCount: existing.correctCount,
-                lastReviewed: existing.lastReviewed,
-                nextReview: existing.nextReview,
-                updatedAt: getNow()
-            });
-            words.splice(existingIndex, 1, committedWord);
-        } else {
-            words.push(normalized);
+        const vocab = await requireVocabData();
+        const context = payload.context && typeof payload.context === 'object' ? payload.context : {};
+        const examId = String(context.examId || payload.examId || '').trim();
+        if (!examId) throw new Error('Reading vocabulary requires an article identity');
+        let source = context.source || (payload.source && typeof payload.source === 'object' ? payload.source : null);
+        const configurationId = Object.prototype.hasOwnProperty.call(context, 'libraryConfigurationId')
+            ? context.libraryConfigurationId
+            : payload.libraryConfigurationId;
+        if (configurationId !== undefined || !source) {
+            if (configurationId === undefined) throw new Error('Reading vocabulary requires a library identity');
+            source = configurationId == null || configurationId === ''
+                ? { kind: 'builtin', id: 'default' }
+                : { kind: 'imported', id: String(configurationId).trim() };
         }
-        await saveListData(listId, words.filter(Boolean));
+        const observed = await vocab.getReadingSnapshot();
+        const command = {
+            source,
+            article: { examId, title: String(context.title || '') },
+            word: normalized,
+            manual: !payload.occurrence,
+            at: getNow()
+        };
+        if (payload.occurrence) command.occurrence = cloneValue(payload.occurrence);
+        const receipt = await vocab.mutateReading('collect', command, {
+            observedRevision: observed.revision,
+            observedGeneration: observed.generation
+        });
+        if (!receipt || receipt.saved !== true || !receipt.snapshot) {
+            throw new Error('Reading vocabulary was not durably acknowledged');
+        }
+        const snapshot = receipt.snapshot;
+        const term = snapshot.reading.terms.find((entry) => entry.normalizedTerm === normalized.word.toLowerCase());
+        if (!term) throw new Error('Saved reading vocabulary has no canonical owner');
+        const listId = term.wordRef.listId;
+        const storedList = listId === DEFAULT_LIST_ID ? snapshot.words : snapshot.lists[listId];
+        const words = Array.isArray(storedList) ? storedList : storedList && storedList.words || [];
+        const committedWord = words.find((entry) => entry.id === term.wordRef.wordId);
+        if (!committedWord) throw new Error('Saved reading vocabulary has no canonical word');
         state.listCache.delete(listId);
         if (state.activeListId === listId) {
-            setWordsInternal(words.map((word) => resolveWordPhonetic(word)).filter(Boolean));
+            setWordsInternal(normalizeStoredListWords(storedList, listId));
         }
         return cloneValue(resolveWordPhonetic(committedWord));
     }

--- a/js/core/vocabStore.js
+++ b/js/core/vocabStore.js
@@ -668,7 +668,7 @@
                 return backfilled;
             }
             const vocab = await requireVocabData();
-            if (!await vocab.shouldInitializeDefaultWords()) {
+            if (!pollutedBySpellingList && !await vocab.shouldInitializeDefaultWords()) {
                 if (state.activeListId === DEFAULT_LIST_ID) setWordsInternal(normalizedStored);
                 return normalizedStored;
             }
@@ -678,7 +678,9 @@
                 console.warn('[VocabStore] 默认词库为空');
                 return [];
             }
-            const receipt = await vocab.initializeDefaultWords({ words: normalized });
+            const receipt = pollutedBySpellingList
+                ? await vocab.repairDefaultWords({ words: normalized })
+                : await vocab.initializeDefaultWords({ words: normalized });
             normalized = normalizeStoredListWords(receipt.words, DEFAULT_LIST_ID);
             if (state.activeListId === DEFAULT_LIST_ID) {
                 setWordsInternal(normalized);

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -1713,7 +1713,7 @@
         const { replaceDocuments, replacePractice } = resolveImportReplaceFlags(options);
         // Preserve local-only reading data before capturing revisions for any
         // reading collection this plan will install, including present arrays.
-        const readingKeys = Object.keys(READING_LEGACY_KEYS).filter((key) => {
+        const readingKeys = READING_DOCUMENT_KEYS.filter((key) => {
             const envelope = asObject(parsed.envelopes)[key];
             return (replaceDocuments && parsed.scope === 'full')
                 || (envelope && (envelope.state === 'present' || replaceDocuments || options.applyClears === true));
@@ -1755,6 +1755,8 @@
                 clearedKeys.push(entry.logicalKey);
             }
         }
+
+        await prepareReadingImport(parsed, snapshot, revisionToken, keys, clearedKeys, replaceDocuments);
 
         // Any successful practice import installs all three stores together. Merge
         // may update a subset only when the final recordId sets remain identical.
@@ -1848,28 +1850,102 @@
         return createImportPlan(parsed, { replace: true });
     }
 
-    async function migrateLegacyReadingData({ required = false, logicalKeys = Object.keys(READING_LEGACY_KEYS) } = {}) {
-        for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
-            if (!logicalKeys.includes(logicalKey)) continue;
-            try {
-                const current = await kernel.read(logicalKey, { withMeta: true });
-                // A present empty array or a cleared envelope is authoritative too.
-                // Legacy mirrors only seed documents that have never been written.
-                if (current.envelope) continue;
-                if (!global.localStorage) return;
-                const raw = global.localStorage.getItem(storageKey);
-                const parsed = raw ? JSON.parse(raw) : null;
-                if (!Array.isArray(parsed)) continue;
-                await kernel.mutate([{ logicalKey, data: parsed, expectedRevision: 0 }], {
-                    operationId: randomId('migrate-reading')
-                });
-            } catch (error) {
-                // Startup can retry later; a backup or destructive installation
-                // must not discard a legacy copy that has never reached the kernel.
-                if (required) throw error;
-                if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
-            }
+    async function migrateLegacyReadingData({ required = false, logicalKeys } = {}) {
+        // The versioned marker and recovered source bytes are committed in the
+        // same transaction as the model. No later startup/export re-reads mirrors.
+        if (Array.isArray(logicalKeys) && !logicalKeys.some((key) => READING_DOCUMENT_KEYS.includes(key))) return;
+        try { await ensureReadingMigration(); }
+        catch (error) {
+            if (required) throw error;
+            if (global.console && console.warn) console.warn('[AppData v2] legacy reading migration skipped:', error);
         }
+    }
+
+    function legacyReadingAt(value, fallback = '1970-01-01T00:00:00.000Z') {
+        const parsed = typeof value === 'number' ? value : Date.parse(value);
+        return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+    }
+    function legacyReadingSource(row) {
+        const source = asObject(row && row.source);
+        if ((source.kind === 'builtin' || source.kind === 'imported') && source.id) return source;
+        return { kind: row && row.sourceKind === 'imported' ? 'imported' : 'builtin',
+            id: String(row && (row.libraryId || row.sourceId) || 'default') };
+    }
+    function convertLegacyReading(snapshot, words, bookshelf, rejected = [], activityAt = null) {
+        const model = readingModel(); let next = snapshot;
+        for (const row of asArray(words)) {
+            try {
+                if (!row || typeof row.word !== 'string' || !row.word.trim()) throw new Error('Missing word');
+                const at = activityAt || legacyReadingAt(row.createdAt);
+                const highlights = asArray(row.highlights);
+                const examIds = new Set([row.examId, ...highlights.map((item) => item && item.examId)].filter(Boolean).map(String));
+                if (!examIds.size) throw new Error('Missing article identity');
+                for (const examId of examIds) {
+                    const command = { source: legacyReadingSource(row), article: { examId, title: String(row.examTitle || '') },
+                        word: Object.assign({}, row, { word: row.word.trim(), meaning: String(row.meaning || '待补充释义') }), at, manual: true };
+                    next = model.recordVisit(model.collect(next, command), command);
+                    for (const highlight of highlights.filter((item) => String(item && item.examId || row.examId) === examId)) {
+                        const quote = String(highlight.quote || highlight.text || row.word);
+                        if (Number.isSafeInteger(highlight.startOffset) && Number.isSafeInteger(highlight.endOffset)
+                            && highlight.endOffset - highlight.startOffset === quote.length) {
+                            try {
+                                next = model.collect(next, Object.assign({}, command, { manual: false, occurrence: {
+                                    scopeId: String(highlight.scopeId || highlight.scope || 'passage'),
+                                    contentVersion: String(highlight.contentVersion || 'legacy-v1'),
+                                    startOffset: highlight.startOffset, endOffset: highlight.endOffset, quote,
+                                    before: String(highlight.before || ''), after: String(highlight.after || '')
+                                } }));
+                            } catch (error) { rejected.push({ kind: 'occurrence', value: clone(highlight), reason: error.message }); }
+                        } else rejected.push({ kind: 'occurrence', value: clone(highlight), reason: 'Missing exact selection anchor' });
+                    }
+                }
+            } catch (error) { rejected.push({ kind: 'word', value: clone(row), reason: error.message }); }
+        }
+        for (const row of asArray(bookshelf)) {
+            try {
+                if (!row || !row.examId) throw new Error('Missing article identity');
+                const command = { source: legacyReadingSource(row), article: { examId: String(row.examId),
+                    title: String(row.examTitle || row.title || '') }, at: legacyReadingAt(row.firstUsedAt) };
+                next = model.recordVisit(next, command);
+                next = model.recordVisit(next, Object.assign({}, command, { at: legacyReadingAt(row.lastOpenedAt, command.at) }));
+            } catch (error) { rejected.push({ kind: 'visit', value: clone(row), reason: error.message }); }
+        }
+        return next;
+    }
+    async function ensureReadingMigration() {
+        if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
+        return retryMergeConflict({}, async () => {
+            const migration = await kernel.read('system.migrations', { withMeta: true });
+            if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
+            const current = await readReadingDocuments();
+            const recoverable = { localStorage: {}, documents: {}, rejected: [] };
+            const values = {};
+            for (const [logicalKey, storageKey] of Object.entries(READING_LEGACY_KEYS)) {
+                const meta = current.metas[logicalKey];
+                recoverable.documents[logicalKey] = clone(meta.data);
+                let raw = null;
+                if (global.localStorage) raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) recoverable.localStorage[storageKey] = raw;
+                let parsed = null;
+                try { parsed = raw === null ? null : JSON.parse(raw); }
+                catch (_) { recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Invalid JSON' }); }
+                if (raw !== null && !Array.isArray(parsed)) recoverable.rejected.push({ kind: 'storage', key: storageKey, reason: 'Unrecognized legacy payload' });
+                values[logicalKey] = meta.envelope ? meta.data : (Array.isArray(parsed) ? parsed : []);
+            }
+            let next = current.snapshot;
+            current.state.allowDefaultWordSeed = !current.metas['vocab.words'].envelope;
+            if (!current.metas[READING_STATE_KEY].envelope) {
+                next = convertLegacyReading(next, values['vocab.readingVocabWords'], values['vocab.readingBookshelfExams'], recoverable.rejected);
+            }
+            const changes = readingChanges(current, next, current.state);
+            // Preserve recognizable prototype arrays for compatibility/export as
+            // well as storing lossless originals in the recovery marker.
+            for (const change of changes) if (hasOwn(values, change.logicalKey)) change.data = values[change.logicalKey];
+            changes.push({ logicalKey: 'system.migrations', data: Object.assign({}, asObject(migration.data), {
+                readingVocabularyV1: { version: 1, completed: true, completedAt: nowIso(), recoverable }
+            }), expectedRevision: metaRevision(migration) });
+            await kernel.mutate(changes, { operationId: randomId('migrate-reading') });
+        }, 12);
     }
 
     async function refreshReadingMirrors(logicalKeys = Object.keys(READING_LEGACY_KEYS)) {
@@ -1878,7 +1954,11 @@
             try {
                 if (!global.localStorage) return;
                 const current = await kernel.read(logicalKey, { withMeta: true });
-                if (current.envelope && Array.isArray(current.data)) {
+                // Unknown prototype payloads remain recoverable in-place too.
+                let recognized = true;
+                const raw = global.localStorage.getItem(storageKey);
+                if (raw !== null) { try { recognized = Array.isArray(JSON.parse(raw)); } catch (_) { recognized = false; } }
+                if (recognized && current.envelope && Array.isArray(current.data)) {
                     global.localStorage.setItem(storageKey, JSON.stringify(current.data));
                 }
             } catch (error) {
@@ -1927,7 +2007,10 @@
         async delete(id, options = {}) { await ready; const current = await readCollectionMeta('backups.entries'); return kernel.mutate([{ logicalKey: 'backups.entries', data: current.items.filter((item) => String(item.id) !== String(id)), expectedRevision: current.revision }], optionsMutationOptions(options, 'backup-delete', { id: String(id) })); },
         async export(options = {}) {
             await ready;
-            await migrateLegacyReadingData();
+            if ((options.backupId === undefined || options.backupId === null)
+                && (!Array.isArray(options.domains) || options.domains.includes('vocab'))) {
+                await migrateLegacyReadingData({ required: true });
+            }
             if (options.backupId !== undefined && options.backupId !== null) {
                 const backupId = String(options.backupId);
                 const stored = asArray(await kernel.read('backups.entries'))
@@ -2048,17 +2131,396 @@
         return enqueueVocabMutation(() => retryMergeConflict(options, task));
     }
 
+    const READING_STATE_KEY = 'vocab.readingState';
+    const READING_DOCUMENT_KEYS = ['vocab.words', 'vocab.lists', READING_STATE_KEY,
+        'vocab.readingVocabWords', 'vocab.readingBookshelfExams'];
+    function readingModel() {
+        const model = global.ReadingVocabularyModel;
+        if (!model) throw new AppDataError('INITIALIZATION_BLOCKED', 'ReadingVocabularyModel is required');
+        return model;
+    }
+    function emptyReadingState(generation = 'initial') {
+        return { schemaVersion: 1, generation, reading: readingModel().createSnapshot().reading,
+            tombstones: { articles: {}, visits: {}, terms: {}, canonicalTerms: {}, associations: {}, occurrences: {}, all: null } };
+    }
+    function normalizeReadingState(value) {
+        if (!value || !Object.keys(value).length) return emptyReadingState();
+        if (value.schemaVersion !== 1 || !value.reading || typeof value.generation !== 'string') {
+            throw new AppDataError('VALIDATION', 'Unsupported reading persistence state');
+        }
+        const result = Object.assign(emptyReadingState(value.generation), clone(value), {
+            tombstones: Object.assign(emptyReadingState().tombstones, clone(asObject(value.tombstones)))
+        });
+        const validStamp = (stamp) => stamp && typeof stamp.at === 'string' && Number.isFinite(Date.parse(stamp.at))
+            && new Date(stamp.at).toISOString() === stamp.at && Number.isSafeInteger(stamp.revision) && stamp.revision >= 0;
+        for (const [table, rows] of Object.entries(result.tombstones)) {
+            if (table === 'all') {
+                if (rows !== null && !validStamp(rows)) throw new AppDataError('VALIDATION', 'Invalid reading deletion fence');
+            } else if (!rows || typeof rows !== 'object' || Array.isArray(rows) || Object.values(rows).some((stamp) => !validStamp(stamp))) {
+                throw new AppDataError('VALIDATION', `Invalid reading ${table} deletion fences`);
+            }
+        }
+        return result;
+    }
+    const metaRevision = (meta) => Number(meta && meta.envelope && meta.envelope.revision) || 0;
+    async function readReadingDocuments() {
+        // Every canonical vocabulary mutation also checks/increments readingState.
+        // Read that fence twice so a split readonly read never exposes mixed owners.
+        for (let attempt = 0; attempt < 12; attempt += 1) {
+            const before = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            const values = await Promise.all(READING_DOCUMENT_KEYS.filter((key) => key !== READING_STATE_KEY)
+                .map(async (key) => [key, await kernel.read(key, { withMeta: true })]));
+            const after = await kernel.read(READING_STATE_KEY, { withMeta: true });
+            if (metaRevision(before) !== metaRevision(after)) continue;
+            const metas = Object.fromEntries(values.concat([[READING_STATE_KEY, after]]));
+            const state = normalizeReadingState(after.data);
+            const snapshot = readingModel().createSnapshot({ words: metas['vocab.words'].data,
+                lists: metas['vocab.lists'].data, reading: state.reading });
+            return { metas, state, snapshot, revision: metaRevision(after), generation: state.generation };
+        }
+        throw new AppDataError('CONFLICT', 'Vocabulary changed repeatedly while reading; retry');
+    }
+    function readingResult(current) {
+        return { snapshot: clone(current.snapshot), revision: current.revision, generation: current.generation };
+    }
+    function readingActivityClock(snapshot, state) {
+        const timestamps = [state.clockAt];
+        for (const table of ['articles', 'terms', 'associations', 'occurrences', 'visits']) {
+            for (const row of snapshot.reading[table]) timestamps.push(row.updatedAt, row.createdAt, row.lastVisitedAt);
+        }
+        for (const [table, rows] of Object.entries(state.tombstones)) {
+            if (table === 'all') timestamps.push(rows && rows.at);
+            else for (const stamp of Object.values(rows)) timestamps.push(stamp.at);
+        }
+        return timestamps.reduce((latest, at) => Math.max(latest, Date.parse(at || '') || 0), 0);
+    }
+    function mergeReadingTombstones(existing, incoming) {
+        const result = clone(existing);
+        const latest = (left, right) => !left ? right : !right ? left
+            : String(left.at) >= String(right.at) ? left : right;
+        for (const table of ['articles', 'visits', 'terms', 'canonicalTerms', 'associations', 'occurrences']) {
+            for (const [id, stamp] of Object.entries(asObject(incoming[table]))) {
+                result[table][id] = clone(latest(result[table][id], stamp));
+            }
+        }
+        result.all = clone(latest(result.all, incoming.all));
+        return result;
+    }
+    function applyReadingTombstones(snapshot, tombstones) {
+        let next = clone(snapshot);
+        const deleted = (stamp, at) => stamp && String(stamp.at) >= String(at);
+        for (const [termId, stamp] of Object.entries(tombstones.canonicalTerms)) {
+            const term = next.reading.terms.find((row) => row.id === termId);
+            if (!term || deleted(stamp, term.createdAt)) next = readingModel().deleteCanonicalTerm(next, { termId });
+        }
+        next.reading.associations = next.reading.associations.filter((row) => ![
+            tombstones.all, tombstones.articles[row.articleId], tombstones.terms[row.termId], tombstones.associations[row.id]
+        ].some((stamp) => deleted(stamp, row.updatedAt)));
+        const associations = new Set(next.reading.associations.map((row) => row.id));
+        next.reading.occurrences = next.reading.occurrences.filter((row) => associations.has(row.associationId)
+            && !deleted(tombstones.occurrences[row.id], row.updatedAt));
+        next.reading.associations = next.reading.associations.filter((row) => row.manual
+            || next.reading.occurrences.some((occurrence) => occurrence.associationId === row.id));
+        next.reading.visits = next.reading.visits.filter((row) => !deleted(tombstones.visits[row.articleId], row.lastVisitedAt));
+        readingModel().validate(next);
+        return next;
+    }
+    async function prepareReadingImport(parsed, target, revisionToken, keys, clearedKeys, replace) {
+        if (!global.ReadingVocabularyModel) return;
+        const incomingEnvelopes = asObject(parsed.envelopes);
+        const hasReading = [READING_STATE_KEY, ...Object.keys(READING_LEGACY_KEYS)]
+            .some((key) => hasOwn(target.envelopes, key));
+        const hasOwners = ['vocab.words', 'vocab.lists'].some((key) => hasOwn(target.envelopes, key));
+        if (!hasReading && !hasOwners) return;
+        const current = await readReadingDocuments(); const model = readingModel();
+        const value = (envelopes, key, fallback) => {
+            const envelope = envelopes[key];
+            return !envelope ? fallback : envelope.state === 'cleared' ? catalog.get(key).defaultValue() : envelope.data;
+        };
+        const native = incomingEnvelopes[READING_STATE_KEY];
+        let state; let next;
+        if (hasReading) {
+            let incomingState = normalizeReadingState(value(incomingEnvelopes, READING_STATE_KEY, {}));
+            let incoming = model.createSnapshot({
+                words: value(incomingEnvelopes, 'vocab.words', replace && parsed.scope !== 'full' ? current.snapshot.words : []),
+                lists: value(incomingEnvelopes, 'vocab.lists', replace && parsed.scope !== 'full' ? current.snapshot.lists : {}),
+                reading: incomingState.reading
+            });
+            if (!native) {
+                incoming = convertLegacyReading(incoming,
+                    value(incomingEnvelopes, 'vocab.readingVocabWords', replace && parsed.scope !== 'full' ? current.metas['vocab.readingVocabWords'].data : []),
+                    value(incomingEnvelopes, 'vocab.readingBookshelfExams', replace && parsed.scope !== 'full' ? current.metas['vocab.readingBookshelfExams'].data : []));
+            }
+            if (replace) {
+                next = incoming; state = incomingState;
+                state.generation = randomId('reading-replace');
+            } else {
+                state = clone(current.state);
+                state.tombstones = mergeReadingTombstones(state.tombstones, incomingState.tombstones);
+                // Filter each history before union: an old backup must not lower
+                // a deliberately recollected term's creation clock below deletion.
+                next = model.merge(applyReadingTombstones(current.snapshot, state.tombstones),
+                    applyReadingTombstones(incoming, state.tombstones));
+                next = applyReadingTombstones(next, state.tombstones);
+            }
+        } else {
+            state = clone(current.state);
+            const ownerValue = (key, stored) => {
+                if (!hasOwn(target.envelopes, key)) return stored;
+                const envelope = incomingEnvelopes[key];
+                if (!replace && envelope && envelope.state === 'present') {
+                    return mergeImportValue(catalog.get(key), stored, envelope.data);
+                }
+                return value(target.envelopes, key, stored);
+            };
+            next = model.createSnapshot({ words: ownerValue('vocab.words', current.snapshot.words),
+                lists: ownerValue('vocab.lists', current.snapshot.lists), reading: state.reading });
+        }
+        // Imported revisions belong to another snapshot/installation. Install a
+        // new local epoch and rebase every fence to this transaction's revision.
+        state.generation = randomId('reading-import');
+        const stamps = Object.entries(state.tombstones).flatMap(([table, rows]) => table === 'all' ? (rows ? [rows] : []) : Object.values(rows));
+        for (const stamp of stamps) stamp.revision = current.revision + 1;
+        state.clockAt = [state.clockAt, ...stamps.map((stamp) => stamp.at)].filter(Boolean).sort().pop() || nowIso();
+        state.allowDefaultWordSeed = false;
+        const changes = readingChanges(current, next, state);
+        for (const change of changes) {
+            revisionToken.documents[change.logicalKey] = metaRevision(current.metas[change.logicalKey]);
+            // Legacy-only backups retain their original portable arrays. New
+            // model backups derive compatibility arrays from the merged graph.
+            if (!native && hasOwn(READING_LEGACY_KEYS, change.logicalKey) && target.envelopes[change.logicalKey]) {
+                const incoming = incomingEnvelopes[change.logicalKey];
+                if (!replace && incoming && incoming.state === 'present') {
+                    target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey),
+                        mergeImportValue(catalog.get(change.logicalKey), current.metas[change.logicalKey].data, incoming.data),
+                        { operationId: randomId('import-reading-compatibility') });
+                }
+                continue;
+            }
+            target.envelopes[change.logicalKey] = internals.makeEnvelope(catalog.get(change.logicalKey), change.data,
+                { operationId: randomId('import-reading') });
+            if (!keys.includes(change.logicalKey)) keys.push(change.logicalKey);
+            const clearIndex = clearedKeys.indexOf(change.logicalKey);
+            if (clearIndex >= 0) clearedKeys.splice(clearIndex, 1);
+        }
+    }
+    function readingProjection(snapshot) {
+        const model = readingModel();
+        const query = model.query(snapshot);
+        const articles = new Map(snapshot.reading.articles.map((row) => [row.id, row]));
+        const sources = new Map(snapshot.reading.sources.map((row) => [row.id, row]));
+        const words = query.terms.map((row) => {
+            const first = articles.get(row.associations[0].articleId);
+            return Object.assign({}, clone(row.word), { id: row.term.id, termId: row.term.id,
+                wordRef: row.wordRef, examId: first.examId, examTitle: first.title,
+                associations: row.associations, occurrences: row.occurrences,
+                highlights: row.occurrences.map((occurrence) => {
+                    const association = row.associations.find((item) => item.id === occurrence.associationId);
+                    const article = articles.get(association.articleId);
+                    return Object.assign({}, occurrence, { examId: article.examId,
+                        articleId: article.id, scope: occurrence.scopeId, text: occurrence.quote });
+                }) });
+        });
+        const bookshelf = snapshot.reading.visits.map((visit) => {
+            const article = articles.get(visit.articleId); const source = sources.get(article.sourceId);
+            return { id: article.id, articleId: article.id, examId: article.examId, examTitle: article.title,
+                source: { kind: source.kind, id: source.libraryId },
+                firstUsedAt: Date.parse(visit.firstVisitedAt), lastOpenedAt: Date.parse(visit.lastVisitedAt) };
+        });
+        return { words, bookshelf };
+    }
+    function readingChanges(current, snapshot, state) {
+        state.reading = snapshot.reading;
+        const projection = readingProjection(snapshot);
+        const values = { 'vocab.words': snapshot.words, 'vocab.lists': snapshot.lists,
+            [READING_STATE_KEY]: state, 'vocab.readingVocabWords': projection.words,
+            'vocab.readingBookshelfExams': projection.bookshelf };
+        return READING_DOCUMENT_KEYS.map((logicalKey) => ({ logicalKey, data: values[logicalKey],
+            expectedRevision: metaRevision(current.metas[logicalKey]) }));
+    }
+    function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
+    function assertFreshReadingIntent(current, type, command, observed) {
+        if (type !== 'collect' && type !== 'recordVisit') return;
+        if (observed.generation !== current.generation) {
+            throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
+        }
+        const model = readingModel(); const tombstones = current.state.tombstones;
+        const articleId = model.articleId(command.source, command.article.examId);
+        const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
+            : [tombstones.visits[articleId]];
+        if (type === 'collect') {
+            const termId = model.termId(command.word.word);
+            const associationId = JSON.stringify(['association', articleId, termId]);
+            fences.push(tombstones.terms[termId], tombstones.associations[associationId]);
+            if (command.occurrence) fences.push(tombstones.occurrences[model.occurrenceId(articleId, termId, command.occurrence)]);
+        }
+        if (fences.some((fence) => tombstoneRevision(fence) > observed.revision)) {
+            throw new AppDataError('CONFLICT', 'This reading association was removed; reload before collecting again');
+        }
+    }
+    async function mutateReading(type, input = {}, options = {}) {
+        await ready; await ensureReadingMigration();
+        assertObject(input, 'Reading command must be an object');
+        const command = Object.assign({ at: nowIso() }, clone(input));
+        const initial = await readReadingDocuments();
+        const observed = { revision: options.observedRevision ?? initial.revision,
+            generation: options.observedGeneration ?? initial.generation };
+        const mutation = optionsMutationOptions(options, `reading-${type}`, { type, command: input });
+        return retryVocabMutation(options, async () => {
+            const current = await readReadingDocuments();
+            assertFreshReadingIntent(current, type, command, observed);
+            const model = readingModel(); let next = current.snapshot;
+            const state = clone(current.state); const tombstones = state.tombstones;
+            if (typeof command.at !== 'string' || !Number.isFinite(Date.parse(command.at))
+                || new Date(command.at).toISOString() !== command.at) throw new AppDataError('VALIDATION', 'Reading at must be a UTC ISO timestamp');
+            // Timestamp order is advanced at the acknowledged write boundary, not
+            // trusted to the stale page's wall clock. A fresh deliberate re-add
+            // therefore sorts after deletion when backups are merged later.
+            const previousClock = readingActivityClock(current.snapshot, state);
+            command.at = new Date(Math.max(Date.now(), Date.parse(command.at), previousClock + 1)).toISOString();
+            state.clockAt = command.at;
+            const stamp = { at: command.at, revision: current.revision + 1 };
+            const mark = (table, id) => { tombstones[table][id] = stamp; };
+            if (type === 'collect') next = model.recordVisit(model.collect(next, command), command);
+            else if (type === 'recordVisit') next = model.recordVisit(next, command);
+            else if (type === 'removeOccurrence') { next = model.removeOccurrence(next, command); mark('occurrences', command.occurrenceId); }
+            else if (type === 'removeArticleTerm') {
+                next = model.removeArticleTerm(next, command);
+                mark('associations', JSON.stringify(['association', command.articleId, command.termId]));
+            } else if (type === 'clearArticle') { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+            else if (type === 'deleteCanonicalTerm') { next = model.deleteCanonicalTerm(next, command); mark('terms', command.termId); mark('canonicalTerms', command.termId); }
+            else if (type === 'removeTermAssociations') {
+                for (const row of next.reading.associations.filter((row) => row.termId === command.termId)) {
+                    next = model.removeArticleTerm(next, row); mark('associations', row.id);
+                }
+                mark('terms', command.termId);
+            } else if (type === 'clearReading') {
+                for (const row of next.reading.articles) next = model.clearArticle(next, { articleId: row.id });
+                tombstones.all = stamp;
+            } else if (type === 'removeArticle') {
+                if (!command.articleId) throw new AppDataError('VALIDATION', 'articleId is required');
+                if (command.clearWords === true) { next = model.clearArticle(next, command); mark('articles', command.articleId); }
+                next.reading.visits = next.reading.visits.filter((row) => row.articleId !== command.articleId);
+                mark('visits', command.articleId);
+            } else throw new AppDataError('VALIDATION', `Unknown reading operation: ${type}`);
+            // Remember concrete removals as well as broad fences for portable merges.
+            for (const row of current.snapshot.reading.associations) {
+                if (!next.reading.associations.some((item) => item.id === row.id)) mark('associations', row.id);
+            }
+            for (const row of current.snapshot.reading.occurrences) {
+                if (!next.reading.occurrences.some((item) => item.id === row.id)) mark('occurrences', row.id);
+            }
+            model.validate(next);
+            const receipt = await kernel.mutate(readingChanges(current, next, state), mutation);
+            if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Reading save was not acknowledged');
+            // A replay may acknowledge an earlier operation; return current durable data.
+            const committed = await readReadingDocuments();
+            if (type === 'collect') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                const termId = model.termId(command.word.word);
+                const association = committed.snapshot.reading.associations.find((row) => row.articleId === articleId && row.termId === termId);
+                const occurrenceId = command.occurrence && model.occurrenceId(articleId, termId, command.occurrence);
+                if (!association || (occurrenceId && !committed.snapshot.reading.occurrences.some((row) => row.id === occurrenceId))) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged reading selection has since been removed; reload before retrying');
+                }
+            } else if (type === 'recordVisit') {
+                const articleId = model.articleId(command.source, command.article.examId);
+                if (!committed.snapshot.reading.visits.some((row) => row.articleId === articleId)) {
+                    throw new AppDataError('CONFLICT', 'The acknowledged bookshelf visit has since been removed; reload before retrying');
+                }
+            }
+            return Object.assign({}, receipt, readingResult(committed), { saved: true,
+                added: type === 'collect', changed: checksum(next) !== checksum(current.snapshot) });
+        });
+    }
+
+    async function mutateVocabDocuments(changes, options) {
+        const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
+        if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        const current = await readReadingDocuments();
+        const next = clone(current.snapshot);
+        for (const change of changes) {
+            if (change.logicalKey === 'vocab.words') { next.words = change.state === 'cleared' ? [] : change.data; current.state.allowDefaultWordSeed = false; }
+            if (change.logicalKey === 'vocab.lists') next.lists = change.state === 'cleared' ? {} : change.data;
+        }
+        // Bulk canonical writes cannot silently orphan reading relationships. Call
+        // deleteCanonicalTerm for an intentional cascade instead.
+        readingModel().validate(next);
+        const guarded = changes.concat([{ logicalKey: READING_STATE_KEY, data: current.state,
+            expectedRevision: current.revision }]);
+        return kernel.mutate(guarded, options);
+    }
+
+    async function replaceLegacyReadingCollection(logicalKey, rows, options) {
+        await ready; await ensureReadingMigration();
+        assertArray(rows, 'Reading compatibility snapshots require an array');
+        if (!hasOwn(options, 'expectedRevision')) {
+            throw new AppDataError('VALIDATION', 'Reading snapshot writes require the revision from a withMeta read; use mutateReading for interactive changes');
+        }
+        return enqueueVocabMutation(async () => {
+            const current = await readReadingDocuments();
+            if (Number(options.expectedRevision) !== metaRevision(current.metas[logicalKey])) {
+                throw new AppDataError('CONFLICT', 'Reading snapshot changed; reload before replacing it');
+            }
+            let next = clone(current.snapshot); const state = clone(current.state);
+            const stamp = { at: new Date(Math.max(Date.now(), readingActivityClock(current.snapshot, state) + 1)).toISOString(), revision: current.revision + 1 };
+            const rejected = [];
+            if (logicalKey === 'vocab.readingVocabWords') {
+                next.reading.associations = []; next.reading.occurrences = [];
+                next = convertLegacyReading(next, rows, [], rejected, stamp.at);
+                for (const row of current.snapshot.reading.associations) if (!next.reading.associations.some((item) => item.id === row.id)) state.tombstones.associations[row.id] = stamp;
+                for (const row of current.snapshot.reading.occurrences) if (!next.reading.occurrences.some((item) => item.id === row.id)) state.tombstones.occurrences[row.id] = stamp;
+            } else {
+                next.reading.visits = [];
+                next = convertLegacyReading(next, [], rows, rejected);
+                for (const row of current.snapshot.reading.visits) if (!next.reading.visits.some((item) => item.id === row.id)) state.tombstones.visits[row.id] = stamp;
+            }
+            state.clockAt = stamp.at; state.generation = randomId('reading-snapshot');
+            const changes = readingChanges(current, next, state);
+            for (const change of changes) {
+                if (change.logicalKey === logicalKey) change.data = rows;
+                else if (hasOwn(READING_LEGACY_KEYS, change.logicalKey)) change.data = current.metas[change.logicalKey].data;
+            }
+            return kernel.mutate(changes, optionsMutationOptions(options, 'reading-compatibility-replace', { logicalKey, rows },
+                { warnings: rejected.map((entry) => `Retained unrecognized legacy ${entry.kind}: ${entry.reason}`) }));
+        });
+    }
+
     const vocab = Object.freeze({
         // Pure schema/relationship operations. Persistence commands consume this
         // contract; a returned snapshot is not a durable commit acknowledgement.
         get readingModel() { return global.ReadingVocabularyModel; },
+        async getReadingSnapshot() { await ready; await ensureReadingMigration(); return readingResult(await readReadingDocuments()); },
+        async shouldInitializeDefaultWords() {
+            await ready; await ensureReadingMigration();
+            if (!global.ReadingVocabularyModel) return !(await kernel.read('vocab.words', { withMeta: true })).envelope;
+            const current = await readReadingDocuments();
+            return current.state.allowDefaultWordSeed === true && current.snapshot.words.length === 0;
+        },
+        async initializeDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary initialization requires a command');
+            assertArray(command.words, 'Default vocabulary initialization requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                if (current.state.allowDefaultWordSeed !== true || current.snapshot.words.length) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-initialize', command));
+                return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        mutateReading,
         async listWords() { await ready; return kernel.read('vocab.words'); },
         async saveWords(words, options = {}) {
             await ready; assertArray(words, 'vocab.saveWords requires an array');
             const mutation = optionsMutationOptions(options, 'vocab-words', words);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.words', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.words',
                     data: words,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2071,7 +2533,7 @@
             const mutation = optionsMutationOptions(options, 'vocab-config', config);
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: asObject(config),
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2084,7 +2546,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.userConfig', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), clone(patch));
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.userConfig',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2100,7 +2562,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), { [collectionId]: clone(value) });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2115,7 +2577,7 @@
             return retryVocabMutation(options, async () => {
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const next = Object.assign({}, asObject(current.data), upserts);
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: next,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2147,7 +2609,7 @@
                 if (index >= 0) list.words[index] = nextWord; else list.words.push(nextWord);
                 list.updatedAt = nowIso();
                 collections[id] = list;
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2165,7 +2627,7 @@
                 const current = await kernel.read('vocab.lists', { withMeta: true });
                 const collections = Object.assign({}, asObject(current.data));
                 collections[id] = Object.assign({}, asObject(collections[id]), { id, words, updatedAt: nowIso() });
-                return kernel.mutate([{
+                return mutateVocabDocuments([{
                     logicalKey: 'vocab.lists',
                     data: collections,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2238,7 +2700,7 @@
                             { id: listId, words: merged, updatedAt: nowIso() }
                         )
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2297,7 +2759,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, asObject(collections[listId]), { id: listId, words })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
@@ -2339,7 +2801,7 @@
                     : Object.assign({}, collections, {
                         [listId]: Object.assign({}, collection, { id: listId, words: next, updatedAt: nowIso() })
                     });
-                const receipt = await kernel.mutate([{
+                const receipt = await mutateVocabDocuments([{
                     logicalKey,
                     data,
                     expectedRevision: options.expectedRevision ?? (current.envelope ? Number(current.envelope.revision) : 0)
@@ -2376,35 +2838,17 @@
                     lists[listId] = Object.assign({}, existingList, { id: listId, words: committedWords });
                     changes.push({ logicalKey: 'vocab.lists', data: lists, expectedRevision: listsMeta.envelope ? listsMeta.envelope.revision : 0 });
                 }
-                const receipt = await kernel.mutate(changes, mutation);
+                const receipt = await mutateVocabDocuments(changes, mutation);
                 return Object.assign({}, receipt, { listId, words: clone(committedWords) });
             });
         },
         async listReadingWords(options = {}) { await ready; return kernel.read('vocab.readingVocabWords', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingWords(words, options = {}) {
-            await ready; assertArray(words, 'vocab.saveReadingWords requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-words', words);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingVocabWords', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingVocabWords',
-                    data: words,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingVocabWords', words, options);
         },
         async listReadingBookshelfExams(options = {}) { await ready; return kernel.read('vocab.readingBookshelfExams', { withMeta: asObject(options).withMeta === true }); },
         async saveReadingBookshelfExams(records, options = {}) {
-            await ready; assertArray(records, 'vocab.saveReadingBookshelfExams requires an array');
-            const mutation = optionsMutationOptions(options, 'vocab-reading-bookshelf', records);
-            return retryVocabMutation(options, async () => {
-                const current = await kernel.read('vocab.readingBookshelfExams', { withMeta: true });
-                return kernel.mutate([{
-                    logicalKey: 'vocab.readingBookshelfExams',
-                    data: records,
-                    expectedRevision: options.expectedRevision ?? (current.envelope ? current.envelope.revision : 0)
-                }], mutation);
-            });
+            return replaceLegacyReadingCollection('vocab.readingBookshelfExams', records, options);
         }
     });
 
@@ -2664,6 +3108,11 @@
     }
     async function prepareLegacyDocumentChange(logicalKey, legacyValue) {
         const entry = catalog.get(logicalKey);
+        // A completed reading installation owns its canonical records as well
+        // as projections. An interrupted older, broader migration must not merge
+        // stale default/list records back after an authoritative empty restore.
+        if ((logicalKey === 'vocab.words' || logicalKey === 'vocab.lists')
+            && await kernel.getEnvelope(READING_STATE_KEY)) return null;
         const currentEnvelope = await kernel.getEnvelope(logicalKey);
         if (!currentEnvelope) {
             return { logicalKey, data: clone(legacyValue), expectedRevision: 0 };
@@ -2872,7 +3321,6 @@
             }
             try {
                 await migrateLegacyReadingData();
-                await refreshReadingMirrors();
             } catch (error) {
                 if (global.console && console.warn) console.warn('[AppData v2] reading data sync skipped:', error);
             }

--- a/js/data/v2/appData.js
+++ b/js/data/v2/appData.js
@@ -1916,6 +1916,13 @@
         if (!global.ReadingVocabularyModel) return; // Old non-reader test/embed bootstraps remain supported.
         return retryMergeConflict({}, async () => {
             const migration = await kernel.read('system.migrations', { withMeta: true });
+            // The canonical V1 vocabulary must land before reading initialization
+            // creates words/lists envelopes that become authoritative on reload.
+            // Keep public reading and backup calls behind the same recovery fence.
+            if (typeof internals.readLegacyValues === 'function'
+                && asObject(asObject(migration.data).v1ToV2).status !== 'complete') {
+                throw new AppDataError('BACKEND_UNAVAILABLE', 'Legacy vocabulary recovery is pending; reload before reading or saving vocabulary');
+            }
             if (asObject(migration.data).readingVocabularyV1?.completed === true) return;
             const current = await readReadingDocuments();
             const recoverable = { localStorage: {}, documents: {}, rejected: [] };
@@ -2340,10 +2347,10 @@
     }
     function tombstoneRevision(value) { return Number(value && value.revision) || 0; }
     function assertFreshReadingIntent(current, type, command, observed) {
-        if (type !== 'collect' && type !== 'recordVisit') return;
         if (observed.generation !== current.generation) {
             throw new AppDataError('CONFLICT', 'Reading data was replaced; reload before saving');
         }
+        if (type !== 'collect' && type !== 'recordVisit') return;
         const model = readingModel(); const tombstones = current.state.tombstones;
         const articleId = model.articleId(command.source, command.article.examId);
         const fences = type === 'collect' ? [tombstones.all, tombstones.articles[articleId], tombstones.visits[articleId]]
@@ -2448,6 +2455,7 @@
     async function mutateVocabDocuments(changes, options) {
         const ownsWords = changes.some((change) => change.logicalKey === 'vocab.words' || change.logicalKey === 'vocab.lists');
         if (!ownsWords || !global.ReadingVocabularyModel) return kernel.mutate(changes, options);
+        await ensureReadingMigration();
         const current = await readReadingDocuments();
         const next = clone(current.snapshot);
         for (const change of changes) {
@@ -2522,6 +2530,53 @@
                 const receipt = await kernel.mutate(readingChanges(current, next, current.state),
                     optionsMutationOptions(options, 'vocab-default-initialize', command));
                 return Object.assign({}, receipt, { words: clone(next.words) });
+            });
+        },
+        async repairDefaultWords(command, options = {}) {
+            await ready; await ensureReadingMigration();
+            assertObject(command, 'Default vocabulary repair requires a command');
+            assertArray(command.words, 'Default vocabulary repair requires words');
+            return retryVocabMutation(options, async () => {
+                const current = await readReadingDocuments();
+                const words = current.snapshot.words.filter((word) => word && typeof word.word === 'string'
+                    && word.word.trim() && typeof word.meaning === 'string' && word.meaning.trim());
+                const pollutedCount = words.filter((word) => word.meaning.trim().startsWith('你曾拼写为:')).length;
+                // Repair existing corruption independently of first-run seeding.
+                // Recheck after every conflict so a newer empty restore wins.
+                if (!words.length || pollutedCount / words.length < 0.6) {
+                    return { committed: false, words: clone(current.snapshot.words) };
+                }
+                const next = clone(current.snapshot); next.words = clone(command.words);
+                const ownedTerms = next.reading.terms.filter((term) => term.wordRef.listId === 'default');
+                if (ownedTerms.length) {
+                    // Reader progress belongs to the acknowledged canonical row,
+                    // whose ID may differ from (or be absent in) the bundled list.
+                    const listId = readingModel().READING_LIST_ID;
+                    const collection = next.lists[listId];
+                    const retainedWords = Array.isArray(collection) ? collection : asArray(asObject(collection).words);
+                    const retainedIds = new Set(retainedWords.map((word) => word && word.id));
+                    const replacements = new Map();
+                    for (const term of ownedTerms) {
+                        const oldId = term.wordRef.wordId;
+                        if (!replacements.has(oldId)) {
+                            const owner = current.snapshot.words.find((word) => word && word.id === oldId);
+                            const baseId = JSON.stringify(['default-repair', oldId]);
+                            let id = baseId; let suffix = 1;
+                            while (retainedIds.has(id)) id = `${baseId}-${suffix++}`;
+                            retainedIds.add(id);
+                            retainedWords.push(Object.assign({}, clone(owner), { id }));
+                            replacements.set(oldId, { listId, wordId: id });
+                        }
+                        term.wordRef = clone(replacements.get(oldId));
+                    }
+                    next.lists[listId] = Array.isArray(collection) ? retainedWords
+                        : Object.assign({}, asObject(collection), { id: listId, words: retainedWords });
+                }
+                current.state.allowDefaultWordSeed = false; readingModel().validate(next);
+                const receipt = await kernel.mutate(readingChanges(current, next, current.state),
+                    optionsMutationOptions(options, 'vocab-default-repair', command));
+                if (!receipt || receipt.committed !== true) throw new AppDataError('BACKEND_UNAVAILABLE', 'Default vocabulary repair was not acknowledged');
+                return Object.assign({}, receipt, { words: clone((await readReadingDocuments()).snapshot.words) });
             });
         },
         mutateReading,

--- a/js/data/v2/dataCatalog.js
+++ b/js/data/v2/dataCatalog.js
@@ -138,6 +138,11 @@
             export: true, import: 'patch'
         },
         {
+            logicalKey: 'vocab.readingState', classification: 'authoritative',
+            defaultValue: objectDefault, normalize: normalizeObject, validate: isObject,
+            export: true, import: 'replace'
+        },
+        {
             logicalKey: 'vocab.readingVocabWords', classification: 'authoritative',
             defaultValue: arrayDefault, normalize: normalizeArray, validate: isArray,
             export: true, import: 'merge-by-id'

--- a/js/data/v2/readingVocabularyModel.js
+++ b/js/data/v2/readingVocabularyModel.js
@@ -415,6 +415,141 @@
         return finish(next);
     }
 
+    // Backups merge relationships, never review progress. The authoritative
+    // persistence layer applies deletion tombstones before/after this union.
+    function stableJson(value) {
+        if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map((name) => `${JSON.stringify(name)}:${stableJson(value[name])}`).join(',')}}`;
+        }
+        return JSON.stringify(value);
+    }
+
+    function mergeMetadata(existing, incoming, clock) {
+        const next = { ...existing };
+        const leftAt = clock ? existing[clock] || '' : '';
+        const rightAt = clock ? incoming[clock] || '' : '';
+        for (const name of Object.keys(incoming)) {
+            if (!own(existing, name) || rightAt > leftAt
+                || (rightAt === leftAt && stableJson(incoming[name]) > stableJson(existing[name]))) {
+                Object.defineProperty(next, name, {
+                    value: incoming[name], enumerable: true, writable: true, configurable: true
+                });
+            }
+        }
+        return next;
+    }
+
+    function mergeVocabulary(next, incoming) {
+        const owners = new Map();
+        for (const listId of allLists(next)) {
+            const words = listWords(next, listId);
+            const ids = new Map();
+            for (const word of words) {
+                if (word && typeof word.id === 'string') ids.set(word.id, (ids.get(word.id) || 0) + 1);
+            }
+            for (const word of words) {
+                if (word && typeof word.word === 'string' && word.word.trim()
+                    && typeof word.id === 'string' && word.id.trim() === word.id && word.id
+                    && ids.get(word.id) === 1) {
+                    const normalized = normalizeTerm(word.word);
+                    if (!owners.has(normalized)) owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        // An explicitly selected existing owner is stronger than list order.
+        for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
+        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+
+        for (const listId of allLists(incoming)) {
+            const incomingWords = listWords(incoming, listId);
+            if (listId !== 'default' && !own(next.lists, listId)) {
+                const incomingList = incoming.lists[listId];
+                const list = Array.isArray(incomingList) ? []
+                    : incomingList && Array.isArray(incomingList.words) ? { ...copy(incomingList), words: [] }
+                        : copy(incomingList);
+                Object.defineProperty(next.lists, listId, {
+                    value: list, enumerable: true, writable: true, configurable: true
+                });
+            }
+            if (!incomingWords.length) continue;
+            if (listId !== 'default' && !Array.isArray(next.lists[listId])
+                && !(next.lists[listId] && Array.isArray(next.lists[listId].words))) {
+                fail(`Cannot merge vocabulary into malformed lists.${listId}`);
+            }
+            const destination = listWords(next, listId);
+            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            let serialized;
+            for (const rawWord of incomingWords) {
+                const word = copy(rawWord);
+                const normalized = word && typeof word.word === 'string' && word.word.trim()
+                    ? normalizeTerm(word.word) : null;
+                if (normalized && owners.has(normalized)) continue;
+                const preferred = normalized && preferredIncoming.get(normalized);
+                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
+                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                    if (!serialized) serialized = new Set(destination.map(stableJson));
+                    const encoded = stableJson(word);
+                    if (serialized.has(encoded)) continue;
+                    serialized.add(encoded);
+                }
+                if (word && typeof word.id === 'string' && ids.has(word.id)) {
+                    if (!normalized) continue;
+                    const originalId = word.id;
+                    let suffix = 0;
+                    do {
+                        word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
+                    } while (ids.has(word.id));
+                }
+                destination.push(word);
+                if (word && typeof word.id === 'string') ids.add(word.id);
+                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
+                    owners.set(normalized, { listId, wordId: word.id });
+                }
+            }
+        }
+        return owners;
+    }
+
+    function merge(existingSnapshot, incomingSnapshot) {
+        const next = writable(existingSnapshot);
+        const incoming = writable(incomingSnapshot);
+        const owners = mergeVocabulary(next, incoming);
+        for (const table of TABLES) {
+            const rows = new Map(next.reading[table].map((row) => [row.id, row]));
+            for (const incomingRow of incoming.reading[table]) {
+                const existing = rows.get(incomingRow.id);
+                let merged = existing ? mergeMetadata(existing, incomingRow,
+                    table === 'visits' ? 'lastVisitedAt' : 'updatedAt') : copy(incomingRow);
+                if (existing && own(existing, 'createdAt')) {
+                    merged.createdAt = existing.createdAt < incomingRow.createdAt ? existing.createdAt : incomingRow.createdAt;
+                }
+                if (existing && own(existing, 'updatedAt')) {
+                    merged.updatedAt = existing.updatedAt > incomingRow.updatedAt ? existing.updatedAt : incomingRow.updatedAt;
+                }
+                if (table === 'terms') {
+                    merged.wordRef = existing ? copy(existing.wordRef) : copy(owners.get(incomingRow.normalizedTerm));
+                } else if (existing && table === 'articles') {
+                    const title = mergeMetadata(
+                        { title: existing.title, titleUpdatedAt: existing.titleUpdatedAt },
+                        { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
+                    merged.title = title.title;
+                    merged.titleUpdatedAt = title.titleUpdatedAt;
+                } else if (existing && table === 'associations') {
+                    merged.manual = existing.manual || incomingRow.manual;
+                } else if (existing && table === 'visits') {
+                    merged.firstVisitedAt = existing.firstVisitedAt < incomingRow.firstVisitedAt
+                        ? existing.firstVisitedAt : incomingRow.firstVisitedAt;
+                    merged.lastVisitedAt = existing.lastVisitedAt > incomingRow.lastVisitedAt
+                        ? existing.lastVisitedAt : incomingRow.lastVisitedAt;
+                }
+                rows.set(merged.id, merged);
+            }
+            next.reading[table] = [...rows.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+        }
+        return finish(next);
+    }
+
     function query(snapshot, options = {}) {
         validate(snapshot);
         object(options, 'query options');
@@ -446,7 +581,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;

--- a/js/data/v2/readingVocabularyModel.js
+++ b/js/data/v2/readingVocabularyModel.js
@@ -459,7 +459,7 @@
         }
         // An explicitly selected existing owner is stronger than list order.
         for (const term of next.reading.terms) owners.set(term.normalizedTerm, copy(term.wordRef));
-        const preferredIncoming = new Map(incoming.reading.terms.map((term) => [term.normalizedTerm, term.wordRef]));
+        const importedRefs = new Map();
 
         for (const listId of allLists(incoming)) {
             const incomingWords = listWords(incoming, listId);
@@ -478,34 +478,58 @@
                 fail(`Cannot merge vocabulary into malformed lists.${listId}`);
             }
             const destination = listWords(next, listId);
-            const ids = new Set(destination.filter((word) => word && typeof word.id === 'string').map((word) => word.id));
+            const ids = new Map();
+            for (const word of destination) {
+                if (word && typeof word.id === 'string') {
+                    if (!ids.has(word.id)) ids.set(word.id, []);
+                    ids.get(word.id).push(word);
+                }
+            }
             let serialized;
             for (const rawWord of incomingWords) {
                 const word = copy(rawWord);
                 const normalized = word && typeof word.word === 'string' && word.word.trim()
                     ? normalizeTerm(word.word) : null;
-                if (normalized && owners.has(normalized)) continue;
-                const preferred = normalized && preferredIncoming.get(normalized);
-                if (preferred && (preferred.listId !== listId || preferred.wordId !== word.id)) continue;
-                if (!normalized || !(word && typeof word.id === 'string' && word.id && word.id.trim() === word.id)) {
+                const referenceable = normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id;
+                if (!referenceable) {
                     if (!serialized) serialized = new Set(destination.map(stableJson));
                     const encoded = stableJson(word);
                     if (serialized.has(encoded)) continue;
                     serialized.add(encoded);
                 }
+                let existingWord = false;
                 if (word && typeof word.id === 'string' && ids.has(word.id)) {
                     if (!normalized) continue;
                     const originalId = word.id;
                     let suffix = 0;
-                    do {
+                    while (ids.has(word.id)) {
+                        const matches = ids.get(word.id);
+                        if (matches.length === 1 && typeof matches[0].word === 'string'
+                            && matches[0].word.trim().toLowerCase() === normalized) {
+                            existingWord = true;
+                            break;
+                        }
                         word.id = key('reading-merge-word', listId, originalId, normalized, suffix++);
-                    } while (ids.has(word.id));
+                    }
                 }
-                destination.push(word);
-                if (word && typeof word.id === 'string') ids.add(word.id);
-                if (normalized && typeof word.id === 'string' && word.id && word.id.trim() === word.id) {
-                    owners.set(normalized, { listId, wordId: word.id });
+                // Vocabulary identity is scoped to its list. Same-term records
+                // in other lists have independent membership and review history.
+                // A matching local record keeps all of its existing progress.
+                if (!existingWord) {
+                    destination.push(word);
+                    if (word && typeof word.id === 'string') ids.set(word.id, [word]);
                 }
+                if (referenceable) {
+                    importedRefs.set(key(listId, rawWord.id), { listId, wordId: word.id });
+                }
+            }
+        }
+        // Reader canonical ownership is separate from vocabulary membership.
+        // Reuse local owners, otherwise retain the incoming explicit owner,
+        // including any deterministic ID remapping within its own list.
+        for (const term of incoming.reading.terms) {
+            if (!owners.has(term.normalizedTerm)) {
+                owners.set(term.normalizedTerm, importedRefs.get(key(term.wordRef.listId, term.wordRef.wordId)));
             }
         }
         return owners;

--- a/js/main.js
+++ b/js/main.js
@@ -830,9 +830,11 @@ async function saveReadingHighlightVocab(payload) {
     } catch (error) {
         console.warn('[VocabStore] 阅读高亮生词保存失败:', error);
         if (typeof showMessage === 'function') {
-            showMessage('高亮生词已在阅读页本地缓存，主词表稍后同步', 'warning');
+            showMessage(error && error.code === 'BACKEND_UNAVAILABLE'
+                ? '高亮生词保存失败，请刷新主页并重新打开阅读页后重试'
+                : '高亮生词保存失败，请在阅读页重试', 'warning');
         }
-        return null;
+        throw error;
     }
 }
 
@@ -1005,11 +1007,19 @@ function setupMessageListener() {
             const payload = data.data && typeof data.data === 'object' ? data.data : data;
             const requestId = payload && payload.requestId != null ? String(payload.requestId).trim() : '';
             if (!requestId) return;
-            saveReadingHighlightVocab(payload).then((saved) => {
+            const launchContext = matched.rec.initPayload || matched.rec;
+            const savePayload = Object.assign({}, payload, {
+                context: Object.assign({}, payload.context || {}, {
+                    examId: matched.rec.examId,
+                    libraryConfigurationId: launchContext.libraryConfigurationId == null
+                        ? null : launchContext.libraryConfigurationId
+                })
+            });
+            saveReadingHighlightVocab(savePayload).then((saved) => {
                 sendFallbackVocabOutcome(matched.rec, payload, Boolean(saved), saved ? '' : 'save_failed');
             }).catch((error) => {
                 console.warn('[VocabStore] 阅读高亮生词保存异常:', error);
-                sendFallbackVocabOutcome(matched.rec, payload, false, 'save_failed');
+                sendFallbackVocabOutcome(matched.rec, payload, false, error && error.code || 'save_failed');
             });
         } else if (type === 'PRACTICE_COMPLETE' || type === 'practice_completed') {
             const payload = extractCompletionPayload(data) || {};

--- a/js/runtime/reviewHighlightDictionary.js
+++ b/js/runtime/reviewHighlightDictionary.js
@@ -466,16 +466,21 @@
         if (payload.phonetic) {
             word.phonetic = payload.phonetic;
         }
-        if (typeof global.AppData.vocab.mergeListWords === 'function') {
-            // mergeListWords 对已有词条只更新词典字段，保留用户笔记与学习进度。
-            await global.AppData.vocab.mergeListWords({
-                listId: 'reading-highlights',
-                words: [word]
-            });
-        } else {
-            await global.AppData.vocab.upsertCollectionWord('reading-highlights', word);
-        }
-        return true;
+        const context = payload.context || {};
+        if (!context.examId || context.libraryConfigurationId === undefined) return false;
+        const configurationId = context.libraryConfigurationId;
+        const source = configurationId == null || configurationId === ''
+            ? { kind: 'builtin', id: 'default' }
+            : { kind: 'imported', id: String(configurationId).trim() };
+        const observed = await global.AppData.vocab.getReadingSnapshot();
+        const receipt = await global.AppData.vocab.mutateReading('collect', {
+            source,
+            article: { examId: String(context.examId), title: String(context.title || '') },
+            word,
+            manual: true,
+            at: now
+        }, { observedRevision: observed.revision, observedGeneration: observed.generation });
+        return Boolean(receipt && receipt.saved === true);
     }
 
     function createRequestId() {
@@ -489,19 +494,19 @@
         return `vocab-highlight-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     }
 
-    function settleSaveRequest(requestId, succeeded) {
+    function settleSaveRequest(requestId, succeeded, errorCode = '') {
         const id = String(requestId || '').trim();
         const pending = pendingSaveRequests.get(id);
         if (!id || !pending) return false;
         pendingSaveRequests.delete(id);
         clearTimeout(pending.timer);
-        pending.resolve(Boolean(succeeded));
+        pending.resolve({ saved: Boolean(succeeded), errorCode: String(errorCode || '') });
         return true;
     }
 
     function handleSaveOutcome(payload, succeeded) {
         const requestId = payload && payload.requestId != null ? String(payload.requestId).trim() : '';
-        return settleSaveRequest(requestId, succeeded);
+        return settleSaveRequest(requestId, succeeded, payload && payload.errorCode);
     }
 
     function postVocabPayload(payload) {
@@ -511,7 +516,7 @@
         const outcome = new Promise((resolve) => {
             const timer = setTimeout(() => {
                 pendingSaveRequests.delete(requestId);
-                resolve(false);
+                resolve({ saved: false, errorCode: 'timeout' });
             }, 5000);
             pendingSaveRequests.set(requestId, { resolve, timer });
         });
@@ -533,13 +538,26 @@
         if (!payload.word) {
             return;
         }
+        if (button instanceof HTMLButtonElement) {
+            button.textContent = '保存中…';
+            button.disabled = true;
+        }
         const hostOutcome = postVocabPayload(payload);
-        let persisted = hostOutcome ? await hostOutcome : false;
-        if (!persisted) {
-            try { persisted = await writeAppDataVocab(payload); } catch (_) { persisted = false; }
+        const hostResult = hostOutcome ? await hostOutcome : null;
+        let persisted = Boolean(hostResult && hostResult.saved);
+        let errorCode = hostResult && hostResult.errorCode || '';
+        if (!hostOutcome) {
+            try { persisted = await writeAppDataVocab(payload); } catch (error) {
+                persisted = false;
+                errorCode = error && error.code || '';
+            }
         }
         if (button instanceof HTMLButtonElement) {
-            button.textContent = persisted ? '已加入' : '保存失败';
+            const unavailable = errorCode === 'BACKEND_UNAVAILABLE';
+            button.textContent = persisted ? '已加入' : unavailable
+                ? (hostOutcome ? '请刷新主页并重开阅读页后重试' : '请刷新页面后重试')
+                : '保存失败';
+            button.title = !persisted && unavailable ? button.textContent : '';
             button.disabled = persisted;
         }
     }

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -79,6 +79,7 @@
 
     const state = {
         examId: null,
+        libraryConfigurationId: undefined,
         dataKey: null,
         sessionId: null,
         suiteSessionId: null,
@@ -1068,6 +1069,7 @@
     function getReviewDictionaryContext() {
         return {
             examId: state.examId,
+            libraryConfigurationId: state.libraryConfigurationId,
             dataKey: state.dataKey,
             title: state.dataset?.meta?.title || '',
             category: state.dataset?.meta?.category || '',
@@ -2275,9 +2277,9 @@
         ensureVocabReaderStyles();
 
         if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-            global.ReadingVocabReader.open(examId, { fromPractice: true });
+            global.ReadingVocabReader.open(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
         } else if (typeof global.openReadingVocabReader === 'function') {
-            global.openReadingVocabReader(examId, { fromPractice: true });
+            global.openReadingVocabReader(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
         } else {
             console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
         }
@@ -8125,6 +8127,9 @@
             }
             if (data.sessionId) {
                 state.sessionId = data.sessionId;
+            }
+            if (Object.prototype.hasOwnProperty.call(data, 'libraryConfigurationId')) {
+                state.libraryConfigurationId = data.libraryConfigurationId;
             }
             if (data.suiteSessionId) {
                 state.suiteSessionId = data.suiteSessionId;


### PR DESCRIPTION
Collecting vocabulary now applies acknowledged operations to fresh IndexedDB state, so concurrent readers retain both additions and their source associations. Canonical words, reading relationships, selected occurrences and bookshelf visits commit together; failed writes preserve the last acknowledged UI state and support retry.

- Add revision/generation fences and separate deletion markers for article membership, visits, occurrences and canonical vocabulary. Replayed receipts are checked against current durable state.
- Migrate prototype data once with a versioned recovery record. Merge backups by stable identities while preserving existing review progress; treat empty replacement as authoritative and refresh loaded views across pages.
- Switch reader, bookshelf and dictionary consumers to the operation APIs, document the contract, and preserve the latest reader isolation and lifecycle changes from opensource.

Backup merge preserves independent vocabulary-list records and their review progress. Every reading mutation checks its generation after replacement; reading initialization and canonical writes wait for legacy recovery. Polluted defaults are repaired atomically while retaining referenced reading owners and their progress.

Validation:

- 261 JavaScript tests passed through the developer test entry point.
- 58 focused persistence/backup checks passed in Chromium using production AppData, actual IndexedDB, transaction faults and shared storage across real pages.
- 26 Python tests passed; reading data integrity passed; all 14 generated bundles are current.
- Unified E2E: all 10 scenarios passed, including file-protocol popup/INIT/submission checks and UI backup export/import.

Implementation head: `0e3ead13c446fd047e6e7fd65b21bbfe0c7647c7`.
Reviewed target: `opensource` at `059c5ed958c1dde2d0336952c61e754b322f3490`.
Commits are GPG-signed.

The built-in reader rejects unsupported imported-source navigation before creating associations; imported data remains available to storage, bookshelf queries and export. Full source navigation and content/occurrence qualification remain in the other v1 work items.

Closes #156.
References #149; the parent remains open for combined v1 acceptance.

