### PR TITLE
feat(reading): normalize content and restore selected occurrences

### DIFF
--- a/css/vocab-reader.css
+++ b/css/vocab-reader.css
@@ -445,8 +445,8 @@ mark.vocab-highlight,
 .vocab-highlight {
     background-color: #fef08a !important; /* 明亮舒适的经典纯正柔黄 */
     color: #0f172a !important;
-    padding: 2px 4px !important;
-    margin: 0 1px !important;
+    padding: 2px 0 !important;
+    margin: 0 !important;
     border-radius: 4px !important;
     border-bottom: 2px solid #eab308 !important; /* 黄色强化底边 */
     box-decoration-break: clone;
@@ -1665,3 +1665,52 @@ mark.vocab-highlight:active,
         transform: translateY(0) scale(1);
     }
 }
+
+.vocab-occurrence-actions,
+.vocab-occurrence-undo,
+.vocab-anchor-status {
+    flex-shrink: 0;
+    padding: 10px 18px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    background: #fffbea;
+    color: #493b10;
+    border-top: 1px solid #e5d89a;
+}
+
+.vocab-occurrence-actions:empty,
+.vocab-occurrence-undo:empty,
+.vocab-anchor-status:empty { display: none; }
+
+.vocab-occurrence-undo {
+    position: relative;
+    z-index: 10002;
+}
+
+.vocab-occurrence-row {
+    margin-top: 10px;
+    padding: 10px;
+    border-left: 3px solid #d6b432;
+    background: #fffbea;
+    color: #493b10;
+    font-size: 0.85rem;
+    overflow-wrap: anywhere;
+}
+
+.vocab-occurrence-row > span,
+.vocab-occurrence-row > strong { display: block; margin-bottom: 6px; }
+
+.vocab-occurrence-row[data-anchor-status="unresolved"] { border-color: #b45d18; }
+
+.vocab-reader-overlay [data-action] {
+    border: 1px solid #8a741d;
+    border-radius: 6px;
+    padding: 7px 12px;
+    background: #fff;
+    color: #493b10;
+    cursor: pointer;
+}
+
+.vocab-highlight:focus-visible { outline: 2px solid #315ac8; outline-offset: 2px; }

--- a/developer/doc/Intensive-Reading-Anchors.md
+++ b/developer/doc/Intensive-Reading-Anchors.md
@@ -1,0 +1,107 @@
+# Intensive reading content and selected occurrences
+
+Issue #158 extends the shared vocabulary and acknowledged persistence contracts
+from #155–#157. It does not close the aggregate Intensive Reading v1 gate in #149.
+
+## Content and identities
+
+`ReadingVocabContent.normalizePassage` uses the practice renderer's ordered
+`passage.blocks` contract and `bodyHtml || html` precedence. It preserves every
+prose block, short paragraph, list, table, figure, heading and subtitle. Introductory
+instructions and subtitles appear together above the passage. Reader questions
+retain their `leadHtml`, body, instructions and displayed numbering through the
+existing inert, non-answering conversion.
+
+Internal paragraph IDs (`p-1`, `p-2`, …), question section IDs (`q-1`, `q-2`, …)
+and nested text scopes are independent of displayed paragraph letters. An ordinary
+sentence starting with “A” is not a structural label. Each source DOM ID is
+namespaced before insertion. Paragraph tabs and translation containers use the
+internal ID; a translation label is used only when it identifies one card.
+
+Examples of persisted scopes are `passage/p-1`, `passage/p-1/p-2`, and
+`questions/q-1/p-3`. The surrounding article association supplies the existing
+library/source and article identity. The current payload loader still exposes
+built-in content only; unavailable imported sources preserve vocabulary and show
+the recoverable source error rather than displaying built-in content as imported.
+
+## Selection and restoration
+
+Mouse `mouseup`, touch `touchend`, and keyboard Shift release finish a selection.
+Shift plus arrow keys may extend the selection without saving intermediate letters.
+Keyboard-focusable text scopes support arrow-key caret movement and Shift selection
+without enabling a browser-wide caret mode. Navigation stays within one scope. A selection must
+contain English letters, span at most 45 UTF-16 code units after trimming boundary
+whitespace/punctuation, stay in one text scope and logical block, and contain no
+line break. Controls, answer blanks, hidden content, translation cards, paragraph
+tags, existing vocabulary marks and practice `.hl` annotations are ineligible.
+Manual addition remains available without an occurrence anchor.
+
+`ReadingVocabAnchors` maps actual DOM Range boundaries, including element endpoints
+and inline formatting, to exact UTF-16 offsets. It stores the exact quote and up to
+48 characters on each side; the resulting context always includes the selected
+text, even near the end of a long paragraph. Existing painted text contributes to
+the same offset map. Multiple inline fragments share one occurrence ID without
+splitting or rewriting the source's formatting.
+
+New `contentVersion` values combine a fingerprint of the complete payload, the
+scope text fingerprint, and an original-context uniqueness marker:
+
+```
+reader-scope-v2:<source fingerprint>:<text fingerprint>|context-unique
+reader-scope-v2:<source fingerprint>:<text fingerprint>|context-scoped
+```
+
+The unchanged source and scope require an exact quote at the stored offsets.
+After a source change, restoration requires a context that was unique when saved
+and remains a unique complete quote/before/after match in the same passage or
+question area. Missing or duplicated original scope IDs are unresolved. A context
+that was duplicated when captured cannot migrate after source changes: deleting
+one identical paragraph must not attach its highlight to the surviving paragraph.
+No ordinal, nearest-score, case-insensitive, or first-match fallback is used.
+Old anchors lacking a compatible scope or sufficient evidence remain recoverable
+in the vocabulary list instead of guessing a new location.
+
+Unresolved occurrences preserve the canonical term, article association and saved
+anchor. The reader shows a status with a reload action, and the vocabulary list
+shows the saved context and a per-occurrence removal action. Restoring the original
+source makes its valid anchors visible again. A learner can remove an obsolete
+anchor and select the intended current location.
+
+## Acknowledgement, removal and undo
+
+Collection waits for `ReadingVocabStore.mutate` / `AppData.vocab.mutateReading`
+acknowledgement before painting success. A pending occurrence is deduplicated;
+failed saves retain a retryable selection and do not create a saved-looking mark.
+Store updates remove only `mark.vocab-highlight` wrappers and restore the current
+article's acknowledged occurrences. Manual associations never invent highlights.
+
+Click or keyboard-activate a mark to expose “remove this occurrence”; the list
+also exposes removal for each resolved or unresolved occurrence. `removeOccurrence`
+uses the shared final-occurrence/manual-membership semantics. Another article,
+visited shelf records, and canonical definitions/review history remain intact.
+
+The immediate undo action replays the original collection intent through the
+same mutation API. It retains the removal transaction's committed reading-state
+revision (`receipt.revisions['vocab.readingState']`) and the observed pre-removal
+generation. A later clear or replacement must reject undo, even if it occurs
+between that removal's commit and AppData's subsequent snapshot read. Save failures
+leave the action available for retry; reopening/closing discards the local undo
+action. No alternate persistence store is introduced.
+
+## Regression entry points
+
+- `npm test --prefix developer`: production content/anchor browser tests, reader
+  lifecycle and safety tests, acknowledged persistence and vocabulary regressions.
+- `python developer/tests/e2e/reading_reader_occurrences.py`: production bundles,
+  actual DOM Range, IndexedDB receipts and page reloads over local HTTP and `file://`.
+  Covers all seven named regression assets including Petri, ordered multi-block
+  content, inline repeated terms, mouse/touch/keyboard paths, invalid selections,
+  manual associations, occurrence removal/undo and unresolved recovery.
+- `python developer/tests/e2e/e2e_runner.py`: the new occurrence case plus existing
+  practice, isolation, recovery, listening, suite and backup flows.
+- `node scripts/build-bundles.mjs --check`, Python unit tests and
+  `developer/tests/ci/check_reading_data_integrity.py`: required consistency gates.
+
+The combined static HTTPS and fresh extracted release acceptance remains owned
+by #160; these browser regressions do not claim a mobile-device gesture matrix or
+the aggregate release gate.

--- a/developer/doc/Intensive-Reading-Anchors.md
+++ b/developer/doc/Intensive-Reading-Anchors.md
@@ -70,8 +70,12 @@ anchor and select the intended current location.
 ## Acknowledgement, removal and undo
 
 Collection waits for `ReadingVocabStore.mutate` / `AppData.vocab.mutateReading`
-acknowledgement before painting success. A pending occurrence is deduplicated;
-failed saves retain a retryable selection and do not create a saved-looking mark.
+acknowledgement before painting success. Pending intervals in the same source,
+article and text scope reject overlapping selections until acknowledgement;
+adjacent or disjoint intervals remain eligible. Completed or failed saves release
+their reservations. Reservations survive closing and reopening because their
+durable writes can still succeed; other articles remain independently selectable.
+Failed saves retain a retryable selection and do not create a saved-looking mark.
 Store updates remove only `mark.vocab-highlight` wrappers and restore the current
 article's acknowledged occurrences. Manual associations never invent highlights.
 
@@ -79,6 +83,14 @@ Click or keyboard-activate a mark to expose “remove this occurrence”; the li
 also exposes removal for each resolved or unresolved occurrence. `removeOccurrence`
 uses the shared final-occurrence/manual-membership semantics. Another article,
 visited shelf records, and canonical definitions/review history remain intact.
+
+The current-article tab lists that article's occurrences; the All tab lists every
+occurrence of its global terms, including terms found only in another article.
+Each All-tab occurrence identifies its owning article. Only current-article
+anchors have been evaluated for restoration; other articles' anchors remain
+unverified until opened. Removal and undo derive the owning article and library
+from the saved occurrence association, including identical exam IDs in different
+libraries, instead of using the currently open reader's identity.
 
 The immediate undo action replays the original collection intent through the
 same mutation API. It retains the removal transaction's committed reading-state

--- a/developer/tests/e2e/e2e_runner.py
+++ b/developer/tests/e2e/e2e_runner.py
@@ -26,6 +26,7 @@ E2E_CASES = [
     "browse_preference_toggle_flow.py",
     "reading_single_flow.py",
     "reading_reader_isolation.py",
+    "reading_reader_occurrences.py",
     "interrupted_history_flow.py",
     "listening_practice_flow.py",
     "suite_practice_flow.py",

--- a/developer/tests/e2e/reading_reader_occurrences.node.js
+++ b/developer/tests/e2e/reading_reader_occurrences.node.js
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/** #158: production reader rendering, DOM Range selection, and IndexedDB receipts. */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const reports = path.join(root, 'developer/tests/e2e/reports');
+const source = { kind: 'builtin', id: 'default' };
+const fixtureId = 'issue158-occurrence-fixture';
+const reviewedCoral = {
+    id: 'issue158-reviewed-coral', word: 'coral', meaning: 'A preserved definition',
+    note: 'A preserved learner note', easeFactor: 2.4, repetitions: 8, interval: 32,
+    correctCount: 11, lastReviewed: '2026-09-01T00:00:00.000Z',
+    nextReview: '2026-10-03T00:00:00.000Z',
+    reviewHistory: [{ at: '2026-09-01T00:00:00.000Z', grade: 4 }]
+};
+const longLead = 'A scientist recorded the changing temperature and light around the ocean. '.repeat(9);
+const fixture = {
+    schemaVersion: 'ReadingExamSourceV1', examId: fixtureId,
+    meta: { title: 'Occurrence regression fixture', category: 'P1' },
+    passage: { blocks: [
+        { blockId: 'first-block', kind: 'text', bodyHtml: `<h2>READING PASSAGE 1</h2><p>You should spend about 20 minutes on Questions 1–3.</p><h3>Occurrence regression fixture</h3><h5>Every ordered block survives</h5><p>The first coral is close to the shore. ${longLead}The second <em>cor</em>al shelters tiny fish beside this distinctive ledge. A distantword appears near the end. The third coral grows deeper.</p><p>A (keyboardword), remains available for keyboard collection, while touchword supports a touch selection.</p><p>The preserved <span class="hl" data-note-id="issue158-original">annotationword</span> belongs to the practice annotation system.</p>` },
+        { blockId: 'second-block', kind: 'text', html: '<h4>Second ordered block</h4><p>A second block contains finalblockword and must remain after the first block.</p>' }
+    ] },
+    questionGroups: [
+        { groupId: 'question-first', kind: 'sentence_completion', questionIds: ['q1'], leadHtml: '<p>Choose ONE WORD ONLY from the passage.</p>', bodyHtml: '<h4>Questions 1–2</h4><p>1. The coral grows near questionword. <input name="q1" id="q1" type="text"></p>' },
+        { groupId: 'question-second', kind: 'true_false_not_given', questionIds: ['q2'], bodyHtml: '<h4>Question 2</h4><p>2. Different coral belongs to a separate question section.</p><label><input type="radio" name="q2" id="q2" value="true">True</label>' }
+    ], answerKey: { q1: 'coral', q2: 'true' }
+};
+fs.mkdirSync(reports, { recursive: true });
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+const server = http.createServer((req, res) => {
+    const relative = decodeURIComponent(new URL(req.url, 'http://localhost').pathname).replace(/^\/+/, '') || 'index.html';
+    const filename = path.resolve(root, relative);
+    if (!filename.startsWith(root + path.sep)) { res.writeHead(403).end(); return; }
+    try {
+        const body = fs.readFileSync(filename);
+        res.writeHead(200, { 'Content-Type': mime[path.extname(filename)] || 'application/octet-stream' });
+        res.end(body);
+    } catch { res.writeHead(404).end(); }
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}), args: ['--allow-file-access-from-files'] }).catch(async error => {
+    await new Promise(resolve => server.close(resolve));
+    throw error;
+});
+const report = { generatedAt: new Date().toISOString(), browser: browser.version(), cases: [] };
+const pass = (name, evidence = {}) => report.cases.push({ name, status: 'pass', ...evidence });
+
+async function ready(page, protocol = 'http') {
+    const url = protocol === 'file' ? pathToFileURL(path.join(root, 'index.html')).href : `${origin}/index.html`;
+    await page.goto(`${url}?test_env=1`);
+    await page.waitForFunction(() => window.app?.isInitialized && window.AppData, null, { timeout: 60_000 });
+    await page.evaluate(async () => {
+        await AppData.ready;
+        await window.LicenseModal?.accept();
+        document.querySelector('#library-loader-overlay [data-library-action="close"]')?.click();
+        await window.AppLazyLoader.ensureGroup('browse-runtime');
+    });
+    await page.waitForFunction(() => !!window.ReadingVocabReader);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+    await page.evaluate(() => {
+        // Observe the production mutation boundary; do not replace its implementation.
+        window.__occurrenceReceipts = [];
+        const mutate = ReadingVocabStore.mutate;
+        ReadingVocabStore.mutate = async function(type, command, ...options) {
+            const receipt = await mutate.call(this, type, command, ...options);
+            window.__occurrenceReceipts.push({ type, saved: receipt.saved, revision: receipt.revision });
+            return receipt;
+        };
+    });
+}
+
+async function open(page, id = fixtureId, payload = null) {
+    await page.evaluate(async ({ id, payload, source }) => {
+        if (payload) window.__READING_EXAM_DATA__.register(id, payload);
+        await ReadingVocabReader.open(id, { source });
+    }, { id, payload, source });
+    await page.locator('#vocab-reader-tabs [data-para="questions"]').waitFor();
+    assert.equal(await page.locator('.vocab-error-state').count(), 0);
+}
+
+async function snapshot(page) {
+    return page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+}
+
+async function occurrences(page, word = null, article = fixtureId) {
+    return page.evaluate(async ({ word, article, source }) => {
+        const state = (await AppData.vocab.getReadingSnapshot()).snapshot;
+        const model = AppData.vocab.readingModel;
+        return model.query(state, { articleId: model.articleId(source, article) }).terms
+            .filter(row => !word || row.word.word.toLowerCase() === word.toLowerCase())
+            .flatMap(row => row.occurrences);
+    }, { word, article, source });
+}
+
+async function waitForOccurrences(page, count, word = null) {
+    // Playwright waitForFunction treats a returned Promise as truthy; poll the
+    // acknowledged async persistence read explicitly rather than racing it.
+    const deadline = Date.now() + 15_000;
+    while ((await occurrences(page, word)).length !== count) {
+        if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${count} acknowledged ${word || 'total'} occurrences`);
+        await page.waitForTimeout(50);
+    }
+    await page.waitForFunction(() => ReadingVocabReader._selectionPending.size === 0 && !ReadingVocabReader._occurrenceBusy);
+}
+
+async function select(page, selector, quote, occurrence = 0, event = 'mouse') {
+    return page.evaluate(({ selector, quote, occurrence, event }) => {
+        const target = document.querySelector(selector);
+        if (!target) throw new Error(`Missing selection root: ${selector}`);
+        const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        let text = '';
+        while (walker.nextNode()) {
+            const node = walker.currentNode;
+            nodes.push({ node, start: text.length });
+            text += node.textContent;
+        }
+        let start = -1;
+        for (let index = 0; index <= occurrence; index++) start = text.indexOf(quote, start + 1);
+        if (start < 0) throw new Error(`Missing occurrence ${occurrence} of ${quote}`);
+        const end = start + quote.length;
+        const from = nodes.find(item => item.start <= start && item.start + item.node.length > start);
+        const to = nodes.find(item => item.start < end && item.start + item.node.length >= end);
+        const range = document.createRange();
+        range.setStart(from.node, start - from.start);
+        range.setEnd(to.node, end - to.start);
+        const selection = getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+        const eventTarget = from.node.parentElement;
+        if (event === 'mouse') eventTarget.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+        else if (event === 'touch') eventTarget.dispatchEvent(new TouchEvent('touchend', { bubbles: true }));
+        else if (event === 'keyboard') eventTarget.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift', bubbles: true }));
+        return { start, end, quote: range.toString(), crossesInlineNodes: from.node !== to.node };
+    }, { selector, quote, occurrence, event });
+}
+
+async function marks(page, selector = '#vocab-passage-content') {
+    return page.locator(`${selector} mark.vocab-highlight`).evaluateAll(nodes => {
+        const grouped = new Map();
+        for (const node of nodes) {
+            if (grouped.has(node.dataset.occurrenceId)) {
+                const existing = grouped.get(node.dataset.occurrenceId);
+                existing.text += node.textContent;
+                existing.fragments += 1;
+            } else {
+                const range = document.createRange();
+                range.selectNodeContents(node.closest('.vocab-paragraph-text') || node.closest('[data-vocab-scope]'));
+                range.setEndBefore(node);
+                grouped.set(node.dataset.occurrenceId, { text: node.textContent,
+                    occurrenceId: node.dataset.occurrenceId, fragments: 1,
+                    scope: node.closest('[data-vocab-scope]')?.dataset.vocabScope,
+                    before: range.toString() });
+            }
+        }
+        return [...grouped.values()];
+    });
+}
+
+async function selectWithKeyboard(page, quote) {
+    await select(page, '#vocab-passage-content', quote, 0, 'none');
+    await page.evaluate(() => {
+        const selection = getSelection();
+        const range = selection.getRangeAt(0).cloneRange();
+        range.collapse(true);
+        range.startContainer.parentElement.closest('[data-vocab-scope]').focus();
+        selection.removeAllRanges();
+        selection.addRange(range);
+    });
+    await page.keyboard.down('Shift');
+    for (let index = 0; index < quote.length; index++) await page.keyboard.press('ArrowRight');
+    assert.equal(await page.evaluate(() => getSelection().toString()), quote, 'trusted keyboard events must build the intended real DOM Range');
+    await page.waitForTimeout(75);
+    assert.equal((await occurrences(page, 'keyboardword')).length, 0, 'holding Shift while extending a selection must not save partial words');
+    await page.keyboard.up('Shift');
+}
+
+async function assets(page) {
+    for (const id of ['p1-high-216', 'p2-high-192', 'p2-low-051', 'p1-high-101', 'p1-high-171', 'p1-high-229', 'p2-low-08']) {
+        await open(page, id);
+        const evidence = await page.evaluate(() => {
+            const reader = ReadingVocabReader;
+            const overlay = document.querySelector('#reading-vocab-reader-overlay');
+            const visibleText = overlay.querySelector('#vocab-passage-content').textContent;
+            const rendered = [overlay.querySelector('#vocab-passage-title').textContent, overlay.querySelector('#vocab-passage-intro').textContent, visibleText].join(' ');
+            const normalize = value => value.replace(/\s+/g, ' ').trim();
+            const doc = document.createElement('div');
+            doc.innerHTML = (reader.currentPayload.passage?.blocks || []).map(block => block.bodyHtml || block.html || '').join('\n');
+            const expected = [...doc.querySelectorAll('p,h3,h4,h5')]
+                .filter(node => !node.closest('.paragraph-dropzone,.dropzone,.match-dropzone,script,style'))
+                .map(node => normalize(node.textContent)).filter(text => text.length >= 40);
+            const missing = expected.filter(text => !normalize(rendered).includes(text));
+            const ids = [...overlay.querySelectorAll('[id]')].map(node => node.id);
+            const scopes = [...overlay.querySelectorAll('[data-vocab-scope]')].map(node => node.dataset.vocabScope);
+            return { characters: normalize(visibleText).length, expectedParagraphs: expected.length, missing, duplicateIds: ids.filter((id, index) => ids.indexOf(id) !== index), duplicateScopes: scopes.filter((id, index) => scopes.indexOf(id) !== index), paragraphCount: overlay.querySelectorAll('.vocab-paragraph-text').length, h5: [...doc.querySelectorAll('h5')].map(node => normalize(node.textContent)), rendered: normalize(rendered) };
+        });
+        assert.ok(evidence.characters > 1000, `${id}: passage must be nonempty`);
+        assert.deepEqual(evidence.missing, [], `${id}: all source paragraphs and instructions must survive`);
+        assert.deepEqual(evidence.duplicateIds, [], `${id}: DOM IDs must be unique`);
+        assert.deepEqual(evidence.duplicateScopes, [], `${id}: internal scope identities must be unique`);
+        for (const subtitle of evidence.h5) assert.ok(evidence.rendered.includes(subtitle), `${id}: H5 subtitle must survive`);
+        delete evidence.rendered;
+        pass(`${id}-complete-render-and-identities`, evidence);
+    }
+}
+
+async function occurrenceRegression(page, protocol) {
+    await page.evaluate(async word => {
+        const receipt = await AppData.vocab.saveWords([word]);
+        if (receipt.committed !== true) throw new Error('Canonical review seed was not acknowledged');
+    }, reviewedCoral);
+    await open(page, fixtureId, fixture);
+    const ordered = await page.locator('#vocab-passage-content').textContent();
+    assert.ok(ordered.indexOf('first coral') < ordered.indexOf('finalblockword'));
+    assert.ok(await page.locator('#vocab-passage-intro').textContent().then(text => text.includes('Every ordered block survives')));
+    const scopes = await page.locator('[data-vocab-scope]').evaluateAll(nodes => nodes.map(node => node.dataset.vocabScope));
+    assert.equal(new Set(scopes).size, scopes.length);
+    const annotationBefore = await page.locator('#vocab-passage-content .hl').evaluateAll(nodes => nodes.map(node => node.outerHTML));
+    assert.equal(annotationBefore.length, 1);
+    const second = await select(page, '.vocab-paragraph-text', 'coral', 1);
+    assert.equal(second.crossesInlineNodes, true, 'selected second term must cross real inline text nodes');
+    assert.ok(second.start > 500, 'selected context must come from far into a long paragraph');
+    await waitForOccurrences(page, 1, 'coral');
+    const [saved] = await occurrences(page, 'coral');
+    let highlighted = await marks(page);
+    assert.equal(highlighted.length, 1, JSON.stringify(await page.evaluate(saved => ({ saved,
+        unresolved: ReadingVocabReader.unresolvedOccurrences,
+        resolved: ReadingVocabAnchors.resolve(document.querySelector('#vocab-reader-body'), saved)?.toString(),
+        toast: document.querySelector('#vocab-toast').textContent
+    }), saved)));
+    assert.equal(highlighted[0].text, 'coral');
+    assert.equal(highlighted[0].occurrenceId, saved.id);
+    assert.equal(highlighted[0].before.length, second.start);
+    const coralEntry = await page.evaluate(id => ReadingVocabStore.getByExam(id).find(row => row.word === 'coral'), fixtureId);
+    // The selection context is retained on the occurrence even if an existing
+    // canonical word owns the learner's original example field.
+    assert.ok(saved.quote === 'coral' && saved.before && saved.after);
+    if (coralEntry.context) assert.ok(coralEntry.context.includes('coral'));
+    assert.deepEqual(await page.locator('#vocab-passage-content .hl').evaluateAll(nodes => nodes.map(node => node.outerHTML)), annotationBefore);
+    await page.locator('#vocab-reader-back-btn').click();
+    await open(page);
+    highlighted = await marks(page);
+    assert.equal(highlighted.length, 1);
+    assert.equal(highlighted[0].before.length, second.start);
+    assert.equal(highlighted[0].occurrenceId, saved.id);
+
+    await select(page, '#vocab-passage-content', 'distantword');
+    await waitForOccurrences(page, 1, 'distantword');
+    const distantEntry = await page.evaluate(id => ReadingVocabStore.getByExam(id).find(row => row.word === 'distantword'), fixtureId);
+    assert.ok(distantEntry, JSON.stringify(await page.evaluate(async id => ({
+        projected: ReadingVocabStore.getByExam(id), persisted: (await AppData.vocab.getReadingSnapshot()).snapshot,
+        pending: [...ReadingVocabReader._selectionPending], receipts: window.__occurrenceReceipts,
+        toast: document.querySelector('#vocab-toast').textContent
+    }), fixtureId)));
+    assert.ok(distantEntry.context.includes('distantword'), 'stored context must contain a selected term far beyond the first 150 paragraph characters');
+    await selectWithKeyboard(page, '(keyboardword),');
+    await waitForOccurrences(page, 1, 'keyboardword');
+    await select(page, '#vocab-passage-content', 'touchword', 0, 'touch');
+    // Browsers may emit a compatibility mouseup after touchend. It must not
+    // create a second occurrence for the same selected Range.
+    await page.locator('#vocab-passage-content').dispatchEvent('mouseup');
+    await waitForOccurrences(page, 1, 'touchword');
+    const keyboardEntry = await page.evaluate(id => ReadingVocabStore.getByExam(id).find(row => row.word === 'keyboardword'), fixtureId);
+    assert.ok(keyboardEntry.context.includes('keyboardword'));
+    await page.locator('#vocab-reader-tabs [data-para="questions"]').click();
+    assert.equal(await page.locator('#vocab-questions-content input,#vocab-questions-content select,#vocab-questions-content textarea,#vocab-questions-content [contenteditable="true"]').count(), 0);
+    await select(page, '#vocab-questions-content .vocab-question-group', 'coral');
+    await waitForOccurrences(page, 2, 'coral');
+    const questionMarks = await marks(page, '#vocab-questions-content');
+    assert.equal(questionMarks.length, 1);
+    assert.notEqual(questionMarks[0].scope, highlighted[0].scope);
+    const beforeReload = await occurrences(page);
+    const selectionReceipts = await page.evaluate(() => window.__occurrenceReceipts.filter(row => row.type === 'collect'));
+    assert.equal(selectionReceipts.length, 5, 'each input path must receive one acknowledged collection receipt');
+    assert.ok(selectionReceipts.every(row => row.saved === true));
+    await ready(page, protocol);
+    await open(page, fixtureId, fixture);
+    assert.deepEqual(await occurrences(page), beforeReload, 'actual page reload must retain acknowledged occurrences');
+    const allRestored = [...await marks(page), ...await marks(page, '#vocab-questions-content')];
+    assert.deepEqual(allRestored.map(mark => mark.occurrenceId).sort(), beforeReload.map(row => row.id).sort(), 'every mouse, touch and keyboard occurrence must visibly restore');
+    assert.equal((await marks(page)).filter(mark => mark.text === 'coral').length, 1);
+    assert.equal((await marks(page, '#vocab-questions-content')).length, 1);
+    assert.deepEqual((await snapshot(page)).words.find(word => word.id === reviewedCoral.id), reviewedCoral, 'collecting an existing canonical word must preserve its original review history');
+    await page.screenshot({ path: path.join(reports, `issue158-${protocol}-occurrences.png`) });
+    pass(`${protocol}-exact-inline-occurrence-and-input-paths`, { selectedOffset: second.start, persistedOccurrenceIds: beforeReload.map(row => row.id), scopeIds: beforeReload.map(row => row.scopeId), selectionReceipts });
+    return { saved, annotationBefore };
+}
+
+async function rejectedSelections(page) {
+    const before = await snapshot(page);
+    await select(page, '#vocab-passage-content', 'annotationword');
+    await page.waitForTimeout(75);
+    await page.evaluate(() => {
+        const start = document.querySelector('.vocab-paragraph-text').firstChild;
+        const end = document.querySelectorAll('.vocab-paragraph-text')[1].lastChild;
+        const range = document.createRange();
+        range.setStart(start, 0); range.setEnd(end, end.childNodes.length || end.length || 0);
+        const selection = getSelection(); selection.removeAllRanges(); selection.addRange(range);
+        document.querySelector('#vocab-passage-content').dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await page.waitForTimeout(75);
+    await page.locator('#vocab-reader-tabs [data-para="questions"]').click();
+    await page.evaluate(() => {
+        const groups = document.querySelectorAll('#vocab-questions-content .vocab-question-group');
+        const range = document.createRange(); range.setStart(groups[0], 0); range.setEnd(groups[1], groups[1].childNodes.length);
+        const selection = getSelection(); selection.removeAllRanges(); selection.addRange(range);
+        groups[0].dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await page.waitForTimeout(75);
+    await select(page, '#vocab-reader-back-btn', '返回题库');
+    // Give the production selection debounce a chance to reject every path.
+    await page.waitForTimeout(400);
+    assert.deepEqual(await snapshot(page), before, 'annotations, controls and cross-section selections must not mutate vocabulary');
+    await page.locator('#vocab-reader-tabs [data-para="all"]').click();
+    pass('ineligible-and-cross-section-selections-do-not-mutate');
+}
+
+async function removalRegression(page, saved, annotationBefore) {
+    await page.evaluate(async ({ source, fixtureId }) => {
+        for (const examId of [fixtureId, 'issue158-other-article']) {
+            const receipt = await ReadingVocabStore.mutate('collect', { source, article: { examId, title: examId }, word: { word: 'coral', meaning: 'Ignored duplicate meaning' }, manual: true, at: '2026-09-08T02:00:00.000Z' });
+            if (receipt.saved !== true) throw new Error('Manual association was not acknowledged');
+        }
+        const receipt = await ReadingVocabStore.mutate('collect', { source, article: { examId: fixtureId, title: fixtureId }, word: { word: 'finalblockword', meaning: 'Manual only' }, manual: true, at: '2026-09-08T02:00:01.000Z' });
+        if (receipt.saved !== true) throw new Error('Manual term was not acknowledged');
+    }, { source, fixtureId });
+    assert.equal((await marks(page)).filter(mark => mark.text === 'finalblockword').length, 0, 'manual terms must not highlight matching text');
+    const before = await snapshot(page);
+    const selectedMark = page.locator('#vocab-passage-content mark.vocab-highlight[data-word="coral"]').first();
+    await selectedMark.click();
+    await page.locator('#vocab-occurrence-actions [data-action="remove-occurrence"]').click();
+    await waitForOccurrences(page, 1, 'coral');
+    assert.equal((await marks(page)).filter(mark => mark.text === 'coral').length, 0);
+    const removed = await snapshot(page);
+    assert.deepEqual(removed.words, before.words, 'canonical review history must survive occurrence removal');
+    assert.deepEqual(removed.lists, before.lists);
+    assert.deepEqual(removed.reading.associations, before.reading.associations, 'manual and other article associations must survive');
+    assert.ok(removed.reading.occurrences.every(row => row.id !== saved.id));
+    await page.locator('[data-action="undo-occurrence"]').click();
+    await waitForOccurrences(page, 2, 'coral');
+    assert.ok((await occurrences(page, 'coral')).some(row => row.id === saved.id));
+    assert.deepEqual((await snapshot(page)).words, before.words);
+    assert.deepEqual((await snapshot(page)).lists, before.lists);
+
+    // A sole nonmanual occurrence drops its article association; undo restores
+    // that association while the canonical word remains intact throughout.
+    await page.locator('mark.vocab-highlight').filter({ hasText: /^keyboardword$/ }).click();
+    await page.locator('#vocab-occurrence-actions [data-action="remove-occurrence"]').click();
+    await waitForOccurrences(page, 0, 'keyboardword');
+    assert.equal(await page.evaluate(id => ReadingVocabStore.getByExam(id).some(row => row.word === 'keyboardword'), fixtureId), false);
+    await page.locator('[data-action="undo-occurrence"]').click();
+    await waitForOccurrences(page, 1, 'keyboardword');
+    assert.deepEqual(await page.locator('#vocab-passage-content .hl').evaluateAll(nodes => nodes.map(node => node.outerHTML)), annotationBefore);
+    pass('remove-undo-preserves-manual-other-article-and-canonical-review');
+}
+
+async function unresolvedRegression(page, saved) {
+    const variants = {
+        changed: '<p>The first coral is close to the shore. The selected source text has been rewritten. The third coral grows deeper.</p>',
+        missing: '<p>This replacement paragraph has no selected term and the original paragraph is absent.</p>',
+        ambiguous: `<p>${saved.before}${saved.quote}${saved.after} A separating sentence. ${saved.before}${saved.quote}${saved.after}</p>`
+    };
+    for (const [name, bodyHtml] of Object.entries(variants)) {
+        const changed = structuredClone(fixture);
+        changed.passage.blocks[0].bodyHtml = bodyHtml;
+        await open(page, fixtureId, changed);
+        assert.equal((await marks(page)).filter(mark => mark.text === 'coral').length, 0, `${name}: must not choose another matching occurrence`);
+        assert.ok((await occurrences(page, 'coral')).some(row => row.id === saved.id), `${name}: association and anchor must remain recoverable`);
+        assert.ok((await page.locator('#vocab-anchor-status').textContent()).includes('无法定位'));
+        await page.locator('#vocab-fab').click();
+        const statuses = await page.locator('[data-anchor-status="unresolved"]').evaluateAll(nodes => nodes.map(node => ({ id: node.dataset.occurrenceId, text: node.textContent })));
+        assert.ok(statuses.some(item => item.id === saved.id), `${name}: unresolved state must be visible in the reader DOM`);
+        await open(page, fixtureId, fixture);
+        assert.ok((await marks(page)).some(mark => mark.occurrenceId === saved.id), `${name}: restoring the source must recover the same anchor`);
+        pass(`${name}-anchor-is-recoverable-without-wrong-highlight`);
+    }
+}
+
+try {
+    for (const protocol of ['http', 'file']) {
+        const context = await browser.newContext({ hasTouch: true });
+        const page = await context.newPage();
+        page.on('dialog', dialog => dialog.accept());
+        try {
+            await ready(page, protocol);
+            if (protocol === 'http') await assets(page);
+            const { saved, annotationBefore } = await occurrenceRegression(page, protocol);
+            if (protocol === 'http') {
+                await rejectedSelections(page);
+                await removalRegression(page, saved, annotationBefore);
+                await unresolvedRegression(page, saved);
+            }
+            const receipts = await page.evaluate(() => window.__occurrenceReceipts);
+            assert.ok(receipts.length && receipts.every(row => row.saved === true && Number.isInteger(row.revision)));
+            pass(`${protocol}-production-mutation-receipts`, { receipts });
+        } finally { await context.close(); }
+    }
+    report.status = 'pass';
+} catch (error) {
+    report.status = 'fail';
+    report.error = error.stack || String(error);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+    await new Promise(resolve => server.close(resolve));
+    console.log(JSON.stringify(report, null, 2));
+    fs.writeFileSync(path.join(reports, 'reading-reader-occurrences-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+}

--- a/developer/tests/e2e/reading_reader_occurrences.py
+++ b/developer/tests/e2e/reading_reader_occurrences.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run the production reader occurrence regression with E2E CI's Chromium."""
+import os
+from pathlib import Path
+import subprocess
+
+from playwright.sync_api import sync_playwright
+
+
+def main():
+    env = os.environ.copy()
+    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
+        with sync_playwright() as playwright:
+            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
+    script = Path(__file__).with_suffix(".node.js")
+    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/developer/tests/js/helpers/readingVocabReaderHarness.js
+++ b/developer/tests/js/helpers/readingVocabReaderHarness.js
@@ -2,10 +2,14 @@ import fs from 'node:fs';
 
 const source = name => fs.readFileSync(new URL(`../../../../js/${name}`, import.meta.url), 'utf8');
 const modelSource = source('data/v2/readingVocabularyModel.js');
+const contentSource = source('components/readingVocabContent.js');
+const anchorsSource = source('components/readingVocabAnchors.js');
 const readerSource = source('components/readingVocabReader.js');
 
 export async function installReadingAuthority(page, { localWords = [], canonicalWords = [], authority = 'ready' } = {}) {
     await page.addScriptTag({ content: modelSource });
+    await page.addScriptTag({ content: contentSource });
+    await page.addScriptTag({ content: anchorsSource });
     await page.evaluate(({ localWords, canonicalWords, authority }) => {
         localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify(localWords));
         const model = window.ReadingVocabularyModel;
@@ -52,7 +56,8 @@ export async function installReadingAuthority(page, { localWords = [], canonical
                         if (type === 'collect') state.snapshot = model.recordVisit(state.snapshot, command);
                         if (type === 'recordVisit' || type === 'collect') window.__recordedExams.push(command.article.examId);
                         state.revision += 1;
-                        return { ...result(), saved: true, added: true };
+                        return { ...result(), saved: true, added: true, changed: true,
+                            revisions: { 'vocab.readingState': state.revision } };
                     }
                 }
             };

--- a/developer/tests/js/readingVocabAnchors.test.js
+++ b/developer/tests/js/readingVocabAnchors.test.js
@@ -1,0 +1,222 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const source = fs.readFileSync(new URL('../../../js/components/readingVocabAnchors.js', import.meta.url), 'utf8');
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
+test('reading vocabulary anchors capture real DOM boundaries and reject unsafe selections', async t => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await browser.newPage();
+    try {
+        await page.setContent('<!doctype html><html><body></body></html>');
+        await page.addScriptTag({ content: source });
+        await t.test('element endpoints and inline markup preserve exact trimmed offsets and a local context', async () => {
+            const result = await page.evaluate(() => {
+                const scope = document.createElement('p');
+                scope.dataset.vocabScope = 'source:article:passage:0';
+                scope.innerHTML = `${'Long introduction. '.repeat(35)}<span> “clean <em>water</em>,” </span>then the ending.`;
+                document.body.replaceChildren(scope);
+                const span = scope.querySelector('span');
+                const range = document.createRange();
+                range.setStart(span, 0);
+                range.setEnd(span, span.childNodes.length);
+                const captured = ReadingVocabAnchors.capture(scope, range);
+                const restored = ReadingVocabAnchors.resolve(document.body, captured);
+                return {
+                    word: captured.word, quote: captured.quote, selected: captured.range.toString(),
+                    start: captured.startOffset, expectedStart: scope.textContent.indexOf('clean'),
+                    end: captured.endOffset, context: captured.context,
+                    restored: restored.toString(), emphasis: scope.querySelector('em').textContent
+                };
+            });
+            assert.equal(result.word, 'clean water');
+            assert.equal(result.quote, 'clean water');
+            assert.equal(result.selected, 'clean water');
+            assert.equal(result.start, result.expectedStart);
+            assert.equal(result.end, result.start + 11);
+            assert.equal(result.context.includes('clean water'), true);
+            assert.ok(result.context.length <= 141);
+            assert.equal(result.restored, 'clean water');
+            assert.equal(result.emphasis, 'water');
+        });
+        await t.test('excluded descendants never enter the text map and cannot be crossed', async () => {
+            const results = await page.evaluate(() => {
+                const cases = [
+                    '<button><span>control</span></button>', '<input value="answer">',
+                    '<textarea>answer</textarea>', '<select><option>answer</option></select>',
+                    '<span class="vocab-translation-card"><b>translation</b></span>',
+                    '<span class="vocab-paragraph-tag">A</span>',
+                    '<span class="vocab-answer-blank">____</span>',
+                    '<span hidden>hidden</span>', '<span style="display:none">hidden</span>',
+                    '<span aria-hidden="true">hidden</span>', '<br>'
+                ];
+                return cases.map(html => {
+                    const scope = document.createElement('div');
+                    scope.dataset.vocabScope = 'scope';
+                    scope.innerHTML = `clean ${html}water`;
+                    document.body.replaceChildren(scope);
+                    const range = document.createRange();
+                    range.selectNodeContents(scope);
+                    return { text: ReadingVocabAnchors.text(scope), rejected: ReadingVocabAnchors.capture(scope, range) === null };
+                });
+            });
+            assert.equal(results.every(result => result.text === 'clean water' && result.rejected), true);
+        });
+        await t.test('highlight overlaps, multiple paragraphs, scopes, newlines and invalid lengths are rejected', async () => {
+            const results = await page.evaluate(() => [
+                'clean <mark class="vocab-highlight">water</mark>', 'clean <span class="hl">water</span>',
+                '<p>clean</p><p>water</p>', 'clean <span data-vocab-scope="other">water</span>',
+                'clean\nwater', '12345', 'a'.repeat(46)
+            ].map(html => {
+                const scope = document.createElement('div');
+                scope.dataset.vocabScope = 'scope';
+                scope.innerHTML = html;
+                document.body.replaceChildren(scope);
+                const range = document.createRange();
+                range.selectNodeContents(scope);
+                return ReadingVocabAnchors.capture(scope, range) === null;
+            }));
+            assert.equal(results.every(Boolean), true);
+        });
+    } finally { await page.close(); await browser.close(); }
+});
+
+test('reading vocabulary restoration requires the exact version or one complete context match', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await browser.newPage();
+    try {
+        await page.setContent('<!doctype html><html><body></body></html>');
+        await page.addScriptTag({ content: source });
+        const result = await page.evaluate(() => {
+            const scope = document.createElement('p');
+            scope.dataset.vocabScope = 'source:article:passage:0';
+            document.body.append(scope);
+            scope.textContent = 'water water water';
+            const range = ReadingVocabAnchors.resolveOffsets(scope, 6, 11);
+            const captured = ReadingVocabAnchors.capture(scope, range);
+            const exact = ReadingVocabAnchors.resolve(document.body, captured).toString();
+            const originalVersion = ReadingVocabAnchors.version(scope);
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight';
+            mark.setAttribute('role', 'button');
+            mark.tabIndex = 0;
+            ReadingVocabAnchors.resolveOffsets(scope, 0, 5).surroundContents(mark);
+            const stableWrapperVersion = originalVersion === ReadingVocabAnchors.version(scope);
+            const sequential = ReadingVocabAnchors.capture(scope, ReadingVocabAnchors.resolveOffsets(scope, 12, 17));
+            const beforeResolve = scope.innerHTML;
+            const stillExact = ReadingVocabAnchors.resolve(document.body, captured).toString();
+            const secondExact = ReadingVocabAnchors.resolve(document.body, sequential).toString();
+            const readOnly = beforeResolve === scope.innerHTML;
+            const alreadyHighlighted = ReadingVocabAnchors.resolve(scope, { ...captured, startOffset: 0, endOffset: 5 });
+            scope.textContent = 'intro water water water ending';
+            const changed = ReadingVocabAnchors.resolve(document.body, captured);
+            const changedLocation = ReadingVocabAnchors.calculateLocation(scope, changed);
+            const noOrdinalFallback = ReadingVocabAnchors.resolve(scope, { scope: captured.scope, text: 'water', occurrence: 1 }) === null;
+            const partial = ReadingVocabAnchors.resolve(scope, { ...captured, before: 'water ', after: 'missing' }) === null;
+            const missing = ReadingVocabAnchors.resolve(document.body, { ...captured, scopeId: 'missing' }) === null;
+            const legacy = ReadingVocabAnchors.resolve(scope, { scope: captured.scope, text: 'water', before: 'water ', after: ' water' });
+            const legacyLocation = ReadingVocabAnchors.calculateLocation(scope, legacy);
+            scope.textContent = 'intro water water water water ending';
+            const ambiguous = ReadingVocabAnchors.resolve(scope, captured) === null;
+            const legacyAmbiguous = ReadingVocabAnchors.resolve(scope, { scope: captured.scope, text: 'water', before: 'water ', after: ' water' }) === null;
+            scope.textContent = 'water water water';
+            const wrongVersionOffset = ReadingVocabAnchors.resolve(scope, { ...captured, startOffset: 100, endOffset: 105 }) === null;
+            const secondScope = scope.cloneNode(true);
+            document.body.append(secondScope);
+            const duplicateScope = ReadingVocabAnchors.resolve(document.body, captured) === null;
+            return {
+                exact, stableWrapperVersion, stillExact, secondExact, readOnly, sequentialOffset: sequential.startOffset,
+                alreadyHighlighted: alreadyHighlighted === null, shiftedOffset: changedLocation.startOffset,
+                noOrdinalFallback, partial, missing, legacyOffset: legacyLocation.startOffset,
+                ambiguous, legacyAmbiguous, wrongVersionOffset, duplicateScope
+            };
+        });
+        assert.deepEqual(result, {
+            exact: 'water', stableWrapperVersion: true, stillExact: 'water', secondExact: 'water', readOnly: true,
+            sequentialOffset: 12, alreadyHighlighted: true,
+            shiftedOffset: 12, noOrdinalFallback: true, partial: true, missing: true, legacyOffset: 12,
+            ambiguous: true, legacyAmbiguous: true, wrongVersionOffset: true, duplicateScope: true
+        });
+    } finally { await page.close(); await browser.close(); }
+});
+
+test('source edits never relocate a captured occurrence onto a different identical paragraph', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await browser.newPage();
+    try {
+        await page.setContent('<!doctype html><html><body data-vocab-source-root></body></html>');
+        await page.addScriptTag({ content: source });
+        const result = await page.evaluate(() => {
+            const anchors = ReadingVocabAnchors;
+            function render(passages, questions = []) {
+                const sourceVersion = anchors.hashText(JSON.stringify({ passages, questions }));
+                const scopes = [];
+                for (const [area, paragraphs] of [['passage', passages], ['questions', questions]]) {
+                    paragraphs.forEach((value, index) => {
+                        const scope = document.createElement('p');
+                        scope.dataset.vocabScope = `${area}/p-${index + 1}`;
+                        scope.dataset.vocabSourceVersion = sourceVersion;
+                        scope.textContent = value;
+                        scopes.push(scope);
+                    });
+                }
+                document.body.replaceChildren(...scopes);
+                return scopes;
+            }
+            function capture(scope) {
+                const offset = scope.textContent.indexOf('water');
+                return anchors.capture(scope, anchors.resolveOffsets(scope, offset, offset + 5));
+            }
+            const paragraph = 'Clean water is precious.';
+            const original = render([paragraph, paragraph]);
+            const firstDuplicate = capture(original[0]);
+            const secondDuplicate = capture(original[1]);
+            const exactFirst = anchors.resolve(document.body, firstDuplicate).startContainer.parentElement.dataset.vocabScope;
+            const exactSecond = anchors.resolve(document.body, secondDuplicate).startContainer.parentElement.dataset.vocabScope;
+            const originalVersion = anchors.version(original[1]);
+            const inserted = render(['A new introductory paragraph.', paragraph, paragraph]);
+            const changedSourceVersion = originalVersion !== anchors.version(inserted[1]);
+            const insertedDuplicateRejected = anchors.resolve(document.body, secondDuplicate) === null;
+            render([paragraph]);
+            const deletedDuplicateRejected = anchors.resolve(document.body, firstDuplicate) === null;
+            const missingOriginalScopeRejected = anchors.resolve(document.body, secondDuplicate) === null;
+
+            const unique = capture(render([paragraph, 'A different paragraph.'])[0]);
+            render(['A different paragraph.', paragraph]);
+            const moved = anchors.resolve(document.body, unique);
+            const movedUniqueScope = moved.startContainer.parentElement.dataset.vocabScope;
+            const missingFlagRejected = anchors.resolve(document.body, {
+                ...unique, contentVersion: unique.contentVersion.replace(/\|context-unique$/, '')
+            }) === null;
+            render([paragraph, paragraph]);
+            const newlyDuplicatedRejected = anchors.resolve(document.body, unique) === null;
+            const mark = document.createElement('mark');
+            mark.className = 'vocab-highlight';
+            const first = document.querySelector('[data-vocab-scope="passage/p-1"]');
+            const offset = first.textContent.indexOf('water');
+            anchors.resolveOffsets(first, offset, offset + 5).surroundContents(mark);
+            const paintedDuplicateStillAmbiguous = anchors.resolve(document.body, unique) === null;
+            render(['A different paragraph.'], [paragraph]);
+            const otherAreaRejected = anchors.resolve(document.body, unique) === null;
+            render(['A different paragraph.', paragraph], [paragraph]);
+            const questionsDoNotCreatePassageAmbiguity = !!anchors.resolve(document.body, unique);
+            return {
+                originalScoped: firstDuplicate.contentVersion.endsWith('|context-scoped'),
+                originalUnique: unique.contentVersion.endsWith('|context-unique'),
+                exactFirst, exactSecond, changedSourceVersion, insertedDuplicateRejected,
+                deletedDuplicateRejected, missingOriginalScopeRejected, movedUniqueScope,
+                missingFlagRejected, newlyDuplicatedRejected, paintedDuplicateStillAmbiguous,
+                otherAreaRejected, questionsDoNotCreatePassageAmbiguity
+            };
+        });
+        assert.deepEqual(result, {
+            originalScoped: true, originalUnique: true, exactFirst: 'passage/p-1', exactSecond: 'passage/p-2',
+            changedSourceVersion: true, insertedDuplicateRejected: true, deletedDuplicateRejected: true,
+            missingOriginalScopeRejected: true, movedUniqueScope: 'passage/p-2', missingFlagRejected: true,
+            newlyDuplicatedRejected: true, paintedDuplicateStillAmbiguous: true, otherAreaRejected: true,
+            questionsDoNotCreatePassageAmbiguity: true
+        });
+    } finally { await page.close(); await browser.close(); }
+});

--- a/developer/tests/js/readingVocabContent.test.js
+++ b/developer/tests/js/readingVocabContent.test.js
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { chromium } from 'playwright';
+
+const contentSource = fs.readFileSync(new URL('../../../js/components/readingVocabContent.js', import.meta.url), 'utf8');
+const ids = ['p1-high-216', 'p2-high-192', 'p2-low-051', 'p1-high-101', 'p1-high-171', 'p1-high-229', 'p2-low-08'];
+const assets = ids.map(id => {
+    let payload;
+    const global = { __READING_EXAM_DATA__: { register: (_key, value) => { payload = value; } } };
+    vm.runInNewContext(fs.readFileSync(new URL(`../../../assets/generated/reading-exams/${id}.js`, import.meta.url), 'utf8'), {
+        window: global, globalThis: global
+    });
+    return { id, payload };
+});
+
+test('passage normalization retains production content and assigns structural identities', async t => {
+    const browser = await chromium.launch({ headless: true,
+        ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}) });
+    const page = await browser.newPage();
+    await page.addScriptTag({ content: contentSource });
+    try {
+        await t.test('all seven regression assets retain every prose paragraph in source order', async () => {
+            const results = await page.evaluate(assets => assets.map(({ id, payload }) => {
+                const data = ReadingVocabContent.normalizePassage(payload.passage, payload.meta.title);
+                const source = document.createElement('div');
+                source.innerHTML = payload.passage.blocks.map(block => block.bodyHtml || block.html || '').join('\n');
+                const rendered = document.createElement('div');
+                rendered.innerHTML = data.blocks.map(block => block.html).join('\n');
+                const expectedParagraphs = [...source.querySelectorAll('p')].map(node => node.textContent.trim())
+                    .filter(text => text && !/^You should spend\b/.test(text));
+                const allContent = document.createElement('div');
+                allContent.innerHTML = data.subtitleHtml + rendered.innerHTML;
+                return {
+                    id, blockCount: data.blocks.length, ids: data.blocks.map(block => block.id),
+                    expectedParagraphs,
+                    actualParagraphs: [...allContent.querySelectorAll('p')].map(node => node.textContent.trim()).filter(Boolean),
+                    labels: data.blocks.map(block => block.letter),
+                    explicitLabels: data.blocks.map(block => block.explicitLabel),
+                    instruction: data.instructionHtml, subtitle: data.subtitleHtml,
+                    title: data.passageTitle,
+                    stable: JSON.stringify(data) === JSON.stringify(ReadingVocabContent.normalizePassage(payload.passage, payload.meta.title))
+                };
+            }), assets);
+            for (const result of results) {
+                assert.ok(result.blockCount > 0, result.id);
+                assert.deepEqual(result.actualParagraphs, result.expectedParagraphs, `${result.id} keeps all paragraphs in source order`);
+                assert.equal(new Set(result.ids).size, result.ids.length, `${result.id} identities are unique`);
+                assert.ok(result.ids.every(id => /^p-\d+$/.test(id)), result.id);
+                assert.ok(result.stable, `${result.id} normalization is deterministic`);
+                assert.match(result.instruction, /You should spend about 20 minutes/, result.id);
+            }
+            for (const id of ['p1-high-101', 'p1-high-171', 'p1-high-229']) {
+                assert.ok(results.find(result => result.id === id).explicitLabels.every(value => !value), `${id} ordinary A sentences are not labels`);
+            }
+            assert.deepEqual(results.find(result => result.id === 'p2-high-192').labels, 'ABCDEFGHI'.split(''));
+            assert.deepEqual(results.find(result => result.id === 'p2-low-051').labels, 'ABCDEFGH'.split(''));
+            const petri = results.find(result => result.id === 'p2-low-08');
+            assert.match(petri.subtitle, /<h5>A simple piece of scientific equipment/);
+            assert.match(petri.instruction, /Questions 14–29/);
+            assert.equal(petri.title, 'How the Petri dish supports scientific advances');
+        });
+
+        await t.test('mixed multi-block sources preserve wrappers, short prose, headings, lists, tables and figures', async () => {
+            const result = await page.evaluate(() => {
+                const passage = { blocks: [
+                    { html: '<h3>Ordered source</h3><p><em>Opening subtitle</em></p><p>First.</p>' },
+                    { bodyHtml: '<div class="paragraph-wrapper"><p><strong>A</strong> Wrapped first.</p><p>Wrapped second.</p></div>', html: '<p>Wrong precedence.</p>' },
+                    { html: '<p>A normal sentence begins here.</p><h4>Interior heading</h4><p>After heading.</p><ul><li>List entry</li></ul>' },
+                    { bodyHtml: '<table><tbody><tr><td>Table cell</td></tr></tbody></table><figure><img alt="Diagram" src="data:image/gif;base64,R0lGODlhAQABAAAAACw="><figcaption>Figure caption</figcaption></figure><h5>Final heading</h5>' }
+                ] };
+                const data = ReadingVocabContent.normalizePassage(passage);
+                const root = document.createElement('div');
+                root.innerHTML = data.blocks.map(block => block.html).join('\n');
+                return {
+                    text: root.textContent,
+                    paragraphs: [...root.querySelectorAll('p')].map(node => node.textContent),
+                    headings: [...root.querySelectorAll('h4, h5')].map(node => node.textContent),
+                    structures: ['ul li', 'table td', 'figure img', 'figcaption'].map(selector => !!root.querySelector(selector)),
+                    wrappers: data.blocks.filter(block => /Wrapped first/.test(block.html)).map(block => block.text),
+                    ids: data.blocks.map(block => block.id),
+                    ordinarySentenceExplicit: data.blocks.find(block => /A normal sentence/.test(block.html)).explicitLabel
+                };
+            });
+            assert.deepEqual(result.paragraphs, ['First.', 'A Wrapped first.', 'Wrapped second.', 'A normal sentence begins here.', 'After heading.']);
+            assert.deepEqual(result.headings, ['Interior heading', 'Final heading']);
+            assert.deepEqual(result.structures, [true, true, true, true]);
+            assert.deepEqual(result.wrappers, ['A Wrapped first.Wrapped second.']);
+            assert.equal(result.ordinarySentenceExplicit, false);
+            assert.equal(new Set(result.ids).size, result.ids.length);
+            assert.doesNotMatch(result.text, /Wrong precedence/);
+            const markers = ['First.', 'Wrapped first.', 'Wrapped second.', 'A normal sentence', 'Interior heading', 'After heading.', 'List entry', 'Table cell', 'Figure caption', 'Final heading'];
+            assert.deepEqual(markers.map(marker => result.text.indexOf(marker)), markers.map(marker => result.text.indexOf(marker)).sort((a, b) => a - b));
+        });
+
+        await t.test('repeated labels and source IDs never become internal paragraph IDs', async () => {
+            const result = await page.evaluate(() => ReadingVocabContent.normalizePassage({ blocks: [{ html: `
+                <h3>Duplicate source labels</h3><p id="same"><strong>A</strong> First labelled paragraph.</p>
+                <p id="same"><strong>A</strong> Second labelled paragraph.</p>
+                <h4>B</h4><p>Third paragraph.</p><p>Continued third paragraph.</p>` }] }));
+            assert.deepEqual(result.blocks.map(block => block.id), ['p-1', 'p-2', 'p-3']);
+            assert.deepEqual(result.blocks.map(block => block.letter), ['A', 'A', 'B']);
+            assert.equal(result.blocks[2].text, 'Third paragraph.Continued third paragraph.');
+        });
+
+        await t.test('a heading-only or image-only final source block remains visible', async () => {
+            const result = await page.evaluate(() => {
+                const data = ReadingVocabContent.normalizePassage({ blocks: [
+                    { html: '<h3>Title</h3><p>Short.</p>' },
+                    { bodyHtml: '<img alt="Last illustration" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">' },
+                    { html: '<h6>Closing note</h6>' }
+                ] });
+                return { count: data.blocks.length, html: data.blocks.map(block => block.html).join('') };
+            });
+            assert.equal(result.count, 3);
+            assert.match(result.html, /<p>Short\.<\/p>.*Last illustration.*<h6>Closing note<\/h6>/);
+        });
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});

--- a/developer/tests/js/readingVocabHighlightInstance.test.js
+++ b/developer/tests/js/readingVocabHighlightInstance.test.js
@@ -14,6 +14,7 @@ test('production range calculation and restoration preserve one selected instanc
         const results = await page.evaluate(() => {
             const fullText = 'Clean water is essential for life, but contaminated water causes severe diseases. Stored water must be protected.';
             const root = document.createElement('p');
+            root.dataset.vocabScope = 'passage/p-1';
             root.textContent = fullText;
             document.body.append(root);
             return [6, 52, 89].map((offset, occurrence) => {
@@ -21,19 +22,22 @@ test('production range calculation and restoration preserve one selected instanc
                 range.setStart(root.firstChild, offset);
                 range.setEnd(root.firstChild, offset + 5);
                 const location = ReadingVocabReader.calculateRangeLocation(root, range, 'water');
-                const restored = ReadingVocabReader.resolveRangeForHighlight(root, { ...location, text: 'water' });
-                const fallback = ReadingVocabReader.resolveRangeForHighlight(root, { startOffset: -1, endOffset: -1, occurrence, text: 'water' });
+                const restored = ReadingVocabReader.resolveRangeForHighlight(root, { ...location, scopeId: 'passage/p-1', text: 'water' });
+                const fallback = ReadingVocabReader.resolveRangeForHighlight(root, { scopeId: 'passage/p-1', startOffset: -1, endOffset: -1, occurrence, text: 'water' });
                 return {
-                    startOffset: location.startOffset, endOffset: location.endOffset, occurrence: location.occurrence,
+                    startOffset: location.startOffset, endOffset: location.endOffset,
+                    quoted: location.quote,
+                    contextContainsQuote: location.context.includes(location.quote),
                     restored: { text: restored.toString(), start: restored.startOffset, end: restored.endOffset },
-                    fallback: { text: fallback.toString(), start: fallback.startOffset, end: fallback.endOffset }
+                    fallback
                 };
             });
         });
-        assert.deepEqual(results, [6, 52, 89].map((offset, occurrence) => ({
-            startOffset: offset, endOffset: offset + 5, occurrence,
+        assert.deepEqual(results, [6, 52, 89].map(offset => ({
+            startOffset: offset, endOffset: offset + 5,
+            quoted: 'water', contextContainsQuote: true,
             restored: { text: 'water', start: offset, end: offset + 5 },
-            fallback: { text: 'water', start: offset, end: offset + 5 }
+            fallback: null
         })));
     } finally { await page.close(); await browser.close(); }
 });

--- a/developer/tests/js/readingVocabOccurrenceScope.test.js
+++ b/developer/tests/js/readingVocabOccurrenceScope.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { chromium } from 'playwright';
+import { createPage, openArticle } from './helpers/readingVocabReaderHarness.js';
+
+test('All-tab occurrence removal and undo retain the owning article and library', async t => {
+    const browser = await chromium.launch({ headless: true,
+        ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}) });
+    t.after(() => browser.close());
+
+    for (const other of [
+        { source: { kind: 'builtin', id: 'default' }, article: { examId: 'article-b', title: 'Article B' } },
+        { source: { kind: 'imported', id: 'library-b' }, article: { examId: 'article-a', title: 'Library B article' } }
+    ]) {
+        await t.test(other.article.title, async t => {
+            const page = await createPage(browser);
+            t.after(() => page.close());
+            await openArticle(page, 'article-a', 'Article A');
+            const seeded = await page.evaluate(async other => {
+                __selectText('#vocab-passage-content', 'passage');
+                await ReadingVocabReader.captureSelection();
+                const currentOccurrence = ReadingVocabStore.getByExam('article-a')[0].occurrences[0];
+                // A shared term and an other-article-only term must both appear in All.
+                await ReadingVocabStore.add('passage', other.article.examId, other.article.title,
+                    'Other saved passage context', currentOccurrence, other.source);
+                await ReadingVocabStore.add('exclusive', other.article.examId, other.article.title,
+                    'An exclusive saved context', { ...currentOccurrence, quote: 'exclusive',
+                        startOffset: 0, endOffset: 9, before: '', after: ' saved context' }, other.source);
+                // Manual membership and canonical review fields survive occurrence removal.
+                await ReadingVocabStore.add('passage', other.article.examId, other.article.title, '', null, other.source);
+                const state = ReadingVocabStore._state.snapshot;
+                const words = state.lists['reading-highlights'].words;
+                words.find(row => row.word === 'passage').note = 'Keep the canonical note';
+                __readingAuthority.snapshot = structuredClone(state);
+                const otherItems = ReadingVocabStore.getByExam(other.article.examId, other.source);
+                ReadingVocabReader.openModal();
+                return { currentOccurrence, otherItems, words: structuredClone(words) };
+            }, other);
+
+            assert.equal(await page.locator('.vocab-occurrence-row').count(), 1);
+            assert.equal(await page.locator('.vocab-item').count(), 1);
+            await page.locator('#v-tab-all').click();
+            assert.equal(await page.locator('.vocab-item').count(), 2);
+            assert.equal(await page.locator('.vocab-occurrence-row').count(), 3);
+            assert.equal(await page.locator('.vocab-occurrence-row[data-anchor-status="resolved"]').count(), 1);
+            assert.equal(await page.locator('.vocab-occurrence-row[data-anchor-status="unverified"]').count(), 2,
+                'unopened article anchors must not be claimed as restored in the current article');
+            assert.deepEqual(await page.locator('.vocab-occurrence-row .vocab-item__source').allTextContents(),
+                ['Article A', other.article.title, other.article.title]);
+
+            for (const item of seeded.otherItems) {
+                const occurrence = item.occurrences[0];
+                // Select by exact persisted identity because shared quotes can be identical.
+                await page.evaluate(id => {
+                    const button = [...document.querySelectorAll('#vocab-list [data-action="remove-occurrence"]')]
+                        .find(button => button.dataset.occurrenceId === id);
+                    button.click();
+                }, occurrence.id);
+                await page.waitForFunction(() => !ReadingVocabReader._occurrenceBusy);
+                const removed = await page.evaluate(({ other, id }) => ({
+                    current: ReadingVocabStore.getByExam('article-a'),
+                    other: ReadingVocabStore.getByExam(other.article.examId, other.source),
+                    undo: ReadingVocabReader._undoOccurrence,
+                    exists: __readingAuthority.snapshot.reading.occurrences.some(row => row.id === id),
+                    revision: __readingAuthority.revision,
+                    generation: __readingAuthority.generation
+                }), { other, id: occurrence.id });
+                assert.equal(removed.exists, false);
+                assert.equal(removed.current[0].occurrences[0].id, seeded.currentOccurrence.id);
+                assert.equal(removed.undo.command.article.examId, other.article.examId);
+                assert.equal(removed.undo.command.article.title, other.article.title);
+                assert.deepEqual(removed.undo.command.source, other.source);
+                assert.deepEqual(removed.undo.observed, { revision: removed.revision, generation: removed.generation });
+                assert.equal(await page.locator('.vocab-occurrence-row').count(), 2);
+                assert.equal(await page.locator('mark.vocab-highlight').count(), 1);
+                if (item.word === 'passage') {
+                    const retained = removed.other.find(row => row.word === 'passage');
+                    assert.equal(retained.occurrences.length, 0);
+                    assert.equal(retained.associations[0].manual, true);
+                } else assert.equal(removed.other.some(row => row.word === 'exclusive'), false);
+
+                await page.locator('[data-action="undo-occurrence"]').click();
+                await page.waitForFunction(() => !ReadingVocabReader._occurrenceBusy);
+                const restored = await page.evaluate(({ other, id }) => ({
+                    current: ReadingVocabStore.getByExam('article-a'),
+                    other: ReadingVocabStore.getByExam(other.article.examId, other.source),
+                    occurrences: __readingAuthority.snapshot.reading.occurrences.filter(row => row.id === id),
+                    words: __readingAuthority.snapshot.lists['reading-highlights'].words,
+                    lastCall: __readingAuthority.calls.at(-1), undo: ReadingVocabReader._undoOccurrence
+                }), { other, id: occurrence.id });
+                assert.equal(restored.occurrences.length, 1, 'undo must restore the original occurrence identity');
+                assert.equal(restored.other.find(row => row.word === item.word).occurrences[0].id, occurrence.id);
+                assert.equal(restored.current[0].occurrences.length, 1);
+                assert.equal(restored.current[0].occurrences[0].id, seeded.currentOccurrence.id);
+                assert.deepEqual(restored.words, seeded.words);
+                assert.deepEqual(restored.lastCall.options, {
+                    observedRevision: removed.revision, observedGeneration: removed.generation
+                });
+                assert.equal(restored.undo, null);
+                assert.equal(await page.locator('.vocab-occurrence-row').count(), 3);
+                assert.equal(await page.locator('mark.vocab-highlight').count(), 1);
+            }
+            await page.locator('#v-tab-current').click();
+            assert.equal(await page.locator('.vocab-occurrence-row').count(), 1);
+            assert.equal(await page.locator('.vocab-item').count(), 1);
+        });
+    }
+});

--- a/developer/tests/js/readingVocabOccurrenceUndo.test.js
+++ b/developer/tests/js/readingVocabOccurrenceUndo.test.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+const source = name => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const runtime = [
+    'data/v2/dataCatalog.js', 'data/v2/dataKernel.js',
+    'data/practiceRecordSource.js', 'data/v2/readingVocabularyModel.js'
+].map(source);
+const appData = source('data/v2/appData.js');
+const readerRuntime = [
+    'components/readingVocabAnchors.js', 'components/readingVocabContent.js',
+    'components/readingVocabReader.js'
+].map(source);
+const collection = {
+    source: { kind: 'builtin', id: 'default' },
+    article: { examId: 'undo-receipt-race', title: 'Undo receipt race' },
+    word: { word: 'coral', meaning: 'An existing definition', note: 'Keep this note' },
+    occurrence: {
+        scopeId: 'passage/p-1', contentVersion: 'fixture-v1',
+        quote: 'coral', startOffset: 0, endOffset: 5, before: '', after: ' here.'
+    },
+    at: '2026-09-08T02:00:00.000Z'
+};
+
+async function initialize(page, url, withReader = false) {
+    await page.goto(url);
+    for (const content of runtime) await page.addScriptTag({ content });
+    if (withReader) {
+        await page.evaluate(() => {
+            window.undoBoundary = {};
+            const prototype = window.__AppDataV2Internals.DataKernel.prototype;
+            const mutate = prototype.mutate;
+            prototype.mutate = async function (changes, options) {
+                const receipt = await mutate.call(this, changes, options);
+                if (window.undoBoundary.enabled && options.intent?.command === 'reading-removeOccurrence') {
+                    window.undoBoundary.receipt = receipt;
+                    window.undoBoundary.paused = true;
+                    // Only pause delivery of a real, committed IndexedDB receipt.
+                    // The other page can now commit before AppData's readback.
+                    await new Promise(resolve => { window.undoBoundary.release = resolve; });
+                }
+                return receipt;
+            };
+        });
+    }
+    await page.addScriptTag({ content: appData });
+    await page.evaluate(() => AppData.ready);
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+    if (withReader) {
+        for (const content of readerRuntime) await page.addScriptTag({ content });
+        await page.evaluate(() => ReadingVocabStore.init());
+    }
+}
+
+test('occurrence undo uses its committed removal fence across concurrent readback changes', { timeout: 60_000 }, async t => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+        response.end('<!doctype html><title>Occurrence undo integration</title>');
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    let browser;
+    t.after(async () => {
+        if (browser) await browser.close();
+        server.closeAllConnections();
+        await new Promise(resolve => server.close(resolve));
+    });
+    browser = await chromium.launch({ headless: true,
+        ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}) });
+    const url = `http://127.0.0.1:${server.address().port}/`;
+
+    for (const intervening of ['clearReading', 'replace', 'unrelatedCollection']) {
+        await t.test(intervening, async t => {
+            const context = await browser.newContext();
+            t.after(() => context.close());
+            const reader = await context.newPage();
+            const writer = await context.newPage();
+            await initialize(reader, url, true);
+            await initialize(writer, url);
+            const seeded = await reader.evaluate(async command => {
+                const receipt = await ReadingVocabStore.mutate('collect', command);
+                ReadingVocabReader.currentExamId = command.article.examId;
+                ReadingVocabReader.currentSource = command.source;
+                ReadingVocabReader.currentExam = { title: command.article.title };
+                return receipt;
+            }, collection);
+            await reader.evaluate(() => {
+                const occurrence = ReadingVocabStore.getByExam(ReadingVocabReader.currentExamId)[0].occurrences[0];
+                window.undoBoundary.enabled = true;
+                window.pendingRemoval = ReadingVocabReader.removeOccurrence(occurrence.id);
+            });
+            await reader.waitForFunction(() => window.undoBoundary.paused);
+            const ownRevision = await reader.evaluate(() => window.undoBoundary.receipt.revisions['vocab.readingState']);
+
+            await writer.evaluate(async ({ intervening, collection }) => {
+                if (intervening === 'clearReading') {
+                    await AppData.vocab.mutateReading('clearReading', {});
+                } else if (intervening === 'replace') {
+                    const current = await AppData.backups.export({ domains: ['vocab'] });
+                    const plan = await AppData.backups.previewImport(current, { replace: true });
+                    await AppData.backups.commitImport(plan.id, { confirmDestructive: true });
+                } else {
+                    await AppData.vocab.mutateReading('collect', {
+                        ...collection, article: { examId: 'another-article', title: 'Another article' },
+                        word: { word: 'water', meaning: 'Water' }, occurrence: {
+                            ...collection.occurrence, quote: 'water'
+                        }
+                    });
+                }
+            }, { intervening, collection });
+            const fence = await reader.evaluate(async () => {
+                window.undoBoundary.release();
+                await window.pendingRemoval;
+                const durable = await AppData.vocab.getReadingSnapshot();
+                return { observed: ReadingVocabReader._undoOccurrence?.observed,
+                    currentRevision: durable.revision, currentGeneration: durable.generation };
+            });
+            assert.equal(fence.observed.revision, ownRevision, 'undo must retain its own committed revision, not the newer readback revision');
+            assert.equal(fence.observed.generation, seeded.generation, 'undo must retain the generation in which removal began');
+            assert.ok(fence.currentRevision > ownRevision, 'the second page must commit in the removal/readback gap');
+            if (intervening === 'replace') assert.notEqual(fence.currentGeneration, seeded.generation);
+
+            const after = await reader.evaluate(async () => {
+                await ReadingVocabReader.undoOccurrence();
+                const durable = await AppData.vocab.getReadingSnapshot();
+                return { snapshot: durable.snapshot, pendingUndo: !!ReadingVocabReader._undoOccurrence,
+                    message: document.querySelector('#vocab-toast').textContent };
+            });
+            const coral = after.snapshot.reading.occurrences.filter(row => row.quote === 'coral');
+            if (intervening === 'unrelatedCollection') {
+                assert.equal(coral.length, 1, 'an unrelated acknowledged write must not block a valid undo');
+                assert.equal(after.snapshot.reading.occurrences.filter(row => row.quote === 'water').length, 1);
+                assert.equal(after.pendingUndo, false);
+            } else {
+                assert.equal(coral.length, 0, 'undo must not resurrect an occurrence after a newer clear or replacement');
+                assert.equal(after.snapshot.reading.associations.length, 0);
+                assert.equal(after.pendingUndo, true, 'failed undo retains its explicit recoverable state');
+                assert.match(after.message, /撤销失败/);
+            }
+            const originalOwner = seeded.snapshot.lists['reading-highlights'].words[0];
+            const owner = after.snapshot.lists['reading-highlights'].words.find(row => row.id === originalOwner.id);
+            assert.deepEqual(owner, originalOwner, 'removal and undo must preserve the canonical word');
+        });
+    }
+});

--- a/developer/tests/js/readingVocabQuestionIsolation.test.js
+++ b/developer/tests/js/readingVocabQuestionIsolation.test.js
@@ -59,7 +59,8 @@ test('reader questions are selectable text with isolated identities and no answe
             questions.querySelector('.vocab-question-options').click();
             return {
                 selected, text: questions.textContent,
-                controls: questions.querySelectorAll('input, textarea, select, button, form, label, [name], [for], [href], [contenteditable], [draggable], [tabindex], [onclick], [onmousedown], .drag-item, .match-dropzone, .drop-target-summary, .draggable-word, .card, .pool-items, .options-pool, .cardpool, [data-question]').length,
+                controls: questions.querySelectorAll('input, textarea, select, button, form, label, [name], [for], [href], [contenteditable], [draggable], [tabindex]:not([data-vocab-scope]), [onclick], [onmousedown], .drag-item, .match-dropzone, .drop-target-summary, .draggable-word, .card, .pool-items, .options-pool, .cardpool, [data-question]').length,
+                keyboardScopes: [...questions.querySelectorAll('[data-vocab-scope]')].map(node => ({ id: node.dataset.vocabScope, tabIndex: node.tabIndex })),
                 duplicateIds: identities.filter((id, index) => identities.indexOf(id) !== index),
                 answer: document.getElementById('answer').value,
                 checked: document.getElementById('choice-a').checked,
@@ -68,6 +69,9 @@ test('reader questions are selectable text with isolated identities and no answe
         });
         assert.equal(state.selected, 'question');
         assert.equal(state.controls, 0);
+        assert.ok(state.keyboardScopes.length > 0, 'Question text remains reachable for keyboard selections');
+        assert.ok(state.keyboardScopes.every(scope => /^questions\/q-\d+\/p-\d+$/.test(scope.id) && scope.tabIndex === 0));
+        assert.equal(new Set(state.keyboardScopes.map(scope => scope.id)).size, state.keyboardScopes.length);
         assert.deepEqual(state.duplicateIds, []);
         assert.equal(state.answer, 'original');
         assert.equal(state.checked, true, 'checked reader radios must be inert before insertion');

--- a/developer/tests/js/readingVocabReaderLayout.test.js
+++ b/developer/tests/js/readingVocabReaderLayout.test.js
@@ -10,20 +10,20 @@ const vocabReaderPath = path.join(root, 'js/components/readingVocabReader.js');
 const cssPath = path.join(root, 'css/vocab-reader.css');
 
 const vocabReaderSource = fs.readFileSync(vocabReaderPath, 'utf8');
+const contentSource = fs.readFileSync(path.join(root, 'js/components/readingVocabContent.js'), 'utf8');
 const cssSource = fs.readFileSync(cssPath, 'utf8');
 
-// 1. 验证 isPassageInstruction 函数存在并能够识别指导语句子
+// Source normalization belongs to the shared content helper.
 assert.match(
-    vocabReaderSource,
-    /function isPassageInstruction\(text\)/,
-    'isPassageInstruction function must be defined'
+    contentSource,
+    /function isInstruction\(text\)/,
+    'The content helper must identify introductory instructions'
 );
 
-// 2. 验证 extractPassageData 函数能够分离指导语与段落
 assert.match(
     vocabReaderSource,
-    /function extractPassageData\(rawHtml/,
-    'extractPassageData function must be defined'
+    /ReadingVocabContent\.normalizePassage\(/,
+    'The reader must use the complete ordered-passage normalizer'
 );
 
 // 3. 验证 Tab 按钮文本改为 "全文"，并且不再是 "全部全文"
@@ -42,13 +42,13 @@ assert.match(
 // 4. 验证段落标题与标签使用英文缩写 Para A、Para B 等，而非中文“段落 A”
 assert.doesNotMatch(
     vocabReaderSource,
-    /data-para="\$\{b\.letter\}">段落 \$\{b\.letter\}<\/button>/,
+    /data-para="\$\{b\.id\}">段落 \$\{b\.letter\}<\/button>/,
     'Tab buttons must not use Chinese 段落'
 );
 
 assert.match(
     vocabReaderSource,
-    /data-para="\$\{b\.letter\}">Para \$\{b\.letter\}<\/button>/,
+    /data-para="\$\{b\.id\}">Para \$\{b\.letter\}<\/button>/,
     'Tab buttons must use English abbreviation Para ${b.letter}'
 );
 

--- a/developer/tests/js/readingVocabReaderSafety.test.js
+++ b/developer/tests/js/readingVocabReaderSafety.test.js
@@ -228,6 +228,30 @@ test('reading vocab reader preserves text boundaries and the active reading sess
             } finally { await page.close(); }
         });
 
+        await t.test('a failed source load retains the requested library and its recoverable occurrences', async () => {
+            const page = await createPage(browser);
+            try {
+                await openArticle(page);
+                const state = await page.evaluate(async () => {
+                    const source = { kind: 'builtin', id: 'default' };
+                    await ReadingVocabStore.add('retained', 'missing-builtin', 'Missing article', 'retained context', {
+                        scopeId: 'passage/p-1', contentVersion: 'legacy-reader-v1',
+                        quote: 'retained', text: 'retained', startOffset: 0, endOffset: 8, before: '', after: ' context'
+                    }, source);
+                    await ReadingVocabReader.open('article', { source: { kind: 'imported', id: 'unavailable-library' } });
+                    await __queueOpen('missing-builtin', '__missing', 'missing-builtin.js', { source });
+                    __finishScript('missing-builtin.js', 'missing-builtin', { error: true });
+                    await __missing;
+                    ReadingVocabReader.openModal();
+                    return { source: ReadingVocabReader.currentSource,
+                        unresolved: document.querySelectorAll('[data-anchor-status="unresolved"]').length,
+                        words: ReadingVocabStore.getByExam('missing-builtin', source).map(row => row.word),
+                        marks: document.querySelectorAll('mark.vocab-highlight').length };
+                });
+                assert.deepEqual(state, { source: { kind: 'builtin', id: 'default' }, unresolved: 1, words: ['retained'], marks: 0 });
+            } finally { await page.close(); }
+        });
+
         await t.test('exam badges render literal text while generated passage formatting remains intact', async () => {
             const page = await createPage(browser);
             try {
@@ -286,14 +310,14 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     const cleared = ReadingVocabReader.currentPayload === null && ReadingVocabReader.currentExam === null && ReadingVocabReader.currentExplanation === null;
                     __finishScript('b.js', 'b');
                     await __openB;
-                    const before = document.getElementById('vocab-trans-text-A').textContent;
+                    const before = document.getElementById('vocab-trans-text-p-1').textContent;
                     __finishScript('b-explanation.js', 'b', { explanation: true, title: 'B translation' });
                     await Promise.resolve();
                     await Promise.resolve();
                     __finishScript('a-explanation.js', 'a', { explanation: true, title: 'A translation' });
                     await Promise.resolve();
                     await Promise.resolve();
-                    return { cleared, before, translation: document.getElementById('vocab-trans-text-A').textContent, current: ReadingVocabReader.currentExplanation.passageNotes[0].text };
+                    return { cleared, before, translation: document.getElementById('vocab-trans-text-p-1').textContent, current: ReadingVocabReader.currentExplanation.passageNotes[0].text };
                 });
                 assert.deepEqual(state, { cleared: true, before: '加载中...', translation: 'B translation', current: 'B translation' });
             } finally { await page.close(); }
@@ -372,11 +396,11 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     __finishScript('a.js', 'a');
                     await __openA;
                     ReadingVocabReader.close();
-                    const before = document.getElementById('vocab-trans-text-A').textContent;
+                    const before = document.getElementById('vocab-trans-text-p-1').textContent;
                     __finishScript('a-explanation.js', 'a', { explanation: true, title: 'closed translation' });
                     await Promise.resolve();
                     await Promise.resolve();
-                    const closedUnchanged = before === document.getElementById('vocab-trans-text-A').textContent;
+                    const closedUnchanged = before === document.getElementById('vocab-trans-text-p-1').textContent;
                     __READING_EXAM_DATA__.clear();
                     await __queueOpen('a', '__oldOpen', 'old-a.js');
                     ReadingVocabReader.close();
@@ -405,6 +429,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     const errorText = document.querySelector('.vocab-error-state p').textContent;
                     const unsafeNodes = document.querySelectorAll('.vocab-error-state img, .vocab-error-state [onclick]').length;
                     document.querySelector('.vocab-error-state button').click();
+                    for (let step = 0; step < 50 && !__pendingScripts.length; step++) await Promise.resolve();
                     return { errorText, unsafeNodes, current: ReadingVocabReader.currentExamId, retryCount: __pendingScripts.length, injected: !!window.__injected, back: document.querySelector('#vocab-reader-back-btn span').textContent };
                 });
                 assert.ok(state.errorText.includes('<img src=x onerror=alert(1)>'));

--- a/developer/tests/js/readingVocabSelectionPending.test.js
+++ b/developer/tests/js/readingVocabSelectionPending.test.js
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { chromium } from 'playwright';
+import { createPage, openArticle } from './helpers/readingVocabReaderHarness.js';
+
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
+async function select(page, word, key, selector = '#vocab-passage-content', occurrence = 0) {
+    await page.evaluate(({ word, key, selector, occurrence }) => {
+        __selectText(selector, word, occurrence);
+        window[key] = ReadingVocabReader.captureSelection();
+    }, { word, key, selector, occurrence });
+}
+
+async function state(page) {
+    return page.evaluate(() => ({
+        calls: __readingAuthority.calls.filter(call => call.type === 'collect').length,
+        pending: __readingAuthority.pending.length,
+        quotes: __readingAuthority.snapshot.reading.occurrences.map(row => row.quote),
+        marks: [...document.querySelectorAll('mark.vocab-highlight')].map(mark => mark.textContent),
+        unresolved: ReadingVocabReader.unresolvedOccurrences.length,
+        message: document.querySelector('#vocab-toast').textContent
+    }));
+}
+
+test('pending selections reserve only overlapping intervals until save acknowledgement', { timeout: 60_000 }, async t => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    t.after(() => browser.close());
+
+    for (const [label, first, second] of [
+        ['identical', 'passage with', 'passage with'],
+        ['contained', 'passage with', 'passage'],
+        ['containing', 'passage', 'passage with'],
+        ['partial overlap', 'passage with', 'with enough']
+    ]) {
+        await t.test(`rejects ${label} selection while the first save is delayed`, async t => {
+            const page = await createPage(browser);
+            t.after(() => page.close());
+            await openArticle(page);
+            await page.evaluate(() => { __readingAuthority.defer = true; });
+            await select(page, first, '__firstCapture');
+            await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+            await select(page, second, '__secondCapture');
+            await page.evaluate(() => __secondCapture);
+            assert.deepEqual(await state(page), {
+                calls: 1, pending: 1, quotes: [], marks: [], unresolved: 0, message: '正在保存…'
+            });
+            await page.evaluate(async () => {
+                __readingAuthority.pending.shift().resolve();
+                await __firstCapture;
+            });
+            const saved = await state(page);
+            assert.deepEqual({ ...saved, message: undefined }, {
+                calls: 1, pending: 0, quotes: [first], marks: [first], unresolved: 0, message: undefined
+            });
+            assert.equal(saved.message, `✅ "${first}" 已收录并黄色高亮`);
+        });
+    }
+
+    await t.test('allows adjacent and disjoint intervals in the same scope', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page, 'article', 'watermelon water');
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'water', '__firstCapture', '#vocab-passage-content em');
+        await select(page, 'melon', '__adjacentCapture', '#vocab-passage-content em');
+        await select(page, 'water', '__disjointCapture', '#vocab-passage-content em', 1);
+        await page.waitForFunction(() => __readingAuthority.pending.length === 3);
+        assert.deepEqual(await state(page), {
+            calls: 3, pending: 3, quotes: [], marks: [], unresolved: 0, message: '正在保存…'
+        });
+        const intervals = await page.evaluate(() => __readingAuthority.calls.filter(call => call.type === 'collect')
+            .map(call => call.command.occurrence));
+        assert.equal(intervals[0].endOffset, intervals[1].startOffset, 'the first two captures share an endpoint');
+        assert.ok(intervals[1].endOffset < intervals[2].startOffset);
+        await page.evaluate(async () => {
+            for (const key of ['__firstCapture', '__adjacentCapture', '__disjointCapture']) {
+                __readingAuthority.pending.shift().resolve();
+                await window[key];
+            }
+        });
+        const saved = await state(page);
+        assert.deepEqual(saved.quotes, ['water', 'melon', 'water']);
+        assert.deepEqual(saved.marks, ['water', 'melon', 'water']);
+        assert.equal(saved.unresolved, 0);
+    });
+
+    await t.test('allows the same interval in separate text scopes', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page, 'article', 'water');
+        await page.evaluate(() => {
+            const question = document.querySelector('#vocab-questions-content [data-vocab-scope]');
+            question.textContent = document.querySelector('#vocab-passage-content [data-vocab-scope]').textContent;
+            __readingAuthority.defer = true;
+        });
+        await select(page, 'water', '__passageCapture');
+        await select(page, 'water', '__questionCapture', '#vocab-questions-content');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 2);
+        const intervals = await page.evaluate(() => __readingAuthority.calls.filter(call => call.type === 'collect')
+            .map(call => call.command.occurrence));
+        assert.equal(intervals[0].startOffset, intervals[1].startOffset);
+        assert.equal(intervals[0].endOffset, intervals[1].endOffset);
+        assert.notEqual(intervals[0].scopeId, intervals[1].scopeId);
+        assert.deepEqual((await state(page)).marks, []);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __passageCapture;
+            __readingAuthority.pending.shift().resolve();
+            await __questionCapture;
+        });
+        const saved = await state(page);
+        assert.deepEqual(saved.quotes, ['water', 'water']);
+        assert.deepEqual(saved.marks, ['water', 'water']);
+        assert.equal(saved.unresolved, 0);
+    });
+
+    await t.test('releases a failed interval so an overlapping retry can save', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page);
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'passage with', '__firstCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().reject(new Error('Injected save failure'));
+            await __firstCapture;
+        });
+        const failed = await state(page);
+        assert.deepEqual(failed.quotes, []);
+        assert.deepEqual(failed.marks, []);
+        assert.match(failed.message, /保存失败/);
+        await select(page, 'passage', '__retryCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __retryCapture;
+        });
+        const saved = await state(page);
+        assert.equal(saved.calls, 2);
+        assert.deepEqual(saved.quotes, ['passage']);
+        assert.deepEqual(saved.marks, ['passage']);
+        assert.equal(saved.unresolved, 0);
+    });
+
+    await t.test('reopening the same article retains overlapping reservations until a stale save succeeds', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page);
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'passage with', '__oldCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+        await page.evaluate(async () => {
+            ReadingVocabReader.close();
+            __readingAuthority.defer = false;
+            await ReadingVocabReader.open('article');
+            __readingAuthority.defer = true;
+        });
+        await select(page, 'passage', '__newCapture');
+        await page.evaluate(() => __newCapture);
+        assert.deepEqual(await state(page), {
+            calls: 1, pending: 1, quotes: [], marks: [], unresolved: 0, message: ''
+        });
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __oldCapture;
+        });
+        await select(page, 'passage', '__overlapCapture');
+        await page.evaluate(() => __overlapCapture);
+        assert.deepEqual(await state(page), {
+            calls: 1, pending: 0, quotes: ['passage with'], marks: ['passage with'], unresolved: 0, message: ''
+        });
+    });
+
+    await t.test('stale failure releases only its own interval and permits an overlapping retry', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page);
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'passage with', '__oldCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+        await page.evaluate(async () => {
+            ReadingVocabReader.close();
+            __readingAuthority.defer = false;
+            await ReadingVocabReader.open('article');
+            __readingAuthority.defer = true;
+        });
+        await select(page, 'enough text', '__newCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 2);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().reject(new Error('Injected stale-session failure'));
+            await __oldCapture;
+        });
+        await select(page, 'enough', '__overlapCapture');
+        await page.evaluate(() => __overlapCapture);
+        assert.deepEqual(await state(page), {
+            calls: 2, pending: 1, quotes: [], marks: [], unresolved: 0, message: '正在保存…'
+        });
+        await select(page, 'passage', '__retryCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 2);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __newCapture;
+            __readingAuthority.pending.shift().resolve();
+            await __retryCapture;
+        });
+        const saved = await state(page);
+        assert.equal(saved.calls, 3);
+        assert.deepEqual(saved.quotes, ['enough text', 'passage']);
+        assert.deepEqual(saved.marks, ['passage', 'enough text']);
+        assert.equal(saved.unresolved, 0);
+    });
+
+    await t.test('a pending save does not reserve matching text in a different article', async t => {
+        const page = await createPage(browser);
+        t.after(() => page.close());
+        await openArticle(page, 'article-a', 'same title');
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'passage with', '__oldCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 1);
+        await page.evaluate(() => { __readingAuthority.defer = false; });
+        await openArticle(page, 'article-b', 'same title');
+        await page.evaluate(() => { __readingAuthority.defer = true; });
+        await select(page, 'passage', '__newCapture');
+        await page.waitForFunction(() => __readingAuthority.pending.length === 2);
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __oldCapture;
+        });
+        const pending = await state(page);
+        assert.deepEqual(pending.quotes, ['passage with']);
+        assert.deepEqual(pending.marks, []);
+        assert.equal(pending.message, '正在保存…');
+        await page.evaluate(async () => {
+            __readingAuthority.pending.shift().resolve();
+            await __newCapture;
+        });
+        const saved = await state(page);
+        assert.equal(saved.calls, 2);
+        assert.deepEqual(saved.quotes, ['passage with', 'passage']);
+        assert.deepEqual(saved.marks, ['passage']);
+        assert.equal(saved.unresolved, 0);
+    });
+});

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -16078,6 +16078,17 @@ if (typeof module !== 'undefined' && module.exports) {
             return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
         },
 
+        getOccurrenceOwner(occurrence) {
+            const reading = this._state?.snapshot.reading;
+            const association = reading?.associations.find(row => row.id === occurrence.associationId);
+            const article = reading?.articles.find(row => row.id === association?.articleId);
+            const source = reading?.sources.find(row => row.id === article?.sourceId);
+            if (!article || !source) return null;
+            return { articleId: article.id,
+                source: { kind: source.kind, id: source.libraryId },
+                article: { examId: article.examId, title: article.title } };
+        },
+
         adopt(state) {
             if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
             this._state = state;
@@ -16523,6 +16534,7 @@ if (typeof module !== 'undefined' && module.exports) {
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        // Durable writes survive closing/reopening; release only when they settle.
         _selectionPending: new Set(),
         _undoOccurrence: null,
         _occurrenceBusy: false,
@@ -16534,7 +16546,6 @@ if (typeof module !== 'undefined' && module.exports) {
             this.toastTimer = null;
             this._undoOccurrence = null;
             this.unresolvedOccurrences = [];
-            this._selectionPending.clear();
             this._occurrenceBusy = false;
             overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
             overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
@@ -17325,9 +17336,15 @@ if (typeof module !== 'undefined' && module.exports) {
             const captured = global.ReadingVocabAnchors.capture(scope, range);
             if (!captured) return;
             const requestId = this._openRequestId;
-            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
-            if (this._selectionPending.has(pendingId)) return;
-            this._selectionPending.add(pendingId);
+            // Pending saves have no paint yet, so reserve their text intervals
+            // until acknowledgement to prevent invisible overlapping captures.
+            const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId));
+            const pendingSelection = { articleId, scopeId: captured.scopeId,
+                startOffset: captured.startOffset, endOffset: captured.endOffset };
+            if ([...this._selectionPending].some(pending => pending.articleId === articleId &&
+                pending.scopeId === captured.scopeId && captured.startOffset < pending.endOffset &&
+                captured.endOffset > pending.startOffset)) return;
+            this._selectionPending.add(pendingSelection);
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
@@ -17342,7 +17359,7 @@ if (typeof module !== 'undefined' && module.exports) {
             } catch (error) {
                 if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
             } finally {
-                this._selectionPending.delete(pendingId);
+                this._selectionPending.delete(pendingSelection);
             }
         },
 
@@ -17422,13 +17439,14 @@ if (typeof module !== 'undefined' && module.exports) {
 
         async removeOccurrence(occurrenceId) {
             if (this._occurrenceBusy) return;
-            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+            const item = ReadingVocabStore.getAll()
                 .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
             const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
             if (!occurrence) return;
+            const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+            if (!owner) return;
             const requestId = this._openRequestId;
-            const undo = { source: { ...this.currentSource },
-                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+            const undo = { source: owner.source, article: owner.article,
                 word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
                 occurrence: { ...occurrence }, manual: false };
             const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
@@ -17613,15 +17631,22 @@ if (typeof module !== 'undefined' && module.exports) {
 
             let html = '';
             const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
+            const currentArticleId = this.currentExamId
+                ? global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId)) : null;
             list.forEach(item => {
-                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
-                    .find(row => row.id === item.id)?.occurrences || [];
-                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
-                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
-                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
-                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
-                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
-                    + '">移除这一处</button></div>').join('');
+                const occurrenceRows = item.occurrences.map(occurrence => {
+                    const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+                    const status = owner?.articleId === currentArticleId
+                        ? (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') : 'unverified';
+                    return '<div class="vocab-occurrence-row" data-occurrence-id="'
+                        + escapeHtml(occurrence.id) + '" data-anchor-status="' + status + '">'
+                        + (!isCurrent && owner ? '<span class="vocab-item__source">'
+                            + escapeHtml(owner.article.title || owner.article.examId) + '</span>' : '')
+                        + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                        + (status === 'unresolved' ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                        + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                        + '">移除这一处</button></div>';
+                }).join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -15552,6 +15552,467 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 
+/* ===== js/components/readingVocabContent.js ===== */
+(function (global) {
+    'use strict';
+
+    const CONTAINERS = new Set(['DIV', 'SECTION', 'ARTICLE', 'MAIN']);
+    const HEADING = /^H[1-6]$/;
+
+    function labelFromText(value) {
+        const match = String(value || '').trim().match(/^(?:Paragraph\s+)?([A-Z])(?:[.:)])?$/);
+        return match ? match[1] : '';
+    }
+
+    function standaloneLabel(node) {
+        if (HEADING.test(node.tagName) || node.matches('.paragraph-label, strong, b, p')) {
+            return labelFromText(node.textContent);
+        }
+        return '';
+    }
+
+    function leadingLabel(node) {
+        // A capital article at the start of an ordinary sentence is not a label.
+        // Inline labels must have their own leading element or say "Paragraph X".
+        const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+        let firstText;
+        while ((firstText = walker.nextNode()) && !firstText.textContent.trim()) {}
+        if (!firstText) return '';
+        const marker = firstText.parentElement.closest('strong, b, .paragraph-label');
+        if (marker && node.contains(marker)) {
+            const label = labelFromText(marker.textContent);
+            if (label) return label;
+        }
+        const explicit = node.textContent.trim().match(/^Paragraph\s+([A-Z])(?:\s*[:.)]\s*|\s+)/);
+        return explicit ? explicit[1] : '';
+    }
+
+    function isInstruction(text) {
+        return /^(?:You should spend\b[^.]*\bminutes\b|Questions\s+\d+\s*(?:[-–—]|to)\s*\d+\s+(?:are based|refer to)\b)/i.test(text.trim());
+    }
+
+    function isItalicSubtitle(node) {
+        if (node.tagName !== 'P') return false;
+        const text = node.textContent.trim();
+        const italicText = Array.from(node.querySelectorAll('em, i'))
+            .filter(element => !element.parentElement.closest('em, i'))
+            .map(element => element.textContent.trim()).join(' ').trim();
+        return !!text && text === italicText;
+    }
+
+    function hasContent(node) {
+        return !!node.textContent.trim() || node.matches('img, svg, video, audio, canvas, hr, math') ||
+            !!node.querySelector('img, svg, video, audio, canvas, hr, math');
+    }
+
+    function collectUnits(root) {
+        const units = [];
+        function visit(node) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (node.textContent.trim()) {
+                    const paragraph = document.createElement('p');
+                    paragraph.textContent = node.textContent;
+                    units.push(paragraph);
+                }
+                return;
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) return;
+            if (CONTAINERS.has(node.tagName) && !node.classList.contains('paragraph-wrapper')) {
+                Array.from(node.childNodes).forEach(visit);
+            } else if (hasContent(node)) {
+                units.push(node);
+            }
+        }
+        Array.from(root.childNodes).forEach(visit);
+        return units;
+    }
+
+    function ordinalLetter(index) {
+        let label = '';
+        for (let value = index + 1; value > 0; value = Math.floor((value - 1) / 26)) {
+            label = String.fromCharCode(65 + (value - 1) % 26) + label;
+        }
+        return label;
+    }
+
+    function normalizePassage(passage, fallbackTitle = '') {
+        // This is the same bodyHtml/html precedence and ordered-block contract
+        // used by the practice page's renderDataset implementation.
+        const rawHtml = (Array.isArray(passage?.blocks) ? passage.blocks : [])
+            .map(block => block?.bodyHtml || block?.html || '').join('\n');
+        const root = document.createElement('div');
+        root.innerHTML = rawHtml;
+        root.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone, .empty-space, #divider')
+            .forEach(node => node.remove());
+
+        let passageTitle = fallbackTitle;
+        let titleFound = false;
+        let beforeBody = true;
+        const instructions = [];
+        const subtitles = [];
+        const body = [];
+        for (const node of collectUnits(root)) {
+            const text = node.textContent.trim();
+            if (HEADING.test(node.tagName) && /^READING PASSAGE\s*\d*$/i.test(text)) continue;
+            if (beforeBody && isInstruction(text)) {
+                instructions.push(node.outerHTML);
+                continue;
+            }
+            if (beforeBody && !titleFound && /^H[1-3]$/.test(node.tagName) && !standaloneLabel(node)) {
+                passageTitle = text;
+                titleFound = true;
+                continue;
+            }
+            if (beforeBody && !standaloneLabel(node) &&
+                (/^H[4-6]$/.test(node.tagName) || (titleFound && isItalicSubtitle(node)))) {
+                subtitles.push(node.outerHTML);
+                continue;
+            }
+            beforeBody = false;
+            body.push(node);
+        }
+
+        const blocks = [];
+        let current = null;
+        let pendingHeadingHtml = '';
+        function finish() {
+            if (!current) return;
+            const textRoot = document.createElement('div');
+            textRoot.innerHTML = current.html;
+            if (hasContent(textRoot)) {
+                const index = blocks.length;
+                blocks.push({
+                    id: `p-${index + 1}`,
+                    letter: current.label || ordinalLetter(index),
+                    explicitLabel: !!current.label,
+                    html: current.html,
+                    text: textRoot.textContent.trim()
+                });
+            }
+            current = null;
+        }
+        function start(html, label = '') {
+            current = { html: pendingHeadingHtml + html, label };
+            pendingHeadingHtml = '';
+        }
+
+        for (const node of body) {
+            const marker = standaloneLabel(node);
+            if (marker) {
+                finish();
+                start('', marker);
+                continue;
+            }
+            if (node.classList.contains('paragraph-wrapper')) {
+                finish();
+                start(node.innerHTML, leadingLabel(node));
+                finish();
+                continue;
+            }
+            const inlineLabel = leadingLabel(node);
+            if (inlineLabel) {
+                finish();
+                start(node.outerHTML, inlineLabel);
+                continue;
+            }
+            if (HEADING.test(node.tagName) && !current?.label) {
+                finish();
+                pendingHeadingHtml += node.outerHTML;
+                continue;
+            }
+            if (current?.label) {
+                // Some sources split one lettered paragraph across multiple p
+                // elements. Keep every element under the explicit section label.
+                current.html += node.outerHTML;
+            } else {
+                finish();
+                start(node.outerHTML);
+            }
+        }
+        finish();
+        if (pendingHeadingHtml) {
+            start('');
+            finish();
+        }
+
+        return {
+            passageTitle,
+            instructionHtml: instructions.join('\n'),
+            subtitleHtml: subtitles.join('\n'),
+            rawHtml,
+            blocks
+        };
+    }
+
+    global.ReadingVocabContent = Object.freeze({ normalizePassage });
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
+/* ===== js/components/readingVocabAnchors.js ===== */
+(function (global) {
+    'use strict';
+
+    const SCOPE = '[data-vocab-scope]';
+    const EXCLUDED = 'script,style,noscript,template,button,input,textarea,select,option,' +
+        '[role="button"]:not(.vocab-highlight):not(.hl),[contenteditable]:not([contenteditable="false"]),' +
+        '.vocab-translation-card,.vocab-paragraph-tag,.vocab-answer-blank';
+    const HIGHLIGHT = '.vocab-highlight,.hl';
+    const BLOCK = 'p,div,li,td,th,blockquote,pre,h1,h2,h3,h4,h5,h6,section,article';
+    const CONTEXT_LENGTH = 48;
+
+    function hidden(element) {
+        if (element.hidden || element.getAttribute('aria-hidden') === 'true') return true;
+        const style = element.ownerDocument.defaultView.getComputedStyle(element);
+        return style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse';
+    }
+
+    function excluded(element, root) {
+        for (let current = element; current; current = current.parentElement) {
+            if (current.matches(EXCLUDED) || hidden(current)) return true;
+            if (current === root) break;
+        }
+        return false;
+    }
+
+    // Highlight wrappers contribute their original text. This keeps offsets and
+    // content versions stable while other occurrences are painted or removed.
+    function textNodes(root) {
+        if (!root || !root.ownerDocument) return [];
+        const nodes = [];
+        const walker = root.ownerDocument.createTreeWalker(root, 4);
+        let node;
+        while ((node = walker.nextNode())) {
+            if (node.parentElement && !excluded(node.parentElement, root)) nodes.push(node);
+        }
+        return nodes;
+    }
+
+    function text(root) {
+        return textNodes(root).map(node => node.nodeValue || '').join('');
+    }
+
+    function textVersion(value) {
+        let first = 0x811c9dc5;
+        let second = 0x9e3779b9;
+        for (let index = 0; index < value.length; index += 1) {
+            const code = value.charCodeAt(index);
+            first = Math.imul(first ^ code, 0x01000193);
+            second = Math.imul(second ^ code, 0x85ebca6b);
+        }
+        return `reader-text-v1:${value.length}:${(first >>> 0).toString(16)}:${(second >>> 0).toString(16)}`;
+    }
+
+    function versionForText(root, value) {
+        const sourceVersion = root.getAttribute('data-vocab-source-version');
+        const scopeVersion = textVersion(value);
+        return sourceVersion ? `reader-scope-v2:${sourceVersion}:${scopeVersion}` : scopeVersion;
+    }
+
+    function version(root) { return versionForText(root, text(root)); }
+
+    function comparePoints(doc, leftNode, leftOffset, rightNode, rightOffset) {
+        const left = doc.createRange();
+        const right = doc.createRange();
+        left.setStart(leftNode, leftOffset);
+        left.collapse(true);
+        right.setStart(rightNode, rightOffset);
+        right.collapse(true);
+        return left.compareBoundaryPoints(0, right);
+    }
+
+    function offsetAtPoint(root, nodes, container, offset) {
+        if (container !== root && !root.contains(container)) return null;
+        let position = 0;
+        for (const node of nodes) {
+            const length = (node.nodeValue || '').length;
+            if (container === node) return position + offset;
+            if (comparePoints(root.ownerDocument, container, offset, node, 0) <= 0) return position;
+            if (comparePoints(root.ownerDocument, container, offset, node, length) < 0) return null;
+            position += length;
+        }
+        return position;
+    }
+
+    function resolveOffsets(root, start, end) {
+        if (!root || !Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start) return null;
+        const nodes = textNodes(root);
+        let position = 0;
+        let startNode;
+        let startInNode;
+        for (const node of nodes) {
+            const next = position + (node.nodeValue || '').length;
+            if (!startNode && start >= position && start < next) {
+                startNode = node;
+                startInNode = start - position;
+            }
+            if (startNode && end > position && end <= next) {
+                const range = root.ownerDocument.createRange();
+                range.setStart(startNode, startInNode);
+                range.setEnd(node, end - position);
+                return range;
+            }
+            position = next;
+        }
+        return null;
+    }
+
+    function calculateLocation(root, range) {
+        if (!root || !range || range.collapsed) return null;
+        try {
+            const nodes = textNodes(root);
+            const fullText = nodes.map(node => node.nodeValue || '').join('');
+            const startOffset = offsetAtPoint(root, nodes, range.startContainer, range.startOffset);
+            const endOffset = offsetAtPoint(root, nodes, range.endContainer, range.endOffset);
+            if (startOffset === null || endOffset === null || endOffset <= startOffset) return null;
+            const quote = fullText.slice(startOffset, endOffset);
+            return {
+                startOffset, endOffset, quote, text: quote,
+                before: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), startOffset),
+                after: fullText.slice(endOffset, endOffset + CONTEXT_LENGTH),
+                contentVersion: versionForText(root, fullText),
+                context: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), endOffset + CONTEXT_LENGTH)
+            };
+        } catch (_) { return null; }
+    }
+
+    function overlaps(range, node) {
+        const other = node.ownerDocument.createRange();
+        other.selectNode(node);
+        const doc = node.ownerDocument;
+        return comparePoints(doc, range.startContainer, range.startOffset, other.endContainer, other.endOffset) < 0 &&
+            comparePoints(doc, range.endContainer, range.endOffset, other.startContainer, other.startOffset) > 0;
+    }
+
+    function validRange(scope, range, allowHighlights = false) {
+        if (!range || range.collapsed || excluded(scope, scope)) return false;
+        if ((range.startContainer !== scope && !scope.contains(range.startContainer)) ||
+            (range.endContainer !== scope && !scope.contains(range.endContainer))) return false;
+        for (const element of scope.querySelectorAll('*')) {
+            if ((element.matches(EXCLUDED + ',br,hr') || (!allowHighlights && element.matches(HIGHLIGHT)) || hidden(element)) && overlaps(range, element)) return false;
+        }
+        let selectedBlock = null;
+        for (const node of textNodes(scope)) {
+            const doc = node.ownerDocument;
+            const selected = comparePoints(doc, range.startContainer, range.startOffset, node, node.length) < 0 &&
+                comparePoints(doc, range.endContainer, range.endOffset, node, 0) > 0;
+            if (!selected) continue;
+            if (node.parentElement.closest(SCOPE) !== scope || (!allowHighlights && node.parentElement.closest(HIGHLIGHT))) return false;
+            const block = node.parentElement.closest(BLOCK);
+            const boundary = block && scope.contains(block) ? block : scope;
+            if (selectedBlock && selectedBlock !== boundary) return false;
+            selectedBlock = boundary;
+        }
+        return selectedBlock !== null;
+    }
+
+    function cleanWord(value) {
+        return value.replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '').trim();
+    }
+
+    function capture(scope, range) {
+        if (!scope || !scope.matches(SCOPE)) return null;
+        try {
+            if (!validRange(scope, range)) return null;
+            const rawText = range.toString();
+            if (/[\r\n]/.test(rawText)) return null;
+            const word = cleanWord(rawText);
+            if (!word || word.length > 45 || !/[A-Za-z]/.test(word)) return null;
+            const rawLocation = calculateLocation(scope, range);
+            if (!rawLocation || rawLocation.quote !== rawText) return null;
+            const startOffset = rawLocation.startOffset + rawText.indexOf(word);
+            const trimmed = resolveOffsets(scope, startOffset, startOffset + word.length);
+            if (!trimmed || !validRange(scope, trimmed)) return null;
+            const scopeId = scope.getAttribute('data-vocab-scope');
+            if (!scopeId) return null;
+            const location = calculateLocation(scope, trimmed);
+            if (scope.getAttribute('data-vocab-source-version')) {
+                const sourceRoot = scope.closest('[data-vocab-source-root]');
+                const unique = sourceRoot && contextCandidates(sourceRoot, scope, location).length === 1;
+                location.contentVersion += unique ? '|context-unique' : '|context-scoped';
+            }
+            return { ...location, range: trimmed, word, scopeId, scope: scopeId };
+        } catch (_) { return null; }
+    }
+
+    function findScope(root, scopeId) {
+        if (!root || !scopeId) return null;
+        const matches = [];
+        if (root.matches && root.matches(SCOPE) && root.getAttribute('data-vocab-scope') === scopeId) matches.push(root);
+        for (const scope of root.querySelectorAll(SCOPE)) {
+            if (scope.getAttribute('data-vocab-scope') === scopeId) matches.push(scope);
+        }
+        return matches.length === 1 ? matches[0] : null;
+    }
+
+    function areaScopes(root, originalScope) {
+        const scopeId = originalScope.getAttribute('data-vocab-scope');
+        const area = /^(passage|questions)\//.exec(scopeId);
+        if (!area) return [originalScope];
+        const candidates = root.matches && root.matches(SCOPE) ? [root] : [];
+        candidates.push(...root.querySelectorAll(SCOPE));
+        return candidates.filter(scope => scope.getAttribute('data-vocab-scope').startsWith(area[0]));
+    }
+
+    function contextCandidates(root, originalScope, highlight) {
+        if (typeof highlight.before !== 'string' || typeof highlight.after !== 'string') return [];
+        const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+        const candidates = [];
+        for (const scope of areaScopes(root, originalScope)) {
+            const fullText = text(scope);
+            let position = fullText.indexOf(quote);
+            while (position !== -1) {
+                const end = position + quote.length;
+                const beforeMatches = highlight.before ?
+                    position >= highlight.before.length && fullText.slice(position - highlight.before.length, position) === highlight.before : position === 0;
+                const afterMatches = highlight.after ?
+                    fullText.slice(end, end + highlight.after.length) === highlight.after : end === fullText.length;
+                if (beforeMatches && afterMatches) {
+                    const range = resolveOffsets(scope, position, end);
+                    // Existing paint cannot turn an ambiguous textual anchor into
+                    // a unique one. Ignore paint only while counting candidates.
+                    if (range && range.toString() === quote && validRange(scope, range, true)) candidates.push({ scope, range });
+                }
+                if (candidates.length > 1) return candidates;
+                position = fullText.indexOf(quote, position + 1);
+            }
+        }
+        return candidates;
+    }
+
+    function resolve(root, highlight) {
+        if (!highlight) return null;
+        try {
+            const scope = findScope(root, highlight.scopeId || highlight.scope);
+            const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+            if (!scope || typeof quote !== 'string' || !quote || quote.length > 45 || /[\r\n]/.test(quote) || !/[A-Za-z]/.test(quote)) return null;
+            const fullText = text(scope);
+            const storedVersion = String(highlight.contentVersion || '');
+            const contextFlag = /\|context-(unique|scoped)$/.exec(storedVersion);
+            const baseVersion = contextFlag ? storedVersion.slice(0, contextFlag.index) : storedVersion;
+            if (baseVersion === versionForText(scope, fullText)) {
+                const start = highlight.startOffset;
+                const end = highlight.endOffset;
+                if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start || fullText.slice(start, end) !== quote) return null;
+                const range = resolveOffsets(scope, start, end);
+                return range && range.toString() === quote && validRange(scope, range) ? range : null;
+            }
+            // A source edit can shift an ordinal onto an identical paragraph.
+            // Current uniqueness alone is insufficient if the original source
+            // contained duplicates: removing the selected copy leaves a false
+            // unique survivor. Source-aware capture records that distinction.
+            const sourceAware = scope.getAttribute('data-vocab-source-version') || baseVersion.startsWith('reader-scope-v2:');
+            if (sourceAware && (!contextFlag || contextFlag[1] !== 'unique')) return null;
+            const candidates = contextCandidates(root, scope, highlight);
+            if (candidates.length !== 1) return null;
+            const candidate = candidates[0];
+            return validRange(candidate.scope, candidate.range) ? candidate.range : null;
+        } catch (_) { return null; }
+    }
+
+    global.ReadingVocabAnchors = Object.freeze({ textNodes, text, version, hashText: textVersion, resolveOffsets, calculateLocation, capture, resolve });
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
 /* ===== js/components/readingVocabReader.js ===== */
 (function initReadingVocabReader(global) {
     'use strict';
@@ -15633,9 +16094,9 @@ if (typeof module !== 'undefined' && module.exports) {
             return state;
         },
 
-        async mutate(type, command) {
+        async mutate(type, command, observedState = null) {
             if (!this._state) await this.init();
-            const observed = this._state;
+            const observed = observedState || this._state;
             let result;
             try {
                 result = await global.AppData.vocab.mutateReading(type, command, {
@@ -15665,7 +16126,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 scopeId: highlight.scopeId || highlight.scope,
                 contentVersion: highlight.contentVersion || 'legacy-reader-v1',
                 startOffset: highlight.startOffset, endOffset: highlight.endOffset,
-                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+                quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
                 source, article: { examId: String(examId), title: examTitle || '' },
@@ -15951,231 +16412,8 @@ if (typeof module !== 'undefined' && module.exports) {
     // ============================================================================
     // 阅读文本与段落清洗器
     // ============================================================================
-    function cleanPassageHtml(rawHtml) {
-        if (!rawHtml) return '';
-        const temp = document.createElement('div');
-        temp.innerHTML = rawHtml;
-
-        // 移除练习交互用的 dropzone 提示与容器
-        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
-        dropzones.forEach(dz => dz.remove());
-
-        // 移除多余的空占位与 divider
-        const empties = temp.querySelectorAll('.empty-space, #divider');
-        empties.forEach(el => el.remove());
-
-        return temp.innerHTML;
-    }
-
-    /**
-     * 判断文本是否属于考试指导语/前置题目说明
-     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
-     */
-    function isPassageInstruction(text) {
-        if (!text) return false;
-        const s = text.trim();
-        if (/spend about \d+ minutes/i.test(s)) return true;
-        if (/which are based on reading passage/i.test(s)) return true;
-        if (/based on reading passage \d*/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
-        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
-        return false;
-    }
-
-    /**
-     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
-     */
-    function extractPassageData(rawHtml, fallbackTitle = '') {
-        if (!rawHtml) {
-            return {
-                passageTitle: fallbackTitle,
-                subtitleHtml: '',
-                instructionHtml: '',
-                blocks: []
-            };
-        }
-
-        const cleaned = cleanPassageHtml(rawHtml);
-        const temp = document.createElement('div');
-        temp.innerHTML = cleaned;
-
-        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
-        let passageTitle = fallbackTitle;
-        const h3 = temp.querySelector('h3');
-        if (h3 && h3.textContent.trim()) {
-            passageTitle = h3.textContent.trim();
-            h3.remove();
-        } else {
-            const h2 = temp.querySelector('h2');
-            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
-                passageTitle = h2.textContent.trim();
-                h2.remove();
-            }
-        }
-
-        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
-        const readingPassageHeadings = temp.querySelectorAll('h2');
-        readingPassageHeadings.forEach(h => {
-            if (/^reading passage/i.test(h.textContent.trim())) {
-                h.remove();
-            }
-        });
-
-        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
-        let instructionHtml = '';
-        const allPs = Array.from(temp.querySelectorAll('p'));
-        for (const p of allPs) {
-            const text = p.textContent.trim();
-            if (isPassageInstruction(text)) {
-                if (!instructionHtml) {
-                    instructionHtml = p.innerHTML.trim();
-                }
-                p.remove(); // 绝不作为正文段落，不分配任何段落标签
-            }
-        }
-
-        // 3. 提取副标题 (如 h4)
-        let subtitleHtml = '';
-        const h4 = temp.querySelector('h4');
-        if (h4 && h4.textContent.trim()) {
-            subtitleHtml = h4.innerHTML.trim();
-            h4.remove();
-        }
-
-        // 4. 解析段落 blocks
-        const blocks = [];
-        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
-
-        if (wrappers && wrappers.length > 0) {
-            wrappers.forEach((wrap, index) => {
-                // 查找段落标识 letter
-                let letter = '';
-                const strong = wrap.querySelector('strong');
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
-                    if (match) {
-                        letter = match[1];
-                    } else {
-                        letter = String.fromCharCode(65 + index);
-                    }
-                }
-
-                // 获取段落主体 HTML
-                const p = wrap.querySelector('p');
-                const html = p ? p.innerHTML : wrap.innerHTML;
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: html,
-                    text: wrap.textContent.trim()
-                });
-            });
-        } else {
-            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
-            const remainingPs = temp.querySelectorAll('p');
-            let validIdx = 0;
-            remainingPs.forEach((p) => {
-                const text = p.textContent.trim();
-                if (!text || text.length < 20) return;
-                // 防御：若依然属于指导语，跳过
-                if (isPassageInstruction(text)) return;
-
-                const strong = p.querySelector('strong');
-                let letter = '';
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
-                    if (leadMatch) {
-                        letter = leadMatch[1];
-                    } else {
-                        letter = String.fromCharCode(65 + validIdx);
-                    }
-                }
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: p.innerHTML,
-                    text: text
-                });
-                validIdx++;
-            });
-        }
-
-        return {
-            passageTitle,
-            subtitleHtml,
-            instructionHtml,
-            blocks
-        };
-    }
-
-    function extractParagraphBlocks(rawHtml) {
-        return extractPassageData(rawHtml).blocks;
-    }
-
-    function getTextNodes(root) {
-        if (!root) return [];
-        const textNodes = [];
-        const walker = document.createTreeWalker(
-            root,
-            NodeFilter.SHOW_TEXT,
-            {
-                acceptNode(node) {
-                    const parent = node.parentElement;
-                    if (!parent) return NodeFilter.FILTER_REJECT;
-                    const tag = parent.tagName.toUpperCase();
-                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    return NodeFilter.FILTER_ACCEPT;
-                }
-            },
-            false
-        );
-        let n;
-        while ((n = walker.nextNode())) {
-            textNodes.push(n);
-        }
-        return textNodes;
-    }
-
-    function resolveRangeFromOffsets(root, start, end) {
-        const nodes = getTextNodes(root);
-        let offset = 0;
-        let startNode = null;
-        let endNode = null;
-        let startOffset = 0;
-        let endOffset = 0;
-        for (let i = 0; i < nodes.length; i++) {
-            const node = nodes[i];
-            const text = node.nodeValue || '';
-            const nextOffset = offset + text.length;
-            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
-                startNode = node;
-                startOffset = Math.max(0, start - offset);
-            }
-            if (!endNode && end > offset && end <= nextOffset) {
-                endNode = node;
-                endOffset = Math.max(0, end - offset);
-            }
-            if (startNode && endNode) break;
-            offset = nextOffset;
-        }
-        if (!startNode || !endNode) return null;
-        const range = document.createRange();
-        range.setStart(startNode, startOffset);
-        range.setEnd(endNode, endOffset);
-        return range;
-    }
+    // Content and Range rules are shared with the real-browser regression suite.
+    function getTextNodes(root) { return global.ReadingVocabAnchors.textNodes(root); }
 
     // ============================================================================
     // Parse in an inert template: even a pre-checked radio must never join a
@@ -16285,11 +16523,22 @@ if (typeof module !== 'undefined' && module.exports) {
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        _selectionPending: new Set(),
+        _undoOccurrence: null,
+        _occurrenceBusy: false,
+        unresolvedOccurrences: [],
 
         clearPendingWork(overlay) {
             this._pendingTimers.forEach(timer => clearTimeout(timer));
             this._pendingTimers.clear();
             this.toastTimer = null;
+            this._undoOccurrence = null;
+            this.unresolvedOccurrences = [];
+            this._selectionPending.clear();
+            this._occurrenceBusy = false;
+            overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
+            overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
+            overlay?.querySelector('#vocab-anchor-status')?.replaceChildren();
             const toast = overlay?.querySelector('#vocab-toast');
             if (toast) {
                 toast.classList.remove('show');
@@ -16355,13 +16604,13 @@ if (typeof module !== 'undefined' && module.exports) {
                     <!-- 沉浸式提示栏 -->
                     <div class="vocab-reader-banner">
                         <span class="vocab-banner-icon">✨</span>
-                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中用鼠标、触屏或 Shift＋方向键选择生词或短语（最多 45 字符）。保存后以<strong>黄色高亮</strong>标注；点击高亮可移除这一处。</span>
                     </div>
 
                     <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
                     <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
                         <!-- 阅读核心主内容区 -->
-                        <main class="vocab-reader-body" id="vocab-reader-body">
+                        <main class="vocab-reader-body" id="vocab-reader-body" data-vocab-source-root>
                             <!-- 文章区域 -->
                             <section class="vocab-passage-section" id="vocab-passage-section">
                                 <div class="vocab-passage-header">
@@ -16395,6 +16644,9 @@ if (typeof module !== 'undefined' && module.exports) {
 
                     <!-- 划词收录 Toast 提示 -->
                     <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+                    <div class="vocab-occurrence-actions" id="vocab-occurrence-actions" aria-live="polite"></div>
+                    <div class="vocab-occurrence-undo" id="vocab-occurrence-undo" role="status" aria-live="polite"></div>
+                    <div class="vocab-anchor-status" id="vocab-anchor-status" role="status" aria-live="polite"></div>
 
                     <!-- 生词本弹窗 Modal -->
                     <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
@@ -16688,156 +16940,43 @@ if (typeof module !== 'undefined' && module.exports) {
                 });
             }
 
-            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
-                const handleSelectionCapture = () => {
-                    const requestId = this._openRequestId;
-                    this.defer(async () => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
-                        const selection = window.getSelection();
-                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
-                        const rawText = selection.toString();
-                        const text = rawText.trim();
-
-                        // 限制在1到45个字符之间，避免大段全文误选
-                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
-                            return;
-                        }
-
-                        let range;
-                        try {
-                            range = selection.getRangeAt(0);
-                        } catch (_) {
-                            return;
-                        }
-                        if (!range || range.collapsed) return;
-
-                        // 确保选区位于文章正文或题目区域内
-                        const passageContent = overlay.querySelector('#vocab-passage-content');
-                        const questionsContent = overlay.querySelector('#vocab-questions-content');
-                        const commonNode = range.commonAncestorContainer;
-                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
-                        if (!commonEl) return;
-                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
-                            return;
-                        }
-                        // 忽略译文卡片、段落标签、按钮等非正文区域
-                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
-                            return;
-                        }
-
-                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
-                        const existingMark = commonEl.closest('mark.vocab-highlight');
-                        if (existingMark) {
-                            return;
-                        }
-
-                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
-                        const trimmedRange = this.trimRangeWhitespace(range);
-                        if (!trimmedRange || trimmedRange.collapsed) return;
-
-                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
-                        const targetCard = commonEl.closest('.vocab-paragraph-card');
-                        const targetQGroup = commonEl.closest('.vocab-question-group');
-                        let scope = 'passage';
-                        let scopeElement = passageContent;
-
-                        if (targetCard) {
-                            const letter = targetCard.dataset.letter || '';
-                            scope = letter ? `para-${letter}` : 'passage';
-                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
-                        } else if (targetQGroup) {
-                            scope = targetQGroup.id || 'questions';
-                            scopeElement = targetQGroup;
-                        } else if (questionsContent?.contains(commonEl)) {
-                            scope = 'questions';
-                            scopeElement = questionsContent;
-                        }
-
-                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
-                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
-
-                        // 获取上下文句子
-                        let contextSentence = '';
-                        try {
-                            const parentBlock = commonEl;
-                            if (parentBlock) {
-                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
-                            }
-                        } catch (_) {}
-
-                        const cleanWord = ReadingVocabStore.cleanWord(text);
-                        if (!cleanWord) return;
-
-                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
-                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
-                        if (!wrappedMark) return;
-
-                        const highlightRecord = {
-                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                            examId: this.currentExamId || '',
-                            scope: scope,
-                            startOffset: locInfo.startOffset,
-                            endOffset: locInfo.endOffset,
-                            before: locInfo.before,
-                            after: locInfo.after,
-                            occurrence: locInfo.occurrence,
-                            text: cleanWord
-                        };
-
-                        this.showToast('正在保存…');
-                        try {
-                            const result = await ReadingVocabStore.add(
-                                cleanWord,
-                                this.currentExamId,
-                                this.currentExam?.title || '',
-                                contextSentence,
-                                highlightRecord, this.currentSource
-                            );
-
-                            if (requestId !== this._openRequestId) return;
-                            if (result.added) {
-                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                                this.updateCounts();
-                                if (this.modalOpen) {
-                                    this.renderVocabList();
-                                }
-                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
-                            } else {
-                                throw new Error('Selection was not saved');
-                            }
-                        } catch (error) {
-                            if (wrappedMark.parentNode) {
-                                const parent = wrappedMark.parentNode;
-                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
-                                wrappedMark.remove();
-                                parent.normalize();
-                            }
-                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
-                        }
-                    }, 20);
+                const capture = event => {
+                    if (event?.target?.closest('button, input, textarea, select, .vocab-translation-card, .vocab-paragraph-tag')) return;
+                    this.defer(() => this.captureSelection(), 20);
                 };
-
-                on(readerBody, 'mouseup', handleSelectionCapture);
-                on(readerBody, 'touchend', handleSelectionCapture);
-
-                // 点击黄色高亮生词：朗读发音并轻量提示
-                on(readerBody, 'click', (e) => {
-                    const mark = e.target.closest('mark.vocab-highlight');
-                    if (mark) {
-                        const selection = window.getSelection();
-                        if (selection && selection.toString().trim().length > 0) {
-                            return; // 划选操作中不触发点击发音
-                        }
-                        const word = mark.dataset.word || mark.textContent.trim();
-                        if (word) {
-                            speakWord(word);
-                            this.showToast(`🔊 ${word} (已收录生词)`);
-                        }
+                on(readerBody, 'mouseup', capture);
+                on(readerBody, 'touchend', capture);
+                on(overlay, 'keyup', event => {
+                    if (event.key === 'Shift') capture(event);
+                });
+                on(readerBody, 'click', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && !window.getSelection()?.toString().trim()) this.showOccurrenceActions(mark);
+                });
+                on(readerBody, 'keydown', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && (event.key === 'Enter' || event.key === ' ')) {
+                        event.preventDefault();
+                        this.showOccurrenceActions(mark);
+                    } else {
+                        this.moveKeyboardSelection(event);
                     }
                 });
             }
+            on(overlay, 'click', event => {
+                const button = event.target.closest('[data-action]');
+                if (!button || button.disabled) return;
+                if (button.dataset.action === 'remove-occurrence') {
+                    event.stopPropagation();
+                    this.removeOccurrence(button.dataset.occurrenceId);
+                } else if (button.dataset.action === 'undo-occurrence') {
+                    this.undoOccurrence();
+                } else if (button.dataset.action === 'retry-anchors') {
+                    this.open(this.currentExamId, { source: this.currentSource });
+                }
+            });
 
             // ESC 键监听
             on(window, 'keydown', (e) => {
@@ -16908,9 +17047,10 @@ if (typeof module !== 'undefined' && module.exports) {
 
             try {
                 // 加载试卷数据
-                const [payload, source] = await Promise.all([
-                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
-                ]);
+                const source = await ReadingVocabStore.resolveSource(options);
+                if (requestId !== this._openRequestId) return;
+                this.currentSource = source;
+                const payload = await loadReadingExamPayload(examId);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
@@ -16955,6 +17095,11 @@ if (typeof module !== 'undefined' && module.exports) {
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
+                this.currentPayload = null;
+                await ReadingVocabStore.init().catch(() => {});
+                if (requestId !== this._openRequestId) return;
+                this.applyVocabHighlights();
+                this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
@@ -16998,8 +17143,7 @@ if (typeof module !== 'undefined' && module.exports) {
             }
 
             // 解析文章大标题、考试指导语与真实段落
-            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
-            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
             const blocks = passageData.blocks;
             const instructionHtml = passageData.instructionHtml;
             const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
@@ -17014,21 +17158,21 @@ if (typeof module !== 'undefined' && module.exports) {
             // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
             const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
             if (passageIntroEl) {
+                passageIntroEl.replaceChildren();
                 if (instructionHtml) {
-                    passageIntroEl.innerHTML = `
-                        <div class="vocab-passage-instruction" role="note">
-                            <span class="vocab-instruction-icon">📋</span>
-                            <div class="vocab-instruction-text">${instructionHtml}</div>
-                        </div>
-                    `;
-                    passageIntroEl.style.display = 'block';
-                } else if (passageData.subtitleHtml) {
-                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
-                    passageIntroEl.style.display = 'block';
-                } else {
-                    passageIntroEl.innerHTML = '';
-                    passageIntroEl.style.display = 'none';
+                    const instruction = document.createElement('div');
+                    instruction.className = 'vocab-passage-instruction';
+                    instruction.setAttribute('role', 'note');
+                    instruction.appendChild(createReadOnlyQuestionContent(instructionHtml, 'vocab-passage-instruction'));
+                    passageIntroEl.appendChild(instruction);
                 }
+                if (passageData.subtitleHtml) {
+                    const subtitle = document.createElement('div');
+                    subtitle.className = 'vocab-passage-subtitle';
+                    subtitle.appendChild(createReadOnlyQuestionContent(passageData.subtitleHtml, 'vocab-passage-subtitle'));
+                    passageIntroEl.appendChild(subtitle);
+                }
+                passageIntroEl.style.display = passageIntroEl.childNodes.length ? 'block' : 'none';
             }
 
             // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
@@ -17036,7 +17180,7 @@ if (typeof module !== 'undefined' && module.exports) {
             if (tabsContainer) {
                 let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
                 blocks.forEach(b => {
-                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.id}">Para ${b.letter}</button>`;
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
@@ -17049,22 +17193,27 @@ if (typeof module !== 'undefined' && module.exports) {
                     let passageHtml = '';
                     blocks.forEach(b => {
                         passageHtml += `
-                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.id}" data-paragraph-id="${b.id}" data-letter="${b.letter}">
                                 <div class="vocab-paragraph-tag">
                                     <span class="vocab-para-letter">Para ${b.letter}</span>
                                 </div>
-                                <div class="vocab-paragraph-text">${b.html}</div>
-                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                <div class="vocab-paragraph-text" data-content-id="${b.id}"></div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.id}" style="display: ${this.showTranslation ? 'block' : 'none'};">
                                     <div class="vocab-trans-label">中文参考译文：</div>
-                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.id}">加载中...</div>
                                 </div>
                             </div>
                         `;
                     });
                     passageContent.innerHTML = passageHtml;
+                    blocks.forEach(block => {
+                        const text = passageContent.querySelector('[data-content-id="' + block.id + '"]');
+                        text.appendChild(createReadOnlyQuestionContent(block.html, 'vocab-' + block.id));
+                        this.assignTextScopes(text, 'passage/' + block.id);
+                    });
                 } else {
                     // 原生清洗后渲染
-                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                    passageContent.innerHTML = '<p class="vocab-empty-tip">本篇暂无可用正文</p>';
                 }
             }
 
@@ -17078,7 +17227,10 @@ if (typeof module !== 'undefined' && module.exports) {
                         const group = document.createElement('div');
                         group.className = 'vocab-question-group';
                         group.id = `vocab-qgroup-${idx + 1}`;
-                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        group.dataset.sectionId = 'q-' + (idx + 1);
+                        const html = (g.leadHtml || '') + (g.bodyHtml || g.html || '');
+                        group.appendChild(createReadOnlyQuestionContent(html, group.id));
+                        this.assignTextScopes(group, 'questions/q-' + (idx + 1), true);
                         groups.appendChild(group);
                     });
                     questionsContent.replaceChildren(groups);
@@ -17096,317 +17248,234 @@ if (typeof module !== 'undefined' && module.exports) {
             this.applyVocabHighlights();
         },
 
-        trimRangeWhitespace(range) {
-            if (!range || range.collapsed) return range;
-            const startNode = range.startContainer;
-            let startOffset = range.startOffset;
-            const endNode = range.endContainer;
-            let endOffset = range.endOffset;
-
-            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
-                const text = startNode.nodeValue || '';
-                const segment = text.slice(startOffset, endOffset);
-                const leadSpace = segment.search(/\S/);
-                if (leadSpace > 0) {
-                    startOffset += leadSpace;
-                } else if (leadSpace === -1) {
-                    return null;
+        assignTextScopes(root, prefix, alwaysNumber = false) {
+            const boundaries = 'p, li, td, th, dt, dd, h1, h2, h3, h4, h5, h6, blockquote, div, section, table, ul, ol';
+            const scopes = [];
+            const visit = element => {
+                if (!element.querySelector(boundaries)) {
+                    if (global.ReadingVocabAnchors.text(element).trim()) scopes.push(element);
+                    return;
                 }
-                const trailSpace = segment.length - segment.trimEnd().length;
-                if (trailSpace > 0) {
-                    endOffset -= trailSpace;
-                }
-                if (endOffset <= startOffset) return null;
-
-                const trimmed = document.createRange();
-                trimmed.setStart(startNode, startOffset);
-                trimmed.setEnd(endNode, endOffset);
-                return trimmed;
-            }
-
-            if (startNode.nodeType === Node.TEXT_NODE) {
-                const text = (startNode.nodeValue || '').slice(startOffset);
-                const m = text.match(/^\s+/);
-                if (m) {
-                    range.setStart(startNode, startOffset + m[0].length);
-                }
-            }
-            if (endNode.nodeType === Node.TEXT_NODE) {
-                const text = (endNode.nodeValue || '').slice(0, endOffset);
-                const m = text.match(/\s+$/);
-                if (m) {
-                    range.setEnd(endNode, endOffset - m[0].length);
-                }
-            }
-            return range;
+                let run = [];
+                const flush = () => {
+                    if (!run.length) return;
+                    if (run.some(node => node.textContent.trim())) {
+                        const span = document.createElement('span');
+                        element.insertBefore(span, run[0]);
+                        span.append(...run);
+                        scopes.push(span);
+                    }
+                    run = [];
+                };
+                [...element.childNodes].forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE && (node.matches(boundaries) || node.querySelector(boundaries))) {
+                        flush();
+                        visit(node);
+                    } else run.push(node);
+                });
+                flush();
+            };
+            visit(root);
+            scopes.forEach((scope, index) => {
+                scope.dataset.vocabScope = alwaysNumber || scopes.length > 1 ? prefix + '/p-' + (index + 1) : prefix;
+                scope.dataset.vocabSourceVersion = global.ReadingVocabAnchors.hashText(JSON.stringify(this.currentPayload));
+                scope.tabIndex = 0;
+            });
         },
 
-        calculateRangeLocation(scopeElement, range, text) {
-            const textNodes = getTextNodes(scopeElement);
-            let runningOffset = 0;
-            let startOffset = -1;
-
-            for (let i = 0; i < textNodes.length; i++) {
-                const node = textNodes[i];
-                if (node === range.startContainer) {
-                    startOffset = runningOffset + range.startOffset;
-                    break;
-                }
-                runningOffset += (node.nodeValue || '').length;
-            }
-
-            if (startOffset === -1) {
-                startOffset = 0;
-            }
-
-            const endOffset = startOffset + text.length;
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
-            const after = fullText.slice(endOffset, endOffset + 30);
-
-            let occurrence = 0;
-            const lowerFull = fullText.toLowerCase();
-            const lowerWord = text.toLowerCase();
-            let idx = -1;
-            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
-                occurrence += 1;
-            }
-
-            return { startOffset, endOffset, before, after, occurrence };
+        calculateRangeLocation(scopeElement, range) {
+            return global.ReadingVocabAnchors.calculateLocation(scopeElement, range);
         },
 
-        wrapRangeWithHighlight(range, word) {
-            if (!range || range.collapsed) return null;
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight vocab-highlight--pulse';
-            mark.dataset.word = word;
-            mark.title = `生词本: ${word} (点击发音)`;
+        moveKeyboardSelection(event) {
+            if (this.modalOpen || !/^(ArrowLeft|ArrowRight|ArrowUp|ArrowDown|Home|End)$/.test(event.key)) return;
+            const scope = event.target.closest('[data-vocab-scope]');
+            if (!scope || event.target.closest('button, input, textarea, select, [role="button"]')) return;
+            const selection = window.getSelection();
+            if (!selection || typeof selection.modify !== 'function') return;
+            const nodes = getTextNodes(scope);
+            if (!nodes.length) return;
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.collapse(nodes[0], 0);
+            }
+            const previous = { anchor: selection.anchorNode, start: selection.anchorOffset,
+                focus: selection.focusNode, end: selection.focusOffset };
+            const forward = /^(ArrowRight|ArrowDown|End)$/.test(event.key);
+            let unit = /^(ArrowUp|ArrowDown)$/.test(event.key) ? 'line' : 'character';
+            if (event.ctrlKey || event.metaKey) unit = 'word';
+            if (event.key === 'Home' || event.key === 'End') unit = 'lineboundary';
+            event.preventDefault();
+            // Static selectable text has no native caret navigation in some
+            // supported browsers unless their global caret-browsing mode is on.
+            selection.modify(event.shiftKey ? 'extend' : 'move', forward ? 'forward' : 'backward', unit);
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.setBaseAndExtent(previous.anchor, previous.start, previous.focus, previous.end);
+            }
+        },
 
+        async captureSelection() {
+            const overlay = this.ensureOverlay();
+            if (overlay.classList.contains('is-hidden') || this.modalOpen || !this.currentPayload) return;
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) return;
+            const range = selection.getRangeAt(0);
+            const start = range.startContainer.nodeType === Node.ELEMENT_NODE ? range.startContainer : range.startContainer.parentElement;
+            const scope = start?.closest('[data-vocab-scope]');
+            if (!scope || !overlay.querySelector('#vocab-reader-body')?.contains(scope)) return;
+            const captured = global.ReadingVocabAnchors.capture(scope, range);
+            if (!captured) return;
+            const requestId = this._openRequestId;
+            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
+            if (this._selectionPending.has(pendingId)) return;
+            this._selectionPending.add(pendingId);
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-            } catch (e) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                } catch (err) {
-                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
-                    return null;
-                }
+                const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                if (requestId !== this._openRequestId) return;
+                if (!result.added) throw new Error('Selection was not saved');
+                selection.removeAllRanges();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('✅ "' + captured.word + '" 已收录并黄色高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
+            } finally {
+                this._selectionPending.delete(pendingId);
             }
+        },
 
-            this.defer(() => {
-                mark.classList.remove('vocab-highlight--pulse');
-            }, 1500);
-
-            return mark;
+        wrapRangeWithHighlight(range, word, occurrenceId) {
+            if (!range || range.collapsed) return false;
+            // Wrap each text fragment separately so repeated restore never splits,
+            // extracts, or rewrites the source's inline formatting or annotations.
+            const fragments = getTextNodes(range.commonAncestorContainer.nodeType === Node.TEXT_NODE
+                ? range.commonAncestorContainer.parentElement : range.commonAncestorContainer)
+                .filter(node => range.intersectsNode(node)).map(node => ({ node,
+                    start: node === range.startContainer ? range.startOffset : 0,
+                    end: node === range.endContainer ? range.endOffset : node.length
+                })).filter(fragment => fragment.end > fragment.start);
+            for (const fragment of fragments.reverse()) {
+                const selected = document.createRange();
+                selected.setStart(fragment.node, fragment.start);
+                selected.setEnd(fragment.node, fragment.end);
+                const mark = document.createElement('mark');
+                mark.className = 'vocab-highlight';
+                mark.dataset.word = word;
+                mark.dataset.occurrenceId = occurrenceId;
+                mark.tabIndex = 0;
+                mark.setAttribute('role', 'button');
+                mark.title = '生词本: ' + word + '（查看或移除这一处）';
+                selected.surroundContents(mark);
+            }
+            return fragments.length > 0;
         },
 
         applyVocabHighlights() {
             const overlay = this.ensureOverlay();
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-
-            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
-            this.removeVocabHighlights(passageContent);
-            this.removeVocabHighlights(questionsContent);
-
-            if (!this.currentExamId) return;
-
-            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
-            if (!examItems || examItems.length === 0) return;
-
-            examItems.forEach(item => {
-                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
-                    item.highlights.forEach(hl => {
-                        if (String(hl.examId) === String(this.currentExamId)) {
-                            this.restoreVocabHighlight(overlay, hl, item.word);
+            this.removeVocabHighlights(overlay.querySelector('#vocab-reader-body'));
+            this.unresolvedOccurrences = [];
+            if (this.currentExamId) {
+                ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).forEach(item => {
+                    item.occurrences.forEach(occurrence => {
+                        if (!this.restoreVocabHighlight(overlay, occurrence, item.word)) {
+                            this.unresolvedOccurrences.push({ ...occurrence, word: item.word });
                         }
                     });
-                }
-            });
+                });
+            }
+            this.renderAnchorStatus();
         },
 
-        restoreVocabHighlight(overlay, hl, word) {
-            if (!overlay || !hl) return false;
-            let scopeElement = null;
+        restoreVocabHighlight(overlay, occurrence, word) {
+            if (!this.currentPayload) return false;
+            const range = this.resolveRangeForHighlight(overlay.querySelector('#vocab-reader-body'), occurrence);
+            return !!range && this.wrapRangeWithHighlight(range, word || occurrence.quote, occurrence.id);
+        },
 
-            if (hl.scope && hl.scope.startsWith('para-')) {
-                const letter = hl.scope.replace('para-', '');
-                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
-                if (card) {
-                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
-                }
-            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
-                scopeElement = overlay.querySelector(`#${hl.scope}`);
-            } else if (hl.scope === 'questions') {
-                scopeElement = overlay.querySelector('#vocab-questions-content');
-            } else {
-                scopeElement = overlay.querySelector('#vocab-passage-content');
-            }
+        resolveRangeForHighlight(root, occurrence) {
+            return global.ReadingVocabAnchors.resolve(root, occurrence);
+        },
 
-            if (!scopeElement) {
-                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
-            }
-            if (!scopeElement) return false;
+        showOccurrenceActions(mark) {
+            const actions = this.ensureOverlay().querySelector('#vocab-occurrence-actions');
+            actions.innerHTML = '<span>' + escapeHtml(mark.dataset.word) + '</span> <button type="button" data-action="remove-occurrence" data-occurrence-id="'
+                + escapeHtml(mark.dataset.occurrenceId) + '">移除这一处高亮</button>';
+            actions.querySelector('button').focus({ preventScroll: true });
+            speakWord(mark.dataset.word);
+        },
 
-            const range = this.resolveRangeForHighlight(scopeElement, hl);
-            if (!range || range.collapsed) return false;
+        renderAnchorStatus() {
+            const status = this.ensureOverlay().querySelector('#vocab-anchor-status');
+            if (!status) return;
+            status.replaceChildren();
+            if (!this.unresolvedOccurrences.length) return;
+            const message = document.createElement('span');
+            message.textContent = this.unresolvedOccurrences.length + ' 处原文暂时无法定位，生词仍保留。可重试加载，或在生词本移除旧位置后重新划选。';
+            const retry = document.createElement('button');
+            retry.type = 'button';
+            retry.dataset.action = 'retry-anchors';
+            retry.textContent = '重试定位';
+            status.append(message, retry);
+        },
 
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight';
-            mark.dataset.word = word || hl.text;
-            mark.title = `生词本: ${word || hl.text} (点击发音)`;
-
+        async removeOccurrence(occurrenceId) {
+            if (this._occurrenceBusy) return;
+            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
+            const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
+            if (!occurrence) return;
+            const requestId = this._openRequestId;
+            const undo = { source: { ...this.currentSource },
+                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+                word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
+                occurrence: { ...occurrence }, manual: false };
+            const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-                return true;
-            } catch (_) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                    return true;
-                } catch (e) {
-                    return false;
-                }
+                const result = await ReadingVocabStore.mutate('removeOccurrence', { occurrenceId }, observed);
+                if (requestId !== this._openRequestId) return;
+                // Keep the acknowledged deletion fence: a later clear/replace must
+                // reject this undo instead of resurrecting deleted relationships.
+                const committedRevision = result.revisions?.['vocab.readingState'];
+                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                    ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
+                    this._undoOccurrence ? '<span>已移除这一处高亮</span> <button type="button" data-action="undo-occurrence">撤销</button>' : '';
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已移除这一处高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '移除失败，请重试');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
         },
 
-        resolveRangeForHighlight(root, hl) {
-            if (!root || !hl) return null;
-            const textNodes = getTextNodes(root);
-            if (!textNodes.length) return null;
-
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const targetText = String(hl.text || '').trim();
-            if (!targetText) return null;
-
-            const startOffset = Number(hl.startOffset);
-            const endOffset = Number(hl.endOffset);
-
-            // 1. 优先尝试 offset 精确匹配
-            if (
-                Number.isFinite(startOffset) &&
-                Number.isFinite(endOffset) &&
-                endOffset > startOffset &&
-                startOffset >= 0 &&
-                endOffset <= fullText.length
-            ) {
-                const segment = fullText.slice(startOffset, endOffset);
-                if (segment.toLowerCase() === targetText.toLowerCase()) {
-                    return resolveRangeFromOffsets(root, startOffset, endOffset);
-                }
+        async undoOccurrence() {
+            if (this._occurrenceBusy || !this._undoOccurrence) return;
+            const requestId = this._openRequestId;
+            const undo = this._undoOccurrence;
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
+            try {
+                await ReadingVocabStore.mutate('collect', { ...undo.command, at: new Date().toISOString() }, undo.observed);
+                if (requestId !== this._openRequestId) return;
+                this._undoOccurrence = null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').replaceChildren();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已撤销移除');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '撤销失败，数据可能已更改；可重试或重新划选');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
-
-            // 2. 次优：使用 before / after 上下文精确定位单处实例
-            if (hl.before || hl.after) {
-                let searchPos = 0;
-                let matchIdx = -1;
-                let bestIdx = -1;
-                let bestScore = -1;
-                const lowerFull = fullText.toLowerCase();
-                const lowerTarget = targetText.toLowerCase();
-
-                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
-                    let score = 0;
-                    if (hl.before) {
-                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
-                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
-                            score += 3;
-                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (hl.after) {
-                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
-                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
-                            score += 3;
-                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestIdx = matchIdx;
-                    }
-                    searchPos = matchIdx + 1;
-                }
-
-                if (bestIdx !== -1 && bestScore > 0) {
-                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
-                }
-            }
-
-            // 3. 兜底：使用 occurrence（第 N 次出现）
-            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
-            let currentOccurrence = 0;
-            let pos = 0;
-            let matchPos = -1;
-            const lowerFull = fullText.toLowerCase();
-            const lowerTarget = targetText.toLowerCase();
-
-            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
-                if (currentOccurrence === occurrence) {
-                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
-                }
-                currentOccurrence += 1;
-                pos = matchPos + 1;
-            }
-
-            return null;
-        },
-
-        restoreLegacyHighlightByContext(overlay, word, context) {
-            if (!overlay || !word) return false;
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-            const roots = [passageContent, questionsContent].filter(Boolean);
-
-            const targetWord = String(word).trim();
-            const lowerWord = targetWord.toLowerCase();
-            const lowerContext = String(context || '').trim().toLowerCase();
-
-            for (const root of roots) {
-                const textNodes = getTextNodes(root);
-                const fullText = textNodes.map(n => n.nodeValue || '').join('');
-                const lowerFull = fullText.toLowerCase();
-
-                let targetIdx = -1;
-                if (lowerContext && lowerFull.includes(lowerContext)) {
-                    const ctxIdx = lowerFull.indexOf(lowerContext);
-                    const wordInCtx = lowerContext.indexOf(lowerWord);
-                    if (wordInCtx !== -1) {
-                        targetIdx = ctxIdx + wordInCtx;
-                    }
-                }
-
-                // 无论如何，只恢复单处实例，绝不全篇高亮
-                if (targetIdx !== -1) {
-                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
-                    if (range && !range.collapsed) {
-                        const mark = document.createElement('mark');
-                        mark.className = 'vocab-highlight';
-                        mark.dataset.word = targetWord;
-                        mark.title = `生词本: ${targetWord} (点击发音)`;
-                        try {
-                            range.surroundContents(mark);
-                            return true;
-                        } catch (_) {
-                            try {
-                                const frag = range.extractContents();
-                                mark.appendChild(frag);
-                                range.insertNode(mark);
-                                return true;
-                            } catch (e) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
         },
 
         removeVocabHighlights(container) {
@@ -17451,7 +17520,8 @@ if (typeof module !== 'undefined' && module.exports) {
                 const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
                 if (match) {
                     const letter = match[1].toUpperCase();
-                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    const cards = [...overlay.querySelectorAll('.vocab-paragraph-card')].filter(card => card.dataset.letter === letter);
+                    const transEl = cards.length === 1 ? cards[0].querySelector('.vocab-trans-text') : null;
                     if (transEl) {
                         transEl.textContent = note.text || '';
                     }
@@ -17492,7 +17562,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 if (passageSection) passageSection.style.display = 'block';
                 if (questionsSection) questionsSection.style.display = 'none';
                 cards.forEach(c => {
-                    if (c.dataset.letter === target) {
+                    if (c.dataset.paragraphId === target) {
                         c.style.display = 'block';
                         c.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     } else {
@@ -17542,7 +17612,16 @@ if (typeof module !== 'undefined' && module.exports) {
             }
 
             let html = '';
+            const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
             list.forEach(item => {
+                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                    .find(row => row.id === item.id)?.occurrences || [];
+                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
+                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
+                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                    + '">移除这一处</button></div>').join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
@@ -17551,6 +17630,7 @@ if (typeof module !== 'undefined' && module.exports) {
                                 <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
                             ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${occurrenceRows}
                             ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
                         <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
@@ -17632,9 +17712,9 @@ if (typeof module !== 'undefined' && module.exports) {
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
             if (ReadingVocabReader.currentExamId) {
-                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
             }
         });
     }
@@ -25672,6 +25752,8 @@ ensurePracticeSessionSyncListener();
     "js/app/examSessionMixin.js",
     "js/app/browseController.js",
     "js/components/PDFHandler.js",
+    "js/components/readingVocabContent.js",
+    "js/components/readingVocabAnchors.js",
     "js/components/readingVocabReader.js",
     "js/components/BrowseStateManager.js",
     "js/utils/suiteBackGuard.js",

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -8320,6 +8320,467 @@
 })(typeof window !== 'undefined' ? window : globalThis);
 
 
+/* ===== js/components/readingVocabContent.js ===== */
+(function (global) {
+    'use strict';
+
+    const CONTAINERS = new Set(['DIV', 'SECTION', 'ARTICLE', 'MAIN']);
+    const HEADING = /^H[1-6]$/;
+
+    function labelFromText(value) {
+        const match = String(value || '').trim().match(/^(?:Paragraph\s+)?([A-Z])(?:[.:)])?$/);
+        return match ? match[1] : '';
+    }
+
+    function standaloneLabel(node) {
+        if (HEADING.test(node.tagName) || node.matches('.paragraph-label, strong, b, p')) {
+            return labelFromText(node.textContent);
+        }
+        return '';
+    }
+
+    function leadingLabel(node) {
+        // A capital article at the start of an ordinary sentence is not a label.
+        // Inline labels must have their own leading element or say "Paragraph X".
+        const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+        let firstText;
+        while ((firstText = walker.nextNode()) && !firstText.textContent.trim()) {}
+        if (!firstText) return '';
+        const marker = firstText.parentElement.closest('strong, b, .paragraph-label');
+        if (marker && node.contains(marker)) {
+            const label = labelFromText(marker.textContent);
+            if (label) return label;
+        }
+        const explicit = node.textContent.trim().match(/^Paragraph\s+([A-Z])(?:\s*[:.)]\s*|\s+)/);
+        return explicit ? explicit[1] : '';
+    }
+
+    function isInstruction(text) {
+        return /^(?:You should spend\b[^.]*\bminutes\b|Questions\s+\d+\s*(?:[-–—]|to)\s*\d+\s+(?:are based|refer to)\b)/i.test(text.trim());
+    }
+
+    function isItalicSubtitle(node) {
+        if (node.tagName !== 'P') return false;
+        const text = node.textContent.trim();
+        const italicText = Array.from(node.querySelectorAll('em, i'))
+            .filter(element => !element.parentElement.closest('em, i'))
+            .map(element => element.textContent.trim()).join(' ').trim();
+        return !!text && text === italicText;
+    }
+
+    function hasContent(node) {
+        return !!node.textContent.trim() || node.matches('img, svg, video, audio, canvas, hr, math') ||
+            !!node.querySelector('img, svg, video, audio, canvas, hr, math');
+    }
+
+    function collectUnits(root) {
+        const units = [];
+        function visit(node) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (node.textContent.trim()) {
+                    const paragraph = document.createElement('p');
+                    paragraph.textContent = node.textContent;
+                    units.push(paragraph);
+                }
+                return;
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) return;
+            if (CONTAINERS.has(node.tagName) && !node.classList.contains('paragraph-wrapper')) {
+                Array.from(node.childNodes).forEach(visit);
+            } else if (hasContent(node)) {
+                units.push(node);
+            }
+        }
+        Array.from(root.childNodes).forEach(visit);
+        return units;
+    }
+
+    function ordinalLetter(index) {
+        let label = '';
+        for (let value = index + 1; value > 0; value = Math.floor((value - 1) / 26)) {
+            label = String.fromCharCode(65 + (value - 1) % 26) + label;
+        }
+        return label;
+    }
+
+    function normalizePassage(passage, fallbackTitle = '') {
+        // This is the same bodyHtml/html precedence and ordered-block contract
+        // used by the practice page's renderDataset implementation.
+        const rawHtml = (Array.isArray(passage?.blocks) ? passage.blocks : [])
+            .map(block => block?.bodyHtml || block?.html || '').join('\n');
+        const root = document.createElement('div');
+        root.innerHTML = rawHtml;
+        root.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone, .empty-space, #divider')
+            .forEach(node => node.remove());
+
+        let passageTitle = fallbackTitle;
+        let titleFound = false;
+        let beforeBody = true;
+        const instructions = [];
+        const subtitles = [];
+        const body = [];
+        for (const node of collectUnits(root)) {
+            const text = node.textContent.trim();
+            if (HEADING.test(node.tagName) && /^READING PASSAGE\s*\d*$/i.test(text)) continue;
+            if (beforeBody && isInstruction(text)) {
+                instructions.push(node.outerHTML);
+                continue;
+            }
+            if (beforeBody && !titleFound && /^H[1-3]$/.test(node.tagName) && !standaloneLabel(node)) {
+                passageTitle = text;
+                titleFound = true;
+                continue;
+            }
+            if (beforeBody && !standaloneLabel(node) &&
+                (/^H[4-6]$/.test(node.tagName) || (titleFound && isItalicSubtitle(node)))) {
+                subtitles.push(node.outerHTML);
+                continue;
+            }
+            beforeBody = false;
+            body.push(node);
+        }
+
+        const blocks = [];
+        let current = null;
+        let pendingHeadingHtml = '';
+        function finish() {
+            if (!current) return;
+            const textRoot = document.createElement('div');
+            textRoot.innerHTML = current.html;
+            if (hasContent(textRoot)) {
+                const index = blocks.length;
+                blocks.push({
+                    id: `p-${index + 1}`,
+                    letter: current.label || ordinalLetter(index),
+                    explicitLabel: !!current.label,
+                    html: current.html,
+                    text: textRoot.textContent.trim()
+                });
+            }
+            current = null;
+        }
+        function start(html, label = '') {
+            current = { html: pendingHeadingHtml + html, label };
+            pendingHeadingHtml = '';
+        }
+
+        for (const node of body) {
+            const marker = standaloneLabel(node);
+            if (marker) {
+                finish();
+                start('', marker);
+                continue;
+            }
+            if (node.classList.contains('paragraph-wrapper')) {
+                finish();
+                start(node.innerHTML, leadingLabel(node));
+                finish();
+                continue;
+            }
+            const inlineLabel = leadingLabel(node);
+            if (inlineLabel) {
+                finish();
+                start(node.outerHTML, inlineLabel);
+                continue;
+            }
+            if (HEADING.test(node.tagName) && !current?.label) {
+                finish();
+                pendingHeadingHtml += node.outerHTML;
+                continue;
+            }
+            if (current?.label) {
+                // Some sources split one lettered paragraph across multiple p
+                // elements. Keep every element under the explicit section label.
+                current.html += node.outerHTML;
+            } else {
+                finish();
+                start(node.outerHTML);
+            }
+        }
+        finish();
+        if (pendingHeadingHtml) {
+            start('');
+            finish();
+        }
+
+        return {
+            passageTitle,
+            instructionHtml: instructions.join('\n'),
+            subtitleHtml: subtitles.join('\n'),
+            rawHtml,
+            blocks
+        };
+    }
+
+    global.ReadingVocabContent = Object.freeze({ normalizePassage });
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
+/* ===== js/components/readingVocabAnchors.js ===== */
+(function (global) {
+    'use strict';
+
+    const SCOPE = '[data-vocab-scope]';
+    const EXCLUDED = 'script,style,noscript,template,button,input,textarea,select,option,' +
+        '[role="button"]:not(.vocab-highlight):not(.hl),[contenteditable]:not([contenteditable="false"]),' +
+        '.vocab-translation-card,.vocab-paragraph-tag,.vocab-answer-blank';
+    const HIGHLIGHT = '.vocab-highlight,.hl';
+    const BLOCK = 'p,div,li,td,th,blockquote,pre,h1,h2,h3,h4,h5,h6,section,article';
+    const CONTEXT_LENGTH = 48;
+
+    function hidden(element) {
+        if (element.hidden || element.getAttribute('aria-hidden') === 'true') return true;
+        const style = element.ownerDocument.defaultView.getComputedStyle(element);
+        return style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse';
+    }
+
+    function excluded(element, root) {
+        for (let current = element; current; current = current.parentElement) {
+            if (current.matches(EXCLUDED) || hidden(current)) return true;
+            if (current === root) break;
+        }
+        return false;
+    }
+
+    // Highlight wrappers contribute their original text. This keeps offsets and
+    // content versions stable while other occurrences are painted or removed.
+    function textNodes(root) {
+        if (!root || !root.ownerDocument) return [];
+        const nodes = [];
+        const walker = root.ownerDocument.createTreeWalker(root, 4);
+        let node;
+        while ((node = walker.nextNode())) {
+            if (node.parentElement && !excluded(node.parentElement, root)) nodes.push(node);
+        }
+        return nodes;
+    }
+
+    function text(root) {
+        return textNodes(root).map(node => node.nodeValue || '').join('');
+    }
+
+    function textVersion(value) {
+        let first = 0x811c9dc5;
+        let second = 0x9e3779b9;
+        for (let index = 0; index < value.length; index += 1) {
+            const code = value.charCodeAt(index);
+            first = Math.imul(first ^ code, 0x01000193);
+            second = Math.imul(second ^ code, 0x85ebca6b);
+        }
+        return `reader-text-v1:${value.length}:${(first >>> 0).toString(16)}:${(second >>> 0).toString(16)}`;
+    }
+
+    function versionForText(root, value) {
+        const sourceVersion = root.getAttribute('data-vocab-source-version');
+        const scopeVersion = textVersion(value);
+        return sourceVersion ? `reader-scope-v2:${sourceVersion}:${scopeVersion}` : scopeVersion;
+    }
+
+    function version(root) { return versionForText(root, text(root)); }
+
+    function comparePoints(doc, leftNode, leftOffset, rightNode, rightOffset) {
+        const left = doc.createRange();
+        const right = doc.createRange();
+        left.setStart(leftNode, leftOffset);
+        left.collapse(true);
+        right.setStart(rightNode, rightOffset);
+        right.collapse(true);
+        return left.compareBoundaryPoints(0, right);
+    }
+
+    function offsetAtPoint(root, nodes, container, offset) {
+        if (container !== root && !root.contains(container)) return null;
+        let position = 0;
+        for (const node of nodes) {
+            const length = (node.nodeValue || '').length;
+            if (container === node) return position + offset;
+            if (comparePoints(root.ownerDocument, container, offset, node, 0) <= 0) return position;
+            if (comparePoints(root.ownerDocument, container, offset, node, length) < 0) return null;
+            position += length;
+        }
+        return position;
+    }
+
+    function resolveOffsets(root, start, end) {
+        if (!root || !Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start) return null;
+        const nodes = textNodes(root);
+        let position = 0;
+        let startNode;
+        let startInNode;
+        for (const node of nodes) {
+            const next = position + (node.nodeValue || '').length;
+            if (!startNode && start >= position && start < next) {
+                startNode = node;
+                startInNode = start - position;
+            }
+            if (startNode && end > position && end <= next) {
+                const range = root.ownerDocument.createRange();
+                range.setStart(startNode, startInNode);
+                range.setEnd(node, end - position);
+                return range;
+            }
+            position = next;
+        }
+        return null;
+    }
+
+    function calculateLocation(root, range) {
+        if (!root || !range || range.collapsed) return null;
+        try {
+            const nodes = textNodes(root);
+            const fullText = nodes.map(node => node.nodeValue || '').join('');
+            const startOffset = offsetAtPoint(root, nodes, range.startContainer, range.startOffset);
+            const endOffset = offsetAtPoint(root, nodes, range.endContainer, range.endOffset);
+            if (startOffset === null || endOffset === null || endOffset <= startOffset) return null;
+            const quote = fullText.slice(startOffset, endOffset);
+            return {
+                startOffset, endOffset, quote, text: quote,
+                before: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), startOffset),
+                after: fullText.slice(endOffset, endOffset + CONTEXT_LENGTH),
+                contentVersion: versionForText(root, fullText),
+                context: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), endOffset + CONTEXT_LENGTH)
+            };
+        } catch (_) { return null; }
+    }
+
+    function overlaps(range, node) {
+        const other = node.ownerDocument.createRange();
+        other.selectNode(node);
+        const doc = node.ownerDocument;
+        return comparePoints(doc, range.startContainer, range.startOffset, other.endContainer, other.endOffset) < 0 &&
+            comparePoints(doc, range.endContainer, range.endOffset, other.startContainer, other.startOffset) > 0;
+    }
+
+    function validRange(scope, range, allowHighlights = false) {
+        if (!range || range.collapsed || excluded(scope, scope)) return false;
+        if ((range.startContainer !== scope && !scope.contains(range.startContainer)) ||
+            (range.endContainer !== scope && !scope.contains(range.endContainer))) return false;
+        for (const element of scope.querySelectorAll('*')) {
+            if ((element.matches(EXCLUDED + ',br,hr') || (!allowHighlights && element.matches(HIGHLIGHT)) || hidden(element)) && overlaps(range, element)) return false;
+        }
+        let selectedBlock = null;
+        for (const node of textNodes(scope)) {
+            const doc = node.ownerDocument;
+            const selected = comparePoints(doc, range.startContainer, range.startOffset, node, node.length) < 0 &&
+                comparePoints(doc, range.endContainer, range.endOffset, node, 0) > 0;
+            if (!selected) continue;
+            if (node.parentElement.closest(SCOPE) !== scope || (!allowHighlights && node.parentElement.closest(HIGHLIGHT))) return false;
+            const block = node.parentElement.closest(BLOCK);
+            const boundary = block && scope.contains(block) ? block : scope;
+            if (selectedBlock && selectedBlock !== boundary) return false;
+            selectedBlock = boundary;
+        }
+        return selectedBlock !== null;
+    }
+
+    function cleanWord(value) {
+        return value.replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '').trim();
+    }
+
+    function capture(scope, range) {
+        if (!scope || !scope.matches(SCOPE)) return null;
+        try {
+            if (!validRange(scope, range)) return null;
+            const rawText = range.toString();
+            if (/[\r\n]/.test(rawText)) return null;
+            const word = cleanWord(rawText);
+            if (!word || word.length > 45 || !/[A-Za-z]/.test(word)) return null;
+            const rawLocation = calculateLocation(scope, range);
+            if (!rawLocation || rawLocation.quote !== rawText) return null;
+            const startOffset = rawLocation.startOffset + rawText.indexOf(word);
+            const trimmed = resolveOffsets(scope, startOffset, startOffset + word.length);
+            if (!trimmed || !validRange(scope, trimmed)) return null;
+            const scopeId = scope.getAttribute('data-vocab-scope');
+            if (!scopeId) return null;
+            const location = calculateLocation(scope, trimmed);
+            if (scope.getAttribute('data-vocab-source-version')) {
+                const sourceRoot = scope.closest('[data-vocab-source-root]');
+                const unique = sourceRoot && contextCandidates(sourceRoot, scope, location).length === 1;
+                location.contentVersion += unique ? '|context-unique' : '|context-scoped';
+            }
+            return { ...location, range: trimmed, word, scopeId, scope: scopeId };
+        } catch (_) { return null; }
+    }
+
+    function findScope(root, scopeId) {
+        if (!root || !scopeId) return null;
+        const matches = [];
+        if (root.matches && root.matches(SCOPE) && root.getAttribute('data-vocab-scope') === scopeId) matches.push(root);
+        for (const scope of root.querySelectorAll(SCOPE)) {
+            if (scope.getAttribute('data-vocab-scope') === scopeId) matches.push(scope);
+        }
+        return matches.length === 1 ? matches[0] : null;
+    }
+
+    function areaScopes(root, originalScope) {
+        const scopeId = originalScope.getAttribute('data-vocab-scope');
+        const area = /^(passage|questions)\//.exec(scopeId);
+        if (!area) return [originalScope];
+        const candidates = root.matches && root.matches(SCOPE) ? [root] : [];
+        candidates.push(...root.querySelectorAll(SCOPE));
+        return candidates.filter(scope => scope.getAttribute('data-vocab-scope').startsWith(area[0]));
+    }
+
+    function contextCandidates(root, originalScope, highlight) {
+        if (typeof highlight.before !== 'string' || typeof highlight.after !== 'string') return [];
+        const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+        const candidates = [];
+        for (const scope of areaScopes(root, originalScope)) {
+            const fullText = text(scope);
+            let position = fullText.indexOf(quote);
+            while (position !== -1) {
+                const end = position + quote.length;
+                const beforeMatches = highlight.before ?
+                    position >= highlight.before.length && fullText.slice(position - highlight.before.length, position) === highlight.before : position === 0;
+                const afterMatches = highlight.after ?
+                    fullText.slice(end, end + highlight.after.length) === highlight.after : end === fullText.length;
+                if (beforeMatches && afterMatches) {
+                    const range = resolveOffsets(scope, position, end);
+                    // Existing paint cannot turn an ambiguous textual anchor into
+                    // a unique one. Ignore paint only while counting candidates.
+                    if (range && range.toString() === quote && validRange(scope, range, true)) candidates.push({ scope, range });
+                }
+                if (candidates.length > 1) return candidates;
+                position = fullText.indexOf(quote, position + 1);
+            }
+        }
+        return candidates;
+    }
+
+    function resolve(root, highlight) {
+        if (!highlight) return null;
+        try {
+            const scope = findScope(root, highlight.scopeId || highlight.scope);
+            const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+            if (!scope || typeof quote !== 'string' || !quote || quote.length > 45 || /[\r\n]/.test(quote) || !/[A-Za-z]/.test(quote)) return null;
+            const fullText = text(scope);
+            const storedVersion = String(highlight.contentVersion || '');
+            const contextFlag = /\|context-(unique|scoped)$/.exec(storedVersion);
+            const baseVersion = contextFlag ? storedVersion.slice(0, contextFlag.index) : storedVersion;
+            if (baseVersion === versionForText(scope, fullText)) {
+                const start = highlight.startOffset;
+                const end = highlight.endOffset;
+                if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start || fullText.slice(start, end) !== quote) return null;
+                const range = resolveOffsets(scope, start, end);
+                return range && range.toString() === quote && validRange(scope, range) ? range : null;
+            }
+            // A source edit can shift an ordinal onto an identical paragraph.
+            // Current uniqueness alone is insufficient if the original source
+            // contained duplicates: removing the selected copy leaves a false
+            // unique survivor. Source-aware capture records that distinction.
+            const sourceAware = scope.getAttribute('data-vocab-source-version') || baseVersion.startsWith('reader-scope-v2:');
+            if (sourceAware && (!contextFlag || contextFlag[1] !== 'unique')) return null;
+            const candidates = contextCandidates(root, scope, highlight);
+            if (candidates.length !== 1) return null;
+            const candidate = candidates[0];
+            return validRange(candidate.scope, candidate.range) ? candidate.range : null;
+        } catch (_) { return null; }
+    }
+
+    global.ReadingVocabAnchors = Object.freeze({ textNodes, text, version, hashText: textVersion, resolveOffsets, calculateLocation, capture, resolve });
+})(typeof window !== 'undefined' ? window : globalThis);
+
+
 /* ===== js/components/readingVocabReader.js ===== */
 (function initReadingVocabReader(global) {
     'use strict';
@@ -8401,9 +8862,9 @@
             return state;
         },
 
-        async mutate(type, command) {
+        async mutate(type, command, observedState = null) {
             if (!this._state) await this.init();
-            const observed = this._state;
+            const observed = observedState || this._state;
             let result;
             try {
                 result = await global.AppData.vocab.mutateReading(type, command, {
@@ -8433,7 +8894,7 @@
                 scopeId: highlight.scopeId || highlight.scope,
                 contentVersion: highlight.contentVersion || 'legacy-reader-v1',
                 startOffset: highlight.startOffset, endOffset: highlight.endOffset,
-                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+                quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
                 source, article: { examId: String(examId), title: examTitle || '' },
@@ -8719,231 +9180,8 @@
     // ============================================================================
     // 阅读文本与段落清洗器
     // ============================================================================
-    function cleanPassageHtml(rawHtml) {
-        if (!rawHtml) return '';
-        const temp = document.createElement('div');
-        temp.innerHTML = rawHtml;
-
-        // 移除练习交互用的 dropzone 提示与容器
-        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
-        dropzones.forEach(dz => dz.remove());
-
-        // 移除多余的空占位与 divider
-        const empties = temp.querySelectorAll('.empty-space, #divider');
-        empties.forEach(el => el.remove());
-
-        return temp.innerHTML;
-    }
-
-    /**
-     * 判断文本是否属于考试指导语/前置题目说明
-     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
-     */
-    function isPassageInstruction(text) {
-        if (!text) return false;
-        const s = text.trim();
-        if (/spend about \d+ minutes/i.test(s)) return true;
-        if (/which are based on reading passage/i.test(s)) return true;
-        if (/based on reading passage \d*/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
-        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
-        return false;
-    }
-
-    /**
-     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
-     */
-    function extractPassageData(rawHtml, fallbackTitle = '') {
-        if (!rawHtml) {
-            return {
-                passageTitle: fallbackTitle,
-                subtitleHtml: '',
-                instructionHtml: '',
-                blocks: []
-            };
-        }
-
-        const cleaned = cleanPassageHtml(rawHtml);
-        const temp = document.createElement('div');
-        temp.innerHTML = cleaned;
-
-        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
-        let passageTitle = fallbackTitle;
-        const h3 = temp.querySelector('h3');
-        if (h3 && h3.textContent.trim()) {
-            passageTitle = h3.textContent.trim();
-            h3.remove();
-        } else {
-            const h2 = temp.querySelector('h2');
-            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
-                passageTitle = h2.textContent.trim();
-                h2.remove();
-            }
-        }
-
-        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
-        const readingPassageHeadings = temp.querySelectorAll('h2');
-        readingPassageHeadings.forEach(h => {
-            if (/^reading passage/i.test(h.textContent.trim())) {
-                h.remove();
-            }
-        });
-
-        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
-        let instructionHtml = '';
-        const allPs = Array.from(temp.querySelectorAll('p'));
-        for (const p of allPs) {
-            const text = p.textContent.trim();
-            if (isPassageInstruction(text)) {
-                if (!instructionHtml) {
-                    instructionHtml = p.innerHTML.trim();
-                }
-                p.remove(); // 绝不作为正文段落，不分配任何段落标签
-            }
-        }
-
-        // 3. 提取副标题 (如 h4)
-        let subtitleHtml = '';
-        const h4 = temp.querySelector('h4');
-        if (h4 && h4.textContent.trim()) {
-            subtitleHtml = h4.innerHTML.trim();
-            h4.remove();
-        }
-
-        // 4. 解析段落 blocks
-        const blocks = [];
-        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
-
-        if (wrappers && wrappers.length > 0) {
-            wrappers.forEach((wrap, index) => {
-                // 查找段落标识 letter
-                let letter = '';
-                const strong = wrap.querySelector('strong');
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
-                    if (match) {
-                        letter = match[1];
-                    } else {
-                        letter = String.fromCharCode(65 + index);
-                    }
-                }
-
-                // 获取段落主体 HTML
-                const p = wrap.querySelector('p');
-                const html = p ? p.innerHTML : wrap.innerHTML;
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: html,
-                    text: wrap.textContent.trim()
-                });
-            });
-        } else {
-            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
-            const remainingPs = temp.querySelectorAll('p');
-            let validIdx = 0;
-            remainingPs.forEach((p) => {
-                const text = p.textContent.trim();
-                if (!text || text.length < 20) return;
-                // 防御：若依然属于指导语，跳过
-                if (isPassageInstruction(text)) return;
-
-                const strong = p.querySelector('strong');
-                let letter = '';
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
-                    if (leadMatch) {
-                        letter = leadMatch[1];
-                    } else {
-                        letter = String.fromCharCode(65 + validIdx);
-                    }
-                }
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: p.innerHTML,
-                    text: text
-                });
-                validIdx++;
-            });
-        }
-
-        return {
-            passageTitle,
-            subtitleHtml,
-            instructionHtml,
-            blocks
-        };
-    }
-
-    function extractParagraphBlocks(rawHtml) {
-        return extractPassageData(rawHtml).blocks;
-    }
-
-    function getTextNodes(root) {
-        if (!root) return [];
-        const textNodes = [];
-        const walker = document.createTreeWalker(
-            root,
-            NodeFilter.SHOW_TEXT,
-            {
-                acceptNode(node) {
-                    const parent = node.parentElement;
-                    if (!parent) return NodeFilter.FILTER_REJECT;
-                    const tag = parent.tagName.toUpperCase();
-                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    return NodeFilter.FILTER_ACCEPT;
-                }
-            },
-            false
-        );
-        let n;
-        while ((n = walker.nextNode())) {
-            textNodes.push(n);
-        }
-        return textNodes;
-    }
-
-    function resolveRangeFromOffsets(root, start, end) {
-        const nodes = getTextNodes(root);
-        let offset = 0;
-        let startNode = null;
-        let endNode = null;
-        let startOffset = 0;
-        let endOffset = 0;
-        for (let i = 0; i < nodes.length; i++) {
-            const node = nodes[i];
-            const text = node.nodeValue || '';
-            const nextOffset = offset + text.length;
-            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
-                startNode = node;
-                startOffset = Math.max(0, start - offset);
-            }
-            if (!endNode && end > offset && end <= nextOffset) {
-                endNode = node;
-                endOffset = Math.max(0, end - offset);
-            }
-            if (startNode && endNode) break;
-            offset = nextOffset;
-        }
-        if (!startNode || !endNode) return null;
-        const range = document.createRange();
-        range.setStart(startNode, startOffset);
-        range.setEnd(endNode, endOffset);
-        return range;
-    }
+    // Content and Range rules are shared with the real-browser regression suite.
+    function getTextNodes(root) { return global.ReadingVocabAnchors.textNodes(root); }
 
     // ============================================================================
     // Parse in an inert template: even a pre-checked radio must never join a
@@ -9053,11 +9291,22 @@
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        _selectionPending: new Set(),
+        _undoOccurrence: null,
+        _occurrenceBusy: false,
+        unresolvedOccurrences: [],
 
         clearPendingWork(overlay) {
             this._pendingTimers.forEach(timer => clearTimeout(timer));
             this._pendingTimers.clear();
             this.toastTimer = null;
+            this._undoOccurrence = null;
+            this.unresolvedOccurrences = [];
+            this._selectionPending.clear();
+            this._occurrenceBusy = false;
+            overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
+            overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
+            overlay?.querySelector('#vocab-anchor-status')?.replaceChildren();
             const toast = overlay?.querySelector('#vocab-toast');
             if (toast) {
                 toast.classList.remove('show');
@@ -9123,13 +9372,13 @@
                     <!-- 沉浸式提示栏 -->
                     <div class="vocab-reader-banner">
                         <span class="vocab-banner-icon">✨</span>
-                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中用鼠标、触屏或 Shift＋方向键选择生词或短语（最多 45 字符）。保存后以<strong>黄色高亮</strong>标注；点击高亮可移除这一处。</span>
                     </div>
 
                     <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
                     <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
                         <!-- 阅读核心主内容区 -->
-                        <main class="vocab-reader-body" id="vocab-reader-body">
+                        <main class="vocab-reader-body" id="vocab-reader-body" data-vocab-source-root>
                             <!-- 文章区域 -->
                             <section class="vocab-passage-section" id="vocab-passage-section">
                                 <div class="vocab-passage-header">
@@ -9163,6 +9412,9 @@
 
                     <!-- 划词收录 Toast 提示 -->
                     <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+                    <div class="vocab-occurrence-actions" id="vocab-occurrence-actions" aria-live="polite"></div>
+                    <div class="vocab-occurrence-undo" id="vocab-occurrence-undo" role="status" aria-live="polite"></div>
+                    <div class="vocab-anchor-status" id="vocab-anchor-status" role="status" aria-live="polite"></div>
 
                     <!-- 生词本弹窗 Modal -->
                     <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
@@ -9456,156 +9708,43 @@
                 });
             }
 
-            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
-                const handleSelectionCapture = () => {
-                    const requestId = this._openRequestId;
-                    this.defer(async () => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
-                        const selection = window.getSelection();
-                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
-                        const rawText = selection.toString();
-                        const text = rawText.trim();
-
-                        // 限制在1到45个字符之间，避免大段全文误选
-                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
-                            return;
-                        }
-
-                        let range;
-                        try {
-                            range = selection.getRangeAt(0);
-                        } catch (_) {
-                            return;
-                        }
-                        if (!range || range.collapsed) return;
-
-                        // 确保选区位于文章正文或题目区域内
-                        const passageContent = overlay.querySelector('#vocab-passage-content');
-                        const questionsContent = overlay.querySelector('#vocab-questions-content');
-                        const commonNode = range.commonAncestorContainer;
-                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
-                        if (!commonEl) return;
-                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
-                            return;
-                        }
-                        // 忽略译文卡片、段落标签、按钮等非正文区域
-                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
-                            return;
-                        }
-
-                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
-                        const existingMark = commonEl.closest('mark.vocab-highlight');
-                        if (existingMark) {
-                            return;
-                        }
-
-                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
-                        const trimmedRange = this.trimRangeWhitespace(range);
-                        if (!trimmedRange || trimmedRange.collapsed) return;
-
-                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
-                        const targetCard = commonEl.closest('.vocab-paragraph-card');
-                        const targetQGroup = commonEl.closest('.vocab-question-group');
-                        let scope = 'passage';
-                        let scopeElement = passageContent;
-
-                        if (targetCard) {
-                            const letter = targetCard.dataset.letter || '';
-                            scope = letter ? `para-${letter}` : 'passage';
-                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
-                        } else if (targetQGroup) {
-                            scope = targetQGroup.id || 'questions';
-                            scopeElement = targetQGroup;
-                        } else if (questionsContent?.contains(commonEl)) {
-                            scope = 'questions';
-                            scopeElement = questionsContent;
-                        }
-
-                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
-                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
-
-                        // 获取上下文句子
-                        let contextSentence = '';
-                        try {
-                            const parentBlock = commonEl;
-                            if (parentBlock) {
-                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
-                            }
-                        } catch (_) {}
-
-                        const cleanWord = ReadingVocabStore.cleanWord(text);
-                        if (!cleanWord) return;
-
-                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
-                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
-                        if (!wrappedMark) return;
-
-                        const highlightRecord = {
-                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                            examId: this.currentExamId || '',
-                            scope: scope,
-                            startOffset: locInfo.startOffset,
-                            endOffset: locInfo.endOffset,
-                            before: locInfo.before,
-                            after: locInfo.after,
-                            occurrence: locInfo.occurrence,
-                            text: cleanWord
-                        };
-
-                        this.showToast('正在保存…');
-                        try {
-                            const result = await ReadingVocabStore.add(
-                                cleanWord,
-                                this.currentExamId,
-                                this.currentExam?.title || '',
-                                contextSentence,
-                                highlightRecord, this.currentSource
-                            );
-
-                            if (requestId !== this._openRequestId) return;
-                            if (result.added) {
-                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                                this.updateCounts();
-                                if (this.modalOpen) {
-                                    this.renderVocabList();
-                                }
-                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
-                            } else {
-                                throw new Error('Selection was not saved');
-                            }
-                        } catch (error) {
-                            if (wrappedMark.parentNode) {
-                                const parent = wrappedMark.parentNode;
-                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
-                                wrappedMark.remove();
-                                parent.normalize();
-                            }
-                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
-                        }
-                    }, 20);
+                const capture = event => {
+                    if (event?.target?.closest('button, input, textarea, select, .vocab-translation-card, .vocab-paragraph-tag')) return;
+                    this.defer(() => this.captureSelection(), 20);
                 };
-
-                on(readerBody, 'mouseup', handleSelectionCapture);
-                on(readerBody, 'touchend', handleSelectionCapture);
-
-                // 点击黄色高亮生词：朗读发音并轻量提示
-                on(readerBody, 'click', (e) => {
-                    const mark = e.target.closest('mark.vocab-highlight');
-                    if (mark) {
-                        const selection = window.getSelection();
-                        if (selection && selection.toString().trim().length > 0) {
-                            return; // 划选操作中不触发点击发音
-                        }
-                        const word = mark.dataset.word || mark.textContent.trim();
-                        if (word) {
-                            speakWord(word);
-                            this.showToast(`🔊 ${word} (已收录生词)`);
-                        }
+                on(readerBody, 'mouseup', capture);
+                on(readerBody, 'touchend', capture);
+                on(overlay, 'keyup', event => {
+                    if (event.key === 'Shift') capture(event);
+                });
+                on(readerBody, 'click', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && !window.getSelection()?.toString().trim()) this.showOccurrenceActions(mark);
+                });
+                on(readerBody, 'keydown', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && (event.key === 'Enter' || event.key === ' ')) {
+                        event.preventDefault();
+                        this.showOccurrenceActions(mark);
+                    } else {
+                        this.moveKeyboardSelection(event);
                     }
                 });
             }
+            on(overlay, 'click', event => {
+                const button = event.target.closest('[data-action]');
+                if (!button || button.disabled) return;
+                if (button.dataset.action === 'remove-occurrence') {
+                    event.stopPropagation();
+                    this.removeOccurrence(button.dataset.occurrenceId);
+                } else if (button.dataset.action === 'undo-occurrence') {
+                    this.undoOccurrence();
+                } else if (button.dataset.action === 'retry-anchors') {
+                    this.open(this.currentExamId, { source: this.currentSource });
+                }
+            });
 
             // ESC 键监听
             on(window, 'keydown', (e) => {
@@ -9676,9 +9815,10 @@
 
             try {
                 // 加载试卷数据
-                const [payload, source] = await Promise.all([
-                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
-                ]);
+                const source = await ReadingVocabStore.resolveSource(options);
+                if (requestId !== this._openRequestId) return;
+                this.currentSource = source;
+                const payload = await loadReadingExamPayload(examId);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
@@ -9723,6 +9863,11 @@
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
+                this.currentPayload = null;
+                await ReadingVocabStore.init().catch(() => {});
+                if (requestId !== this._openRequestId) return;
+                this.applyVocabHighlights();
+                this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
@@ -9766,8 +9911,7 @@
             }
 
             // 解析文章大标题、考试指导语与真实段落
-            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
-            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
             const blocks = passageData.blocks;
             const instructionHtml = passageData.instructionHtml;
             const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
@@ -9782,21 +9926,21 @@
             // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
             const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
             if (passageIntroEl) {
+                passageIntroEl.replaceChildren();
                 if (instructionHtml) {
-                    passageIntroEl.innerHTML = `
-                        <div class="vocab-passage-instruction" role="note">
-                            <span class="vocab-instruction-icon">📋</span>
-                            <div class="vocab-instruction-text">${instructionHtml}</div>
-                        </div>
-                    `;
-                    passageIntroEl.style.display = 'block';
-                } else if (passageData.subtitleHtml) {
-                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
-                    passageIntroEl.style.display = 'block';
-                } else {
-                    passageIntroEl.innerHTML = '';
-                    passageIntroEl.style.display = 'none';
+                    const instruction = document.createElement('div');
+                    instruction.className = 'vocab-passage-instruction';
+                    instruction.setAttribute('role', 'note');
+                    instruction.appendChild(createReadOnlyQuestionContent(instructionHtml, 'vocab-passage-instruction'));
+                    passageIntroEl.appendChild(instruction);
                 }
+                if (passageData.subtitleHtml) {
+                    const subtitle = document.createElement('div');
+                    subtitle.className = 'vocab-passage-subtitle';
+                    subtitle.appendChild(createReadOnlyQuestionContent(passageData.subtitleHtml, 'vocab-passage-subtitle'));
+                    passageIntroEl.appendChild(subtitle);
+                }
+                passageIntroEl.style.display = passageIntroEl.childNodes.length ? 'block' : 'none';
             }
 
             // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
@@ -9804,7 +9948,7 @@
             if (tabsContainer) {
                 let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
                 blocks.forEach(b => {
-                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.id}">Para ${b.letter}</button>`;
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
@@ -9817,22 +9961,27 @@
                     let passageHtml = '';
                     blocks.forEach(b => {
                         passageHtml += `
-                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.id}" data-paragraph-id="${b.id}" data-letter="${b.letter}">
                                 <div class="vocab-paragraph-tag">
                                     <span class="vocab-para-letter">Para ${b.letter}</span>
                                 </div>
-                                <div class="vocab-paragraph-text">${b.html}</div>
-                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                <div class="vocab-paragraph-text" data-content-id="${b.id}"></div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.id}" style="display: ${this.showTranslation ? 'block' : 'none'};">
                                     <div class="vocab-trans-label">中文参考译文：</div>
-                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.id}">加载中...</div>
                                 </div>
                             </div>
                         `;
                     });
                     passageContent.innerHTML = passageHtml;
+                    blocks.forEach(block => {
+                        const text = passageContent.querySelector('[data-content-id="' + block.id + '"]');
+                        text.appendChild(createReadOnlyQuestionContent(block.html, 'vocab-' + block.id));
+                        this.assignTextScopes(text, 'passage/' + block.id);
+                    });
                 } else {
                     // 原生清洗后渲染
-                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                    passageContent.innerHTML = '<p class="vocab-empty-tip">本篇暂无可用正文</p>';
                 }
             }
 
@@ -9846,7 +9995,10 @@
                         const group = document.createElement('div');
                         group.className = 'vocab-question-group';
                         group.id = `vocab-qgroup-${idx + 1}`;
-                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        group.dataset.sectionId = 'q-' + (idx + 1);
+                        const html = (g.leadHtml || '') + (g.bodyHtml || g.html || '');
+                        group.appendChild(createReadOnlyQuestionContent(html, group.id));
+                        this.assignTextScopes(group, 'questions/q-' + (idx + 1), true);
                         groups.appendChild(group);
                     });
                     questionsContent.replaceChildren(groups);
@@ -9864,317 +10016,234 @@
             this.applyVocabHighlights();
         },
 
-        trimRangeWhitespace(range) {
-            if (!range || range.collapsed) return range;
-            const startNode = range.startContainer;
-            let startOffset = range.startOffset;
-            const endNode = range.endContainer;
-            let endOffset = range.endOffset;
-
-            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
-                const text = startNode.nodeValue || '';
-                const segment = text.slice(startOffset, endOffset);
-                const leadSpace = segment.search(/\S/);
-                if (leadSpace > 0) {
-                    startOffset += leadSpace;
-                } else if (leadSpace === -1) {
-                    return null;
+        assignTextScopes(root, prefix, alwaysNumber = false) {
+            const boundaries = 'p, li, td, th, dt, dd, h1, h2, h3, h4, h5, h6, blockquote, div, section, table, ul, ol';
+            const scopes = [];
+            const visit = element => {
+                if (!element.querySelector(boundaries)) {
+                    if (global.ReadingVocabAnchors.text(element).trim()) scopes.push(element);
+                    return;
                 }
-                const trailSpace = segment.length - segment.trimEnd().length;
-                if (trailSpace > 0) {
-                    endOffset -= trailSpace;
-                }
-                if (endOffset <= startOffset) return null;
-
-                const trimmed = document.createRange();
-                trimmed.setStart(startNode, startOffset);
-                trimmed.setEnd(endNode, endOffset);
-                return trimmed;
-            }
-
-            if (startNode.nodeType === Node.TEXT_NODE) {
-                const text = (startNode.nodeValue || '').slice(startOffset);
-                const m = text.match(/^\s+/);
-                if (m) {
-                    range.setStart(startNode, startOffset + m[0].length);
-                }
-            }
-            if (endNode.nodeType === Node.TEXT_NODE) {
-                const text = (endNode.nodeValue || '').slice(0, endOffset);
-                const m = text.match(/\s+$/);
-                if (m) {
-                    range.setEnd(endNode, endOffset - m[0].length);
-                }
-            }
-            return range;
+                let run = [];
+                const flush = () => {
+                    if (!run.length) return;
+                    if (run.some(node => node.textContent.trim())) {
+                        const span = document.createElement('span');
+                        element.insertBefore(span, run[0]);
+                        span.append(...run);
+                        scopes.push(span);
+                    }
+                    run = [];
+                };
+                [...element.childNodes].forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE && (node.matches(boundaries) || node.querySelector(boundaries))) {
+                        flush();
+                        visit(node);
+                    } else run.push(node);
+                });
+                flush();
+            };
+            visit(root);
+            scopes.forEach((scope, index) => {
+                scope.dataset.vocabScope = alwaysNumber || scopes.length > 1 ? prefix + '/p-' + (index + 1) : prefix;
+                scope.dataset.vocabSourceVersion = global.ReadingVocabAnchors.hashText(JSON.stringify(this.currentPayload));
+                scope.tabIndex = 0;
+            });
         },
 
-        calculateRangeLocation(scopeElement, range, text) {
-            const textNodes = getTextNodes(scopeElement);
-            let runningOffset = 0;
-            let startOffset = -1;
-
-            for (let i = 0; i < textNodes.length; i++) {
-                const node = textNodes[i];
-                if (node === range.startContainer) {
-                    startOffset = runningOffset + range.startOffset;
-                    break;
-                }
-                runningOffset += (node.nodeValue || '').length;
-            }
-
-            if (startOffset === -1) {
-                startOffset = 0;
-            }
-
-            const endOffset = startOffset + text.length;
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
-            const after = fullText.slice(endOffset, endOffset + 30);
-
-            let occurrence = 0;
-            const lowerFull = fullText.toLowerCase();
-            const lowerWord = text.toLowerCase();
-            let idx = -1;
-            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
-                occurrence += 1;
-            }
-
-            return { startOffset, endOffset, before, after, occurrence };
+        calculateRangeLocation(scopeElement, range) {
+            return global.ReadingVocabAnchors.calculateLocation(scopeElement, range);
         },
 
-        wrapRangeWithHighlight(range, word) {
-            if (!range || range.collapsed) return null;
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight vocab-highlight--pulse';
-            mark.dataset.word = word;
-            mark.title = `生词本: ${word} (点击发音)`;
+        moveKeyboardSelection(event) {
+            if (this.modalOpen || !/^(ArrowLeft|ArrowRight|ArrowUp|ArrowDown|Home|End)$/.test(event.key)) return;
+            const scope = event.target.closest('[data-vocab-scope]');
+            if (!scope || event.target.closest('button, input, textarea, select, [role="button"]')) return;
+            const selection = window.getSelection();
+            if (!selection || typeof selection.modify !== 'function') return;
+            const nodes = getTextNodes(scope);
+            if (!nodes.length) return;
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.collapse(nodes[0], 0);
+            }
+            const previous = { anchor: selection.anchorNode, start: selection.anchorOffset,
+                focus: selection.focusNode, end: selection.focusOffset };
+            const forward = /^(ArrowRight|ArrowDown|End)$/.test(event.key);
+            let unit = /^(ArrowUp|ArrowDown)$/.test(event.key) ? 'line' : 'character';
+            if (event.ctrlKey || event.metaKey) unit = 'word';
+            if (event.key === 'Home' || event.key === 'End') unit = 'lineboundary';
+            event.preventDefault();
+            // Static selectable text has no native caret navigation in some
+            // supported browsers unless their global caret-browsing mode is on.
+            selection.modify(event.shiftKey ? 'extend' : 'move', forward ? 'forward' : 'backward', unit);
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.setBaseAndExtent(previous.anchor, previous.start, previous.focus, previous.end);
+            }
+        },
 
+        async captureSelection() {
+            const overlay = this.ensureOverlay();
+            if (overlay.classList.contains('is-hidden') || this.modalOpen || !this.currentPayload) return;
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) return;
+            const range = selection.getRangeAt(0);
+            const start = range.startContainer.nodeType === Node.ELEMENT_NODE ? range.startContainer : range.startContainer.parentElement;
+            const scope = start?.closest('[data-vocab-scope]');
+            if (!scope || !overlay.querySelector('#vocab-reader-body')?.contains(scope)) return;
+            const captured = global.ReadingVocabAnchors.capture(scope, range);
+            if (!captured) return;
+            const requestId = this._openRequestId;
+            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
+            if (this._selectionPending.has(pendingId)) return;
+            this._selectionPending.add(pendingId);
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-            } catch (e) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                } catch (err) {
-                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
-                    return null;
-                }
+                const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                if (requestId !== this._openRequestId) return;
+                if (!result.added) throw new Error('Selection was not saved');
+                selection.removeAllRanges();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('✅ "' + captured.word + '" 已收录并黄色高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
+            } finally {
+                this._selectionPending.delete(pendingId);
             }
+        },
 
-            this.defer(() => {
-                mark.classList.remove('vocab-highlight--pulse');
-            }, 1500);
-
-            return mark;
+        wrapRangeWithHighlight(range, word, occurrenceId) {
+            if (!range || range.collapsed) return false;
+            // Wrap each text fragment separately so repeated restore never splits,
+            // extracts, or rewrites the source's inline formatting or annotations.
+            const fragments = getTextNodes(range.commonAncestorContainer.nodeType === Node.TEXT_NODE
+                ? range.commonAncestorContainer.parentElement : range.commonAncestorContainer)
+                .filter(node => range.intersectsNode(node)).map(node => ({ node,
+                    start: node === range.startContainer ? range.startOffset : 0,
+                    end: node === range.endContainer ? range.endOffset : node.length
+                })).filter(fragment => fragment.end > fragment.start);
+            for (const fragment of fragments.reverse()) {
+                const selected = document.createRange();
+                selected.setStart(fragment.node, fragment.start);
+                selected.setEnd(fragment.node, fragment.end);
+                const mark = document.createElement('mark');
+                mark.className = 'vocab-highlight';
+                mark.dataset.word = word;
+                mark.dataset.occurrenceId = occurrenceId;
+                mark.tabIndex = 0;
+                mark.setAttribute('role', 'button');
+                mark.title = '生词本: ' + word + '（查看或移除这一处）';
+                selected.surroundContents(mark);
+            }
+            return fragments.length > 0;
         },
 
         applyVocabHighlights() {
             const overlay = this.ensureOverlay();
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-
-            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
-            this.removeVocabHighlights(passageContent);
-            this.removeVocabHighlights(questionsContent);
-
-            if (!this.currentExamId) return;
-
-            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
-            if (!examItems || examItems.length === 0) return;
-
-            examItems.forEach(item => {
-                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
-                    item.highlights.forEach(hl => {
-                        if (String(hl.examId) === String(this.currentExamId)) {
-                            this.restoreVocabHighlight(overlay, hl, item.word);
+            this.removeVocabHighlights(overlay.querySelector('#vocab-reader-body'));
+            this.unresolvedOccurrences = [];
+            if (this.currentExamId) {
+                ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).forEach(item => {
+                    item.occurrences.forEach(occurrence => {
+                        if (!this.restoreVocabHighlight(overlay, occurrence, item.word)) {
+                            this.unresolvedOccurrences.push({ ...occurrence, word: item.word });
                         }
                     });
-                }
-            });
+                });
+            }
+            this.renderAnchorStatus();
         },
 
-        restoreVocabHighlight(overlay, hl, word) {
-            if (!overlay || !hl) return false;
-            let scopeElement = null;
+        restoreVocabHighlight(overlay, occurrence, word) {
+            if (!this.currentPayload) return false;
+            const range = this.resolveRangeForHighlight(overlay.querySelector('#vocab-reader-body'), occurrence);
+            return !!range && this.wrapRangeWithHighlight(range, word || occurrence.quote, occurrence.id);
+        },
 
-            if (hl.scope && hl.scope.startsWith('para-')) {
-                const letter = hl.scope.replace('para-', '');
-                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
-                if (card) {
-                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
-                }
-            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
-                scopeElement = overlay.querySelector(`#${hl.scope}`);
-            } else if (hl.scope === 'questions') {
-                scopeElement = overlay.querySelector('#vocab-questions-content');
-            } else {
-                scopeElement = overlay.querySelector('#vocab-passage-content');
-            }
+        resolveRangeForHighlight(root, occurrence) {
+            return global.ReadingVocabAnchors.resolve(root, occurrence);
+        },
 
-            if (!scopeElement) {
-                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
-            }
-            if (!scopeElement) return false;
+        showOccurrenceActions(mark) {
+            const actions = this.ensureOverlay().querySelector('#vocab-occurrence-actions');
+            actions.innerHTML = '<span>' + escapeHtml(mark.dataset.word) + '</span> <button type="button" data-action="remove-occurrence" data-occurrence-id="'
+                + escapeHtml(mark.dataset.occurrenceId) + '">移除这一处高亮</button>';
+            actions.querySelector('button').focus({ preventScroll: true });
+            speakWord(mark.dataset.word);
+        },
 
-            const range = this.resolveRangeForHighlight(scopeElement, hl);
-            if (!range || range.collapsed) return false;
+        renderAnchorStatus() {
+            const status = this.ensureOverlay().querySelector('#vocab-anchor-status');
+            if (!status) return;
+            status.replaceChildren();
+            if (!this.unresolvedOccurrences.length) return;
+            const message = document.createElement('span');
+            message.textContent = this.unresolvedOccurrences.length + ' 处原文暂时无法定位，生词仍保留。可重试加载，或在生词本移除旧位置后重新划选。';
+            const retry = document.createElement('button');
+            retry.type = 'button';
+            retry.dataset.action = 'retry-anchors';
+            retry.textContent = '重试定位';
+            status.append(message, retry);
+        },
 
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight';
-            mark.dataset.word = word || hl.text;
-            mark.title = `生词本: ${word || hl.text} (点击发音)`;
-
+        async removeOccurrence(occurrenceId) {
+            if (this._occurrenceBusy) return;
+            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
+            const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
+            if (!occurrence) return;
+            const requestId = this._openRequestId;
+            const undo = { source: { ...this.currentSource },
+                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+                word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
+                occurrence: { ...occurrence }, manual: false };
+            const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-                return true;
-            } catch (_) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                    return true;
-                } catch (e) {
-                    return false;
-                }
+                const result = await ReadingVocabStore.mutate('removeOccurrence', { occurrenceId }, observed);
+                if (requestId !== this._openRequestId) return;
+                // Keep the acknowledged deletion fence: a later clear/replace must
+                // reject this undo instead of resurrecting deleted relationships.
+                const committedRevision = result.revisions?.['vocab.readingState'];
+                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                    ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
+                    this._undoOccurrence ? '<span>已移除这一处高亮</span> <button type="button" data-action="undo-occurrence">撤销</button>' : '';
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已移除这一处高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '移除失败，请重试');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
         },
 
-        resolveRangeForHighlight(root, hl) {
-            if (!root || !hl) return null;
-            const textNodes = getTextNodes(root);
-            if (!textNodes.length) return null;
-
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const targetText = String(hl.text || '').trim();
-            if (!targetText) return null;
-
-            const startOffset = Number(hl.startOffset);
-            const endOffset = Number(hl.endOffset);
-
-            // 1. 优先尝试 offset 精确匹配
-            if (
-                Number.isFinite(startOffset) &&
-                Number.isFinite(endOffset) &&
-                endOffset > startOffset &&
-                startOffset >= 0 &&
-                endOffset <= fullText.length
-            ) {
-                const segment = fullText.slice(startOffset, endOffset);
-                if (segment.toLowerCase() === targetText.toLowerCase()) {
-                    return resolveRangeFromOffsets(root, startOffset, endOffset);
-                }
+        async undoOccurrence() {
+            if (this._occurrenceBusy || !this._undoOccurrence) return;
+            const requestId = this._openRequestId;
+            const undo = this._undoOccurrence;
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
+            try {
+                await ReadingVocabStore.mutate('collect', { ...undo.command, at: new Date().toISOString() }, undo.observed);
+                if (requestId !== this._openRequestId) return;
+                this._undoOccurrence = null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').replaceChildren();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已撤销移除');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '撤销失败，数据可能已更改；可重试或重新划选');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
-
-            // 2. 次优：使用 before / after 上下文精确定位单处实例
-            if (hl.before || hl.after) {
-                let searchPos = 0;
-                let matchIdx = -1;
-                let bestIdx = -1;
-                let bestScore = -1;
-                const lowerFull = fullText.toLowerCase();
-                const lowerTarget = targetText.toLowerCase();
-
-                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
-                    let score = 0;
-                    if (hl.before) {
-                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
-                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
-                            score += 3;
-                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (hl.after) {
-                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
-                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
-                            score += 3;
-                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestIdx = matchIdx;
-                    }
-                    searchPos = matchIdx + 1;
-                }
-
-                if (bestIdx !== -1 && bestScore > 0) {
-                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
-                }
-            }
-
-            // 3. 兜底：使用 occurrence（第 N 次出现）
-            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
-            let currentOccurrence = 0;
-            let pos = 0;
-            let matchPos = -1;
-            const lowerFull = fullText.toLowerCase();
-            const lowerTarget = targetText.toLowerCase();
-
-            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
-                if (currentOccurrence === occurrence) {
-                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
-                }
-                currentOccurrence += 1;
-                pos = matchPos + 1;
-            }
-
-            return null;
-        },
-
-        restoreLegacyHighlightByContext(overlay, word, context) {
-            if (!overlay || !word) return false;
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-            const roots = [passageContent, questionsContent].filter(Boolean);
-
-            const targetWord = String(word).trim();
-            const lowerWord = targetWord.toLowerCase();
-            const lowerContext = String(context || '').trim().toLowerCase();
-
-            for (const root of roots) {
-                const textNodes = getTextNodes(root);
-                const fullText = textNodes.map(n => n.nodeValue || '').join('');
-                const lowerFull = fullText.toLowerCase();
-
-                let targetIdx = -1;
-                if (lowerContext && lowerFull.includes(lowerContext)) {
-                    const ctxIdx = lowerFull.indexOf(lowerContext);
-                    const wordInCtx = lowerContext.indexOf(lowerWord);
-                    if (wordInCtx !== -1) {
-                        targetIdx = ctxIdx + wordInCtx;
-                    }
-                }
-
-                // 无论如何，只恢复单处实例，绝不全篇高亮
-                if (targetIdx !== -1) {
-                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
-                    if (range && !range.collapsed) {
-                        const mark = document.createElement('mark');
-                        mark.className = 'vocab-highlight';
-                        mark.dataset.word = targetWord;
-                        mark.title = `生词本: ${targetWord} (点击发音)`;
-                        try {
-                            range.surroundContents(mark);
-                            return true;
-                        } catch (_) {
-                            try {
-                                const frag = range.extractContents();
-                                mark.appendChild(frag);
-                                range.insertNode(mark);
-                                return true;
-                            } catch (e) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
         },
 
         removeVocabHighlights(container) {
@@ -10219,7 +10288,8 @@
                 const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
                 if (match) {
                     const letter = match[1].toUpperCase();
-                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    const cards = [...overlay.querySelectorAll('.vocab-paragraph-card')].filter(card => card.dataset.letter === letter);
+                    const transEl = cards.length === 1 ? cards[0].querySelector('.vocab-trans-text') : null;
                     if (transEl) {
                         transEl.textContent = note.text || '';
                     }
@@ -10260,7 +10330,7 @@
                 if (passageSection) passageSection.style.display = 'block';
                 if (questionsSection) questionsSection.style.display = 'none';
                 cards.forEach(c => {
-                    if (c.dataset.letter === target) {
+                    if (c.dataset.paragraphId === target) {
                         c.style.display = 'block';
                         c.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     } else {
@@ -10310,7 +10380,16 @@
             }
 
             let html = '';
+            const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
             list.forEach(item => {
+                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                    .find(row => row.id === item.id)?.occurrences || [];
+                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
+                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
+                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                    + '">移除这一处</button></div>').join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
@@ -10319,6 +10398,7 @@
                                 <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
                             ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${occurrenceRows}
                             ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
                         <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
@@ -10400,9 +10480,9 @@
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
             if (ReadingVocabReader.currentExamId) {
-                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
             }
         });
     }
@@ -19004,6 +19084,8 @@
     "js/core/dictionaryService.js",
     "js/runtime/reviewHighlightDictionary.js",
     "js/utils/practiceTimerPreferences.js",
+    "js/components/readingVocabContent.js",
+    "js/components/readingVocabAnchors.js",
     "js/components/readingVocabReader.js",
     "js/runtime/unifiedReadingPage.js"
 ]);

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -8846,6 +8846,17 @@
             return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
         },
 
+        getOccurrenceOwner(occurrence) {
+            const reading = this._state?.snapshot.reading;
+            const association = reading?.associations.find(row => row.id === occurrence.associationId);
+            const article = reading?.articles.find(row => row.id === association?.articleId);
+            const source = reading?.sources.find(row => row.id === article?.sourceId);
+            if (!article || !source) return null;
+            return { articleId: article.id,
+                source: { kind: source.kind, id: source.libraryId },
+                article: { examId: article.examId, title: article.title } };
+        },
+
         adopt(state) {
             if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
             this._state = state;
@@ -9291,6 +9302,7 @@
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        // Durable writes survive closing/reopening; release only when they settle.
         _selectionPending: new Set(),
         _undoOccurrence: null,
         _occurrenceBusy: false,
@@ -9302,7 +9314,6 @@
             this.toastTimer = null;
             this._undoOccurrence = null;
             this.unresolvedOccurrences = [];
-            this._selectionPending.clear();
             this._occurrenceBusy = false;
             overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
             overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
@@ -10093,9 +10104,15 @@
             const captured = global.ReadingVocabAnchors.capture(scope, range);
             if (!captured) return;
             const requestId = this._openRequestId;
-            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
-            if (this._selectionPending.has(pendingId)) return;
-            this._selectionPending.add(pendingId);
+            // Pending saves have no paint yet, so reserve their text intervals
+            // until acknowledgement to prevent invisible overlapping captures.
+            const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId));
+            const pendingSelection = { articleId, scopeId: captured.scopeId,
+                startOffset: captured.startOffset, endOffset: captured.endOffset };
+            if ([...this._selectionPending].some(pending => pending.articleId === articleId &&
+                pending.scopeId === captured.scopeId && captured.startOffset < pending.endOffset &&
+                captured.endOffset > pending.startOffset)) return;
+            this._selectionPending.add(pendingSelection);
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
@@ -10110,7 +10127,7 @@
             } catch (error) {
                 if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
             } finally {
-                this._selectionPending.delete(pendingId);
+                this._selectionPending.delete(pendingSelection);
             }
         },
 
@@ -10190,13 +10207,14 @@
 
         async removeOccurrence(occurrenceId) {
             if (this._occurrenceBusy) return;
-            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+            const item = ReadingVocabStore.getAll()
                 .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
             const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
             if (!occurrence) return;
+            const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+            if (!owner) return;
             const requestId = this._openRequestId;
-            const undo = { source: { ...this.currentSource },
-                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+            const undo = { source: owner.source, article: owner.article,
                 word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
                 occurrence: { ...occurrence }, manual: false };
             const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
@@ -10381,15 +10399,22 @@
 
             let html = '';
             const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
+            const currentArticleId = this.currentExamId
+                ? global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId)) : null;
             list.forEach(item => {
-                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
-                    .find(row => row.id === item.id)?.occurrences || [];
-                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
-                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
-                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
-                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
-                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
-                    + '">移除这一处</button></div>').join('');
+                const occurrenceRows = item.occurrences.map(occurrence => {
+                    const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+                    const status = owner?.articleId === currentArticleId
+                        ? (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') : 'unverified';
+                    return '<div class="vocab-occurrence-row" data-occurrence-id="'
+                        + escapeHtml(occurrence.id) + '" data-anchor-status="' + status + '">'
+                        + (!isCurrent && owner ? '<span class="vocab-item__source">'
+                            + escapeHtml(owner.article.title || owner.article.examId) + '</span>' : '')
+                        + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                        + (status === 'unresolved' ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                        + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                        + '">移除这一处</button></div>';
+                }).join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">

--- a/js/components/readingVocabAnchors.js
+++ b/js/components/readingVocabAnchors.js
@@ -1,0 +1,262 @@
+(function (global) {
+    'use strict';
+
+    const SCOPE = '[data-vocab-scope]';
+    const EXCLUDED = 'script,style,noscript,template,button,input,textarea,select,option,' +
+        '[role="button"]:not(.vocab-highlight):not(.hl),[contenteditable]:not([contenteditable="false"]),' +
+        '.vocab-translation-card,.vocab-paragraph-tag,.vocab-answer-blank';
+    const HIGHLIGHT = '.vocab-highlight,.hl';
+    const BLOCK = 'p,div,li,td,th,blockquote,pre,h1,h2,h3,h4,h5,h6,section,article';
+    const CONTEXT_LENGTH = 48;
+
+    function hidden(element) {
+        if (element.hidden || element.getAttribute('aria-hidden') === 'true') return true;
+        const style = element.ownerDocument.defaultView.getComputedStyle(element);
+        return style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse';
+    }
+
+    function excluded(element, root) {
+        for (let current = element; current; current = current.parentElement) {
+            if (current.matches(EXCLUDED) || hidden(current)) return true;
+            if (current === root) break;
+        }
+        return false;
+    }
+
+    // Highlight wrappers contribute their original text. This keeps offsets and
+    // content versions stable while other occurrences are painted or removed.
+    function textNodes(root) {
+        if (!root || !root.ownerDocument) return [];
+        const nodes = [];
+        const walker = root.ownerDocument.createTreeWalker(root, 4);
+        let node;
+        while ((node = walker.nextNode())) {
+            if (node.parentElement && !excluded(node.parentElement, root)) nodes.push(node);
+        }
+        return nodes;
+    }
+
+    function text(root) {
+        return textNodes(root).map(node => node.nodeValue || '').join('');
+    }
+
+    function textVersion(value) {
+        let first = 0x811c9dc5;
+        let second = 0x9e3779b9;
+        for (let index = 0; index < value.length; index += 1) {
+            const code = value.charCodeAt(index);
+            first = Math.imul(first ^ code, 0x01000193);
+            second = Math.imul(second ^ code, 0x85ebca6b);
+        }
+        return `reader-text-v1:${value.length}:${(first >>> 0).toString(16)}:${(second >>> 0).toString(16)}`;
+    }
+
+    function versionForText(root, value) {
+        const sourceVersion = root.getAttribute('data-vocab-source-version');
+        const scopeVersion = textVersion(value);
+        return sourceVersion ? `reader-scope-v2:${sourceVersion}:${scopeVersion}` : scopeVersion;
+    }
+
+    function version(root) { return versionForText(root, text(root)); }
+
+    function comparePoints(doc, leftNode, leftOffset, rightNode, rightOffset) {
+        const left = doc.createRange();
+        const right = doc.createRange();
+        left.setStart(leftNode, leftOffset);
+        left.collapse(true);
+        right.setStart(rightNode, rightOffset);
+        right.collapse(true);
+        return left.compareBoundaryPoints(0, right);
+    }
+
+    function offsetAtPoint(root, nodes, container, offset) {
+        if (container !== root && !root.contains(container)) return null;
+        let position = 0;
+        for (const node of nodes) {
+            const length = (node.nodeValue || '').length;
+            if (container === node) return position + offset;
+            if (comparePoints(root.ownerDocument, container, offset, node, 0) <= 0) return position;
+            if (comparePoints(root.ownerDocument, container, offset, node, length) < 0) return null;
+            position += length;
+        }
+        return position;
+    }
+
+    function resolveOffsets(root, start, end) {
+        if (!root || !Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start) return null;
+        const nodes = textNodes(root);
+        let position = 0;
+        let startNode;
+        let startInNode;
+        for (const node of nodes) {
+            const next = position + (node.nodeValue || '').length;
+            if (!startNode && start >= position && start < next) {
+                startNode = node;
+                startInNode = start - position;
+            }
+            if (startNode && end > position && end <= next) {
+                const range = root.ownerDocument.createRange();
+                range.setStart(startNode, startInNode);
+                range.setEnd(node, end - position);
+                return range;
+            }
+            position = next;
+        }
+        return null;
+    }
+
+    function calculateLocation(root, range) {
+        if (!root || !range || range.collapsed) return null;
+        try {
+            const nodes = textNodes(root);
+            const fullText = nodes.map(node => node.nodeValue || '').join('');
+            const startOffset = offsetAtPoint(root, nodes, range.startContainer, range.startOffset);
+            const endOffset = offsetAtPoint(root, nodes, range.endContainer, range.endOffset);
+            if (startOffset === null || endOffset === null || endOffset <= startOffset) return null;
+            const quote = fullText.slice(startOffset, endOffset);
+            return {
+                startOffset, endOffset, quote, text: quote,
+                before: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), startOffset),
+                after: fullText.slice(endOffset, endOffset + CONTEXT_LENGTH),
+                contentVersion: versionForText(root, fullText),
+                context: fullText.slice(Math.max(0, startOffset - CONTEXT_LENGTH), endOffset + CONTEXT_LENGTH)
+            };
+        } catch (_) { return null; }
+    }
+
+    function overlaps(range, node) {
+        const other = node.ownerDocument.createRange();
+        other.selectNode(node);
+        const doc = node.ownerDocument;
+        return comparePoints(doc, range.startContainer, range.startOffset, other.endContainer, other.endOffset) < 0 &&
+            comparePoints(doc, range.endContainer, range.endOffset, other.startContainer, other.startOffset) > 0;
+    }
+
+    function validRange(scope, range, allowHighlights = false) {
+        if (!range || range.collapsed || excluded(scope, scope)) return false;
+        if ((range.startContainer !== scope && !scope.contains(range.startContainer)) ||
+            (range.endContainer !== scope && !scope.contains(range.endContainer))) return false;
+        for (const element of scope.querySelectorAll('*')) {
+            if ((element.matches(EXCLUDED + ',br,hr') || (!allowHighlights && element.matches(HIGHLIGHT)) || hidden(element)) && overlaps(range, element)) return false;
+        }
+        let selectedBlock = null;
+        for (const node of textNodes(scope)) {
+            const doc = node.ownerDocument;
+            const selected = comparePoints(doc, range.startContainer, range.startOffset, node, node.length) < 0 &&
+                comparePoints(doc, range.endContainer, range.endOffset, node, 0) > 0;
+            if (!selected) continue;
+            if (node.parentElement.closest(SCOPE) !== scope || (!allowHighlights && node.parentElement.closest(HIGHLIGHT))) return false;
+            const block = node.parentElement.closest(BLOCK);
+            const boundary = block && scope.contains(block) ? block : scope;
+            if (selectedBlock && selectedBlock !== boundary) return false;
+            selectedBlock = boundary;
+        }
+        return selectedBlock !== null;
+    }
+
+    function cleanWord(value) {
+        return value.replace(/^[\s"'“”‘’(（[<{《/\\#]+|[\s"'“”‘’）)\]>}》,.:;!?！？，。；：/\\#]+$/g, '').trim();
+    }
+
+    function capture(scope, range) {
+        if (!scope || !scope.matches(SCOPE)) return null;
+        try {
+            if (!validRange(scope, range)) return null;
+            const rawText = range.toString();
+            if (/[\r\n]/.test(rawText)) return null;
+            const word = cleanWord(rawText);
+            if (!word || word.length > 45 || !/[A-Za-z]/.test(word)) return null;
+            const rawLocation = calculateLocation(scope, range);
+            if (!rawLocation || rawLocation.quote !== rawText) return null;
+            const startOffset = rawLocation.startOffset + rawText.indexOf(word);
+            const trimmed = resolveOffsets(scope, startOffset, startOffset + word.length);
+            if (!trimmed || !validRange(scope, trimmed)) return null;
+            const scopeId = scope.getAttribute('data-vocab-scope');
+            if (!scopeId) return null;
+            const location = calculateLocation(scope, trimmed);
+            if (scope.getAttribute('data-vocab-source-version')) {
+                const sourceRoot = scope.closest('[data-vocab-source-root]');
+                const unique = sourceRoot && contextCandidates(sourceRoot, scope, location).length === 1;
+                location.contentVersion += unique ? '|context-unique' : '|context-scoped';
+            }
+            return { ...location, range: trimmed, word, scopeId, scope: scopeId };
+        } catch (_) { return null; }
+    }
+
+    function findScope(root, scopeId) {
+        if (!root || !scopeId) return null;
+        const matches = [];
+        if (root.matches && root.matches(SCOPE) && root.getAttribute('data-vocab-scope') === scopeId) matches.push(root);
+        for (const scope of root.querySelectorAll(SCOPE)) {
+            if (scope.getAttribute('data-vocab-scope') === scopeId) matches.push(scope);
+        }
+        return matches.length === 1 ? matches[0] : null;
+    }
+
+    function areaScopes(root, originalScope) {
+        const scopeId = originalScope.getAttribute('data-vocab-scope');
+        const area = /^(passage|questions)\//.exec(scopeId);
+        if (!area) return [originalScope];
+        const candidates = root.matches && root.matches(SCOPE) ? [root] : [];
+        candidates.push(...root.querySelectorAll(SCOPE));
+        return candidates.filter(scope => scope.getAttribute('data-vocab-scope').startsWith(area[0]));
+    }
+
+    function contextCandidates(root, originalScope, highlight) {
+        if (typeof highlight.before !== 'string' || typeof highlight.after !== 'string') return [];
+        const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+        const candidates = [];
+        for (const scope of areaScopes(root, originalScope)) {
+            const fullText = text(scope);
+            let position = fullText.indexOf(quote);
+            while (position !== -1) {
+                const end = position + quote.length;
+                const beforeMatches = highlight.before ?
+                    position >= highlight.before.length && fullText.slice(position - highlight.before.length, position) === highlight.before : position === 0;
+                const afterMatches = highlight.after ?
+                    fullText.slice(end, end + highlight.after.length) === highlight.after : end === fullText.length;
+                if (beforeMatches && afterMatches) {
+                    const range = resolveOffsets(scope, position, end);
+                    // Existing paint cannot turn an ambiguous textual anchor into
+                    // a unique one. Ignore paint only while counting candidates.
+                    if (range && range.toString() === quote && validRange(scope, range, true)) candidates.push({ scope, range });
+                }
+                if (candidates.length > 1) return candidates;
+                position = fullText.indexOf(quote, position + 1);
+            }
+        }
+        return candidates;
+    }
+
+    function resolve(root, highlight) {
+        if (!highlight) return null;
+        try {
+            const scope = findScope(root, highlight.scopeId || highlight.scope);
+            const quote = typeof highlight.quote === 'string' ? highlight.quote : highlight.text;
+            if (!scope || typeof quote !== 'string' || !quote || quote.length > 45 || /[\r\n]/.test(quote) || !/[A-Za-z]/.test(quote)) return null;
+            const fullText = text(scope);
+            const storedVersion = String(highlight.contentVersion || '');
+            const contextFlag = /\|context-(unique|scoped)$/.exec(storedVersion);
+            const baseVersion = contextFlag ? storedVersion.slice(0, contextFlag.index) : storedVersion;
+            if (baseVersion === versionForText(scope, fullText)) {
+                const start = highlight.startOffset;
+                const end = highlight.endOffset;
+                if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start || fullText.slice(start, end) !== quote) return null;
+                const range = resolveOffsets(scope, start, end);
+                return range && range.toString() === quote && validRange(scope, range) ? range : null;
+            }
+            // A source edit can shift an ordinal onto an identical paragraph.
+            // Current uniqueness alone is insufficient if the original source
+            // contained duplicates: removing the selected copy leaves a false
+            // unique survivor. Source-aware capture records that distinction.
+            const sourceAware = scope.getAttribute('data-vocab-source-version') || baseVersion.startsWith('reader-scope-v2:');
+            if (sourceAware && (!contextFlag || contextFlag[1] !== 'unique')) return null;
+            const candidates = contextCandidates(root, scope, highlight);
+            if (candidates.length !== 1) return null;
+            const candidate = candidates[0];
+            return validRange(candidate.scope, candidate.range) ? candidate.range : null;
+        } catch (_) { return null; }
+    }
+
+    global.ReadingVocabAnchors = Object.freeze({ textNodes, text, version, hashText: textVersion, resolveOffsets, calculateLocation, capture, resolve });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/components/readingVocabContent.js
+++ b/js/components/readingVocabContent.js
@@ -1,0 +1,193 @@
+(function (global) {
+    'use strict';
+
+    const CONTAINERS = new Set(['DIV', 'SECTION', 'ARTICLE', 'MAIN']);
+    const HEADING = /^H[1-6]$/;
+
+    function labelFromText(value) {
+        const match = String(value || '').trim().match(/^(?:Paragraph\s+)?([A-Z])(?:[.:)])?$/);
+        return match ? match[1] : '';
+    }
+
+    function standaloneLabel(node) {
+        if (HEADING.test(node.tagName) || node.matches('.paragraph-label, strong, b, p')) {
+            return labelFromText(node.textContent);
+        }
+        return '';
+    }
+
+    function leadingLabel(node) {
+        // A capital article at the start of an ordinary sentence is not a label.
+        // Inline labels must have their own leading element or say "Paragraph X".
+        const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+        let firstText;
+        while ((firstText = walker.nextNode()) && !firstText.textContent.trim()) {}
+        if (!firstText) return '';
+        const marker = firstText.parentElement.closest('strong, b, .paragraph-label');
+        if (marker && node.contains(marker)) {
+            const label = labelFromText(marker.textContent);
+            if (label) return label;
+        }
+        const explicit = node.textContent.trim().match(/^Paragraph\s+([A-Z])(?:\s*[:.)]\s*|\s+)/);
+        return explicit ? explicit[1] : '';
+    }
+
+    function isInstruction(text) {
+        return /^(?:You should spend\b[^.]*\bminutes\b|Questions\s+\d+\s*(?:[-–—]|to)\s*\d+\s+(?:are based|refer to)\b)/i.test(text.trim());
+    }
+
+    function isItalicSubtitle(node) {
+        if (node.tagName !== 'P') return false;
+        const text = node.textContent.trim();
+        const italicText = Array.from(node.querySelectorAll('em, i'))
+            .filter(element => !element.parentElement.closest('em, i'))
+            .map(element => element.textContent.trim()).join(' ').trim();
+        return !!text && text === italicText;
+    }
+
+    function hasContent(node) {
+        return !!node.textContent.trim() || node.matches('img, svg, video, audio, canvas, hr, math') ||
+            !!node.querySelector('img, svg, video, audio, canvas, hr, math');
+    }
+
+    function collectUnits(root) {
+        const units = [];
+        function visit(node) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (node.textContent.trim()) {
+                    const paragraph = document.createElement('p');
+                    paragraph.textContent = node.textContent;
+                    units.push(paragraph);
+                }
+                return;
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) return;
+            if (CONTAINERS.has(node.tagName) && !node.classList.contains('paragraph-wrapper')) {
+                Array.from(node.childNodes).forEach(visit);
+            } else if (hasContent(node)) {
+                units.push(node);
+            }
+        }
+        Array.from(root.childNodes).forEach(visit);
+        return units;
+    }
+
+    function ordinalLetter(index) {
+        let label = '';
+        for (let value = index + 1; value > 0; value = Math.floor((value - 1) / 26)) {
+            label = String.fromCharCode(65 + (value - 1) % 26) + label;
+        }
+        return label;
+    }
+
+    function normalizePassage(passage, fallbackTitle = '') {
+        // This is the same bodyHtml/html precedence and ordered-block contract
+        // used by the practice page's renderDataset implementation.
+        const rawHtml = (Array.isArray(passage?.blocks) ? passage.blocks : [])
+            .map(block => block?.bodyHtml || block?.html || '').join('\n');
+        const root = document.createElement('div');
+        root.innerHTML = rawHtml;
+        root.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone, .empty-space, #divider')
+            .forEach(node => node.remove());
+
+        let passageTitle = fallbackTitle;
+        let titleFound = false;
+        let beforeBody = true;
+        const instructions = [];
+        const subtitles = [];
+        const body = [];
+        for (const node of collectUnits(root)) {
+            const text = node.textContent.trim();
+            if (HEADING.test(node.tagName) && /^READING PASSAGE\s*\d*$/i.test(text)) continue;
+            if (beforeBody && isInstruction(text)) {
+                instructions.push(node.outerHTML);
+                continue;
+            }
+            if (beforeBody && !titleFound && /^H[1-3]$/.test(node.tagName) && !standaloneLabel(node)) {
+                passageTitle = text;
+                titleFound = true;
+                continue;
+            }
+            if (beforeBody && !standaloneLabel(node) &&
+                (/^H[4-6]$/.test(node.tagName) || (titleFound && isItalicSubtitle(node)))) {
+                subtitles.push(node.outerHTML);
+                continue;
+            }
+            beforeBody = false;
+            body.push(node);
+        }
+
+        const blocks = [];
+        let current = null;
+        let pendingHeadingHtml = '';
+        function finish() {
+            if (!current) return;
+            const textRoot = document.createElement('div');
+            textRoot.innerHTML = current.html;
+            if (hasContent(textRoot)) {
+                const index = blocks.length;
+                blocks.push({
+                    id: `p-${index + 1}`,
+                    letter: current.label || ordinalLetter(index),
+                    explicitLabel: !!current.label,
+                    html: current.html,
+                    text: textRoot.textContent.trim()
+                });
+            }
+            current = null;
+        }
+        function start(html, label = '') {
+            current = { html: pendingHeadingHtml + html, label };
+            pendingHeadingHtml = '';
+        }
+
+        for (const node of body) {
+            const marker = standaloneLabel(node);
+            if (marker) {
+                finish();
+                start('', marker);
+                continue;
+            }
+            if (node.classList.contains('paragraph-wrapper')) {
+                finish();
+                start(node.innerHTML, leadingLabel(node));
+                finish();
+                continue;
+            }
+            const inlineLabel = leadingLabel(node);
+            if (inlineLabel) {
+                finish();
+                start(node.outerHTML, inlineLabel);
+                continue;
+            }
+            if (HEADING.test(node.tagName) && !current?.label) {
+                finish();
+                pendingHeadingHtml += node.outerHTML;
+                continue;
+            }
+            if (current?.label) {
+                // Some sources split one lettered paragraph across multiple p
+                // elements. Keep every element under the explicit section label.
+                current.html += node.outerHTML;
+            } else {
+                finish();
+                start(node.outerHTML);
+            }
+        }
+        finish();
+        if (pendingHeadingHtml) {
+            start('');
+            finish();
+        }
+
+        return {
+            passageTitle,
+            instructionHtml: instructions.join('\n'),
+            subtitleHtml: subtitles.join('\n'),
+            rawHtml,
+            blocks
+        };
+    }
+
+    global.ReadingVocabContent = Object.freeze({ normalizePassage });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -62,6 +62,17 @@
             return this.project(global.AppData.vocab.readingModel.articleId(source, String(examId)));
         },
 
+        getOccurrenceOwner(occurrence) {
+            const reading = this._state?.snapshot.reading;
+            const association = reading?.associations.find(row => row.id === occurrence.associationId);
+            const article = reading?.articles.find(row => row.id === association?.articleId);
+            const source = reading?.sources.find(row => row.id === article?.sourceId);
+            if (!article || !source) return null;
+            return { articleId: article.id,
+                source: { kind: source.kind, id: source.libraryId },
+                article: { examId: article.examId, title: article.title } };
+        },
+
         adopt(state) {
             if (this._state?.generation === state.generation && this._state.revision > state.revision) return;
             this._state = state;
@@ -507,6 +518,7 @@
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        // Durable writes survive closing/reopening; release only when they settle.
         _selectionPending: new Set(),
         _undoOccurrence: null,
         _occurrenceBusy: false,
@@ -518,7 +530,6 @@
             this.toastTimer = null;
             this._undoOccurrence = null;
             this.unresolvedOccurrences = [];
-            this._selectionPending.clear();
             this._occurrenceBusy = false;
             overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
             overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
@@ -1309,9 +1320,15 @@
             const captured = global.ReadingVocabAnchors.capture(scope, range);
             if (!captured) return;
             const requestId = this._openRequestId;
-            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
-            if (this._selectionPending.has(pendingId)) return;
-            this._selectionPending.add(pendingId);
+            // Pending saves have no paint yet, so reserve their text intervals
+            // until acknowledgement to prevent invisible overlapping captures.
+            const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId));
+            const pendingSelection = { articleId, scopeId: captured.scopeId,
+                startOffset: captured.startOffset, endOffset: captured.endOffset };
+            if ([...this._selectionPending].some(pending => pending.articleId === articleId &&
+                pending.scopeId === captured.scopeId && captured.startOffset < pending.endOffset &&
+                captured.endOffset > pending.startOffset)) return;
+            this._selectionPending.add(pendingSelection);
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
@@ -1326,7 +1343,7 @@
             } catch (error) {
                 if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
             } finally {
-                this._selectionPending.delete(pendingId);
+                this._selectionPending.delete(pendingSelection);
             }
         },
 
@@ -1406,13 +1423,14 @@
 
         async removeOccurrence(occurrenceId) {
             if (this._occurrenceBusy) return;
-            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+            const item = ReadingVocabStore.getAll()
                 .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
             const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
             if (!occurrence) return;
+            const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+            if (!owner) return;
             const requestId = this._openRequestId;
-            const undo = { source: { ...this.currentSource },
-                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+            const undo = { source: owner.source, article: owner.article,
                 word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
                 occurrence: { ...occurrence }, manual: false };
             const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
@@ -1597,15 +1615,22 @@
 
             let html = '';
             const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
+            const currentArticleId = this.currentExamId
+                ? global.AppData.vocab.readingModel.articleId(this.currentSource, String(this.currentExamId)) : null;
             list.forEach(item => {
-                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
-                    .find(row => row.id === item.id)?.occurrences || [];
-                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
-                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
-                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
-                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
-                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
-                    + '">移除这一处</button></div>').join('');
+                const occurrenceRows = item.occurrences.map(occurrence => {
+                    const owner = ReadingVocabStore.getOccurrenceOwner(occurrence);
+                    const status = owner?.articleId === currentArticleId
+                        ? (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') : 'unverified';
+                    return '<div class="vocab-occurrence-row" data-occurrence-id="'
+                        + escapeHtml(occurrence.id) + '" data-anchor-status="' + status + '">'
+                        + (!isCurrent && owner ? '<span class="vocab-item__source">'
+                            + escapeHtml(owner.article.title || owner.article.examId) + '</span>' : '')
+                        + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                        + (status === 'unresolved' ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                        + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                        + '">移除这一处</button></div>';
+                }).join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -78,9 +78,9 @@
             return state;
         },
 
-        async mutate(type, command) {
+        async mutate(type, command, observedState = null) {
             if (!this._state) await this.init();
-            const observed = this._state;
+            const observed = observedState || this._state;
             let result;
             try {
                 result = await global.AppData.vocab.mutateReading(type, command, {
@@ -110,7 +110,7 @@
                 scopeId: highlight.scopeId || highlight.scope,
                 contentVersion: highlight.contentVersion || 'legacy-reader-v1',
                 startOffset: highlight.startOffset, endOffset: highlight.endOffset,
-                quote: highlight.text || word, before: highlight.before || '', after: highlight.after || ''
+                quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
                 source, article: { examId: String(examId), title: examTitle || '' },
@@ -396,231 +396,8 @@
     // ============================================================================
     // 阅读文本与段落清洗器
     // ============================================================================
-    function cleanPassageHtml(rawHtml) {
-        if (!rawHtml) return '';
-        const temp = document.createElement('div');
-        temp.innerHTML = rawHtml;
-
-        // 移除练习交互用的 dropzone 提示与容器
-        const dropzones = temp.querySelectorAll('.paragraph-dropzone, .match-dropzone, .dropzone');
-        dropzones.forEach(dz => dz.remove());
-
-        // 移除多余的空占位与 divider
-        const empties = temp.querySelectorAll('.empty-space, #divider');
-        empties.forEach(el => el.remove());
-
-        return temp.innerHTML;
-    }
-
-    /**
-     * 判断文本是否属于考试指导语/前置题目说明
-     * 例如："You should spend about 20 minutes on Questions 1-13, which are based on Reading Passage 1 below."
-     */
-    function isPassageInstruction(text) {
-        if (!text) return false;
-        const s = text.trim();
-        if (/spend about \d+ minutes/i.test(s)) return true;
-        if (/which are based on reading passage/i.test(s)) return true;
-        if (/based on reading passage \d*/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+.*based on/i.test(s)) return true;
-        if (/you should spend/i.test(s) && /minutes/i.test(s)) return true;
-        if (/questions \d+\s*[-–至to]\s*\d+\s*(?:are\s+based|refer\s+to)/i.test(s)) return true;
-        return false;
-    }
-
-    /**
-     * 解析阅读文章核心数据：分离前置说明、文章大标题与真实段落
-     */
-    function extractPassageData(rawHtml, fallbackTitle = '') {
-        if (!rawHtml) {
-            return {
-                passageTitle: fallbackTitle,
-                subtitleHtml: '',
-                instructionHtml: '',
-                blocks: []
-            };
-        }
-
-        const cleaned = cleanPassageHtml(rawHtml);
-        const temp = document.createElement('div');
-        temp.innerHTML = cleaned;
-
-        // 1. 提取文章主标题 (h3 或独立非 "READING PASSAGE" 的 h2)
-        let passageTitle = fallbackTitle;
-        const h3 = temp.querySelector('h3');
-        if (h3 && h3.textContent.trim()) {
-            passageTitle = h3.textContent.trim();
-            h3.remove();
-        } else {
-            const h2 = temp.querySelector('h2');
-            if (h2 && !/^reading passage/i.test(h2.textContent.trim())) {
-                passageTitle = h2.textContent.trim();
-                h2.remove();
-            }
-        }
-
-        // 移除诸如 <h2>READING PASSAGE 1</h2> 等结构头标签
-        const readingPassageHeadings = temp.querySelectorAll('h2');
-        readingPassageHeadings.forEach(h => {
-            if (/^reading passage/i.test(h.textContent.trim())) {
-                h.remove();
-            }
-        });
-
-        // 2. 识别并提取前置题目指导语（如 "You should spend about 20 minutes..."），移出正文段落列表
-        let instructionHtml = '';
-        const allPs = Array.from(temp.querySelectorAll('p'));
-        for (const p of allPs) {
-            const text = p.textContent.trim();
-            if (isPassageInstruction(text)) {
-                if (!instructionHtml) {
-                    instructionHtml = p.innerHTML.trim();
-                }
-                p.remove(); // 绝不作为正文段落，不分配任何段落标签
-            }
-        }
-
-        // 3. 提取副标题 (如 h4)
-        let subtitleHtml = '';
-        const h4 = temp.querySelector('h4');
-        if (h4 && h4.textContent.trim()) {
-            subtitleHtml = h4.innerHTML.trim();
-            h4.remove();
-        }
-
-        // 4. 解析段落 blocks
-        const blocks = [];
-        const wrappers = temp.querySelectorAll('.paragraph-wrapper');
-
-        if (wrappers && wrappers.length > 0) {
-            wrappers.forEach((wrap, index) => {
-                // 查找段落标识 letter
-                let letter = '';
-                const strong = wrap.querySelector('strong');
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const match = wrap.textContent.match(/\b([A-Z])\s+[A-Z]/);
-                    if (match) {
-                        letter = match[1];
-                    } else {
-                        letter = String.fromCharCode(65 + index);
-                    }
-                }
-
-                // 获取段落主体 HTML
-                const p = wrap.querySelector('p');
-                const html = p ? p.innerHTML : wrap.innerHTML;
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: html,
-                    text: wrap.textContent.trim()
-                });
-            });
-        } else {
-            // 没有 .paragraph-wrapper 的情况，按剩下的实际正文 <p> 分段
-            const remainingPs = temp.querySelectorAll('p');
-            let validIdx = 0;
-            remainingPs.forEach((p) => {
-                const text = p.textContent.trim();
-                if (!text || text.length < 20) return;
-                // 防御：若依然属于指导语，跳过
-                if (isPassageInstruction(text)) return;
-
-                const strong = p.querySelector('strong');
-                let letter = '';
-                if (strong && /^[A-Z]$/.test(strong.textContent.trim())) {
-                    letter = strong.textContent.trim();
-                } else {
-                    const leadMatch = text.match(/^(?:Paragraph\s+)?([A-Z])(?:\.|\s+)/);
-                    if (leadMatch) {
-                        letter = leadMatch[1];
-                    } else {
-                        letter = String.fromCharCode(65 + validIdx);
-                    }
-                }
-
-                blocks.push({
-                    id: `para-${letter}`,
-                    letter: letter,
-                    html: p.innerHTML,
-                    text: text
-                });
-                validIdx++;
-            });
-        }
-
-        return {
-            passageTitle,
-            subtitleHtml,
-            instructionHtml,
-            blocks
-        };
-    }
-
-    function extractParagraphBlocks(rawHtml) {
-        return extractPassageData(rawHtml).blocks;
-    }
-
-    function getTextNodes(root) {
-        if (!root) return [];
-        const textNodes = [];
-        const walker = document.createTreeWalker(
-            root,
-            NodeFilter.SHOW_TEXT,
-            {
-                acceptNode(node) {
-                    const parent = node.parentElement;
-                    if (!parent) return NodeFilter.FILTER_REJECT;
-                    const tag = parent.tagName.toUpperCase();
-                    if (['SCRIPT', 'STYLE', 'BUTTON', 'INPUT', 'TEXTAREA'].includes(tag)) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    if (parent.closest('.vocab-translation-card') || parent.closest('.vocab-paragraph-tag')) {
-                        return NodeFilter.FILTER_REJECT;
-                    }
-                    return NodeFilter.FILTER_ACCEPT;
-                }
-            },
-            false
-        );
-        let n;
-        while ((n = walker.nextNode())) {
-            textNodes.push(n);
-        }
-        return textNodes;
-    }
-
-    function resolveRangeFromOffsets(root, start, end) {
-        const nodes = getTextNodes(root);
-        let offset = 0;
-        let startNode = null;
-        let endNode = null;
-        let startOffset = 0;
-        let endOffset = 0;
-        for (let i = 0; i < nodes.length; i++) {
-            const node = nodes[i];
-            const text = node.nodeValue || '';
-            const nextOffset = offset + text.length;
-            if (!startNode && start >= offset && (start < nextOffset || (i === nodes.length - 1 && start === nextOffset))) {
-                startNode = node;
-                startOffset = Math.max(0, start - offset);
-            }
-            if (!endNode && end > offset && end <= nextOffset) {
-                endNode = node;
-                endOffset = Math.max(0, end - offset);
-            }
-            if (startNode && endNode) break;
-            offset = nextOffset;
-        }
-        if (!startNode || !endNode) return null;
-        const range = document.createRange();
-        range.setStart(startNode, startOffset);
-        range.setEnd(endNode, endOffset);
-        return range;
-    }
+    // Content and Range rules are shared with the real-browser regression suite.
+    function getTextNodes(root) { return global.ReadingVocabAnchors.textNodes(root); }
 
     // ============================================================================
     // Parse in an inert template: even a pre-checked radio must never join a
@@ -730,11 +507,22 @@
         _pendingTimers: new Set(),
         _returnFocus: null,
         _modalReturnFocus: null,
+        _selectionPending: new Set(),
+        _undoOccurrence: null,
+        _occurrenceBusy: false,
+        unresolvedOccurrences: [],
 
         clearPendingWork(overlay) {
             this._pendingTimers.forEach(timer => clearTimeout(timer));
             this._pendingTimers.clear();
             this.toastTimer = null;
+            this._undoOccurrence = null;
+            this.unresolvedOccurrences = [];
+            this._selectionPending.clear();
+            this._occurrenceBusy = false;
+            overlay?.querySelector('#vocab-occurrence-actions')?.replaceChildren();
+            overlay?.querySelector('#vocab-occurrence-undo')?.replaceChildren();
+            overlay?.querySelector('#vocab-anchor-status')?.replaceChildren();
             const toast = overlay?.querySelector('#vocab-toast');
             if (toast) {
                 toast.classList.remove('show');
@@ -800,13 +588,13 @@
                     <!-- 沉浸式提示栏 -->
                     <div class="vocab-reader-banner">
                         <span class="vocab-banner-icon">✨</span>
-                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中鼠标/触屏选中任意生词，系统将自动收入生词本并以<strong>黄色高亮</strong>醒目标注。</span>
+                        <span class="vocab-banner-text"><strong>划词即收录</strong>：在文章或题目中用鼠标、触屏或 Shift＋方向键选择生词或短语（最多 45 字符）。保存后以<strong>黄色高亮</strong>标注；点击高亮可移除这一处。</span>
                     </div>
 
                     <!-- 独立滚动主体区域（确保顶部 header 永远固定在视口顶部） -->
                     <div class="vocab-reader-scroll-area" id="vocab-reader-scroll-area">
                         <!-- 阅读核心主内容区 -->
-                        <main class="vocab-reader-body" id="vocab-reader-body">
+                        <main class="vocab-reader-body" id="vocab-reader-body" data-vocab-source-root>
                             <!-- 文章区域 -->
                             <section class="vocab-passage-section" id="vocab-passage-section">
                                 <div class="vocab-passage-header">
@@ -840,6 +628,9 @@
 
                     <!-- 划词收录 Toast 提示 -->
                     <div class="vocab-toast-msg" id="vocab-toast" role="status" aria-live="polite"></div>
+                    <div class="vocab-occurrence-actions" id="vocab-occurrence-actions" aria-live="polite"></div>
+                    <div class="vocab-occurrence-undo" id="vocab-occurrence-undo" role="status" aria-live="polite"></div>
+                    <div class="vocab-anchor-status" id="vocab-anchor-status" role="status" aria-live="polite"></div>
 
                     <!-- 生词本弹窗 Modal -->
                     <div class="vocab-modal" id="vocab-modal" role="dialog" aria-modal="true" aria-hidden="true">
@@ -1133,156 +924,43 @@
                 });
             }
 
-            // 核心：划选文本自动收录并仅高亮当前选中的具体实例
             const readerBody = overlay.querySelector('#vocab-reader-body');
             if (readerBody) {
-                const handleSelectionCapture = () => {
-                    const requestId = this._openRequestId;
-                    this.defer(async () => {
-                        if (requestId !== this._openRequestId || overlay.classList.contains('is-hidden') || !this.currentPayload) return;
-                        const selection = window.getSelection();
-                        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
-                        const rawText = selection.toString();
-                        const text = rawText.trim();
-
-                        // 限制在1到45个字符之间，避免大段全文误选
-                        if (!text || text.length > 45 || text.includes('\n') || !/[a-zA-Z\u4e00-\u9fa5]/.test(text)) {
-                            return;
-                        }
-
-                        let range;
-                        try {
-                            range = selection.getRangeAt(0);
-                        } catch (_) {
-                            return;
-                        }
-                        if (!range || range.collapsed) return;
-
-                        // 确保选区位于文章正文或题目区域内
-                        const passageContent = overlay.querySelector('#vocab-passage-content');
-                        const questionsContent = overlay.querySelector('#vocab-questions-content');
-                        const commonNode = range.commonAncestorContainer;
-                        const commonEl = commonNode.nodeType === Node.ELEMENT_NODE ? commonNode : commonNode.parentElement;
-                        if (!commonEl) return;
-                        if (!passageContent?.contains(commonEl) && !questionsContent?.contains(commonEl)) {
-                            return;
-                        }
-                        // 忽略译文卡片、段落标签、按钮等非正文区域
-                        if (commonEl.closest('.vocab-translation-card') || commonEl.closest('.vocab-paragraph-tag') || commonEl.closest('button')) {
-                            return;
-                        }
-
-                        // 如果用户选中的区域已经位于高亮生词内，则不重复收录
-                        const existingMark = commonEl.closest('mark.vocab-highlight');
-                        if (existingMark) {
-                            return;
-                        }
-
-                        // 对 range 进行首尾空白去除，确保只高亮纯单词/短语
-                        const trimmedRange = this.trimRangeWhitespace(range);
-                        if (!trimmedRange || trimmedRange.collapsed) return;
-
-                        // 计算高亮所在的 scope（段落 card 或题目 group 或通用容器）
-                        const targetCard = commonEl.closest('.vocab-paragraph-card');
-                        const targetQGroup = commonEl.closest('.vocab-question-group');
-                        let scope = 'passage';
-                        let scopeElement = passageContent;
-
-                        if (targetCard) {
-                            const letter = targetCard.dataset.letter || '';
-                            scope = letter ? `para-${letter}` : 'passage';
-                            scopeElement = targetCard.querySelector('.vocab-paragraph-text') || targetCard;
-                        } else if (targetQGroup) {
-                            scope = targetQGroup.id || 'questions';
-                            scopeElement = targetQGroup;
-                        } else if (questionsContent?.contains(commonEl)) {
-                            scope = 'questions';
-                            scopeElement = questionsContent;
-                        }
-
-                        // 在 scopeElement 内计算精确的 startOffset / endOffset / before / after / occurrence
-                        const locInfo = this.calculateRangeLocation(scopeElement, trimmedRange, text);
-
-                        // 获取上下文句子
-                        let contextSentence = '';
-                        try {
-                            const parentBlock = commonEl;
-                            if (parentBlock) {
-                                contextSentence = parentBlock.textContent.slice(0, 140).trim();
-                            }
-                        } catch (_) {}
-
-                        const cleanWord = ReadingVocabStore.cleanWord(text);
-                        if (!cleanWord) return;
-
-                        // 核心修复：直接在当前选区包裹高亮，只高亮当前选中的这一个单词实例，绝不全篇批量盲高亮！
-                        const wrappedMark = this.wrapRangeWithHighlight(trimmedRange, cleanWord);
-                        if (!wrappedMark) return;
-
-                        const highlightRecord = {
-                            id: 'hl_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
-                            examId: this.currentExamId || '',
-                            scope: scope,
-                            startOffset: locInfo.startOffset,
-                            endOffset: locInfo.endOffset,
-                            before: locInfo.before,
-                            after: locInfo.after,
-                            occurrence: locInfo.occurrence,
-                            text: cleanWord
-                        };
-
-                        this.showToast('正在保存…');
-                        try {
-                            const result = await ReadingVocabStore.add(
-                                cleanWord,
-                                this.currentExamId,
-                                this.currentExam?.title || '',
-                                contextSentence,
-                                highlightRecord, this.currentSource
-                            );
-
-                            if (requestId !== this._openRequestId) return;
-                            if (result.added) {
-                                selection.removeAllRanges(); // 取消选中状态，避免残留蓝色选区
-                                this.updateCounts();
-                                if (this.modalOpen) {
-                                    this.renderVocabList();
-                                }
-                                this.showToast(`✅ "${cleanWord}" 已收录并黄色高亮`);
-                            } else {
-                                throw new Error('Selection was not saved');
-                            }
-                        } catch (error) {
-                            if (wrappedMark.parentNode) {
-                                const parent = wrappedMark.parentNode;
-                                while (wrappedMark.firstChild) parent.insertBefore(wrappedMark.firstChild, wrappedMark);
-                                wrappedMark.remove();
-                                parent.normalize();
-                            }
-                            if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
-                        }
-                    }, 20);
+                const capture = event => {
+                    if (event?.target?.closest('button, input, textarea, select, .vocab-translation-card, .vocab-paragraph-tag')) return;
+                    this.defer(() => this.captureSelection(), 20);
                 };
-
-                on(readerBody, 'mouseup', handleSelectionCapture);
-                on(readerBody, 'touchend', handleSelectionCapture);
-
-                // 点击黄色高亮生词：朗读发音并轻量提示
-                on(readerBody, 'click', (e) => {
-                    const mark = e.target.closest('mark.vocab-highlight');
-                    if (mark) {
-                        const selection = window.getSelection();
-                        if (selection && selection.toString().trim().length > 0) {
-                            return; // 划选操作中不触发点击发音
-                        }
-                        const word = mark.dataset.word || mark.textContent.trim();
-                        if (word) {
-                            speakWord(word);
-                            this.showToast(`🔊 ${word} (已收录生词)`);
-                        }
+                on(readerBody, 'mouseup', capture);
+                on(readerBody, 'touchend', capture);
+                on(overlay, 'keyup', event => {
+                    if (event.key === 'Shift') capture(event);
+                });
+                on(readerBody, 'click', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && !window.getSelection()?.toString().trim()) this.showOccurrenceActions(mark);
+                });
+                on(readerBody, 'keydown', event => {
+                    const mark = event.target.closest('mark.vocab-highlight');
+                    if (mark && (event.key === 'Enter' || event.key === ' ')) {
+                        event.preventDefault();
+                        this.showOccurrenceActions(mark);
+                    } else {
+                        this.moveKeyboardSelection(event);
                     }
                 });
             }
+            on(overlay, 'click', event => {
+                const button = event.target.closest('[data-action]');
+                if (!button || button.disabled) return;
+                if (button.dataset.action === 'remove-occurrence') {
+                    event.stopPropagation();
+                    this.removeOccurrence(button.dataset.occurrenceId);
+                } else if (button.dataset.action === 'undo-occurrence') {
+                    this.undoOccurrence();
+                } else if (button.dataset.action === 'retry-anchors') {
+                    this.open(this.currentExamId, { source: this.currentSource });
+                }
+            });
 
             // ESC 键监听
             on(window, 'keydown', (e) => {
@@ -1353,9 +1031,10 @@
 
             try {
                 // 加载试卷数据
-                const [payload, source] = await Promise.all([
-                    loadReadingExamPayload(examId), ReadingVocabStore.resolveSource(options)
-                ]);
+                const source = await ReadingVocabStore.resolveSource(options);
+                if (requestId !== this._openRequestId) return;
+                this.currentSource = source;
+                const payload = await loadReadingExamPayload(examId);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
@@ -1400,6 +1079,11 @@
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
                 console.error('[ReadingVocabReader] 加载失败:', err);
+                this.currentPayload = null;
+                await ReadingVocabStore.init().catch(() => {});
+                if (requestId !== this._openRequestId) return;
+                this.applyVocabHighlights();
+                this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
@@ -1443,8 +1127,7 @@
             }
 
             // 解析文章大标题、考试指导语与真实段落
-            const rawPassageHtml = payload?.passage?.blocks?.[0]?.html || '';
-            const passageData = extractPassageData(rawPassageHtml, exam.title || '');
+            const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
             const blocks = passageData.blocks;
             const instructionHtml = passageData.instructionHtml;
             const passageTitle = passageData.passageTitle || exam.title || 'Reading Passage';
@@ -1459,21 +1142,21 @@
             // 关键：作为文章头部的说明提示条展现，不赋予任何段落标签（没有段落A标签）
             const passageIntroEl = overlay.querySelector('#vocab-passage-intro');
             if (passageIntroEl) {
+                passageIntroEl.replaceChildren();
                 if (instructionHtml) {
-                    passageIntroEl.innerHTML = `
-                        <div class="vocab-passage-instruction" role="note">
-                            <span class="vocab-instruction-icon">📋</span>
-                            <div class="vocab-instruction-text">${instructionHtml}</div>
-                        </div>
-                    `;
-                    passageIntroEl.style.display = 'block';
-                } else if (passageData.subtitleHtml) {
-                    passageIntroEl.innerHTML = `<div class="vocab-passage-subtitle">${passageData.subtitleHtml}</div>`;
-                    passageIntroEl.style.display = 'block';
-                } else {
-                    passageIntroEl.innerHTML = '';
-                    passageIntroEl.style.display = 'none';
+                    const instruction = document.createElement('div');
+                    instruction.className = 'vocab-passage-instruction';
+                    instruction.setAttribute('role', 'note');
+                    instruction.appendChild(createReadOnlyQuestionContent(instructionHtml, 'vocab-passage-instruction'));
+                    passageIntroEl.appendChild(instruction);
                 }
+                if (passageData.subtitleHtml) {
+                    const subtitle = document.createElement('div');
+                    subtitle.className = 'vocab-passage-subtitle';
+                    subtitle.appendChild(createReadOnlyQuestionContent(passageData.subtitleHtml, 'vocab-passage-subtitle'));
+                    passageIntroEl.appendChild(subtitle);
+                }
+                passageIntroEl.style.display = passageIntroEl.childNodes.length ? 'block' : 'none';
             }
 
             // 渲染顶部段落切换 Tabs（完全平铺展开：全文、Para A、Para B、Para C...与题目）
@@ -1481,7 +1164,7 @@
             if (tabsContainer) {
                 let tabsHtml = `<button type="button" class="vocab-tab-btn active" data-para="all">全文</button>`;
                 blocks.forEach(b => {
-                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.letter}">Para ${b.letter}</button>`;
+                    tabsHtml += `<button type="button" class="vocab-tab-btn" data-para="${b.id}">Para ${b.letter}</button>`;
                 });
                 tabsHtml += `<button type="button" class="vocab-tab-btn vocab-tab-btn--questions" data-para="questions">📝 Questions</button>`;
                 tabsContainer.innerHTML = tabsHtml;
@@ -1494,22 +1177,27 @@
                     let passageHtml = '';
                     blocks.forEach(b => {
                         passageHtml += `
-                            <div class="vocab-paragraph-card" id="vocab-card-${b.letter}" data-letter="${b.letter}">
+                            <div class="vocab-paragraph-card" id="vocab-card-${b.id}" data-paragraph-id="${b.id}" data-letter="${b.letter}">
                                 <div class="vocab-paragraph-tag">
                                     <span class="vocab-para-letter">Para ${b.letter}</span>
                                 </div>
-                                <div class="vocab-paragraph-text">${b.html}</div>
-                                <div class="vocab-translation-card" id="vocab-trans-${b.letter}" style="display: ${this.showTranslation ? 'block' : 'none'};">
+                                <div class="vocab-paragraph-text" data-content-id="${b.id}"></div>
+                                <div class="vocab-translation-card" id="vocab-trans-${b.id}" style="display: ${this.showTranslation ? 'block' : 'none'};">
                                     <div class="vocab-trans-label">中文参考译文：</div>
-                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.letter}">加载中...</div>
+                                    <div class="vocab-trans-text" id="vocab-trans-text-${b.id}">加载中...</div>
                                 </div>
                             </div>
                         `;
                     });
                     passageContent.innerHTML = passageHtml;
+                    blocks.forEach(block => {
+                        const text = passageContent.querySelector('[data-content-id="' + block.id + '"]');
+                        text.appendChild(createReadOnlyQuestionContent(block.html, 'vocab-' + block.id));
+                        this.assignTextScopes(text, 'passage/' + block.id);
+                    });
                 } else {
                     // 原生清洗后渲染
-                    passageContent.innerHTML = cleanPassageHtml(rawPassageHtml);
+                    passageContent.innerHTML = '<p class="vocab-empty-tip">本篇暂无可用正文</p>';
                 }
             }
 
@@ -1523,7 +1211,10 @@
                         const group = document.createElement('div');
                         group.className = 'vocab-question-group';
                         group.id = `vocab-qgroup-${idx + 1}`;
-                        group.appendChild(createReadOnlyQuestionContent(g.bodyHtml, group.id));
+                        group.dataset.sectionId = 'q-' + (idx + 1);
+                        const html = (g.leadHtml || '') + (g.bodyHtml || g.html || '');
+                        group.appendChild(createReadOnlyQuestionContent(html, group.id));
+                        this.assignTextScopes(group, 'questions/q-' + (idx + 1), true);
                         groups.appendChild(group);
                     });
                     questionsContent.replaceChildren(groups);
@@ -1541,317 +1232,234 @@
             this.applyVocabHighlights();
         },
 
-        trimRangeWhitespace(range) {
-            if (!range || range.collapsed) return range;
-            const startNode = range.startContainer;
-            let startOffset = range.startOffset;
-            const endNode = range.endContainer;
-            let endOffset = range.endOffset;
-
-            if (startNode === endNode && startNode.nodeType === Node.TEXT_NODE) {
-                const text = startNode.nodeValue || '';
-                const segment = text.slice(startOffset, endOffset);
-                const leadSpace = segment.search(/\S/);
-                if (leadSpace > 0) {
-                    startOffset += leadSpace;
-                } else if (leadSpace === -1) {
-                    return null;
+        assignTextScopes(root, prefix, alwaysNumber = false) {
+            const boundaries = 'p, li, td, th, dt, dd, h1, h2, h3, h4, h5, h6, blockquote, div, section, table, ul, ol';
+            const scopes = [];
+            const visit = element => {
+                if (!element.querySelector(boundaries)) {
+                    if (global.ReadingVocabAnchors.text(element).trim()) scopes.push(element);
+                    return;
                 }
-                const trailSpace = segment.length - segment.trimEnd().length;
-                if (trailSpace > 0) {
-                    endOffset -= trailSpace;
-                }
-                if (endOffset <= startOffset) return null;
-
-                const trimmed = document.createRange();
-                trimmed.setStart(startNode, startOffset);
-                trimmed.setEnd(endNode, endOffset);
-                return trimmed;
-            }
-
-            if (startNode.nodeType === Node.TEXT_NODE) {
-                const text = (startNode.nodeValue || '').slice(startOffset);
-                const m = text.match(/^\s+/);
-                if (m) {
-                    range.setStart(startNode, startOffset + m[0].length);
-                }
-            }
-            if (endNode.nodeType === Node.TEXT_NODE) {
-                const text = (endNode.nodeValue || '').slice(0, endOffset);
-                const m = text.match(/\s+$/);
-                if (m) {
-                    range.setEnd(endNode, endOffset - m[0].length);
-                }
-            }
-            return range;
+                let run = [];
+                const flush = () => {
+                    if (!run.length) return;
+                    if (run.some(node => node.textContent.trim())) {
+                        const span = document.createElement('span');
+                        element.insertBefore(span, run[0]);
+                        span.append(...run);
+                        scopes.push(span);
+                    }
+                    run = [];
+                };
+                [...element.childNodes].forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE && (node.matches(boundaries) || node.querySelector(boundaries))) {
+                        flush();
+                        visit(node);
+                    } else run.push(node);
+                });
+                flush();
+            };
+            visit(root);
+            scopes.forEach((scope, index) => {
+                scope.dataset.vocabScope = alwaysNumber || scopes.length > 1 ? prefix + '/p-' + (index + 1) : prefix;
+                scope.dataset.vocabSourceVersion = global.ReadingVocabAnchors.hashText(JSON.stringify(this.currentPayload));
+                scope.tabIndex = 0;
+            });
         },
 
-        calculateRangeLocation(scopeElement, range, text) {
-            const textNodes = getTextNodes(scopeElement);
-            let runningOffset = 0;
-            let startOffset = -1;
-
-            for (let i = 0; i < textNodes.length; i++) {
-                const node = textNodes[i];
-                if (node === range.startContainer) {
-                    startOffset = runningOffset + range.startOffset;
-                    break;
-                }
-                runningOffset += (node.nodeValue || '').length;
-            }
-
-            if (startOffset === -1) {
-                startOffset = 0;
-            }
-
-            const endOffset = startOffset + text.length;
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const before = fullText.slice(Math.max(0, startOffset - 30), startOffset);
-            const after = fullText.slice(endOffset, endOffset + 30);
-
-            let occurrence = 0;
-            const lowerFull = fullText.toLowerCase();
-            const lowerWord = text.toLowerCase();
-            let idx = -1;
-            while ((idx = lowerFull.indexOf(lowerWord, idx + 1)) !== -1 && idx < startOffset) {
-                occurrence += 1;
-            }
-
-            return { startOffset, endOffset, before, after, occurrence };
+        calculateRangeLocation(scopeElement, range) {
+            return global.ReadingVocabAnchors.calculateLocation(scopeElement, range);
         },
 
-        wrapRangeWithHighlight(range, word) {
-            if (!range || range.collapsed) return null;
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight vocab-highlight--pulse';
-            mark.dataset.word = word;
-            mark.title = `生词本: ${word} (点击发音)`;
+        moveKeyboardSelection(event) {
+            if (this.modalOpen || !/^(ArrowLeft|ArrowRight|ArrowUp|ArrowDown|Home|End)$/.test(event.key)) return;
+            const scope = event.target.closest('[data-vocab-scope]');
+            if (!scope || event.target.closest('button, input, textarea, select, [role="button"]')) return;
+            const selection = window.getSelection();
+            if (!selection || typeof selection.modify !== 'function') return;
+            const nodes = getTextNodes(scope);
+            if (!nodes.length) return;
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.collapse(nodes[0], 0);
+            }
+            const previous = { anchor: selection.anchorNode, start: selection.anchorOffset,
+                focus: selection.focusNode, end: selection.focusOffset };
+            const forward = /^(ArrowRight|ArrowDown|End)$/.test(event.key);
+            let unit = /^(ArrowUp|ArrowDown)$/.test(event.key) ? 'line' : 'character';
+            if (event.ctrlKey || event.metaKey) unit = 'word';
+            if (event.key === 'Home' || event.key === 'End') unit = 'lineboundary';
+            event.preventDefault();
+            // Static selectable text has no native caret navigation in some
+            // supported browsers unless their global caret-browsing mode is on.
+            selection.modify(event.shiftKey ? 'extend' : 'move', forward ? 'forward' : 'backward', unit);
+            if (!scope.contains(selection.anchorNode) || !scope.contains(selection.focusNode)) {
+                selection.setBaseAndExtent(previous.anchor, previous.start, previous.focus, previous.end);
+            }
+        },
 
+        async captureSelection() {
+            const overlay = this.ensureOverlay();
+            if (overlay.classList.contains('is-hidden') || this.modalOpen || !this.currentPayload) return;
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) return;
+            const range = selection.getRangeAt(0);
+            const start = range.startContainer.nodeType === Node.ELEMENT_NODE ? range.startContainer : range.startContainer.parentElement;
+            const scope = start?.closest('[data-vocab-scope]');
+            if (!scope || !overlay.querySelector('#vocab-reader-body')?.contains(scope)) return;
+            const captured = global.ReadingVocabAnchors.capture(scope, range);
+            if (!captured) return;
+            const requestId = this._openRequestId;
+            const pendingId = JSON.stringify([requestId, captured.scopeId, captured.startOffset, captured.endOffset]);
+            if (this._selectionPending.has(pendingId)) return;
+            this._selectionPending.add(pendingId);
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-            } catch (e) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                } catch (err) {
-                    console.warn('[ReadingVocabReader] wrapRangeWithHighlight error:', err);
-                    return null;
-                }
+                const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                if (requestId !== this._openRequestId) return;
+                if (!result.added) throw new Error('Selection was not saved');
+                selection.removeAllRanges();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('✅ "' + captured.word + '" 已收录并黄色高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '保存失败，请重新划选重试');
+            } finally {
+                this._selectionPending.delete(pendingId);
             }
+        },
 
-            this.defer(() => {
-                mark.classList.remove('vocab-highlight--pulse');
-            }, 1500);
-
-            return mark;
+        wrapRangeWithHighlight(range, word, occurrenceId) {
+            if (!range || range.collapsed) return false;
+            // Wrap each text fragment separately so repeated restore never splits,
+            // extracts, or rewrites the source's inline formatting or annotations.
+            const fragments = getTextNodes(range.commonAncestorContainer.nodeType === Node.TEXT_NODE
+                ? range.commonAncestorContainer.parentElement : range.commonAncestorContainer)
+                .filter(node => range.intersectsNode(node)).map(node => ({ node,
+                    start: node === range.startContainer ? range.startOffset : 0,
+                    end: node === range.endContainer ? range.endOffset : node.length
+                })).filter(fragment => fragment.end > fragment.start);
+            for (const fragment of fragments.reverse()) {
+                const selected = document.createRange();
+                selected.setStart(fragment.node, fragment.start);
+                selected.setEnd(fragment.node, fragment.end);
+                const mark = document.createElement('mark');
+                mark.className = 'vocab-highlight';
+                mark.dataset.word = word;
+                mark.dataset.occurrenceId = occurrenceId;
+                mark.tabIndex = 0;
+                mark.setAttribute('role', 'button');
+                mark.title = '生词本: ' + word + '（查看或移除这一处）';
+                selected.surroundContents(mark);
+            }
+            return fragments.length > 0;
         },
 
         applyVocabHighlights() {
             const overlay = this.ensureOverlay();
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-
-            // 1. 清除已有高亮 mark.vocab-highlight，安全还原为纯文本节点
-            this.removeVocabHighlights(passageContent);
-            this.removeVocabHighlights(questionsContent);
-
-            if (!this.currentExamId) return;
-
-            // 2. 仅获取针对当前篇目已收录的生词（绝不跨篇串显，也绝不全篇正则批量盲高亮）
-            const examItems = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource);
-            if (!examItems || examItems.length === 0) return;
-
-            examItems.forEach(item => {
-                if (Array.isArray(item.highlights) && item.highlights.length > 0) {
-                    item.highlights.forEach(hl => {
-                        if (String(hl.examId) === String(this.currentExamId)) {
-                            this.restoreVocabHighlight(overlay, hl, item.word);
+            this.removeVocabHighlights(overlay.querySelector('#vocab-reader-body'));
+            this.unresolvedOccurrences = [];
+            if (this.currentExamId) {
+                ReadingVocabStore.getByExam(this.currentExamId, this.currentSource).forEach(item => {
+                    item.occurrences.forEach(occurrence => {
+                        if (!this.restoreVocabHighlight(overlay, occurrence, item.word)) {
+                            this.unresolvedOccurrences.push({ ...occurrence, word: item.word });
                         }
                     });
-                }
-            });
+                });
+            }
+            this.renderAnchorStatus();
         },
 
-        restoreVocabHighlight(overlay, hl, word) {
-            if (!overlay || !hl) return false;
-            let scopeElement = null;
+        restoreVocabHighlight(overlay, occurrence, word) {
+            if (!this.currentPayload) return false;
+            const range = this.resolveRangeForHighlight(overlay.querySelector('#vocab-reader-body'), occurrence);
+            return !!range && this.wrapRangeWithHighlight(range, word || occurrence.quote, occurrence.id);
+        },
 
-            if (hl.scope && hl.scope.startsWith('para-')) {
-                const letter = hl.scope.replace('para-', '');
-                const card = overlay.querySelector(`.vocab-paragraph-card[data-letter="${letter}"]`);
-                if (card) {
-                    scopeElement = card.querySelector('.vocab-paragraph-text') || card;
-                }
-            } else if (hl.scope && hl.scope.startsWith('vocab-qgroup-')) {
-                scopeElement = overlay.querySelector(`#${hl.scope}`);
-            } else if (hl.scope === 'questions') {
-                scopeElement = overlay.querySelector('#vocab-questions-content');
-            } else {
-                scopeElement = overlay.querySelector('#vocab-passage-content');
-            }
+        resolveRangeForHighlight(root, occurrence) {
+            return global.ReadingVocabAnchors.resolve(root, occurrence);
+        },
 
-            if (!scopeElement) {
-                scopeElement = overlay.querySelector('#vocab-passage-content') || overlay.querySelector('#vocab-questions-content');
-            }
-            if (!scopeElement) return false;
+        showOccurrenceActions(mark) {
+            const actions = this.ensureOverlay().querySelector('#vocab-occurrence-actions');
+            actions.innerHTML = '<span>' + escapeHtml(mark.dataset.word) + '</span> <button type="button" data-action="remove-occurrence" data-occurrence-id="'
+                + escapeHtml(mark.dataset.occurrenceId) + '">移除这一处高亮</button>';
+            actions.querySelector('button').focus({ preventScroll: true });
+            speakWord(mark.dataset.word);
+        },
 
-            const range = this.resolveRangeForHighlight(scopeElement, hl);
-            if (!range || range.collapsed) return false;
+        renderAnchorStatus() {
+            const status = this.ensureOverlay().querySelector('#vocab-anchor-status');
+            if (!status) return;
+            status.replaceChildren();
+            if (!this.unresolvedOccurrences.length) return;
+            const message = document.createElement('span');
+            message.textContent = this.unresolvedOccurrences.length + ' 处原文暂时无法定位，生词仍保留。可重试加载，或在生词本移除旧位置后重新划选。';
+            const retry = document.createElement('button');
+            retry.type = 'button';
+            retry.dataset.action = 'retry-anchors';
+            retry.textContent = '重试定位';
+            status.append(message, retry);
+        },
 
-            const mark = document.createElement('mark');
-            mark.className = 'vocab-highlight';
-            mark.dataset.word = word || hl.text;
-            mark.title = `生词本: ${word || hl.text} (点击发音)`;
-
+        async removeOccurrence(occurrenceId) {
+            if (this._occurrenceBusy) return;
+            const item = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                .find(row => row.occurrences.some(occurrence => occurrence.id === occurrenceId));
+            const occurrence = item?.occurrences.find(row => row.id === occurrenceId);
+            if (!occurrence) return;
+            const requestId = this._openRequestId;
+            const undo = { source: { ...this.currentSource },
+                article: { examId: String(this.currentExamId), title: this.currentExam?.title || item.examTitle || '' },
+                word: { word: item.word, meaning: item.meaning || '待补充释义', example: item.context || '' },
+                occurrence: { ...occurrence }, manual: false };
+            const observed = { revision: ReadingVocabStore._state.revision, generation: ReadingVocabStore._state.generation };
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
             try {
-                range.surroundContents(mark);
-                return true;
-            } catch (_) {
-                try {
-                    const fragment = range.extractContents();
-                    mark.appendChild(fragment);
-                    range.insertNode(mark);
-                    return true;
-                } catch (e) {
-                    return false;
-                }
+                const result = await ReadingVocabStore.mutate('removeOccurrence', { occurrenceId }, observed);
+                if (requestId !== this._openRequestId) return;
+                // Keep the acknowledged deletion fence: a later clear/replace must
+                // reject this undo instead of resurrecting deleted relationships.
+                const committedRevision = result.revisions?.['vocab.readingState'];
+                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                    ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
+                    this._undoOccurrence ? '<span>已移除这一处高亮</span> <button type="button" data-action="undo-occurrence">撤销</button>' : '';
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已移除这一处高亮');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '移除失败，请重试');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
         },
 
-        resolveRangeForHighlight(root, hl) {
-            if (!root || !hl) return null;
-            const textNodes = getTextNodes(root);
-            if (!textNodes.length) return null;
-
-            const fullText = textNodes.map(n => n.nodeValue || '').join('');
-            const targetText = String(hl.text || '').trim();
-            if (!targetText) return null;
-
-            const startOffset = Number(hl.startOffset);
-            const endOffset = Number(hl.endOffset);
-
-            // 1. 优先尝试 offset 精确匹配
-            if (
-                Number.isFinite(startOffset) &&
-                Number.isFinite(endOffset) &&
-                endOffset > startOffset &&
-                startOffset >= 0 &&
-                endOffset <= fullText.length
-            ) {
-                const segment = fullText.slice(startOffset, endOffset);
-                if (segment.toLowerCase() === targetText.toLowerCase()) {
-                    return resolveRangeFromOffsets(root, startOffset, endOffset);
-                }
+        async undoOccurrence() {
+            if (this._occurrenceBusy || !this._undoOccurrence) return;
+            const requestId = this._openRequestId;
+            const undo = this._undoOccurrence;
+            this._occurrenceBusy = true;
+            this.showToast('正在保存…');
+            try {
+                await ReadingVocabStore.mutate('collect', { ...undo.command, at: new Date().toISOString() }, undo.observed);
+                if (requestId !== this._openRequestId) return;
+                this._undoOccurrence = null;
+                this.ensureOverlay().querySelector('#vocab-occurrence-undo').replaceChildren();
+                this.applyVocabHighlights();
+                this.updateCounts();
+                if (this.modalOpen) this.renderVocabList();
+                this.showToast('已撤销移除');
+            } catch (error) {
+                if (requestId === this._openRequestId) this.showSaveError(error, '撤销失败，数据可能已更改；可重试或重新划选');
+            } finally {
+                if (requestId === this._openRequestId) this._occurrenceBusy = false;
             }
-
-            // 2. 次优：使用 before / after 上下文精确定位单处实例
-            if (hl.before || hl.after) {
-                let searchPos = 0;
-                let matchIdx = -1;
-                let bestIdx = -1;
-                let bestScore = -1;
-                const lowerFull = fullText.toLowerCase();
-                const lowerTarget = targetText.toLowerCase();
-
-                while ((matchIdx = lowerFull.indexOf(lowerTarget, searchPos)) !== -1) {
-                    let score = 0;
-                    if (hl.before) {
-                        const actualBefore = fullText.slice(Math.max(0, matchIdx - hl.before.length), matchIdx);
-                        if (actualBefore.toLowerCase() === hl.before.toLowerCase()) {
-                            score += 3;
-                        } else if (actualBefore.toLowerCase().endsWith(hl.before.slice(-10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (hl.after) {
-                        const actualAfter = fullText.slice(matchIdx + targetText.length, matchIdx + targetText.length + hl.after.length);
-                        if (actualAfter.toLowerCase() === hl.after.toLowerCase()) {
-                            score += 3;
-                        } else if (actualAfter.toLowerCase().startsWith(hl.after.slice(0, 10).toLowerCase())) {
-                            score += 1;
-                        }
-                    }
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestIdx = matchIdx;
-                    }
-                    searchPos = matchIdx + 1;
-                }
-
-                if (bestIdx !== -1 && bestScore > 0) {
-                    return resolveRangeFromOffsets(root, bestIdx, bestIdx + targetText.length);
-                }
-            }
-
-            // 3. 兜底：使用 occurrence（第 N 次出现）
-            const occurrence = Number.isFinite(Number(hl.occurrence)) ? Number(hl.occurrence) : 0;
-            let currentOccurrence = 0;
-            let pos = 0;
-            let matchPos = -1;
-            const lowerFull = fullText.toLowerCase();
-            const lowerTarget = targetText.toLowerCase();
-
-            while ((matchPos = lowerFull.indexOf(lowerTarget, pos)) !== -1) {
-                if (currentOccurrence === occurrence) {
-                    return resolveRangeFromOffsets(root, matchPos, matchPos + targetText.length);
-                }
-                currentOccurrence += 1;
-                pos = matchPos + 1;
-            }
-
-            return null;
-        },
-
-        restoreLegacyHighlightByContext(overlay, word, context) {
-            if (!overlay || !word) return false;
-            const passageContent = overlay.querySelector('#vocab-passage-content');
-            const questionsContent = overlay.querySelector('#vocab-questions-content');
-            const roots = [passageContent, questionsContent].filter(Boolean);
-
-            const targetWord = String(word).trim();
-            const lowerWord = targetWord.toLowerCase();
-            const lowerContext = String(context || '').trim().toLowerCase();
-
-            for (const root of roots) {
-                const textNodes = getTextNodes(root);
-                const fullText = textNodes.map(n => n.nodeValue || '').join('');
-                const lowerFull = fullText.toLowerCase();
-
-                let targetIdx = -1;
-                if (lowerContext && lowerFull.includes(lowerContext)) {
-                    const ctxIdx = lowerFull.indexOf(lowerContext);
-                    const wordInCtx = lowerContext.indexOf(lowerWord);
-                    if (wordInCtx !== -1) {
-                        targetIdx = ctxIdx + wordInCtx;
-                    }
-                }
-
-                // 无论如何，只恢复单处实例，绝不全篇高亮
-                if (targetIdx !== -1) {
-                    const range = resolveRangeFromOffsets(root, targetIdx, targetIdx + targetWord.length);
-                    if (range && !range.collapsed) {
-                        const mark = document.createElement('mark');
-                        mark.className = 'vocab-highlight';
-                        mark.dataset.word = targetWord;
-                        mark.title = `生词本: ${targetWord} (点击发音)`;
-                        try {
-                            range.surroundContents(mark);
-                            return true;
-                        } catch (_) {
-                            try {
-                                const frag = range.extractContents();
-                                mark.appendChild(frag);
-                                range.insertNode(mark);
-                                return true;
-                            } catch (e) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
         },
 
         removeVocabHighlights(container) {
@@ -1896,7 +1504,8 @@
                 const match = note.label ? note.label.match(/Paragraph\s+([A-Z])/i) : null;
                 if (match) {
                     const letter = match[1].toUpperCase();
-                    const transEl = overlay.querySelector(`#vocab-trans-text-${letter}`);
+                    const cards = [...overlay.querySelectorAll('.vocab-paragraph-card')].filter(card => card.dataset.letter === letter);
+                    const transEl = cards.length === 1 ? cards[0].querySelector('.vocab-trans-text') : null;
                     if (transEl) {
                         transEl.textContent = note.text || '';
                     }
@@ -1937,7 +1546,7 @@
                 if (passageSection) passageSection.style.display = 'block';
                 if (questionsSection) questionsSection.style.display = 'none';
                 cards.forEach(c => {
-                    if (c.dataset.letter === target) {
+                    if (c.dataset.paragraphId === target) {
                         c.style.display = 'block';
                         c.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     } else {
@@ -1987,7 +1596,16 @@
             }
 
             let html = '';
+            const unresolved = new Set(this.unresolvedOccurrences.map(row => row.id));
             list.forEach(item => {
+                const currentOccurrences = ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                    .find(row => row.id === item.id)?.occurrences || [];
+                const occurrenceRows = currentOccurrences.map(occurrence => '<div class="vocab-occurrence-row" data-occurrence-id="'
+                    + escapeHtml(occurrence.id) + '" data-anchor-status="' + (unresolved.has(occurrence.id) ? 'unresolved' : 'resolved') + '">'
+                    + '<span>' + escapeHtml(occurrence.before + occurrence.quote + occurrence.after) + '</span>'
+                    + (unresolved.has(occurrence.id) ? '<strong>原文位置无法定位，生词已保留</strong>' : '')
+                    + '<button type="button" data-action="remove-occurrence" data-occurrence-id="' + escapeHtml(occurrence.id)
+                    + '">移除这一处</button></div>').join('');
                 html += `
                     <div class="vocab-item" data-word-id="${escapeHtml(item.id)}">
                         <div class="vocab-item__main">
@@ -1996,6 +1614,7 @@
                                 <button type="button" class="vocab-speak-btn" data-speak-word="${escapeHtml(item.word)}" title="发音">🔊</button>
                             </div>
                             ${item.context ? `<p class="vocab-item__context">"${escapeHtml(item.context)}"</p>` : ''}
+                            ${occurrenceRows}
                             ${!isCurrent && item.examTitle ? `<span class="vocab-item__source">${escapeHtml(item.examTitle)}</span>` : ''}
                         </div>
                         <button type="button" class="vocab-delete-btn" data-del-id="${escapeHtml(item.id)}" title="移出生词本">删除</button>
@@ -2077,9 +1696,9 @@
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
             if (ReadingVocabReader.currentExamId) {
-                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
+                if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
             }
         });
     }

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -62,6 +62,8 @@ const bundles = {
         'js/app/examSessionMixin.js',
         'js/app/browseController.js',
         'js/components/PDFHandler.js',
+        'js/components/readingVocabContent.js',
+        'js/components/readingVocabAnchors.js',
         'js/components/readingVocabReader.js',
         'js/components/BrowseStateManager.js',
         'js/utils/suiteBackGuard.js',
@@ -106,6 +108,8 @@ const bundles = {
         'js/core/dictionaryService.js',
         'js/runtime/reviewHighlightDictionary.js',
         'js/utils/practiceTimerPreferences.js',
+        'js/components/readingVocabContent.js',
+        'js/components/readingVocabAnchors.js',
         'js/components/readingVocabReader.js',
         'js/runtime/unifiedReadingPage.js'
     ],


### PR DESCRIPTION
## Summary

The intensive reader now renders every ordered passage block, including `bodyHtml` sources, and restores only the occurrence that was explicitly selected. Selecting the second repeated term across inline formatting survives reopen and reload without marking the other matches.

- Preserve instructions, subtitles (including Petri's H5), question numbering, and all paragraph content. Use internal paragraph/question scopes independent of displayed letters and keep reader content non-answering.
- Capture mouse, touch, and keyboard selections through acknowledged persistence, with exact quotes, offsets, surrounding context, source versions, and original-context uniqueness. Changed, missing, or ambiguous anchors remain visible as recoverable vocabulary associations; duplicate paragraph insertion or deletion cannot redirect a highlight.
- Add per-occurrence removal and immediate undo through the shared mutation API. Preserve manual membership, other articles, and canonical review history. Undo retains the actual removal transaction's revision and original generation so concurrent clear/replace operations cannot resurrect removed data.
- Show all saved occurrences in the All tab, including shared terms and terms found only in other articles. Resolve removal and undo ownership from each saved occurrence's article and library, including identical exam IDs in different libraries.
- Reject overlapping selections while their first save is pending, including across closing and reopening the same article. Reserve intervals until settlement while allowing adjacent/disjoint selections and preserving acknowledgement before painting.

## Validation

- Configured JavaScript test command, `node --test --test-concurrency=1 "tests/js/**/*.test.js"`, run from `developer`: **291 passed**, including production DOM Range tests, cross-article/library removal and undo, delayed-overlap/reopen cases, and two-page IndexedDB undo races.
- `python -m unittest discover -s developer/tests/py -p "test_*.py"`: **26 passed**.
- `python developer/tests/e2e/e2e_runner.py`: **11/11 passed**. Both reader browser suites were rerun successfully against the final rebuilt bundles: **2/2 isolation** and **16/16 occurrence** cases.
- `python developer/tests/e2e/reading_reader_occurrences.py`: **16 cases passed** on Chromium 151, covering local HTTP and `file://`, all seven regression assets, ordered multi-block content, trusted keyboard selection from a collapsed Range, touch/mouse collection, real reload, removal/undo, and unresolved recovery.
- `node scripts/build-bundles.mjs --check`: **14/14 current**. Reading-data integrity: **238 assets checked**, no blocking errors. Existing practice-answer isolation and `.hl` annotations remain covered.

The source/anchor and removal contracts are documented in `developer/doc/Intensive-Reading-Anchors.md`. The aggregate static HTTPS and extracted-release acceptance remains with #160 and parent #149.

## Revisions

- Base `opensource`: `6457352add5f78d39a30514d7050e02de34a2918`
- Originally reviewed head: `1e8f21b762590a9c9c1fab7964ec3c905ea43ddb`
- Updated head: `5ba1d1e81481d7df685483a5194a5824fa9d58d2` (GPG-signed; signature verified locally and by GitHub)

Closes #158.
References #149; the parent remains open for the combined Intensive Reading v1 acceptance gate.
