### PR TITLE
feat(reading): complete source-safe bookshelf and reader entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install playwright==1.56.0
           python -m playwright install --with-deps chromium
+          # Node E2E scripts use their own version's default headless shell.
+          node developer/node_modules/playwright/cli.js install chromium --only-shell
 
       - name: Check JS bundle drift
         # The committed files under js/bundles/ must match what the build script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,19 @@ jobs:
         run: python developer/tests/ci/check_reading_data_integrity.py
 
       - name: Run unified E2E suite (file:// capable)
+        # Leave time for retained diagnostics before the job's 30-minute limit.
+        timeout-minutes: 15
         run: python developer/tests/e2e/e2e_runner.py
+
+      - name: Upload E2E diagnostics
+        if: always()
+        timeout-minutes: 3
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-diagnostics-${{ github.run_attempt }}
+          path: |
+            developer/tests/e2e/reports/**/*.json
+            developer/tests/e2e/reports/**/*.log
+            developer/tests/e2e/reports/**/*.png
+          if-no-files-found: ignore
+          retention-days: 14

--- a/developer/doc/Intensive-Reading-Entrypoints.md
+++ b/developer/doc/Intensive-Reading-Entrypoints.md
@@ -1,0 +1,89 @@
+# Intensive Reading Entrypoints and Bookshelf
+
+This documents [#159](https://github.com/sallowayma-git/IELTS-practice/issues/159),
+part of [#149](https://github.com/sallowayma-git/IELTS-practice/issues/149).
+The implementation integrates the acknowledged vocabulary model, isolated reader,
+and selected-occurrence contracts delivered by #156–#158.
+
+## Entry and navigation
+
+Browse cards preserve the library configuration and imported content reference
+that produced the card, including the fallback card renderers. The launcher
+loads `exam-data` and `browse-runtime` through `AppLazyLoader` and passes the
+captured identity and initiating control to `ReadingVocabReader.open`.
+
+More and Overview use the shared Bookshelf entry. Bookshelf reader and global
+notebook controls load the required groups on their first use; no Browse visit
+is required. Loading failures expose retry controls. Newer article requests and
+navigation intents supersede pending lazy opens. Closing a reader returns focus
+to its initiating control, or the replacement Bookshelf button after a live
+render. Bookshelf returns to the view from which it was opened.
+
+The practice header/floating vocabulary interface and results entry use the
+same reader with the practice session's source identity. Selection, manual add,
+removal, clearing, and export consume the shared vocabulary APIs. Reader use
+does not start or submit a practice session.
+
+## Shelf projections and updates
+
+An acknowledged visit makes an article visible even with no vocabulary.
+Clearing article A removes only A's relationships and occurrences; A's visit,
+article B's collection, and canonical review records remain intact. Explicitly
+removing an article from the shelf is a separate action.
+
+Each article counts distinct associated term IDs; the global count counts
+distinct intensive-reading terms across all articles. Search examines every
+associated word, title, category, source name, and source ID. Six chips are only
+a visual preview. AppData commits, backup merge/replace, and cross-window
+notifications refresh the projection and source metadata. No localStorage
+mirror is a second persistence authority.
+
+## Source availability
+
+Imported articles resolve through the original configuration's index, never
+the currently active index. An explicit `generated-reading` entry with a
+`dataKey` can reference generated content. Other imports use their original
+HTML path or a current file-picker Blob identified by `importKey`.
+
+The reader validates the article identity, saved title, and captured/persisted
+content reference before opening. Changed references, conflicting backup
+references, duplicate article IDs, ambiguous cross-library file-picker keys,
+missing configurations/files, expired Blob sessions, and unsupported HTML
+produce an explicit unavailable state. Stored vocabulary remains reviewable
+and exportable. Existing backups without a content binding remain valid and
+bind on the next acknowledged visit. Source text changes at the same locator
+continue to use the independent unresolved-anchor behavior from #158.
+
+Imported passage and question fragments are parsed and sanitized in inert
+templates before content normalization. Retained image/resource URLs resolve
+against the fetched article URL. Supported passage containers include
+`#passage`, `#reading-passage`, `.reading-passage`, `#left`, and `.passage`.
+Missing or unrecognized structure is reported rather than substituted with
+another article sharing the same `examId`.
+
+## Acceptance matrix and release boundary
+
+Run `python developer/tests/e2e/reading_bookshelf_entrypoints.py` or the equivalent
+Node script. It is also registered in `e2e_runner.py`. The runner writes its
+browser version, named outcomes, and protocol evidence to
+`developer/tests/e2e/reports/reading-bookshelf-entrypoints-report.json`.
+
+| Run mode | Entry and storage coverage | Imported content |
+| --- | --- | --- |
+| `file://` | First Browse/practice entry, cold zero-word shelf, counts/search, backup and cross-window changes | Actual file-picker session Blobs, without permissive local-file browser flags |
+| Local static HTTP | Same production entry and storage flow | Original static HTML paths |
+| Local static HTTPS | Same production entry and storage flow | Original static HTML paths |
+
+The HTTPS test serves actual TLS URLs using a temporary localhost certificate;
+certificate validation is disabled only in the isolated test contexts. The
+runner requires OpenSSL (or `OPENSSL_EXECUTABLE_PATH`). Plain static HTML reads
+from `file://` remain subject to normal browser file-access restrictions; missing
+access produces the recoverable unavailable state. Built-in generated content
+and current file-picker Blobs do not require those browser flags.
+
+The PR records the exact reviewed base/head and final test results. Unit and
+regression validation uses `npm test --prefix developer`, bundle validation uses
+`node scripts/build-bundles.mjs --check`, and the unified E2E runner exercises
+the existing practice, reader, backup, and navigation flows. Actual deployment,
+fresh release-package qualification, TXT format/import compatibility, and the
+combined v1 release gate remain in #160; #149 stays open.

--- a/developer/doc/Intensive-Reading-Persistence.md
+++ b/developer/doc/Intensive-Reading-Persistence.md
@@ -132,11 +132,11 @@ retry. Quota/conflict failures support retry in the same page. A latched
 `BACKEND_UNAVAILABLE` failure requires refreshing the page before retry, as in
 the existing DataKernel contract.
 
-The current full-text reader loads the built-in generated registry. It rejects
-other source namespaces before recording visits or collections, avoiding an
-association between imported identities and built-in passage content. Existing
-imported-source data remains queryable and exportable in the bookshelf; source
-navigation and content rendering continue under the later reader work items.
+The reader resolves built-in generated content and source-scoped imported
+content through the [entrypoint contract](Intensive-Reading-Entrypoints.md).
+Original content references are persisted through the same acknowledged reading
+operations. Missing, changed, or ambiguous source references leave vocabulary
+reviewable/exportable and cannot silently resolve through the active library.
 
 ## Validation
 

--- a/developer/doc/Intensive-Reading-Vocabulary-Contract.md
+++ b/developer/doc/Intensive-Reading-Vocabulary-Contract.md
@@ -44,7 +44,7 @@ and list metadata are preserved. `reading` has these tables:
 | Table | Record fields | Responsibility |
 | --- | --- | --- |
 | `sources` | `id`, `kind`, `libraryId` | Stable built-in or imported library namespace. |
-| `articles` | `id`, `sourceId`, `examId`, `title`, `titleUpdatedAt`, `createdAt`, `updatedAt` | Source-scoped article identity and display metadata, with a separate title update clock. |
+| `articles` | `id`, `sourceId`, `examId`, `title`, `titleUpdatedAt`, `createdAt`, `updatedAt`, optional `contentRefs` | Source-scoped article identity, display metadata, and original content references. |
 | `terms` | `id`, `normalizedTerm`, `wordRef: {listId, wordId}`, `createdAt` | One normalized reading term linked to a live existing vocabulary record. |
 | `associations` | `id`, `articleId`, `termId`, `manual`, `createdAt`, `updatedAt` | One article-term relationship, with independent manual membership. |
 | `occurrences` | `id`, `associationId`, `scopeId`, `contentVersion`, `startOffset`, `endOffset`, `quote`, `before`, `after`, `createdAt`, `updatedAt` | A specifically selected occurrence belonging to one association. |
@@ -63,6 +63,23 @@ timestamp within the inclusive `createdAt` to `updatedAt` range. An explicitly
 supplied empty title has a timestamp and is distinct from an omitted title.
 Serialization preserves this field and validation rejects a missing or invalid
 title clock.
+
+Issue #159 adds optional `articles.contentRefs` without invalidating earlier
+version-1 snapshots. It is a sorted array of unique, nonempty strings. A visit or
+collection may supply `article.contentRef` to bind the original content locator.
+The first binding is retained; a different reference or an existing ambiguous
+binding rejects the mutation without changing its input. Commands that omit the
+reference preserve an existing binding. Backup merge unions references, so
+conflicting backups remain recoverable and the reader displays an unavailable
+state rather than choosing a different article. Legacy unbound articles acquire
+a reference on their next acknowledged visit.
+
+`contentRef(exam)` serializes `[sourceKind, dataKey, path, filename, importKey]`;
+missing fields become empty strings, values are trimmed, and path/filename
+backslashes become forward slashes. It identifies the content locator, not a
+hash of the passage text. Generated built-in articles use their generated key;
+source-text changes at the same locator still use the occurrence restoration
+rules in [the anchor contract](Intensive-Reading-Anchors.md).
 
 ## Identity and normalization
 

--- a/developer/tests/e2e/e2e_runner.py
+++ b/developer/tests/e2e/e2e_runner.py
@@ -27,6 +27,7 @@ E2E_CASES = [
     "reading_single_flow.py",
     "reading_reader_isolation.py",
     "reading_reader_occurrences.py",
+    "reading_bookshelf_entrypoints.py",
     "interrupted_history_flow.py",
     "listening_practice_flow.py",
     "suite_practice_flow.py",

--- a/developer/tests/e2e/e2e_runner.py
+++ b/developer/tests/e2e/e2e_runner.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +16,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 REPORT_DIR = REPO_ROOT / "developer" / "tests" / "e2e" / "reports"
 REPORT_PATH = REPORT_DIR / "e2e-unified-report.json"
 CASE_TIMEOUT_SECONDS = 180
+PROCESS_CLEANUP_TIMEOUT_SECONDS = 5
+REPORT_REPLACE_ATTEMPTS = 10
+REPORT_REPLACE_RETRY_SECONDS = 0.1
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -38,61 +43,158 @@ E2E_CASES = [
 ]
 
 
-def _run_case(script_name: str) -> dict:
-    script_path = REPO_ROOT / "developer" / "tests" / "e2e" / script_name
-    if not script_path.exists():
-        return {
-            "name": script_name,
-            "status": "fail",
-            "exitCode": 1,
-            "detail": "script missing",
-        }
+def _terminate_process_tree(process: subprocess.Popen) -> list[str]:
+    """Stop the case and its Playwright/Node/browser descendants with bounded waits."""
+    errors = []
+    try:
+        if os.name == "nt":
+            # Kill descendants while their parent is still present for taskkill's
+            # tree lookup. Never capture pipes that a descendant could keep open.
+            killed = subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=PROCESS_CLEANUP_TIMEOUT_SECONDS,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            if killed.returncode:
+                errors.append(f"taskkill exited with code {killed.returncode}")
+        else:
+            # The case starts a new session, so its process group includes its
+            # descendants even if the original Python process exits first.
+            os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        errors.append(f"process tree cleanup failed: {exc}")
 
     try:
-        case_env = os.environ.copy()
-        case_env["PYTHONIOENCODING"] = "utf-8"
-        case_env["PYTHONUTF8"] = "1"
-        completed = subprocess.run(
-            [sys.executable, str(script_path)],
-            cwd=str(REPO_ROOT),
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            env=case_env,
-            timeout=CASE_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return {
-            "name": script_name,
-            "status": "fail",
-            "exitCode": 124,
-            "detail": f"timeout after {CASE_TIMEOUT_SECONDS} seconds",
-        }
-    return {
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=PROCESS_CLEANUP_TIMEOUT_SECONDS)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        errors.append(f"case process cleanup failed: {exc}")
+    return errors
+
+
+def _output_tail(path: Path, limit: int) -> str:
+    # Reports stay compact; the separate artifacts retain the entire output.
+    with path.open("rb") as output:
+        output.seek(0, os.SEEK_END)
+        output.seek(max(0, output.tell() - limit * 4))
+        return output.read().decode("utf-8", errors="replace").strip()[-limit:]
+
+
+def _run_case(script_name: str) -> dict:
+    started_at = datetime.now(timezone.utc)
+    started_clock = time.monotonic()
+    script_path = REPO_ROOT / "developer" / "tests" / "e2e" / script_name
+    output_dir = REPORT_DIR / "cases"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = output_dir / f"{Path(script_name).stem}.stdout.log"
+    stderr_path = output_dir / f"{Path(script_name).stem}.stderr.log"
+    result = {
         "name": script_name,
-        "status": "pass" if completed.returncode == 0 else "fail",
-        "exitCode": completed.returncode,
-        "stdout": (completed.stdout or "").strip()[-4000:],
-        "stderr": (completed.stderr or "").strip()[-2000:],
+        "status": "fail",
+        "exitCode": 1,
+        "startedAt": started_at.isoformat(),
+        "stdoutPath": stdout_path.relative_to(REPO_ROOT).as_posix(),
+        "stderrPath": stderr_path.relative_to(REPO_ROOT).as_posix(),
     }
+    case_env = os.environ.copy()
+    case_env.update(PYTHONIOENCODING="utf-8", PYTHONUTF8="1", PYTHONUNBUFFERED="1")
+    # Files avoid communicate() waiting forever for pipe EOF when a timed-out
+    # Python process leaves a Node driver or browser holding its output open.
+    with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+        if not script_path.is_file():
+            result["detail"] = "script missing"
+        else:
+            try:
+                process = subprocess.Popen(
+                    [sys.executable, "-u", str(script_path)],
+                    cwd=str(REPO_ROOT),
+                    stdout=stdout,
+                    stderr=stderr,
+                    env=case_env,
+                    start_new_session=os.name != "nt",
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+                )
+                try:
+                    result["exitCode"] = process.wait(timeout=CASE_TIMEOUT_SECONDS)
+                    result["status"] = "pass" if result["exitCode"] == 0 else "fail"
+                except subprocess.TimeoutExpired:
+                    result["exitCode"] = 124
+                    result["detail"] = f"timeout after {CASE_TIMEOUT_SECONDS} seconds"
+                    cleanup_errors = _terminate_process_tree(process)
+                    if cleanup_errors:
+                        result["cleanupErrors"] = cleanup_errors
+                except BaseException:
+                    _terminate_process_tree(process)
+                    raise
+            except OSError as exc:
+                result["detail"] = f"could not run script: {exc}"
+        if result.get("detail"):
+            stderr.write((result["detail"] + "\n").encode("utf-8"))
+    result.update(
+        finishedAt=datetime.now(timezone.utc).isoformat(),
+        durationSeconds=round(time.monotonic() - started_clock, 3),
+        stdout=_output_tail(stdout_path, 4000),
+        stderr=_output_tail(stderr_path, 2000),
+    )
+    return result
+
+
+def _write_report(started_at: datetime, started_clock: float, cases: list[dict], status: str) -> dict:
+    report = {
+        "startedAt": started_at.isoformat(),
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "durationSeconds": round(time.monotonic() - started_clock, 3),
+        "status": status,
+        "plannedCases": len(E2E_CASES),
+        "completedCases": sum(item["status"] != "running" for item in cases),
+        "cases": cases,
+    }
+    # An interrupted write must not destroy the last completed case's report.
+    temporary_path = REPORT_PATH.with_suffix(".json.tmp")
+    temporary_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    for attempt in range(REPORT_REPLACE_ATTEMPTS):
+        try:
+            temporary_path.replace(REPORT_PATH)
+            break
+        except PermissionError:
+            # Windows readers or antivirus scanners can briefly block rename.
+            # Preserve the last report and propagate a persistent write failure.
+            if attempt == REPORT_REPLACE_ATTEMPTS - 1:
+                raise
+            time.sleep(REPORT_REPLACE_RETRY_SECONDS)
+    return report
 
 
 def main() -> int:
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
-
     started_at = datetime.now(timezone.utc)
-    cases = [_run_case(name) for name in E2E_CASES]
+    started_clock = time.monotonic()
+    cases = []
+    _write_report(started_at, started_clock, cases, "running")
+    for index, name in enumerate(E2E_CASES, start=1):
+        case_started_at = datetime.now(timezone.utc).isoformat()
+        cases.append({"name": name, "status": "running", "startedAt": case_started_at})
+        _write_report(started_at, started_clock, cases, "running")
+        print(f"[{index}/{len(E2E_CASES)}] START {name} at {case_started_at}", flush=True)
+        result = _run_case(name)
+        cases[-1] = result
+        _write_report(started_at, started_clock, cases, "running")
+        print(
+            f"[{index}/{len(E2E_CASES)}] END {name}: {result['status'].upper()} "
+            f"in {result['durationSeconds']:.3f}s (exit {result['exitCode']})",
+            flush=True,
+        )
+        if result["status"] != "pass":
+            print(result.get("detail") or result["stderr"] or result["stdout"], flush=True)
+        print(f"  stdout: {result['stdoutPath']}\n  stderr: {result['stderrPath']}", flush=True)
     all_passed = all(item["status"] == "pass" for item in cases)
-
-    report = {
-        "generatedAt": datetime.now(timezone.utc).isoformat(),
-        "durationSeconds": (datetime.now(timezone.utc) - started_at).total_seconds(),
-        "status": "pass" if all_passed else "fail",
-        "cases": cases,
-    }
-    REPORT_PATH.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(json.dumps(report, ensure_ascii=False, indent=2))
+    report = _write_report(started_at, started_clock, cases, "pass" if all_passed else "fail")
+    print(json.dumps(report, ensure_ascii=False, indent=2), flush=True)
     return 0 if all_passed else 1
 
 

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
@@ -11,6 +11,7 @@ import { chromium } from 'playwright';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const reports = path.join(root, 'developer/tests/e2e/reports');
+const startedAt = Date.now();
 const builtin = { kind: 'builtin', id: 'default' };
 const vocabulary = ['coral', 'ocean', 'island', 'harbour', 'lagoon', 'turtle', 'beyondpreview'];
 const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
@@ -53,12 +54,52 @@ const browser = await chromium.launch({ headless: true, ...(executablePath ? { e
     await new Promise(resolve => secureServer.close(resolve));
     throw error;
 });
-const report = { generatedAt: new Date().toISOString(), browser: browser.version(),
-    https: 'Local static HTTPS server with an ephemeral certificate; isolated browser ignores certificate validation.', cases: [] };
+const report = { generatedAt: new Date().toISOString(), browser: browser.version(), status: 'running',
+    https: 'Local static HTTPS server with an ephemeral certificate; isolated browser ignores certificate validation.', cases: [], checkpoints: [] };
+const persistReport = () => {
+    report.updatedAt = new Date().toISOString();
+    report.elapsedSeconds = Number(((Date.now() - startedAt) / 1000).toFixed(3));
+    fs.writeFileSync(path.join(reports, 'reading-bookshelf-entrypoints-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+};
+const log = message => console.error(`[issue159 +${((Date.now() - startedAt) / 1000).toFixed(3)}s] ${message}`);
+const recordFailure = error => {
+    report.status = 'fail';
+    report.error ||= error.stack || String(error);
+    persistReport();
+};
+async function checkpoint(name, action) {
+    const entry = { name, status: 'running', startedAt: new Date().toISOString(), elapsedSeconds: (Date.now() - startedAt) / 1000 };
+    report.checkpoints.push(entry);
+    report.currentCheckpoint = name;
+    persistReport();
+    log(`START ${name}`);
+    try {
+        const result = await action();
+        entry.status = 'pass';
+        entry.finishedAt = new Date().toISOString();
+        persistReport();
+        log(`DONE ${name}`);
+        return result;
+    } catch (error) {
+        entry.status = 'fail';
+        entry.error = error.stack || String(error);
+        recordFailure(error);
+        log(`FAIL ${name}: ${error.message || error}`);
+        throw error;
+    }
+}
 const pass = (name, evidence = {}) => {
     report.cases.push({ name, status: 'pass', ...evidence });
-    console.error(`[issue159] ${name}: pass`);
+    persistReport();
+    log(`${name}: pass`);
 };
+
+async function newContext() {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    context.setDefaultTimeout(15_000);
+    context.setDefaultNavigationTimeout(60_000);
+    return context;
+}
 
 async function ready(page, protocol) {
     const url = urlFor(protocol, 'index.html');
@@ -151,9 +192,26 @@ async function expectCounts(page, counts, globalCount) {
 }
 
 async function search(page, query, ids) {
-    await page.locator('.bookshelf-search-input').fill(query);
-    await poll(() => page.locator('.bookshelf-card').evaluateAll(nodes => nodes.map(node => node.dataset.examId).sort()), ids.sort(), `search ${query}`);
-    await page.locator('.bookshelf-search-input').fill('');
+    try {
+        await page.locator('.bookshelf-search-input').fill(query);
+        await poll(() => page.locator('.bookshelf-card').evaluateAll(nodes => nodes.map(node => node.dataset.examId).sort()), ids.sort(), `search ${query}`);
+        await page.locator('.bookshelf-search-input').fill('');
+    } catch (error) {
+        recordFailure(error);
+        report.searchFailure = await page.evaluate(query => ({
+            query, inputValue: document.querySelector('.bookshelf-search-input')?.value,
+            stateQuery: BookshelfView.state.searchQuery,
+            activeElement: document.activeElement?.className,
+            loading: ReadingBookshelfStore._loading, revision: ReadingBookshelfStore._revision,
+            loadSequence: ReadingBookshelfStore._loadSequence,
+            cards: [...document.querySelectorAll('.bookshelf-card')].map(node => ({
+                articleId: node.dataset.articleId, examId: node.dataset.examId,
+                title: node.querySelector('.bookshelf-card__title')?.textContent.trim()
+            }))
+        }), query).catch(diagnosticError => ({ query, error: diagnosticError.message }));
+        persistReport();
+        throw error;
+    }
 }
 
 async function exportText(page, button) {
@@ -235,31 +293,33 @@ async function countsAndControls(page, examA, protocol) {
 }
 
 async function importAndCrossWindow(page, context, examA, examB, protocol) {
-    const donorContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    const donorContext = await checkpoint(`${protocol}-import-donor-context`, () => newContext());
     let backup;
     try {
-        const donor = await donorContext.newPage();
-        await ready(donor, protocol);
-        await collect(donor, 'issue159-restored', vocabulary.map(word => `restored${word}`));
-        backup = await donor.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
-    } finally { await donorContext.close(); }
+        const donor = await checkpoint(`${protocol}-import-donor-page`, () => donorContext.newPage());
+        await checkpoint(`${protocol}-import-donor-ready`, () => ready(donor, protocol));
+        await checkpoint(`${protocol}-import-donor-collect`, () => collect(donor, 'issue159-restored', vocabulary.map(word => `restored${word}`)));
+        backup = await checkpoint(`${protocol}-import-donor-export`, () => donor.evaluate(() => AppData.backups.export({ domains: ['vocab'] })));
+    } finally { await checkpoint(`${protocol}-import-donor-close`, () => donorContext.close()); }
     for (const replace of [false, true]) {
-        const receipt = await page.evaluate(async ({ backup, replace }) => {
-            const plan = await AppData.backups.previewImport(backup, { replace });
-            return AppData.backups.commitImport(plan.id, { confirmDestructive: replace });
-        }, { backup, replace });
+        const mode = replace ? 'replace' : 'merge';
+        const planId = await checkpoint(`${protocol}-import-${mode}-preview`, () => page.evaluate(async ({ backup, replace }) =>
+            (await AppData.backups.previewImport(backup, { replace })).id, { backup, replace }));
+        const receipt = await checkpoint(`${protocol}-import-${mode}-commit`, () => page.evaluate(({ planId, replace }) =>
+            AppData.backups.commitImport(planId, { confirmDestructive: replace }), { planId, replace }));
         assert.equal(receipt.committed, true);
-        await expectCounts(page, replace ? { 'issue159-restored': 7 } : { [examA]: 0, [examB]: 2, 'issue159-restored': 7 }, replace ? 7 : 9);
-        await search(page, 'restoredbeyondpreview', ['issue159-restored']);
+        await checkpoint(`${protocol}-import-${mode}-original-counts`, () =>
+            expectCounts(page, replace ? { 'issue159-restored': 7 } : { [examA]: 0, [examB]: 2, 'issue159-restored': 7 }, replace ? 7 : 9));
+        await checkpoint(`${protocol}-import-${mode}-original-search`, () => search(page, 'restoredbeyondpreview', ['issue159-restored']));
     }
-    const other = await context.newPage();
+    const other = await checkpoint(`${protocol}-cross-window-page`, () => context.newPage());
     try {
-        await ready(other, protocol);
-        await collect(other, 'issue159-restored', ['otherwindowword']);
-        await expectCounts(page, { 'issue159-restored': 8 }, 8);
-        await search(page, 'otherwindowword', ['issue159-restored']);
-    } finally { await other.close(); }
-    await page.screenshot({ path: path.join(reports, `issue159-${protocol}-bookshelf.png`) });
+        await checkpoint(`${protocol}-cross-window-ready`, () => ready(other, protocol));
+        await checkpoint(`${protocol}-cross-window-collect`, () => collect(other, 'issue159-restored', ['otherwindowword']));
+        await checkpoint(`${protocol}-cross-window-original-counts`, () => expectCounts(page, { 'issue159-restored': 8 }, 8));
+        await checkpoint(`${protocol}-cross-window-original-search`, () => search(page, 'otherwindowword', ['issue159-restored']));
+    } finally { await checkpoint(`${protocol}-cross-window-close`, () => other.close()); }
+    await checkpoint(`${protocol}-import-bookshelf-screenshot`, () => page.screenshot({ path: path.join(reports, `issue159-${protocol}-bookshelf.png`) }));
     pass(`${protocol}-merge-replace-cross-window-refresh`, { distinctGlobalCount: 8 });
 }
 
@@ -288,6 +348,17 @@ async function sourceIdentity(page, protocol) {
         await collect(page, examId, [`source${label.toLowerCase()}word`], source, `Library ${label} original article`);
         ids[label] = await articleId(page, examId, source);
     }
+    const fixtureRevision = await page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).revision);
+    // Fixture writes acknowledge persistence before the live shelf finishes
+    // replacing its controls. Wait for the final projection before typing.
+    await checkpoint(`${protocol}-source-fixture-projection`, () => poll(() => page.evaluate(({ ids, fixtureRevision }) => {
+        const store = ReadingBookshelfStore;
+        return !store._loading && store._revision === fixtureRevision && Object.values(ids).every(id => {
+            const article = store._snapshot?.reading.articles.find(row => row.id === id);
+            return article && store._sourceMetadata.get(article.sourceId)?.index?.some(row =>
+                String(row.id || row.examId) === article.examId);
+        });
+    }, { ids, fixtureRevision }), true, 'source fixture projection must finish before search input'));
     await search(page, 'Library A original article', [examId]);
     await search(page, 'P1', [examId, examId]);
     for (const label of ['A', 'B']) {
@@ -326,7 +397,7 @@ async function sourceIdentity(page, protocol) {
 }
 
 async function practiceFirstInvocation(protocol) {
-    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const context = await newContext();
     const page = await context.newPage();
     page.on('dialog', dialog => dialog.accept());
     try {
@@ -365,11 +436,14 @@ async function practiceFirstInvocation(protocol) {
         assert.equal(await page.locator('#reading-vocab-header-btn').evaluate(node => node === document.activeElement), true);
         assert.equal(await page.locator('#question-groups input[name="q1"][value="A"]').isChecked(), true);
         pass(`${protocol}-first-practice-panel-entry-controls-return`);
+    } catch (error) {
+        recordFailure(error);
+        throw error;
     } finally { await context.close(); }
 }
 
 async function browseReplacedArticle(protocol) {
-    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const context = await newContext();
     const page = await context.newPage();
     const source = { kind: 'imported', id: 'issue166-browse-replacement' };
     const examId = 'issue166-shared-article';
@@ -424,33 +498,39 @@ async function browseReplacedArticle(protocol) {
         assert.ok((await exportText(page, page.locator('#vocab-export-btn'))).includes('retainedoriginal'));
         assert.equal(await page.locator('#vocab-manual-add-btn').isEnabled(), false);
         pass(`${protocol}-browse-replacement-preserves-saved-article-and-vocabulary`);
+    } catch (error) {
+        recordFailure(error);
+        throw error;
     } finally { await context.close(); }
 }
 
 try {
     for (const protocol of ['http', 'https', 'file']) {
-        const context = await browser.newContext({ ignoreHTTPSErrors: true });
+        const context = await newContext();
         const page = await context.newPage();
         page.on('dialog', dialog => dialog.accept());
         try {
-            const examA = await browseAndColdShelf(page, protocol);
-            const examB = await countsAndControls(page, examA, protocol);
-            await importAndCrossWindow(page, context, examA, examB, protocol);
-            await sourceIdentity(page, protocol);
+            const examA = await checkpoint(`${protocol}-browse-and-cold-shelf`, () => browseAndColdShelf(page, protocol));
+            const examB = await checkpoint(`${protocol}-counts-and-controls`, () => countsAndControls(page, examA, protocol));
+            await checkpoint(`${protocol}-import-and-cross-window`, () => importAndCrossWindow(page, context, examA, examB, protocol));
+            await checkpoint(`${protocol}-source-identity`, () => sourceIdentity(page, protocol));
             assert.deepEqual(await page.evaluate(() => AppData.practice.list()), [], 'reader and bookshelf use must not create practice records');
+        } catch (error) {
+            recordFailure(error);
+            throw error;
         } finally { await context.close(); }
-        await practiceFirstInvocation(protocol);
-        await browseReplacedArticle(protocol);
+        await checkpoint(`${protocol}-practice-first-invocation`, () => practiceFirstInvocation(protocol));
+        await checkpoint(`${protocol}-browse-replaced-article`, () => browseReplacedArticle(protocol));
     }
     report.status = 'pass';
 } catch (error) {
-    report.status = 'fail';
-    report.error = error.stack || String(error);
+    recordFailure(error);
     process.exitCode = 1;
 } finally {
+    persistReport();
     await browser.close();
     await new Promise(resolve => server.close(resolve));
     await new Promise(resolve => secureServer.close(resolve));
     console.log(JSON.stringify(report, null, 2));
-    fs.writeFileSync(path.join(reports, 'reading-bookshelf-entrypoints-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+    persistReport();
 }

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/** #159: production entrypoints, source identity, and live IndexedDB bookshelf projections. */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const reports = path.join(root, 'developer/tests/e2e/reports');
+const builtin = { kind: 'builtin', id: 'default' };
+const vocabulary = ['coral', 'ocean', 'island', 'harbour', 'lagoon', 'turtle', 'beyondpreview'];
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+fs.mkdirSync(reports, { recursive: true });
+for (const label of ['A', 'B']) {
+    fs.writeFileSync(path.join(reports, `issue159-library-${label.toLowerCase()}.html`),
+        `<!doctype html><title>Library ${label} original article</title><div id="passage"><p>Original source ${label} contains distinctive ${label === 'A' ? 'alphacontent' : 'betacontent'} for intensive reading.</p></div><div id="questions"><p>Question from source ${label}.</p></div>`);
+}
+function serveStatic(request, response) {
+    const relative = decodeURIComponent(new URL(request.url, 'http://localhost').pathname).replace(/^\/+/, '') || 'index.html';
+    const filename = path.resolve(root, relative);
+    if (!filename.startsWith(root + path.sep)) { response.writeHead(403).end(); return; }
+    try {
+        const body = fs.readFileSync(filename);
+        response.writeHead(200, { 'Content-Type': mime[path.extname(filename)] || 'application/octet-stream' });
+        response.end(body);
+    } catch { response.writeHead(404).end(); }
+}
+const server = http.createServer(serveStatic);
+// Exercise real static HTTPS URLs locally. Certificate validation is disabled
+// only in these isolated browser contexts; this is not a deployment smoke test.
+let openssl = process.env.OPENSSL_EXECUTABLE_PATH || 'openssl';
+if (process.platform === 'win32' && !process.env.OPENSSL_EXECUTABLE_PATH) {
+    const git = execFileSync('where.exe', ['git'], { encoding: 'utf8' }).trim().split(/\r?\n/)[0];
+    const bundled = path.resolve(path.dirname(git), '../usr/bin/openssl.exe');
+    if (fs.existsSync(bundled)) openssl = bundled;
+}
+const certificate = path.join(reports, 'issue159-localhost-cert.pem');
+const privateKey = path.join(reports, 'issue159-localhost-key.pem');
+execFileSync(openssl, ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', privateKey,
+    '-out', certificate, '-days', '1', '-subj', '/CN=localhost', '-addext', 'subjectAltName=IP:127.0.0.1,DNS:localhost'], { stdio: 'pipe' });
+const secureServer = https.createServer({ key: fs.readFileSync(privateKey), cert: fs.readFileSync(certificate) }, serveStatic);
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+await new Promise(resolve => secureServer.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const secureOrigin = `https://127.0.0.1:${secureServer.address().port}`;
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) }).catch(async error => {
+    await new Promise(resolve => server.close(resolve));
+    await new Promise(resolve => secureServer.close(resolve));
+    throw error;
+});
+const report = { generatedAt: new Date().toISOString(), browser: browser.version(),
+    https: 'Local static HTTPS server with an ephemeral certificate; isolated browser ignores certificate validation.', cases: [] };
+const pass = (name, evidence = {}) => {
+    report.cases.push({ name, status: 'pass', ...evidence });
+    console.error(`[issue159] ${name}: pass`);
+};
+
+async function ready(page, protocol) {
+    const url = urlFor(protocol, 'index.html');
+    await page.goto(`${url}?test_env=1`);
+    await page.waitForFunction(() => window.app?.isInitialized && window.AppData, null, { timeout: 60_000 });
+    await page.evaluate(async () => {
+        await AppData.ready;
+        await window.LicenseModal?.accept();
+        document.querySelector('#library-loader-overlay [data-library-action="close"]')?.click();
+    });
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+
+function urlFor(protocol, relative) {
+    return protocol === 'file' ? pathToFileURL(path.join(root, relative)).href
+        : `${protocol === 'https' ? secureOrigin : origin}/${relative}`;
+}
+
+async function poll(read, expected, label) {
+    const deadline = Date.now() + 15_000;
+    let actual;
+    while (true) {
+        actual = await read();
+        if (JSON.stringify(actual) === JSON.stringify(expected)) return;
+        if (Date.now() >= deadline) assert.deepEqual(actual, expected, label);
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+}
+
+async function snapshot(page) {
+    return page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+}
+
+async function articleId(page, examId, source = builtin) {
+    return page.evaluate(({ source, examId }) => AppData.vocab.readingModel.articleId(source, examId), { source, examId });
+}
+
+function card(page, id) {
+    return page.locator('.bookshelf-card').filter({ has: page.locator(`[data-action="open-reading-vocab"][data-exam-id="${id}"]`) });
+}
+
+function sourceCard(page, id) {
+    return page.locator(`.bookshelf-card[data-article-id=${JSON.stringify(id)}]`);
+}
+
+async function showShelf(page) {
+    await page.locator('nav button[data-view="more"]').click();
+    await page.locator('#bookshelf-tool-card').click();
+    await page.locator('#bookshelf-view').waitFor({ state: 'visible' });
+    await page.locator('.bookshelf-stat-value').first().waitFor();
+}
+
+async function readerReady(page, examId) {
+    await page.locator('#vocab-reader-tabs [data-para="questions"]').waitFor();
+    await page.waitForFunction(id => ReadingVocabReader.currentExamId === id && !!ReadingVocabReader.currentPayload
+        && !!document.querySelector('.vocab-paragraph-text') && window.BookshelfView?.state.readerLoading !== true, examId);
+    assert.equal(await page.locator('.vocab-error-state').count(), 0);
+}
+
+async function openCard(page, examId) {
+    await card(page, examId).locator('button[data-action="open-reading-vocab"]').click();
+    await readerReady(page, examId);
+}
+
+async function collect(page, examId, words, source = builtin, title = null) {
+    const receipts = await page.evaluate(async ({ examId, words, source, title }) => {
+        const receipts = [];
+        const snapshot = (await AppData.vocab.getReadingSnapshot()).snapshot;
+        const id = AppData.vocab.readingModel.articleId(source, examId);
+        const resolvedTitle = title || snapshot.reading.articles.find(row => row.id === id)?.title
+            || window.__READING_EXAM_MANIFEST__?.[examId]?.title || examId;
+        for (const word of words) {
+            const receipt = await AppData.vocab.mutateReading('collect', {
+                source, article: { examId, title: resolvedTitle }, word: { word, meaning: `Definition of ${word}` }, manual: true
+            });
+            receipts.push({ saved: receipt.saved, revision: receipt.revision });
+        }
+        return receipts;
+    }, { examId, words, source, title });
+    assert.ok(receipts.every(receipt => receipt.saved === true && Number.isInteger(receipt.revision)));
+}
+
+async function expectCounts(page, counts, globalCount) {
+    await poll(() => page.evaluate(() => ReadingBookshelfStore.getBookshelfExams().map(row => [row.examId, row.wordCount]).sort()),
+        Object.entries(counts).sort(), 'acknowledged article counts must refresh automatically');
+    await poll(() => page.locator('.bookshelf-stat-value').nth(1).textContent(), String(globalCount), 'visible global count must deduplicate associated terms');
+    for (const [id, count] of Object.entries(counts)) {
+        if (count) assert.ok((await card(page, id).textContent()).includes(`${count} 个生词`), `${id}: visible article count`);
+    }
+}
+
+async function search(page, query, ids) {
+    await page.locator('.bookshelf-search-input').fill(query);
+    await poll(() => page.locator('.bookshelf-card').evaluateAll(nodes => nodes.map(node => node.dataset.examId).sort()), ids.sort(), `search ${query}`);
+    await page.locator('.bookshelf-search-input').fill('');
+}
+
+async function exportText(page, button) {
+    const downloaded = page.waitForEvent('download');
+    await button.click();
+    const download = await downloaded;
+    return fs.readFileSync(await download.path(), 'utf8');
+}
+
+async function browseAndColdShelf(page, protocol) {
+    await ready(page, protocol);
+    assert.equal(await page.evaluate(() => !!window.ReadingVocabReader), false, 'first load must not prewarm the reader');
+    await page.locator('nav button[data-view="browse"]').click();
+    await page.waitForFunction(async () => typeof window.app?.browseCategory === 'function'
+        && typeof window.resolveActiveLibraryIndex === 'function'
+        && (await window.resolveActiveLibraryIndex()).some(exam => exam.id === 'p2-low-08'), null, { timeout: 60_000 });
+    const entry = page.locator('#exam-list-container [data-action="vocab-book"]').first();
+    await entry.waitFor().catch(async error => {
+        report.browseFailure = await page.evaluate(() => ({
+            view: document.querySelector('.view.active')?.id,
+            text: document.querySelector('#browse-view')?.textContent.slice(-4000),
+            list: document.querySelector('#exam-list-container')?.innerHTML.slice(0, 3000)
+        }));
+        throw error;
+    });
+    const examId = await entry.getAttribute('data-exam-id');
+    await entry.click();
+    await readerReady(page, examId);
+    const initial = await snapshot(page);
+    assert.equal(initial.reading.visits.length, 1);
+    assert.equal(initial.reading.associations.length, 0);
+    await page.locator('#vocab-reader-back-btn').click();
+    assert.equal(await page.locator('#browse-view').isVisible(), true);
+    assert.equal(await entry.evaluate(node => node === document.activeElement), true, 'Browse return must restore the actual entry');
+    // A real page reload removes every reader/Browse module cache; only IndexedDB persists.
+    await ready(page, protocol);
+    assert.equal(await page.evaluate(() => !!window.ReadingVocabReader), false);
+    assert.equal(await page.evaluate(() => performance.getEntriesByType('resource').some(row => /browse\.bundle\.js/.test(row.name))), false);
+    await showShelf(page);
+    await expectCounts(page, { [examId]: 0 }, 0);
+    const shelfEntry = card(page, examId).locator('button[data-action="open-reading-vocab"]');
+    await shelfEntry.click();
+    await readerReady(page, examId);
+    await page.locator('#vocab-reader-back-btn').click();
+    assert.equal(await page.locator('#bookshelf-view').isVisible(), true);
+    assert.equal(await shelfEntry.evaluate(node => node === document.activeElement), true, 'Bookshelf return must restore the entry even after live rerender');
+    assert.equal((await snapshot(page)).reading.visits.length, 1, 'reopening may update a visit, never duplicate it');
+    await page.locator('#bookshelf-root [data-action="return-more"]').click();
+    assert.equal(await page.locator('#more-view').isVisible(), true);
+    await showShelf(page);
+    pass(`${protocol}-first-browse-and-cold-zero-word-bookshelf`, { examId });
+    return examId;
+}
+
+async function countsAndControls(page, examA, protocol) {
+    const examB = examA === 'p2-low-08' ? 'p1-high-216' : 'p2-low-08';
+    await collect(page, examA, vocabulary);
+    await collect(page, examB, ['coral', 'bword']);
+    await expectCounts(page, { [examA]: 7, [examB]: 2 }, 8);
+    assert.equal(await card(page, examA).locator('.bookshelf-vocab-chip').count(), 6);
+    await search(page, 'beyondpreview', [examA]);
+    await openCard(page, examA);
+    await page.locator('#vocab-fab').click();
+    await page.locator('#vocab-manual-input').fill('manualaddition');
+    await page.locator('#vocab-manual-add-btn').click();
+    await poll(() => page.locator('#vocab-fab-count').textContent(), '8', 'manual collection must show acknowledged count');
+    const exported = await exportText(page, page.locator('#vocab-export-btn'));
+    assert.ok(exported.includes('manualaddition') && exported.includes('beyondpreview'));
+    await page.locator('#vocab-clear-btn').click();
+    await poll(() => page.locator('#vocab-fab-count').textContent(), '0', 'clear article control');
+    await page.locator('#vocab-modal-close').click();
+    await page.locator('#vocab-reader-back-btn').click();
+    await expectCounts(page, { [examA]: 0, [examB]: 2 }, 2);
+    const idA = await articleId(page, examA);
+    assert.equal((await snapshot(page)).reading.visits.some(row => row.articleId === idA), true);
+    assert.ok((await exportText(page, page.locator('[data-action="export-all-bookshelf"]'))).includes('bword'));
+    pass(`${protocol}-distinct-counts-full-search-manual-clear-export`, { examA, examB, globalAfterClear: 2 });
+    return examB;
+}
+
+async function importAndCrossWindow(page, context, examA, examB, protocol) {
+    const donorContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    let backup;
+    try {
+        const donor = await donorContext.newPage();
+        await ready(donor, protocol);
+        await collect(donor, 'issue159-restored', vocabulary.map(word => `restored${word}`));
+        backup = await donor.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+    } finally { await donorContext.close(); }
+    for (const replace of [false, true]) {
+        const receipt = await page.evaluate(async ({ backup, replace }) => {
+            const plan = await AppData.backups.previewImport(backup, { replace });
+            return AppData.backups.commitImport(plan.id, { confirmDestructive: replace });
+        }, { backup, replace });
+        assert.equal(receipt.committed, true);
+        await expectCounts(page, replace ? { 'issue159-restored': 7 } : { [examA]: 0, [examB]: 2, 'issue159-restored': 7 }, replace ? 7 : 9);
+        await search(page, 'restoredbeyondpreview', ['issue159-restored']);
+    }
+    const other = await context.newPage();
+    try {
+        await ready(other, protocol);
+        await collect(other, 'issue159-restored', ['otherwindowword']);
+        await expectCounts(page, { 'issue159-restored': 8 }, 8);
+        await search(page, 'otherwindowword', ['issue159-restored']);
+    } finally { await other.close(); }
+    await page.screenshot({ path: path.join(reports, `issue159-${protocol}-bookshelf.png`) });
+    pass(`${protocol}-merge-replace-cross-window-refresh`, { distinctGlobalCount: 8 });
+}
+
+async function sourceIdentity(page, protocol) {
+    const examId = 'p2-low-08'; // Deliberately collides with an existing built-in exam as well.
+    const ids = {};
+    for (const label of ['A', 'B']) {
+        const source = { kind: 'imported', id: `issue159-library-${label.toLowerCase()}` };
+        await page.evaluate(async ({ source, label, examId, protocol, html }) => {
+            let entry = { id: examId, examId, title: `Library ${label} original article`, category: 'P1', type: 'reading',
+                path: 'developer/tests/e2e/reports/', filename: `issue159-library-${label.toLowerCase()}.html`, hasHtml: true, sourceKind: 'custom' };
+            if (protocol === 'file') {
+                const file = new File([html], `issue159-library-${label.toLowerCase()}.html`, { type: 'text/html' });
+                const discovered = await LibraryDiscovery.discover([file], { type: 'reading' });
+                if (discovered.entries.length !== 1 || discovered.runtime.html !== 1) throw new Error('File-picker source fixture registration failed');
+                // Persist only JSON metadata; discovery can also return absent
+                // optional fields such as pdfFilename with undefined values.
+                entry = { ...entry, sourceKind: 'file-picker', sourcePath: discovered.entries[0].sourcePath,
+                    importKey: discovered.entries[0].importKey };
+            }
+            const receipt = await AppData.library.import({ id: source.id,
+                configuration: { name: `Original library ${label}` },
+                index: [entry] });
+            if (receipt.committed !== true) throw new Error('Library import was not acknowledged');
+        }, { source, label, examId, protocol, html: fs.readFileSync(path.join(reports, `issue159-library-${label.toLowerCase()}.html`), 'utf8') });
+        await collect(page, examId, [`source${label.toLowerCase()}word`], source, `Library ${label} original article`);
+        ids[label] = await articleId(page, examId, source);
+    }
+    await search(page, 'Library A original article', [examId]);
+    await search(page, 'P1', [examId, examId]);
+    for (const label of ['A', 'B']) {
+        const original = sourceCard(page, ids[label]);
+        await original.waitFor();
+        assert.ok((await original.locator('.bookshelf-card__source').textContent()).includes(`issue159-library-${label.toLowerCase()}`));
+        await original.locator('button[data-action="open-reading-vocab"]').click();
+        await readerReady(page, examId);
+        const text = await page.locator('#vocab-passage-content').textContent();
+        assert.ok(text.includes(label === 'A' ? 'alphacontent' : 'betacontent'));
+        assert.ok(!text.includes(label === 'A' ? 'betacontent' : 'alphacontent'));
+        await page.locator('#vocab-reader-back-btn').click();
+    }
+    await page.evaluate(async ({ examId, ids }) => {
+        await Promise.all(['A', 'B'].map(label => ReadingVocabReader.open(examId, {
+            source: { kind: 'imported', id: `issue159-library-${label.toLowerCase()}` }, articleId: ids[label]
+        })));
+    }, { examId, ids });
+    await readerReady(page, examId);
+    assert.equal(await page.evaluate(() => ReadingVocabReader.currentSource.id), 'issue159-library-b');
+    assert.ok((await page.locator('#vocab-passage-content').textContent()).includes('betacontent'));
+    await page.locator('#vocab-reader-back-btn').click();
+    const visits = (await snapshot(page)).reading.visits;
+    assert.equal(new Set(visits.map(row => row.articleId)).size, visits.length, 'rapid opens must not duplicate visit rows');
+    await page.evaluate(() => AppData.library.remove('issue159-library-a'));
+    await sourceCard(page, ids.A).locator('button[data-action="open-reading-vocab"]').click();
+    await page.locator('.vocab-error-state').waitFor();
+    assert.equal(await page.evaluate(() => ReadingVocabReader.currentPayload), null, 'a missing imported source must never borrow built-in content');
+    await page.locator('#vocab-fab').click();
+    assert.ok((await page.locator('#vocab-list').textContent()).includes('sourceaword'));
+    assert.ok((await exportText(page, page.locator('#vocab-export-btn'))).includes('sourceaword'));
+    await page.locator('#vocab-modal-close').click();
+    await page.locator('#vocab-reader-back-btn').click();
+    await search(page, 'issue159-library-b', [examId]);
+    pass(`${protocol}-same-exam-distinct-original-sources-and-missing-source-export`, { articleIds: ids });
+}
+
+async function practiceFirstInvocation(protocol) {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const page = await context.newPage();
+    page.on('dialog', dialog => dialog.accept());
+    try {
+        const relative = 'assets/generated/reading-exams/reading-practice-unified.html';
+        const url = urlFor(protocol, relative);
+        await page.goto(`${url}?examId=p2-low-08`);
+        await page.locator('#question-groups input[name="q1"][value="A"]').waitFor();
+        await page.locator('#question-groups input[name="q1"][value="A"]').check();
+        await page.locator('#reading-vocab-header-btn').click();
+        await readerReady(page, 'p2-low-08');
+        assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+        const selected = await page.evaluate(() => {
+            const paragraph = document.querySelector('.vocab-paragraph-text');
+            const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+                const node = walker.currentNode;
+                const match = /[A-Za-z]{4,}/.exec(node.textContent);
+                if (!match) continue;
+                const range = document.createRange();
+                range.setStart(node, match.index); range.setEnd(node, match.index + match[0].length);
+                const selection = getSelection(); selection.removeAllRanges(); selection.addRange(range);
+                node.parentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+                return match[0];
+            }
+            throw new Error('Practice reader has no selectable paragraph word');
+        });
+        await poll(() => page.locator('#vocab-fab-count').textContent(), '1', 'first practice reader selection');
+        await page.locator('#vocab-fab').click();
+        await page.locator('#vocab-manual-input').fill('practicefirstword');
+        await page.locator('#vocab-manual-add-btn').click();
+        await poll(() => page.locator('#vocab-fab-count').textContent(), '2', 'first practice panel manual add');
+        const exported = await exportText(page, page.locator('#vocab-export-btn'));
+        assert.ok(exported.includes('practicefirstword') && exported.includes(selected));
+        await page.locator('#vocab-modal-close').click();
+        await page.locator('#vocab-reader-back-btn').click();
+        assert.equal(await page.locator('#reading-vocab-header-btn').evaluate(node => node === document.activeElement), true);
+        assert.equal(await page.locator('#question-groups input[name="q1"][value="A"]').isChecked(), true);
+        pass(`${protocol}-first-practice-panel-entry-controls-return`);
+    } finally { await context.close(); }
+}
+
+try {
+    for (const protocol of ['http', 'https', 'file']) {
+        const context = await browser.newContext({ ignoreHTTPSErrors: true });
+        const page = await context.newPage();
+        page.on('dialog', dialog => dialog.accept());
+        try {
+            const examA = await browseAndColdShelf(page, protocol);
+            const examB = await countsAndControls(page, examA, protocol);
+            await importAndCrossWindow(page, context, examA, examB, protocol);
+            await sourceIdentity(page, protocol);
+            assert.deepEqual(await page.evaluate(() => AppData.practice.list()), [], 'reader and bookshelf use must not create practice records');
+        } finally { await context.close(); }
+        await practiceFirstInvocation(protocol);
+    }
+    report.status = 'pass';
+} catch (error) {
+    report.status = 'fail';
+    report.error = error.stack || String(error);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+    await new Promise(resolve => server.close(resolve));
+    await new Promise(resolve => secureServer.close(resolve));
+    console.log(JSON.stringify(report, null, 2));
+    fs.writeFileSync(path.join(reports, 'reading-bookshelf-entrypoints-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+}

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
@@ -59,6 +59,7 @@ const report = { generatedAt: new Date().toISOString(), browser: browser.version
 const persistReport = () => {
     report.updatedAt = new Date().toISOString();
     report.elapsedSeconds = Number(((Date.now() - startedAt) / 1000).toFixed(3));
+    report.activeCheckpoints = report.checkpoints.filter(entry => entry.status === 'running').map(entry => entry.name);
     fs.writeFileSync(path.join(reports, 'reading-bookshelf-entrypoints-report.json'), `${JSON.stringify(report, null, 2)}\n`);
 };
 const log = message => console.error(`[issue159 +${((Date.now() - startedAt) / 1000).toFixed(3)}s] ${message}`);
@@ -198,8 +199,8 @@ async function search(page, query, ids) {
         await page.locator('.bookshelf-search-input').fill('');
     } catch (error) {
         recordFailure(error);
-        report.searchFailure = await page.evaluate(query => ({
-            query, inputValue: document.querySelector('.bookshelf-search-input')?.value,
+        const diagnostic = await page.evaluate(query => ({
+            query, url: location.href, inputValue: document.querySelector('.bookshelf-search-input')?.value,
             stateQuery: BookshelfView.state.searchQuery,
             activeElement: document.activeElement?.className,
             loading: ReadingBookshelfStore._loading, revision: ReadingBookshelfStore._revision,
@@ -209,6 +210,7 @@ async function search(page, query, ids) {
                 title: node.querySelector('.bookshelf-card__title')?.textContent.trim()
             }))
         }), query).catch(diagnosticError => ({ query, error: diagnosticError.message }));
+        (report.searchFailures ||= []).push(diagnostic);
         persistReport();
         throw error;
     }
@@ -230,11 +232,12 @@ async function browseAndColdShelf(page, protocol) {
         && (await window.resolveActiveLibraryIndex()).some(exam => exam.id === 'p2-low-08'), null, { timeout: 60_000 });
     const entry = page.locator('#exam-list-container [data-action="vocab-book"]').first();
     await entry.waitFor().catch(async error => {
-        report.browseFailure = await page.evaluate(() => ({
+        const diagnostic = await page.evaluate(() => ({
             view: document.querySelector('.view.active')?.id,
             text: document.querySelector('#browse-view')?.textContent.slice(-4000),
             list: document.querySelector('#exam-list-container')?.innerHTML.slice(0, 3000)
         }));
+        (report.browseFailures ||= []).push({ protocol, ...diagnostic });
         throw error;
     });
     const examId = await entry.getAttribute('data-exam-id');
@@ -504,23 +507,36 @@ async function browseReplacedArticle(protocol) {
     } finally { await context.close(); }
 }
 
-try {
-    for (const protocol of ['http', 'https', 'file']) {
-        const context = await newContext();
+async function runProtocol(protocol) {
+    const context = await newContext();
+    try {
         const page = await context.newPage();
         page.on('dialog', dialog => dialog.accept());
-        try {
-            const examA = await checkpoint(`${protocol}-browse-and-cold-shelf`, () => browseAndColdShelf(page, protocol));
-            const examB = await checkpoint(`${protocol}-counts-and-controls`, () => countsAndControls(page, examA, protocol));
-            await checkpoint(`${protocol}-import-and-cross-window`, () => importAndCrossWindow(page, context, examA, examB, protocol));
-            await checkpoint(`${protocol}-source-identity`, () => sourceIdentity(page, protocol));
-            assert.deepEqual(await page.evaluate(() => AppData.practice.list()), [], 'reader and bookshelf use must not create practice records');
-        } catch (error) {
-            recordFailure(error);
-            throw error;
-        } finally { await context.close(); }
-        await checkpoint(`${protocol}-practice-first-invocation`, () => practiceFirstInvocation(protocol));
-        await checkpoint(`${protocol}-browse-replaced-article`, () => browseReplacedArticle(protocol));
+        const examA = await checkpoint(`${protocol}-browse-and-cold-shelf`, () => browseAndColdShelf(page, protocol));
+        const examB = await checkpoint(`${protocol}-counts-and-controls`, () => countsAndControls(page, examA, protocol));
+        await checkpoint(`${protocol}-import-and-cross-window`, () => importAndCrossWindow(page, context, examA, examB, protocol));
+        await checkpoint(`${protocol}-source-identity`, () => sourceIdentity(page, protocol));
+        assert.deepEqual(await page.evaluate(() => AppData.practice.list()), [], 'reader and bookshelf use must not create practice records');
+    } catch (error) {
+        recordFailure(error);
+        throw error;
+    } finally { await context.close(); }
+    await checkpoint(`${protocol}-practice-first-invocation`, () => practiceFirstInvocation(protocol));
+    await checkpoint(`${protocol}-browse-replaced-article`, () => browseReplacedArticle(protocol));
+}
+
+try {
+    // Protocols have independent storage and download contexts. Wait for every
+    // flow, including after a failure, before closing their shared browser.
+    const protocols = ['http', 'https', 'file'];
+    const results = await Promise.allSettled(protocols.map(protocol => runProtocol(protocol)));
+    report.protocols = results.map((result, index) => ({
+        protocol: protocols[index], status: result.status === 'fulfilled' ? 'pass' : 'fail',
+        ...(result.status === 'rejected' ? { error: result.reason?.stack || String(result.reason) } : {})
+    }));
+    const failures = results.filter(result => result.status === 'rejected');
+    if (failures.length) {
+        throw new AggregateError(failures.map(result => result.reason), 'Bookshelf protocol regressions failed');
     }
     report.status = 'pass';
 } catch (error) {

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.node.js
@@ -368,6 +368,65 @@ async function practiceFirstInvocation(protocol) {
     } finally { await context.close(); }
 }
 
+async function browseReplacedArticle(protocol) {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const page = await context.newPage();
+    const source = { kind: 'imported', id: 'issue166-browse-replacement' };
+    const examId = 'issue166-shared-article';
+    const originalTitle = 'Library A original article';
+    const replacementTitle = 'Replacement at the same article locator';
+    try {
+        await ready(page, protocol);
+        await page.evaluate(async ({ source, examId, originalTitle, protocol, html }) => {
+            let entry = { id: examId, examId, title: originalTitle, category: 'P1', type: 'reading',
+                path: 'developer/tests/e2e/reports/', filename: 'issue159-library-a.html', hasHtml: true, sourceKind: 'custom' };
+            if (protocol === 'file') {
+                const discovered = await LibraryDiscovery.discover([new File([html], 'issue159-library-a.html', { type: 'text/html' })], { type: 'reading' });
+                entry = { ...entry, sourceKind: 'file-picker', sourcePath: discovered.entries[0].sourcePath,
+                    importKey: discovered.entries[0].importKey };
+            }
+            await AppData.library.import({ id: source.id, configuration: { name: 'Browse replacement fixture' }, index: [entry] });
+            await LibraryManager.switchLibraryConfig(source.id);
+        }, { source, examId, originalTitle, protocol, html: fs.readFileSync(path.join(reports, 'issue159-library-a.html'), 'utf8') });
+        await page.locator('nav button[data-view="browse"]').click();
+        const entry = page.locator(`#exam-list-container [data-action="vocab-book"][data-exam-id="${examId}"]`);
+        await entry.waitFor();
+        await entry.click();
+        await readerReady(page, examId);
+        await page.locator('#vocab-fab').click();
+        await page.locator('#vocab-manual-input').fill('retainedoriginal');
+        await page.locator('#vocab-manual-add-btn').click();
+        await poll(() => page.locator('#vocab-fab-count').textContent(), '1', 'original Browse article vocabulary');
+        const originalSnapshot = await snapshot(page);
+        await page.locator('#vocab-modal-close').click();
+        await page.locator('#vocab-reader-back-btn').click();
+        await page.evaluate(async ({ source, replacementTitle }) => {
+            const index = await AppData.library.getIndex(source.id);
+            index[0].title = replacementTitle;
+            await AppData.library.import({ id: source.id, configuration: { name: 'Browse replacement fixture' }, index });
+        }, { source, replacementTitle });
+        // Reload production modules and render the replacement's real Browse
+        // button; its options.title must not override the persisted identity.
+        await ready(page, protocol);
+        await page.locator('nav button[data-view="browse"]').click();
+        await poll(() => entry.getAttribute('data-exam-title'), replacementTitle, 'replacement Browse title');
+        const originalArticle = originalSnapshot.reading.articles.find(row => row.examId === examId);
+        assert.deepEqual(originalArticle.contentRefs, [await entry.getAttribute('data-content-ref')], 'replacement keeps the same content locator');
+        await entry.click();
+        await page.locator('[data-source-unavailable]').waitFor();
+        assert.match(await page.locator('[data-source-unavailable]').textContent(), /文章已更改/);
+        assert.equal(await page.evaluate(() => ReadingVocabReader._openOptions.title), replacementTitle);
+        assert.equal(await page.locator('#vocab-reader-title').textContent(), originalTitle);
+        assert.equal(await page.evaluate(() => ReadingVocabReader.currentPayload), null);
+        assert.equal(await page.locator('#vocab-fab-count').textContent(), '1');
+        assert.deepEqual(await snapshot(page), originalSnapshot, 'blocked Browse opens must preserve the original article and visit');
+        await page.getByRole('button', { name: '查看已保存生词', exact: true }).click();
+        assert.ok((await exportText(page, page.locator('#vocab-export-btn'))).includes('retainedoriginal'));
+        assert.equal(await page.locator('#vocab-manual-add-btn').isEnabled(), false);
+        pass(`${protocol}-browse-replacement-preserves-saved-article-and-vocabulary`);
+    } finally { await context.close(); }
+}
+
 try {
     for (const protocol of ['http', 'https', 'file']) {
         const context = await browser.newContext({ ignoreHTTPSErrors: true });
@@ -381,6 +440,7 @@ try {
             assert.deepEqual(await page.evaluate(() => AppData.practice.list()), [], 'reader and bookshelf use must not create practice records');
         } finally { await context.close(); }
         await practiceFirstInvocation(protocol);
+        await browseReplacedArticle(protocol);
     }
     report.status = 'pass';
 } catch (error) {

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.py
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
-"""Run the production bookshelf and entrypoint regression with E2E CI's Chromium."""
-import os
+"""Run the bookshelf regression with Node Playwright's matching headless browser."""
 from pathlib import Path
 import subprocess
 
-from playwright.sync_api import sync_playwright
-
 
 def main():
-    env = os.environ.copy()
-    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
-        with sync_playwright() as playwright:
-            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
     script = Path(__file__).with_suffix(".node.js")
-    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+    return subprocess.run(["node", str(script)], check=False).returncode
 
 
 if __name__ == "__main__":

--- a/developer/tests/e2e/reading_bookshelf_entrypoints.py
+++ b/developer/tests/e2e/reading_bookshelf_entrypoints.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run the production bookshelf and entrypoint regression with E2E CI's Chromium."""
+import os
+from pathlib import Path
+import subprocess
+
+from playwright.sync_api import sync_playwright
+
+
+def main():
+    env = os.environ.copy()
+    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
+        with sync_playwright() as playwright:
+            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
+    script = Path(__file__).with_suffix(".node.js")
+    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/developer/tests/e2e/reading_reader_isolation.py
+++ b/developer/tests/e2e/reading_reader_isolation.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
-"""Run the real-browser reader regression using the browser installed by E2E CI."""
-import os
+"""Run the reader isolation regression with Node Playwright's matching headless browser."""
 from pathlib import Path
 import subprocess
 
-from playwright.sync_api import sync_playwright
-
 
 def main():
-    env = os.environ.copy()
-    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
-        with sync_playwright() as playwright:
-            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
     script = Path(__file__).with_suffix(".node.js")
-    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+    return subprocess.run(["node", str(script)], check=False).returncode
 
 
 if __name__ == "__main__":

--- a/developer/tests/e2e/reading_reader_occurrences.py
+++ b/developer/tests/e2e/reading_reader_occurrences.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
-"""Run the production reader occurrence regression with E2E CI's Chromium."""
-import os
+"""Run the reader occurrence regression with Node Playwright's matching headless browser."""
 from pathlib import Path
 import subprocess
 
-from playwright.sync_api import sync_playwright
-
 
 def main():
-    env = os.environ.copy()
-    if not env.get("PLAYWRIGHT_EXECUTABLE_PATH"):
-        with sync_playwright() as playwright:
-            env["PLAYWRIGHT_EXECUTABLE_PATH"] = playwright.chromium.executable_path
     script = Path(__file__).with_suffix(".node.js")
-    return subprocess.run(["node", str(script)], env=env, check=False).returncode
+    return subprocess.run(["node", str(script)], check=False).returncode
 
 
 if __name__ == "__main__":

--- a/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
+++ b/developer/tests/js/bookshelfRemoveVocabIsolation.test.js
@@ -17,6 +17,7 @@ const deferred = () => {
 
 function fixture() {
     const events = [];
+    const eventListeners = new Map();
     const commitListeners = [];
     const sandbox = {
         console: { warn() {} }, setTimeout, clearTimeout,
@@ -25,7 +26,14 @@ function fixture() {
             setItem() { throw new Error('A display consumer must not write legacy storage'); }
         },
         CustomEvent: class { constructor(type, options) { this.type = type; this.detail = options.detail; } },
-        addEventListener() {}, dispatchEvent(event) { events.push(event); },
+        addEventListener(type, listener) {
+            if (!eventListeners.has(type)) eventListeners.set(type, []);
+            eventListeners.get(type).push(listener);
+        },
+        dispatchEvent(event) {
+            events.push(event);
+            (eventListeners.get(event.type) || []).forEach((listener) => listener(event));
+        },
         document: { querySelector() { return null; }, getElementById() { return null; } }
     };
     sandbox.window = sandbox;
@@ -77,8 +85,8 @@ function fixture() {
         setCanonical(value) { canonical = value; },
         setFailure(value) { failure = value; },
         setGate(value) { gate = value; },
-        async commit() {
-            commitListeners.forEach((listener) => listener({ targets: [{ logicalKey: 'vocab.readingState' }] }));
+        async commit(target = 'vocab.readingState') {
+            commitListeners.forEach((listener) => listener({ targets: [{ logicalKey: target }] }));
             await new Promise((resolve) => setTimeout(resolve, 0));
         }
     };
@@ -244,4 +252,237 @@ test('Bookshelf backend failure offers page reload instead of retrying a latched
     view.render();
     assert.match(root.innerHTML, /data-action="reload-page"/);
     assert.doesNotMatch(root.innerHTML, /data-action="retry-load"/);
+});
+
+test('Bookshelf counts distinct associated terms, searches beyond previews, and retains a cleared visit', async () => {
+    const f = fixture();
+    await f.store.init();
+    let snapshot = clone(f.canonical.snapshot);
+    for (let index = 2; index <= 8; index += 1) {
+        snapshot = f.model.collect(snapshot, {
+            source: sourceA, article: { examId: 'same-exam' }, word: { word: `word-${index}`, meaning: `Meaning ${index}` }, at
+        });
+    }
+    snapshot = f.model.collect(snapshot, {
+        source: sourceB, article: { examId: 'same-exam' }, word: { word: 'APPLE', meaning: 'apple' }, at
+    });
+    f.setCanonical({ snapshot, revision: 2, generation: 'original' });
+    await f.commit();
+    const rows = f.store.getBookshelfExams();
+    assert.equal(rows[0].wordCount, 8);
+    assert.equal(rows[1].wordCount, 2);
+    assert.equal(f.store.getDistinctWordCount(), 9, 'shared terms count only once globally');
+    assert.equal(rows[0].sampleWords.length, 6);
+    assert.equal(rows[0].allWords.includes('word-8'), true);
+
+    const root = { innerHTML: '' };
+    f.sandbox.document.querySelector = () => root;
+    const view = f.sandbox.BookshelfView;
+    view.bindCardEvents = () => {};
+    view.state.searchQuery = 'word-8';
+    view.render();
+    assert.match(root.innerHTML, /data-article-id=/);
+    assert.doesNotMatch(root.innerHTML, /未找到匹配的篇目/);
+
+    snapshot = f.model.clearArticle(snapshot, { articleId: f.model.articleId(sourceA, 'same-exam'), at });
+    f.setCanonical({ snapshot, revision: 3, generation: 'original' });
+    await f.commit();
+    assert.equal(f.store.getBookshelfExams()[0].wordCount, 0);
+    assert.equal(f.store.getBookshelfExams()[1].wordCount, 2);
+    assert.equal(f.store.getDistinctWordCount(), 2);
+    assert.equal(f.store.getBookshelfExams().length, 2, 'clearing terms preserves independent visits');
+    assert.match(root.innerHTML, /未找到匹配的篇目/);
+});
+
+test('Bookshelf preserves stored titles and displays and searches source identity and imported category', async () => {
+    const f = fixture();
+    f.sandbox.AppData.library.listConfigurations = async () => [{ id: 'library-b', name: 'Research Collection' }];
+    f.sandbox.AppData.library.getIndex = async () => [{ id: 'same-exam', title: 'Changed title', category: 'Science' }];
+    await f.store.init();
+    const article = f.store.getBookshelfExams().find((row) => row.source.id === 'library-b');
+    assert.equal(article.title, 'library-b', 'the original stored article title remains visible');
+    assert.equal(article.sourceLabel, '导入题库 · Research Collection (library-b)');
+    assert.equal(article.category, 'Science');
+    assert.equal(article.sourceUnavailable, false);
+    const root = { innerHTML: '' };
+    f.sandbox.document.querySelector = () => root;
+    const view = f.sandbox.BookshelfView;
+    view.bindCardEvents = () => {};
+    for (const query of ['research collection', 'library-b', 'science']) {
+        view.state.searchQuery = query;
+        view.render();
+        assert.match(root.innerHTML, /Research Collection \(library-b\)/);
+        assert.doesNotMatch(root.innerHTML, /未找到匹配的篇目/);
+    }
+    f.sandbox.AppData.library.getIndex = async () => [];
+    await f.commit('library.importedIndexes');
+    const unavailable = f.store.getBookshelfExams().find((row) => row.source.id === 'library-b');
+    assert.equal(unavailable.sourceUnavailable, true);
+    assert.equal(unavailable.wordCount, 1, 'missing content never discards vocabulary');
+    view.state.searchQuery = '';
+    view.render();
+    assert.match(root.innerHTML, /原题库内容不可用/);
+});
+
+test('Bookshelf adopts acknowledged reader changes immediately and refreshes merge and replacement counts', async () => {
+    const f = fixture();
+    await f.store.init();
+    const added = f.model.collect(f.canonical.snapshot, {
+        source: sourceA, article: { examId: 'same-exam' }, word: { word: 'cedar', meaning: 'A tree' }, at
+    });
+    f.sandbox.ReadingVocabStore = { _state: { snapshot: added, revision: 2, generation: 'original' } };
+    f.sandbox.dispatchEvent({ type: 'reading-vocab-store-updated' });
+    assert.equal(f.store.getDistinctWordCount(), 3);
+    const incoming = f.model.recordVisit(f.model.createSnapshot(), {
+        source: sourceA, article: { examId: 'zero-visit', title: 'No words yet' }, at
+    });
+    f.setCanonical({ snapshot: f.model.merge(added, incoming), revision: 3, generation: 'original' });
+    await f.commit();
+    assert.equal(f.store.getBookshelfExams().length, 3);
+    assert.equal(f.store.getDistinctWordCount(), 3);
+    f.setCanonical({ snapshot: incoming, revision: 4, generation: 'restored' });
+    await f.commit();
+    assert.equal(f.store.getBookshelfExams().length, 1);
+    assert.equal(f.store.getBookshelfExams()[0].wordCount, 0);
+    assert.equal(f.store.getDistinctWordCount(), 0);
+});
+
+test('Cold Bookshelf loads real runtime groups and only opens the latest source-scoped request', async () => {
+    const f = fixture();
+    await f.store.init();
+    const loadedGroups = [];
+    const opens = [];
+    const gate = deferred();
+    f.sandbox.AppLazyLoader = { async ensureGroup(group) {
+        loadedGroups.push(group);
+        await gate.promise;
+        f.sandbox.ReadingVocabReader = { async open(examId, options) { opens.push({ examId, options: clone(options) }); } };
+    } };
+    const view = f.sandbox.BookshelfView;
+    const first = view.launchExamVocabReader('same-exam', sourceA, f.model.articleId(sourceA, 'same-exam'));
+    const second = view.launchExamVocabReader('same-exam', sourceB, f.model.articleId(sourceB, 'same-exam'));
+    assert.equal(view.state.readerLoading, true);
+    assert.deepEqual(loadedGroups, ['exam-data', 'browse-runtime']);
+    gate.resolve();
+    await Promise.all([first, second]);
+    assert.equal(opens.length, 1);
+    assert.equal(opens[0].examId, 'same-exam');
+    assert.deepEqual(opens[0].options.source, sourceB);
+    assert.equal(opens[0].options.articleId, f.model.articleId(sourceB, 'same-exam'));
+    assert.equal(opens[0].options.fromView, 'bookshelf');
+    assert.equal(opens[0].options.title, 'library-b');
+    assert.equal(view.state.readerLoading, false);
+});
+
+test('Bookshelf exposes retry after lazy-load failure and cold global notebook uses the shared reader', async () => {
+    const f = fixture();
+    await f.store.init();
+    const view = f.sandbox.BookshelfView;
+    f.sandbox.AppLazyLoader = { async ensureGroup() { throw new Error('offline'); } };
+    await view.launchGlobalNotebook();
+    assert.match(view.state.readerError.message, /offline/);
+    assert.equal(view.state.readerLoading, false);
+    let options;
+    f.sandbox.AppLazyLoader = { async ensureGroup() {
+        f.sandbox.ReadingVocabReader = { async open() {}, async openNotebook(value) { options = value; } };
+    } };
+    await view.launchGlobalNotebook();
+    assert.equal(options.fromView, 'bookshelf');
+    assert.equal(view.state.readerError, null);
+});
+
+test('Bookshelf practice source guard refuses another active library and removed source content', async () => {
+    const f = fixture();
+    await f.store.init();
+    const view = f.sandbox.BookshelfView;
+    const toasts = [];
+    view.showToast = (message) => toasts.push(message);
+    const article = f.store.getBookshelfExams().find((row) => row.source.id === 'library-b');
+    assert.equal(await view.canOpenOriginalSource(article), false);
+    assert.match(toasts.pop(), /切换至原题库/);
+    f.sandbox.AppData.library.getActive = async () => 'library-b';
+    f.sandbox.AppData.library.getIndex = async () => [];
+    assert.equal(await view.canOpenOriginalSource(article), false);
+    assert.match(toasts.pop(), /原题库内容已不可用/);
+    f.sandbox.AppData.library.getIndex = async () => [{ id: 'same-exam' }];
+    f.sandbox.ReadingVocabReader = { async open() {} };
+    assert.equal(await view.canOpenOriginalSource(article), true);
+});
+
+test('Leaving Bookshelf cancels a pending cold open and returns to the initiating view', async () => {
+    const f = fixture();
+    await f.store.init();
+    const gate = deferred();
+    let opens = 0;
+    const navigations = [];
+    f.sandbox.app = { async navigateToView(view) { navigations.push(view); } };
+    f.sandbox.AppLazyLoader = { async ensureGroup() {
+        await gate.promise;
+        f.sandbox.ReadingVocabReader = { async open() { opens += 1; } };
+    } };
+    const view = f.sandbox.BookshelfView;
+    view.state.fromView = 'overview';
+    const pending = view.launchExamVocabReader('same-exam', sourceA);
+    await view.navigateToMoreView();
+    gate.resolve();
+    await pending;
+    assert.equal(opens, 0);
+    assert.deepEqual(navigations, ['overview']);
+    assert.equal(view.state.fromView, null);
+    await view.navigateToMoreView();
+    assert.deepEqual(navigations, ['overview', 'more']);
+});
+
+test('External navigation away and back cancels a pending Bookshelf reader launch', async () => {
+    const f = fixture();
+    await f.store.init();
+    const gate = deferred();
+    let navigation = 1;
+    let opens = 0;
+    f.sandbox.__getAppNavigationIntentGeneration = () => navigation;
+    f.sandbox.AppLazyLoader = { async ensureGroup() {
+        await gate.promise;
+        f.sandbox.ReadingVocabReader = { async open() { opens += 1; } };
+    } };
+    const view = f.sandbox.BookshelfView;
+    const pending = view.launchExamVocabReader('same-exam', sourceA);
+    navigation += 1; // A navbar action leaves Bookshelf without its back button.
+    navigation += 1; // Returning before the old load completes does not revive it.
+    gate.resolve();
+    await pending;
+    assert.equal(opens, 0);
+    assert.equal(view.state.readerLoading, false);
+    assert.equal(view.state.readerError, null);
+    await view.launchExamVocabReader('same-exam', sourceA);
+    assert.equal(opens, 1, 'a fresh invocation from the returned view still opens normally');
+});
+
+test('Bookshelf practice source guard rechecks source and displayed index provenance after lazy loading', async () => {
+    const f = fixture();
+    await f.store.init();
+    const gate = deferred();
+    let activeId = 'library-b';
+    f.sandbox.AppData.library.getActive = async () => activeId;
+    f.sandbox.AppData.library.getIndex = async () => [{ id: 'same-exam' }];
+    f.sandbox.AppLazyLoader = { async ensureGroup() {
+        await gate.promise;
+        f.sandbox.ReadingVocabReader = { async open() {} };
+    } };
+    const view = f.sandbox.BookshelfView;
+    const toasts = [];
+    view.showToast = (message) => toasts.push(message);
+    const article = f.store.getBookshelfExams().find((row) => row.source.id === 'library-b');
+    const pending = view.canOpenOriginalSource(article);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    activeId = null;
+    gate.resolve();
+    assert.equal(await pending, false, 'a library activation during lazy loading cancels the action');
+    assert.match(toasts.pop(), /题库已切换或正在更新/);
+    activeId = 'library-b';
+    f.sandbox.examIndex = [{ id: 'same-exam', libraryConfigurationId: null }];
+    assert.equal(await view.canOpenOriginalSource(article), false, 'a stale builtin index cannot supply an imported article');
+    f.sandbox.examIndex = [{ id: 'same-exam', libraryConfigurationId: 'library-c' }];
+    assert.equal(await view.canOpenOriginalSource(article), false, 'another imported index with the same exam ID is rejected');
+    f.sandbox.examIndex = [{ id: 'same-exam', libraryConfigurationId: 'library-b' }];
+    assert.equal(await view.canOpenOriginalSource(article), true);
 });

--- a/developer/tests/js/helpers/readingVocabReaderHarness.js
+++ b/developer/tests/js/helpers/readingVocabReaderHarness.js
@@ -30,7 +30,7 @@ export async function installReadingAuthority(page, { localWords = [], canonical
         if (authority !== 'missing') {
             window.AppData = {
                 ready: Promise.resolve(),
-                library: { getActive: async () => null },
+                library: { getActive: async () => null, getIndex: async () => [], listConfigurations: async () => [] },
                 vocab: {
                     readingModel: model,
                     getReadingSnapshot: async () => {

--- a/developer/tests/js/libraryManagerImportConfig.test.js
+++ b/developer/tests/js/libraryManagerImportConfig.test.js
@@ -313,6 +313,7 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
         examId: 'listening-alt',
         type: 'listening',
         title: 'Alt Listening',
+        libraryConfigurationId: 'previous-library',
         category: 'P1',
         path: 'Alt/',
         filename: 'alt.html'
@@ -324,9 +325,11 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
     const before = await window.AppData.practice.list();
     const revisionBeforeSwitch = window.getBrowseFilterMutationRevision();
     const publicationOrder = [];
+    let publishedIndex;
     window.dispatchEvent = function dispatchEvent(event) {
         if (event && event.type === 'examIndexLoaded') {
             publicationOrder.push('index-publication');
+            publishedIndex = event.detail.index;
         }
         return true;
     };
@@ -339,6 +342,8 @@ async function testSwitchConfigurationDoesNotTouchPracticeRecords() {
     const applied = await manager.applyLibraryConfiguration('alt_config');
 
     assert.strictEqual(applied, true, '配置切换应该成功');
+    assert.strictEqual(publishedIndex[0].libraryConfigurationId, 'alt_config', 'switching configurations overrides inherited card provenance');
+    assert.strictEqual(seed.library.importedIndexes.alt_config[0].libraryConfigurationId, 'previous-library', 'render provenance must not mutate the stored source dataset');
     assert.strictEqual(await window.AppData.library.getActive(), 'alt_config', '活动配置应切换到目标配置');
     assert.deepStrictEqual(await window.AppData.practice.list(), before, '配置切换不能触碰练习记录');
     assert.strictEqual(
@@ -504,6 +509,7 @@ async function testBrokenLegacyActiveLibraryFallsBackToReadingManifest() {
 
     assert.deepStrictEqual(loaded.map((exam) => exam.id), ['default-reading-after-repair'], 'a broken v1 active key must not hide the generated Reading manifest');
     assert.strictEqual(getActiveId(), 'exam_index', 'display fallback must not rewrite persistent selection state');
+    assert.strictEqual(loaded[0].libraryConfigurationId, null, 'fallback cards must retain builtin provenance despite the stale active configuration');
     recordResult('错误迁移的 v1 活动题库回退 Reading manifest', { loadedCount: loaded.length });
 }
 
@@ -529,6 +535,7 @@ async function testForceReloadKeepsHealthyCustomLibraryActive() {
 
     assert.deepStrictEqual(loaded.map((exam) => exam.id), ['healthy-custom-reading']);
     assert.strictEqual(getActiveId(), 'healthy-custom', 'force reload must not switch a healthy custom library to default');
+    assert.strictEqual(loaded[0].libraryConfigurationId, 'healthy-custom', 'cards must retain the configuration that produced their content');
     recordResult('强制刷新保留健康自定义题库', { loadedCount: loaded.length });
 }
 

--- a/developer/tests/js/readingEntrypoints.test.js
+++ b/developer/tests/js/readingEntrypoints.test.js
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(done => { resolve = done; });
+    return { promise, resolve };
+}
+
+function harness(script) {
+    let navigation = 1;
+    let activeLibrary = 'current-library';
+    const opens = [];
+    const groups = [];
+    const messages = [];
+    const delegates = new Map();
+    const listeners = new Map();
+    const window = {
+        console: { log() {}, warn() {} },
+        document: {
+            readyState: 'loading', addEventListener(type, listener) {
+                if (!listeners.has(type)) listeners.set(type, []);
+                listeners.get(type).push(listener);
+            },
+            getElementById() { return null; }, querySelector() { return null; }, querySelectorAll() { return []; }
+        },
+        addEventListener() {},
+        __getAppNavigationIntentGeneration: () => navigation,
+        AppData: { library: { async getActive() { return activeLibrary; } } },
+        AppLazyLoader: { async ensureGroup(group) { groups.push(group); } },
+        ReadingVocabReader: { async open(id, options) { opens.push({ id, options }); } },
+        DOM: { delegate(type, selector, callback) { delegates.set(`${type}:${selector}`, callback); } },
+        showMessage: message => messages.push(message)
+    };
+    const context = vm.createContext({ window, document: window.document, console: window.console,
+        setTimeout, clearTimeout, URL, URLSearchParams });
+    vm.runInContext(fs.readFileSync(new URL(`../../../js/${script}`, import.meta.url), 'utf8'), context);
+    return { window, opens, groups, messages, delegates, listeners,
+        navigate() { navigation += 1; }, activate(id) { activeLibrary = id; } };
+}
+
+test('Browse first invocation loads its groups and keeps the rendered card source', async () => {
+    const h = harness('app/examActions.js');
+    const ready = deferred();
+    h.window.AppLazyLoader.ensureGroup = async group => { h.groups.push(group); await ready.promise; };
+    h.window.ExamActions.setupExamActionHandlers();
+    const target = { dataset: { action: 'vocab-book', examId: 'same-id', libraryConfigurationId: 'library-a', contentRef: 'original-source-reference' } };
+    h.delegates.get('click:[data-action="vocab-book"]').call(target, { preventDefault() {} });
+    h.activate('library-b');
+    ready.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(h.groups, ['exam-data', 'browse-runtime']);
+    assert.equal(h.opens.length, 1);
+    assert.equal(h.opens[0].options.libraryConfigurationId, 'library-a');
+    assert.equal(h.opens[0].options.contentRef, 'original-source-reference');
+    assert.equal(h.opens[0].options.returnFocus, target);
+    await h.window.launchBrowseReadingVocab('builtin', { dataset: { libraryConfigurationId: '' } });
+    assert.equal(h.opens[1].options.libraryConfigurationId, null, 'explicit default must not inherit an imported active library');
+});
+
+test('pending Browse reader opens respect the latest article and navigation intent', async () => {
+    const h = harness('app/examActions.js');
+    const ready = deferred();
+    h.window.AppLazyLoader.ensureGroup = async () => ready.promise;
+    const target = { dataset: { libraryConfigurationId: '' } };
+    const first = h.window.launchBrowseReadingVocab('a', target);
+    const second = h.window.launchBrowseReadingVocab('b', target);
+    ready.resolve();
+    await Promise.all([first, second]);
+    assert.deepEqual(h.opens.map(row => row.id), ['b']);
+    const next = deferred();
+    h.window.AppLazyLoader.ensureGroup = async () => next.promise;
+    const abandoned = h.window.launchBrowseReadingVocab('c', target);
+    h.navigate();
+    next.resolve();
+    await abandoned;
+    assert.deepEqual(h.opens.map(row => row.id), ['b']);
+});
+
+test('Browse load failure reports an error and permits a fresh retry', async () => {
+    const h = harness('app/examActions.js');
+    h.window.AppLazyLoader.ensureGroup = async () => { throw new Error('offline'); };
+    await h.window.launchBrowseReadingVocab('a', { dataset: {} });
+    assert.equal(h.opens.length, 0);
+    assert.equal(h.messages.length, 1);
+    h.window.AppLazyLoader.ensureGroup = async () => {};
+    await h.window.launchBrowseReadingVocab('a', { dataset: {} });
+    assert.equal(h.opens.length, 1);
+});
+
+test('cold Bookshelf opens preserve the return view and ignore stale lazy completions', async () => {
+    const h = harness('presentation/app-actions.js');
+    const mounts = [];
+    const navigations = [];
+    h.window.BookshelfView = { mount(selector, options) { mounts.push({ selector, options }); } };
+    h.window.app = { currentView: 'more', navigateToView(view) { navigations.push(view); } };
+    const ready = deferred();
+    h.window.AppLazyLoader.ensureGroup = async () => ready.promise;
+    const stale = h.window.AppActions.openBookshelf({ fromView: 'overview' });
+    await Promise.resolve();
+    h.navigate();
+    ready.resolve();
+    await stale;
+    assert.equal(mounts.length, 0);
+    assert.equal(navigations.length, 0);
+    await h.window.AppActions.openBookshelf({ fromView: 'more' });
+    assert.equal(mounts.length, 1);
+    assert.equal(mounts[0].options.fromView, 'more');
+    assert.deepEqual(navigations, ['bookshelf']);
+});
+
+test('the visible More card accepts its first click before tools bind, without duplicating warm clicks', async () => {
+    const h = harness('presentation/app-actions.js');
+    const ready = deferred();
+    const mounts = [];
+    h.window.AppLazyLoader.ensureGroup = async group => {
+        h.groups.push(group);
+        await ready.promise;
+        h.window.BookshelfView = { mount(selector, options) { mounts.push(options); } };
+    };
+    const target = { closest() { return this; } };
+    const event = { target, defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+    h.listeners.get('click').forEach(listener => listener(event));
+    await Promise.resolve();
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(mounts.length, 0);
+    ready.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(mounts.length, 1);
+    assert.equal(mounts[0].fromView, 'more');
+    assert.deepEqual(h.groups, ['more-tools', 'exam-data']);
+    // An installed More handler owns a warm click by preventing its default.
+    h.listeners.get('click').forEach(listener => listener({ ...event, defaultPrevented: true }));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(mounts.length, 1);
+});

--- a/developer/tests/js/readingVocabReaderSafety.test.js
+++ b/developer/tests/js/readingVocabReaderSafety.test.js
@@ -215,8 +215,12 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     await ReadingVocabReader.open('article', { source: { kind: 'imported', id: 'missing-library' } });
                     ReadingVocabReader.openModal();
                 });
-                await page.locator('#vocab-manual-input').fill('not-collected');
-                await page.locator('#vocab-manual-add-btn').click();
+                assert.equal(await page.locator('#vocab-manual-input').isEnabled(), false);
+                assert.equal(await page.locator('#vocab-manual-add-btn').isEnabled(), false);
+                await page.evaluate(() => {
+                    document.querySelector('#vocab-manual-input').value = 'not-collected';
+                    document.querySelector('#vocab-manual-add-btn').click();
+                });
                 const state = await page.evaluate(() => ({
                     words: ReadingVocabStore.getAll().map(item => item.word),
                     payload: ReadingVocabReader.currentPayload,
@@ -307,7 +311,7 @@ test('reading vocab reader preserves text boundaries and the active reading sess
                     await __openA;
                     ReadingVocabReader.currentExplanation = { passageNotes: [{ label: 'Paragraph A', text: 'old cached translation' }] };
                     await __queueOpen('b', '__openB');
-                    const cleared = ReadingVocabReader.currentPayload === null && ReadingVocabReader.currentExam === null && ReadingVocabReader.currentExplanation === null;
+                    const cleared = ReadingVocabReader.currentPayload === null && ReadingVocabReader.currentExam?.title !== 'a' && ReadingVocabReader.currentExplanation === null;
                     __finishScript('b.js', 'b');
                     await __openB;
                     const before = document.getElementById('vocab-trans-text-p-1').textContent;

--- a/developer/tests/js/readingVocabSourceResolution.test.js
+++ b/developer/tests/js/readingVocabSourceResolution.test.js
@@ -38,13 +38,16 @@ test('reader resolves original libraries, preserves unavailable vocabulary, and 
         assert.match(await page.locator('#vocab-passage-content').innerText(), /Beryl/);
         assert.equal(await page.locator('#vocab-fab-count').innerText(), '0');
         await page.evaluate(() => ReadingVocabStore.add('beryl', 'shared', 'B title', '', null, { kind: 'imported', id: 'b' }));
+        const beforeReplacement = await page.evaluate(() => structuredClone(__readingAuthority.snapshot));
         await page.evaluate(async () => {
             __sourceIndexes.a[0].title = 'Replacement article';
-            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } });
+            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' }, title: 'Replacement article' });
         });
         assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章已更改/);
         assert.equal(await page.locator('#vocab-reader-title').innerText(), 'A title');
         assert.equal(await page.locator('#vocab-fab-count').innerText(), '1');
+        assert.equal(await page.evaluate(() => ReadingVocabReader.currentPayload), null);
+        assert.deepEqual(await page.evaluate(() => __readingAuthority.snapshot), beforeReplacement);
         await page.evaluate(() => ReadingVocabReader.open('shared', {
             source: { kind: 'imported', id: 'b' },
             articleId: AppData.vocab.readingModel.articleId({ kind: 'imported', id: 'a' }, 'shared')
@@ -110,18 +113,60 @@ test('rapid opens of the same examId retain only the latest imported source', as
     }
 });
 
-test('file-picker content requires an unambiguous original import key', async () => {
+test('initiating title is validated independently and normalized like the saved title', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser, { canonicalWords: [{ word: 'amber', examId: 'shared',
+        examTitle: 'Original title', source: { kind: 'imported', id: 'a' } }] });
+    let contentRequests = 0;
+    try {
+        await page.route('https://reader.test/original.html', route => {
+            contentRequests += 1;
+            return route.fulfill({ contentType: 'text/html', body: '<div id="passage"><p>The original amber article remains available for reading.</p></div>' });
+        });
+        await page.evaluate(() => {
+            AppData.library.getIndex = async () => [{ id: 'shared', title: 'Original title', filename: 'original.html' }];
+            AppData.library.listConfigurations = async () => [{ id: 'a' }];
+        });
+        const originalSnapshot = await page.evaluate(() => structuredClone(__readingAuthority.snapshot));
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' }, title: 'Stale initiating title' }));
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章已更改/);
+        assert.equal(await page.locator('#vocab-reader-title').innerText(), 'Original title');
+        assert.equal(contentRequests, 0);
+        assert.deepEqual(await page.evaluate(() => __readingAuthority.snapshot), originalSnapshot);
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' }, title: '  Original\n  title  ' }));
+        assert.equal(await page.locator('[data-source-unavailable]').count(), 0);
+        assert.match(await page.locator('#vocab-passage-content').innerText(), /original amber article/);
+        assert.equal(contentRequests, 1);
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});
+
+for (const [configurationShape, configurations] of [
+    ['id', [{ id: 'a' }, { id: 'b' }]],
+    ['key', [{ key: 'a' }, { key: 'b' }]],
+    ['configId', [{ configId: 'a' }, { configId: 'b' }]],
+    ['string', ['a', 'b']],
+    ['id with legacy configId competitor', [{ id: 'a' }, { configId: 'b' }]],
+    ['id with legacy string competitor', [{ id: 'a' }, 'b']]
+]) test(`file-picker source and competing import key resolve ${configurationShape} configurations`, async () => {
     const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
     const page = await createPage(browser);
     try {
-        const state = await page.evaluate(async () => {
+        const state = await page.evaluate(async configurations => {
             const source = { kind: 'imported', id: 'a' };
             const exam = { id: 'shared', title: 'Original article', sourceKind: 'file-picker', importKey: 'reading:shared.html' };
             const url = URL.createObjectURL(new Blob(['<div id="passage"><p>The original session article with an amber specimen.</p></div>'], { type: 'text/html' }));
             let ambiguous = false;
             let resourceReads = 0;
-            AppData.library.listConfigurations = async () => [{ id: 'a' }, { id: 'b' }];
-            AppData.library.getIndex = async id => id === 'a' || ambiguous ? [exam] : [];
+            const indexReads = [];
+            AppData.library.listConfigurations = async () => configurations;
+            AppData.library.getIndex = async id => {
+                indexReads.push(id);
+                if (!['a', 'b'].includes(id)) throw new Error('Invalid configuration ID');
+                return id === 'a' || ambiguous ? [exam] : [];
+            };
             window.LibraryDiscovery = { resolveRuntimeResource: candidate => {
                 if (Object.keys(candidate).join(',') !== 'importKey') throw new Error('Unsafe examId fallback');
                 resourceReads += 1;
@@ -134,13 +179,14 @@ test('file-picker content requires an unambiguous original import key', async ()
             await ReadingVocabReader.open('shared', { source });
             ReadingVocabReader.openModal();
             URL.revokeObjectURL(url);
-            return { initialContent, resourceReads,
+            return { initialContent, resourceReads, indexReads,
                 unavailable: document.querySelector('[data-source-unavailable]').textContent,
                 words: [...document.querySelectorAll('.vocab-item__word')].map(element => element.textContent),
                 exportEnabled: !document.querySelector('#vocab-export-btn').disabled };
-        });
+        }, configurations);
         assert.match(state.initialContent, /original session article/);
         assert.equal(state.resourceReads, 1);
+        assert.deepEqual(state.indexReads, ['a', 'b', 'a', 'b']);
         assert.match(state.unavailable, /无法确认原文来源/);
         assert.deepEqual(state.words, ['amber']);
         assert.equal(state.exportEnabled, true);

--- a/developer/tests/js/readingVocabSourceResolution.test.js
+++ b/developer/tests/js/readingVocabSourceResolution.test.js
@@ -1,0 +1,259 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { createPage } from './helpers/readingVocabReaderHarness.js';
+
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
+test('reader resolves original libraries, preserves unavailable vocabulary, and opens the global notebook', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    try {
+        await page.route('https://reader.test/libraries/**', route => {
+            const name = route.request().url().includes('/a/') ? 'Amber' : 'Beryl';
+            return route.fulfill({ contentType: 'text/html', body: `<!doctype html><title>${name}</title>
+                <div id="passage"><h2>${name} article</h2><p>A ${name} passage belonging to its original library.</p></div>
+                <div id="questions"><p>${name} question <input name="answer" value="unsafe"></p></div>
+                <script>window.__importExecuted = true;</script>` });
+        });
+        await page.evaluate(() => {
+            window.__sourceIndexes = Object.fromEntries(['a', 'b'].map(id => [id, [{
+                id: 'shared', examId: 'shared', type: 'reading', title: `${id.toUpperCase()} title`,
+                path: `libraries/${id}/`, filename: 'article.html', sourceKind: 'custom'
+            }]]));
+            AppData.library.getActive = async () => 'b';
+            AppData.library.getIndex = async id => __sourceIndexes[id] || [];
+            AppData.library.listConfigurations = async () => ['a', 'b'].map(id => ({ id, name: `Library ${id}` }));
+            window.examIndex = __sourceIndexes.b;
+            window.__READING_EXAM_DATA__ = { get: () => ({ meta: { title: 'Wrong built-in' },
+                passage: { blocks: [{ html: '<p>Wrong built-in content</p>' }] } }), register() {} };
+        });
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } }));
+        assert.match(await page.locator('#vocab-passage-content').innerText(), /Amber/);
+        assert.match(await page.locator('#vocab-reader-badges').innerText(), /Library a · a/);
+        assert.equal(await page.locator('#vocab-questions-content input').count(), 0);
+        assert.equal(await page.evaluate(() => window.__importExecuted), undefined);
+        await page.evaluate(() => ReadingVocabStore.add('amber', 'shared', 'A title', '', null, { kind: 'imported', id: 'a' }));
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'b' } }));
+        assert.match(await page.locator('#vocab-passage-content').innerText(), /Beryl/);
+        assert.equal(await page.locator('#vocab-fab-count').innerText(), '0');
+        await page.evaluate(() => ReadingVocabStore.add('beryl', 'shared', 'B title', '', null, { kind: 'imported', id: 'b' }));
+        await page.evaluate(async () => {
+            __sourceIndexes.a[0].title = 'Replacement article';
+            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } });
+        });
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章已更改/);
+        assert.equal(await page.locator('#vocab-reader-title').innerText(), 'A title');
+        assert.equal(await page.locator('#vocab-fab-count').innerText(), '1');
+        await page.evaluate(() => ReadingVocabReader.open('shared', {
+            source: { kind: 'imported', id: 'b' },
+            articleId: AppData.vocab.readingModel.articleId({ kind: 'imported', id: 'a' }, 'shared')
+        }));
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章与题库来源不匹配/);
+        assert.equal(await page.locator('#vocab-fab-count').innerText(), '0');
+        assert.equal(await page.locator('#vocab-export-btn').isEnabled(), false);
+        await page.evaluate(async () => {
+            delete __sourceIndexes.a;
+            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' }, fromView: 'bookshelf' });
+        });
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /原题库或文章已移除/);
+        assert.equal(await page.locator('#vocab-reader-title').innerText(), 'A title');
+        assert.equal((await page.locator('#vocab-reader-back-btn').innerText()).trim(), '返回书架');
+        assert.equal(await page.locator('#vocab-fab-count').innerText(), '1');
+        await page.getByRole('button', { name: '查看已保存生词' }).click();
+        assert.deepEqual(await page.locator('.vocab-item__word').allTextContents(), ['amber']);
+        assert.equal(await page.locator('#vocab-export-btn').isEnabled(), true);
+        assert.equal(await page.locator('#vocab-manual-add-btn').isEnabled(), false);
+        await page.evaluate(() => ReadingVocabReader.openNotebook({ fromView: 'bookshelf' }));
+        assert.equal(await page.locator('#vocab-modal').getAttribute('aria-hidden'), 'false');
+        assert.deepEqual((await page.locator('.vocab-item__word').allTextContents()).sort(), ['amber', 'beryl']);
+        assert.equal(await page.locator('#v-tab-current').isEnabled(), false);
+        assert.equal(await page.locator('#vocab-clear-btn').isEnabled(), true);
+        assert.equal(await page.evaluate(() => __readingAuthority.snapshot.reading.visits.length), 2);
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});
+
+test('rapid opens of the same examId retain only the latest imported source', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    try {
+        const state = await page.evaluate(async () => {
+            const payloads = { a: 'Amber', b: 'Beryl' };
+            AppData.library.listConfigurations = async () => ['a', 'b'].map(id => ({ id, name: id }));
+            AppData.library.getIndex = async id => [{ id: 'shared', title: payloads[id], filename: `https://content.test/${id}.html` }];
+            const pending = new Map();
+            window.fetch = url => new Promise(resolve => pending.set(url, resolve));
+            const first = ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } });
+            for (let step = 0; step < 50 && !pending.has('https://content.test/a.html'); step += 1) await Promise.resolve();
+            const latest = ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'b' } });
+            for (let step = 0; step < 50 && !pending.has('https://content.test/b.html'); step += 1) await Promise.resolve();
+            for (const [id, promise] of [['b', latest], ['a', first]]) {
+                pending.get(`https://content.test/${id}.html`)({ ok: true, text: async () => `<div id="passage"><p>This is ${payloads[id]} and its original article.</p></div>` });
+                await promise;
+            }
+            return { source: ReadingVocabReader.currentSource.id,
+                title: document.querySelector('#vocab-reader-title').textContent,
+                passage: document.querySelector('#vocab-passage-content').textContent,
+                visits: __readingAuthority.snapshot.reading.visits.length };
+        });
+        assert.equal(state.source, 'b');
+        assert.equal(state.title, 'Beryl');
+        assert.match(state.passage, /Beryl/);
+        assert.doesNotMatch(state.passage, /Amber/);
+        assert.equal(state.visits, 1);
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});
+
+test('file-picker content requires an unambiguous original import key', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    try {
+        const state = await page.evaluate(async () => {
+            const source = { kind: 'imported', id: 'a' };
+            const exam = { id: 'shared', title: 'Original article', sourceKind: 'file-picker', importKey: 'reading:shared.html' };
+            const url = URL.createObjectURL(new Blob(['<div id="passage"><p>The original session article with an amber specimen.</p></div>'], { type: 'text/html' }));
+            let ambiguous = false;
+            let resourceReads = 0;
+            AppData.library.listConfigurations = async () => [{ id: 'a' }, { id: 'b' }];
+            AppData.library.getIndex = async id => id === 'a' || ambiguous ? [exam] : [];
+            window.LibraryDiscovery = { resolveRuntimeResource: candidate => {
+                if (Object.keys(candidate).join(',') !== 'importKey') throw new Error('Unsafe examId fallback');
+                resourceReads += 1;
+                return url;
+            } };
+            await ReadingVocabReader.open('shared', { source });
+            const initialContent = document.querySelector('#vocab-passage-content').textContent;
+            await ReadingVocabStore.add('amber', 'shared', exam.title, '', null, source);
+            ambiguous = true;
+            await ReadingVocabReader.open('shared', { source });
+            ReadingVocabReader.openModal();
+            URL.revokeObjectURL(url);
+            return { initialContent, resourceReads,
+                unavailable: document.querySelector('[data-source-unavailable]').textContent,
+                words: [...document.querySelectorAll('.vocab-item__word')].map(element => element.textContent),
+                exportEnabled: !document.querySelector('#vocab-export-btn').disabled };
+        });
+        assert.match(state.initialContent, /original session article/);
+        assert.equal(state.resourceReads, 1);
+        assert.match(state.unavailable, /无法确认原文来源/);
+        assert.deepEqual(state.words, ['amber']);
+        assert.equal(state.exportEnabled, true);
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});
+
+test('imported passage is sanitized before normalization and keeps its original figure URLs', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser);
+    const executedRequests = [];
+    try {
+        await page.route('https://reader.test/executed**', route => {
+            executedRequests.push(route.request().url());
+            return route.fulfill({ status: 204, body: '' });
+        });
+        await page.route('https://reader.test/content/**', route => {
+            const url = route.request().url();
+            if (!url.endsWith('article.html')) return route.fulfill({ contentType: 'image/svg+xml', body: '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="green"/></svg>' });
+            return route.fulfill({ contentType: 'text/html', body: `<title>Original title</title><div id="passage">
+                <h2>Original title</h2><p>A complete imported passage with a figure.</p>
+                <img alt="Diagram" src="diagram.svg" onload="window.__importExecuted=true;fetch('/executed-load')">
+                <img alt="Responsive diagram" src="fallback.svg" srcset="small.svg 1x, large.svg 2x" onerror="window.__importExecuted=true;fetch('/executed-responsive')">
+                <img alt="Broken figure" src="/broken-import-image" onerror="window.__importExecuted=true;fetch('/executed-error')">
+                <img alt="Unsafe URL" src="javascript:window.__importExecuted=true">
+                <meta http-equiv="refresh" content="0;url=/executed-navigation"><base href="https://incorrect.test/">
+                </div><div id="questions"><p>Questions with a figure <img alt="Question diagram" src="question.svg" onload="window.__importExecuted=true;fetch('/executed-question')"></p></div>` });
+        });
+        await page.route('https://reader.test/broken-import-image', route => route.fulfill({ status: 404, body: '' }));
+        await page.evaluate(() => {
+            AppData.library.getIndex = async () => [{ id: 'shared', title: 'Original title', path: 'content/', filename: 'article.html' }];
+            AppData.library.listConfigurations = async () => [{ id: 'a', name: 'Original library' }];
+        });
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } }));
+        await page.waitForFunction(() => [...document.querySelectorAll('#vocab-reader-body img')].every(image => image.complete));
+        await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+        assert.equal(await page.evaluate(() => window.__importExecuted), undefined);
+        assert.deepEqual(executedRequests, []);
+        assert.equal(await page.locator('#vocab-reader-body [onload], #vocab-reader-body [onerror], #vocab-reader-body meta, #vocab-reader-body base').count(), 0);
+        assert.equal(await page.getByAltText('Diagram', { exact: true }).getAttribute('src'), 'https://reader.test/content/diagram.svg');
+        assert.equal(await page.getByAltText('Question diagram').getAttribute('src'), 'https://reader.test/content/question.svg');
+        assert.equal(await page.getByAltText('Responsive diagram').getAttribute('srcset'), 'https://reader.test/content/small.svg 1x, https://reader.test/content/large.svg 2x');
+        assert.equal(await page.getByAltText('Unsafe URL').getAttribute('src'), null);
+        assert.equal(await page.evaluate(() => document.baseURI), 'https://reader.test/');
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});
+
+test('article source bindings prevent same-title replacement and ambiguous restored references', async () => {
+    const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    const page = await createPage(browser, { canonicalWords: [{ word: 'retained', examId: 'shared', examTitle: 'Original title', source: { kind: 'imported', id: 'a' } }] });
+    const contentRequests = [];
+    try {
+        await page.route('https://reader.test/content/**', route => {
+            contentRequests.push(route.request().url());
+            return route.fulfill({ contentType: 'text/html', body: '<div id="passage"><p>An amber specimen remains in the original passage for collection.</p></div>' });
+        });
+        await page.evaluate(() => {
+            window.__boundExam = { id: 'shared', title: 'Original title', sourceKind: 'custom', path: 'content/original/', filename: 'article.html' };
+            AppData.library.getIndex = async () => [__boundExam];
+            AppData.library.listConfigurations = async () => [{ id: 'a', name: 'Original library' }];
+        });
+        await page.evaluate(() => ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } }));
+        await page.evaluate(() => ReadingVocabReader.openModal());
+        await page.locator('#vocab-manual-input').fill('manual');
+        await page.locator('#vocab-manual-add-btn').click();
+        await page.waitForFunction(() => ReadingVocabStore.getAll().some(row => row.word === 'manual'));
+        const bindings = await page.evaluate(async () => {
+            ReadingVocabReader.closeModal();
+            __selectText('#vocab-passage-content', 'amber');
+            await ReadingVocabReader.captureSelection();
+            return { expected: AppData.vocab.readingModel.contentRef(__boundExam),
+                saved: __readingAuthority.snapshot.reading.articles[0].contentRefs,
+                collected: __readingAuthority.calls.filter(call => call.type === 'collect').map(call => call.command.article.contentRef) };
+        });
+        assert.deepEqual(bindings.saved, [bindings.expected]);
+        assert.deepEqual(bindings.collected, [bindings.expected, bindings.expected]);
+        await page.evaluate(async () => {
+            __boundExam.path = 'content/replacement/';
+            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } });
+            ReadingVocabReader.openModal();
+        });
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章文件已更改或来源记录冲突/);
+        assert.deepEqual((await page.locator('.vocab-item__word').allTextContents()).sort(), ['amber', 'manual', 'retained']);
+        assert.equal(await page.locator('#vocab-export-btn').isEnabled(), true);
+        assert.equal(contentRequests.length, 1);
+        await page.evaluate(async () => {
+            const model = AppData.vocab.readingModel;
+            const incoming = model.recordVisit(model.createSnapshot(), { source: { kind: 'imported', id: 'a' },
+                article: { examId: 'shared', title: 'Original title', contentRef: model.contentRef(__boundExam) }, at: '2026-09-08T02:00:00.000Z' });
+            __readingAuthority.snapshot = model.merge(__readingAuthority.snapshot, incoming);
+            __readingAuthority.revision += 1;
+            __boundExam.path = 'content/original/';
+            await ReadingVocabReader.open('shared', { source: { kind: 'imported', id: 'a' } });
+        });
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /来源记录冲突/);
+        assert.equal(contentRequests.length, 1);
+        await page.evaluate(async () => {
+            const model = AppData.vocab.readingModel;
+            const expected = model.contentRef(__boundExam);
+            __boundExam.id = 'unvisited';
+            __boundExam.path = 'content/replacement/';
+            await ReadingVocabReader.open('unvisited', { source: { kind: 'imported', id: 'a' }, contentRef: expected });
+        });
+        assert.match(await page.locator('[data-source-unavailable]').innerText(), /文章文件已更改/);
+        assert.equal(contentRequests.length, 1);
+        assert.equal(await page.evaluate(() => __readingAuthority.snapshot.reading.articles.some(row => row.examId === 'unvisited')), false);
+    } finally {
+        await page.close();
+        await browser.close();
+    }
+});

--- a/developer/tests/js/readingVocabularyModel.test.js
+++ b/developer/tests/js/readingVocabularyModel.test.js
@@ -123,6 +123,116 @@ test('same normalized term in two libraries has one owner and independent articl
     assert.equal(snapshot.lists[model.READING_LIST_ID], undefined, 'linking an existing owner must not create a duplicate review row');
 });
 
+test('content references use source locator fields and ignore article presentation metadata', () => {
+    const exam = {
+        sourceKind: ' imported ', dataKey: ' data-key ', path: ' folder\\nested ',
+        filename: ' section\\article.html ', importKey: ' import-id ', title: 'Original title'
+    };
+    assert.equal(model.contentRef(exam), JSON.stringify([
+        'imported', 'data-key', 'folder/nested', 'section/article.html', 'import-id'
+    ]));
+    assert.equal(model.contentRef(exam), model.contentRef({ ...exam, title: 'Renamed', id: 'another-id' }));
+    for (const field of ['sourceKind', 'dataKey', 'path', 'filename', 'importKey']) {
+        assert.notEqual(model.contentRef(exam), model.contentRef({ ...exam, [field]: 'changed' }), field);
+    }
+    assert.equal(model.contentRef({}), JSON.stringify(['', '', '', '', '']));
+});
+
+test('visits and collections bind the first source reference while keeping legacy article identities', () => {
+    const ref = model.contentRef({ sourceKind: 'imported', path: 'library', filename: 'article.html' });
+    for (const operation of ['recordVisit', 'collect']) {
+        const input = operation === 'collect'
+            ? command({ article: { ...ARTICLE, contentRef: ref } })
+            : { source: SOURCE_A, article: { ...ARTICLE, contentRef: ref }, at: AT };
+        for (const legacy of [false, true]) {
+            let snapshot = model.createSnapshot();
+            if (legacy) snapshot = mutate('recordVisit', snapshot, { source: SOURCE_A, article: ARTICLE, at: AT });
+            snapshot = mutate(operation, snapshot, input);
+            assert.equal(snapshot.reading.articles[0].id, articleId());
+            assert.deepEqual(plain(snapshot.reading.articles[0].contentRefs), [ref]);
+            const once = plain(snapshot);
+            snapshot = mutate(operation, snapshot, input);
+            assert.deepEqual(plain(snapshot), once, 'binding retries must be idempotent');
+            assert.deepEqual(plain(model.deserialize(model.serialize(snapshot))), once);
+            snapshot = mutate('recordVisit', snapshot, { source: SOURCE_A, article: ARTICLE, at: LATER });
+            snapshot = mutate('collect', snapshot, command());
+            snapshot = mutate('clearArticle', snapshot, { articleId: articleId() });
+            assert.deepEqual(plain(snapshot.reading.articles[0].contentRefs), [ref],
+                'legacy commands and relationship deletion retain the content binding');
+        }
+    }
+});
+
+test('changed and ambiguous content bindings reject visits and collections without partial mutation', () => {
+    const bound = mutate('collect', model.createSnapshot(), command({ article: { ...ARTICLE, contentRef: 'source-a' } }));
+    for (const refs of [['source-a'], ['source-a', 'source-b']]) {
+        const snapshot = plain(bound);
+        snapshot.reading.articles[0].contentRefs = refs;
+        const before = plain(snapshot);
+        for (const operation of ['recordVisit', 'collect']) {
+            const ref = refs.length === 1 ? 'source-b' : 'source-a';
+            const input = operation === 'collect'
+                ? command({ article: { ...ARTICLE, title: 'Changed', contentRef: ref }, at: LATER })
+                : { source: SOURCE_A, article: { ...ARTICLE, title: 'Changed', contentRef: ref }, at: LATER };
+            assert.throws(() => model[operation](deepFreeze(snapshot), deepFreeze(input)),
+                /content reference has changed or is ambiguous/);
+            assert.deepEqual(plain(snapshot), before, `${operation} preserves all existing data on conflict`);
+        }
+    }
+});
+
+test('article reference validation accepts legacy snapshots and rejects malformed bindings', () => {
+    const legacy = mutate('recordVisit', model.createSnapshot(), { source: SOURCE_A, article: ARTICLE, at: AT });
+    assert.equal(Object.hasOwn(legacy.reading.articles[0], 'contentRefs'), false);
+    assert.deepEqual(plain(model.deserialize(model.serialize(legacy))), plain(legacy));
+    for (const contentRefs of [null, 'source', [''], [' padded '], [1], ['same', 'same'], ['z', 'a']]) {
+        const invalid = plain(legacy);
+        invalid.reading.articles[0].contentRefs = contentRefs;
+        assert.throws(() => model.validate(invalid));
+        assert.throws(() => model.deserialize(JSON.stringify(invalid)));
+    }
+    const unbound = plain(legacy);
+    unbound.reading.articles[0].contentRefs = [];
+    const bound = mutate('recordVisit', unbound, {
+        source: SOURCE_A, article: { ...ARTICLE, contentRef: 'source-a' }, at: AT
+    });
+    assert.deepEqual(plain(bound.reading.articles[0].contentRefs), ['source-a']);
+    for (const contentRef of [undefined, null, '', ' ', ' padded ', 1, []]) {
+        for (const operation of ['recordVisit', 'collect']) {
+            const input = operation === 'collect' ? command({ article: { ...ARTICLE, contentRef } })
+                : { source: SOURCE_A, article: { ...ARTICLE, contentRef }, at: AT };
+            assert.throws(() => model[operation](deepFreeze(legacy), input));
+        }
+    }
+});
+
+test('backup merges union content bindings without choosing a newer conflicting source', () => {
+    const withRef = (contentRef, at) => mutate('recordVisit', model.createSnapshot(), {
+        source: SOURCE_A, article: { ...ARTICLE, contentRef }, at
+    });
+    const left = withRef('source-z', AT);
+    const right = withRef('source-a', LATER);
+    const legacy = mutate('recordVisit', model.createSnapshot(), { source: SOURCE_A, article: ARTICLE, at: LATER });
+    for (const [existing, incoming] of [[left, right], [right, left]]) {
+        const merged = mutate('merge', existing, incoming);
+        assert.deepEqual(plain(merged.reading.articles[0].contentRefs), ['source-a', 'source-z']);
+        assert.equal(merged.reading.articles.length, 1);
+        assert.deepEqual(plain(mutate('merge', merged, incoming)), plain(merged));
+        const restored = model.deserialize(model.serialize(merged));
+        for (const ref of ['source-a', 'source-z']) {
+            assert.throws(() => model.recordVisit(restored, {
+                source: SOURCE_A, article: { ...ARTICLE, contentRef: ref }, at: LATER
+            }), /ambiguous/);
+        }
+        assert.deepEqual(plain(mutate('merge', merged, legacy).reading.articles[0].contentRefs), ['source-a', 'source-z']);
+    }
+    for (const [existing, incoming] of [[left, legacy], [legacy, left], [left, left]]) {
+        const merged = mutate('merge', existing, incoming);
+        assert.deepEqual(plain(merged.reading.articles[0].contentRefs), ['source-z']);
+    }
+    assert.equal(Object.hasOwn(mutate('merge', legacy, legacy).reading.articles[0], 'contentRefs'), false);
+});
+
 test('repeated selection and repeated requests are idempotent while separate positions, scopes and revisions survive', () => {
     let snapshot = mutate('collect', model.createSnapshot(), command());
     const once = plain(snapshot);

--- a/developer/tests/py/test_e2e_runner.py
+++ b/developer/tests/py/test_e2e_runner.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import signal
+import tempfile
+import textwrap
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+
+RUNNER_PATH = Path(__file__).resolve().parents[1] / "e2e" / "e2e_runner.py"
+SPEC = importlib.util.spec_from_file_location("e2e_runner", RUNNER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+def process_is_running(pid: int) -> bool:
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        handle = kernel32.OpenProcess(0x00100000, False, pid)  # SYNCHRONIZE
+        if not handle:
+            return False
+        try:
+            return kernel32.WaitForSingleObject(handle, 0) == 258  # WAIT_TIMEOUT
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    # Linux may keep a killed orphan as a zombie until its new parent reaps it.
+    stat_path = Path(f"/proc/{pid}/stat")
+    if stat_path.exists():
+        try:
+            return stat_path.read_text().rsplit(")", 1)[1].split()[0] != "Z"
+        except FileNotFoundError:
+            return False
+    return True
+
+
+class E2ERunnerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.case_dir = self.root / "developer" / "tests" / "e2e"
+        self.case_dir.mkdir(parents=True)
+        self.report_dir = self.case_dir / "reports"
+        self.report_path = self.report_dir / "e2e-unified-report.json"
+        patcher = mock.patch.multiple(
+            runner, REPO_ROOT=self.root, REPORT_DIR=self.report_dir, REPORT_PATH=self.report_path
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def write_case(self, name: str, source: str) -> None:
+        (self.case_dir / name).write_text(textwrap.dedent(source), encoding="utf-8")
+
+    def test_full_output_is_retained_while_report_excerpts_are_bounded(self) -> None:
+        self.write_case(
+            "verbose.py",
+            """
+            import sys
+            print('BEGIN-STDOUT-' + 'x' * 10000 + '-END-STDOUT')
+            print('BEGIN-STDERR-' + 'y' * 5000 + '-END-STDERR', file=sys.stderr)
+            sys.exit(7)
+            """,
+        )
+        result = runner._run_case("verbose.py")
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["exitCode"], 7)
+        self.assertEqual(len(result["stdout"]), 4000)
+        self.assertEqual(len(result["stderr"]), 2000)
+        self.assertTrue(result["stdout"].endswith("-END-STDOUT"))
+        self.assertTrue(result["stderr"].endswith("-END-STDERR"))
+        self.assertTrue((self.root / result["stdoutPath"]).read_text().startswith("BEGIN-STDOUT-"))
+        self.assertTrue((self.root / result["stderrPath"]).read_text().startswith("BEGIN-STDERR-"))
+        self.assertGreater(result["durationSeconds"], 0)
+        self.assertLessEqual(result["startedAt"], result["finishedAt"])
+
+    def test_report_is_available_to_each_running_case_and_suite_continues_after_failure(self) -> None:
+        # The children inspect the on-disk report, not mocked write calls.
+        self.write_case(
+            "first.py",
+            """
+            import json
+            from pathlib import Path
+            report = json.loads(Path('developer/tests/e2e/reports/e2e-unified-report.json').read_text())
+            assert report['status'] == 'running'
+            assert report['completedCases'] == 0
+            assert report['cases'][-1]['name'] == 'first.py'
+            assert report['cases'][-1]['status'] == 'running'
+            raise SystemExit(3)
+            """,
+        )
+        self.write_case(
+            "second.py",
+            """
+            import json
+            from pathlib import Path
+            report = json.loads(Path('developer/tests/e2e/reports/e2e-unified-report.json').read_text())
+            assert report['completedCases'] == 1
+            assert report['cases'][0]['exitCode'] == 3
+            assert report['cases'][-1]['name'] == 'second.py'
+            assert report['cases'][-1]['status'] == 'running'
+            print('previous failure retained')
+            """,
+        )
+        output = io.StringIO()
+        with mock.patch.object(runner, "E2E_CASES", ["first.py", "second.py"]):
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(runner.main(), 1)
+        report = json.loads(self.report_path.read_text(encoding="utf-8"))
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["plannedCases"], 2)
+        self.assertEqual(report["completedCases"], 2)
+        self.assertEqual([case["exitCode"] for case in report["cases"]], [3, 0])
+        self.assertIn("START first.py", output.getvalue())
+        self.assertIn("END second.py: PASS", output.getvalue())
+
+    def test_missing_case_produces_a_failure_with_artifacts(self) -> None:
+        result = runner._run_case("missing.py")
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["detail"], "script missing")
+        self.assertEqual(result["stderr"], "script missing")
+        self.assertTrue((self.root / result["stdoutPath"]).is_file())
+
+    def test_report_retries_temporary_permission_errors_without_losing_previous_report(self) -> None:
+        self.report_dir.mkdir()
+        previous_report = '{"status": "running", "completedCases": 1}\n'
+        self.report_path.write_text(previous_report, encoding="utf-8")
+        original_replace = Path.replace
+        attempts = []
+
+        def replace_after_readers_release(source: Path, target: Path) -> Path:
+            attempts.append(time.monotonic())
+            self.assertEqual(self.report_path.read_text(encoding="utf-8"), previous_report)
+            if len(attempts) < 3:
+                raise PermissionError("report temporarily open by a reader")
+            return original_replace(source, target)
+
+        with mock.patch.object(Path, "replace", replace_after_readers_release):
+            report = runner._write_report(datetime.now(timezone.utc), time.monotonic(), [], "pass")
+        self.assertEqual(json.loads(self.report_path.read_text(encoding="utf-8")), report)
+        self.assertEqual(report["status"], "pass")
+        self.assertFalse(self.report_path.with_suffix(".json.tmp").exists())
+        self.assertEqual(len(attempts), 3)
+
+    def test_persistent_report_permission_error_is_bounded_and_keeps_last_good_report(self) -> None:
+        self.report_dir.mkdir()
+        previous_report = '{"status": "running", "completedCases": 1}\n'
+        self.report_path.write_text(previous_report, encoding="utf-8")
+        started = time.monotonic()
+        with mock.patch.object(Path, "replace", side_effect=PermissionError("report remains locked")):
+            with self.assertRaisesRegex(PermissionError, "report remains locked"):
+                runner._write_report(datetime.now(timezone.utc), started, [], "pass")
+        self.assertLess(time.monotonic() - started, 2)
+        self.assertEqual(self.report_path.read_text(encoding="utf-8"), previous_report)
+        pending_report = json.loads(self.report_path.with_suffix(".json.tmp").read_text(encoding="utf-8"))
+        self.assertEqual(pending_report["status"], "pass")
+
+    def test_timeout_kills_inherited_output_process_tree_and_preserves_partial_logs(self) -> None:
+        self.write_case(
+            "tree.py",
+            """
+            import os
+            import subprocess
+            import sys
+            import time
+            from pathlib import Path
+            level = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+            Path(f'pid-{level}').write_text(str(os.getpid()))
+            print(f'output-before-timeout-{level}', flush=True)
+            print(f'error-before-timeout-{level}', file=sys.stderr, flush=True)
+            if level < 2:
+                subprocess.Popen([sys.executable, '-u', __file__, str(level + 1)])
+            while True:
+                time.sleep(0.05)
+            """,
+        )
+        result = None
+        pids = []
+        try:
+            started = time.monotonic()
+            with mock.patch.object(runner, "CASE_TIMEOUT_SECONDS", 2):
+                result = runner._run_case("tree.py")
+            elapsed = time.monotonic() - started
+            pids = [int(path.read_text()) for path in sorted(self.root.glob("pid-*"))]
+            self.assertEqual(len(pids), 3, "parent, child and grandchild must start before the timeout")
+            self.assertEqual(result["exitCode"], 124)
+            self.assertEqual(result["status"], "fail")
+            self.assertNotIn("cleanupErrors", result)
+            self.assertLess(elapsed, 2 + runner.PROCESS_CLEANUP_TIMEOUT_SECONDS * 2 + 1)
+            self.assertIn("output-before-timeout-2", result["stdout"])
+            self.assertIn("error-before-timeout-2", result["stderr"])
+            deadline = time.monotonic() + 2
+            while any(process_is_running(pid) for pid in pids) and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertEqual([pid for pid in pids if process_is_running(pid)], [])
+            self.assertIn(
+                "output-before-timeout-0",
+                (self.root / result["stdoutPath"]).read_text(encoding="utf-8"),
+            )
+        finally:
+            # Keep a failed regression from leaving fixtures behind.
+            if not pids:
+                pids = [int(path.read_text()) for path in self.root.glob("pid-*")]
+            for pid in reversed(pids):
+                if process_is_running(pid):
+                    try:
+                        os.kill(pid, signal.SIGTERM if os.name == "nt" else signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/js/app.js
+++ b/js/app.js
@@ -849,6 +849,11 @@ class ExamSystemApp {
                             return null;
                         })
                         .then(() => {
+                            if (this.currentView !== 'bookshelf'
+                                || navigationIntentGeneration !== this._navigationIntentGeneration
+                                || (sharedNavigationIntentGeneration != null
+                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
+                                    && sharedNavigationIntentGeneration !== window.__getAppNavigationIntentGeneration())) return;
                             const bookshelfView = document.getElementById('bookshelf-view');
                             if (bookshelfView) {
                                 bookshelfView.removeAttribute('hidden');

--- a/js/app/examActions.js
+++ b/js/app/examActions.js
@@ -1748,8 +1748,15 @@
             vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
             vocabBtn.type = 'button';
             vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
             if (exam.id) {
                 vocabBtn.dataset.examId = exam.id;
+            }
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && global.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = global.AppData.vocab.readingModel.contentRef(exam);
+                }
             }
             vocabBtn.textContent = '精读';
             vocabBtn.title = '打开该题全文精读与生词本';
@@ -1771,6 +1778,42 @@
     // ============================================================================
 
     var examActionHandlersConfigured = false;
+    var readingLaunchSequence = 0;
+
+    async function launchBrowseReadingVocab(examId, target) {
+        const sequence = ++readingLaunchSequence;
+        const navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration() : null;
+        const options = { returnFocus: target, fromView: 'browse', title: target?.dataset?.examTitle || '',
+            contentRef: target?.dataset?.contentRef || '' };
+        if (target?.dataset && Object.prototype.hasOwnProperty.call(target.dataset, 'libraryConfigurationId')) {
+            options.libraryConfigurationId = target.dataset.libraryConfigurationId || null;
+        }
+        try {
+            // Capture provenance before lazy loading or another library activation.
+            if (!Object.prototype.hasOwnProperty.call(options, 'libraryConfigurationId')) {
+                options.libraryConfigurationId = await global.AppData.library.getActive();
+            }
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                await global.AppLazyLoader.ensureGroup('exam-data');
+                await global.AppLazyLoader.ensureGroup('browse-runtime');
+            }
+            if (sequence !== readingLaunchSequence || (navigation != null
+                && global.__getAppNavigationIntentGeneration() !== navigation)) return;
+            if (!global.ReadingVocabReader || typeof global.ReadingVocabReader.open !== 'function') {
+                throw new Error('Reading vocabulary reader is unavailable');
+            }
+            return await global.ReadingVocabReader.open(examId, options);
+        } catch (error) {
+            if (sequence !== readingLaunchSequence) return;
+            console.warn('[ExamActions] Opening intensive reading failed:', error);
+            if (typeof global.showMessage === 'function') {
+                global.showMessage('未能打开精读，请重试。', 'warning');
+            }
+        }
+    }
+
+    global.launchBrowseReadingVocab = launchBrowseReadingVocab;
 
     function setupExamActionHandlers() {
         if (examActionHandlersConfigured) {
@@ -1834,17 +1877,7 @@
             }
 
             if (action === 'vocab-book') {
-                if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                    global.ReadingVocabReader.open(examId);
-                    return;
-                }
-                if (typeof global.openReadingVocabReader === 'function') {
-                    global.openReadingVocabReader(examId);
-                    return;
-                }
-                if (typeof global.showMessage === 'function') {
-                    global.showMessage('生词本阅读模块未就绪', 'warning');
-                }
+                launchBrowseReadingVocab(examId, target);
                 return;
             }
 

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -2858,6 +2858,13 @@
                 type: 'button',
                 title: '打开该题全文精读与生词本'
             }, '精读');
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && global.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = global.AppData.vocab.readingModel.contentRef(exam);
+                }
+            }
             if (isSelecting) {
                 vocabBtn.disabled = true;
                 vocabBtn.setAttribute('aria-disabled', 'true');
@@ -5959,8 +5966,15 @@
             vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
             vocabBtn.type = 'button';
             vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
             if (exam.id) {
                 vocabBtn.dataset.examId = exam.id;
+            }
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && global.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = global.AppData.vocab.readingModel.contentRef(exam);
+                }
             }
             vocabBtn.textContent = '精读';
             vocabBtn.title = '打开该题全文精读与生词本';
@@ -5982,6 +5996,42 @@
     // ============================================================================
 
     var examActionHandlersConfigured = false;
+    var readingLaunchSequence = 0;
+
+    async function launchBrowseReadingVocab(examId, target) {
+        const sequence = ++readingLaunchSequence;
+        const navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration() : null;
+        const options = { returnFocus: target, fromView: 'browse', title: target?.dataset?.examTitle || '',
+            contentRef: target?.dataset?.contentRef || '' };
+        if (target?.dataset && Object.prototype.hasOwnProperty.call(target.dataset, 'libraryConfigurationId')) {
+            options.libraryConfigurationId = target.dataset.libraryConfigurationId || null;
+        }
+        try {
+            // Capture provenance before lazy loading or another library activation.
+            if (!Object.prototype.hasOwnProperty.call(options, 'libraryConfigurationId')) {
+                options.libraryConfigurationId = await global.AppData.library.getActive();
+            }
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                await global.AppLazyLoader.ensureGroup('exam-data');
+                await global.AppLazyLoader.ensureGroup('browse-runtime');
+            }
+            if (sequence !== readingLaunchSequence || (navigation != null
+                && global.__getAppNavigationIntentGeneration() !== navigation)) return;
+            if (!global.ReadingVocabReader || typeof global.ReadingVocabReader.open !== 'function') {
+                throw new Error('Reading vocabulary reader is unavailable');
+            }
+            return await global.ReadingVocabReader.open(examId, options);
+        } catch (error) {
+            if (sequence !== readingLaunchSequence) return;
+            console.warn('[ExamActions] Opening intensive reading failed:', error);
+            if (typeof global.showMessage === 'function') {
+                global.showMessage('未能打开精读，请重试。', 'warning');
+            }
+        }
+    }
+
+    global.launchBrowseReadingVocab = launchBrowseReadingVocab;
 
     function setupExamActionHandlers() {
         if (examActionHandlersConfigured) {
@@ -6045,17 +6095,7 @@
             }
 
             if (action === 'vocab-book') {
-                if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                    global.ReadingVocabReader.open(examId);
-                    return;
-                }
-                if (typeof global.openReadingVocabReader === 'function') {
-                    global.openReadingVocabReader(examId);
-                    return;
-                }
-                if (typeof global.showMessage === 'function') {
-                    global.showMessage('生词本阅读模块未就绪', 'warning');
-                }
+                launchBrowseReadingVocab(examId, target);
                 return;
             }
 
@@ -16028,10 +16068,10 @@ if (typeof module !== 'undefined' && module.exports) {
             .replace(/'/g, '&#39;');
     }
 
-    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE, contentRef = null) {
         if (!examId) return;
         return ReadingVocabStore.mutate('recordVisit', {
-            source, article: { examId: String(examId), title: examTitle },
+            source, article: { examId: String(examId), title: examTitle, category, ...(contentRef ? { contentRef } : {}) },
             at: new Date().toISOString()
         });
     }
@@ -16085,8 +16125,10 @@ if (typeof module !== 'undefined' && module.exports) {
             const source = reading?.sources.find(row => row.id === article?.sourceId);
             if (!article || !source) return null;
             return { articleId: article.id,
+                contentAmbiguous: (article.contentRefs || []).length > 1,
                 source: { kind: source.kind, id: source.libraryId },
-                article: { examId: article.examId, title: article.title } };
+                article: { examId: article.examId, title: article.title,
+                    ...(article.contentRefs?.length === 1 ? { contentRef: article.contentRefs[0] } : {}) } };
         },
 
         adopt(state) {
@@ -16128,7 +16170,7 @@ if (typeof module !== 'undefined' && module.exports) {
         async syncToAppData() { return this.reload(); },
         async flushToAppData() { return this.reload(); },
 
-        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE, contentRef = null) {
             const word = this.cleanWord(rawWord);
             if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
             if (!this._state) await this.init();
@@ -16140,7 +16182,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
-                source, article: { examId: String(examId), title: examTitle || '' },
+                source, article: { examId: String(examId), title: examTitle || '', ...(contentRef ? { contentRef } : {}) },
                 word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
                 ...(occurrence ? { occurrence } : { manual: true }),
                 at: new Date().toISOString()
@@ -16369,6 +16411,125 @@ if (typeof module !== 'undefined' && module.exports) {
         return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
     }
 
+    function manifestEntryFor(examId) {
+        const manifest = global.__READING_EXAM_MANIFEST__ || {};
+        return manifest[examId] || Object.values(manifest).find(entry => entry &&
+            [entry.examId, entry.id, entry.dataKey].some(id => String(id) === String(examId))) || null;
+    }
+
+    async function resolveReadingArticle(examId, source) {
+        if (source.kind === 'builtin' && source.id === 'default') {
+            return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
+        }
+        if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
+        const [index, configurations] = await Promise.all([
+            global.AppData.library.getIndex(source.id),
+            global.AppData.library.listConfigurations()
+        ]);
+        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
+        const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
+        if (!configuration || matches.length !== 1) {
+            return { exam: null, sourceLabel };
+        }
+        const exam = matches[0];
+        if (exam.sourceKind === 'file-picker' && exam.importKey) {
+            // Session blobs predate library-scoped identities. When the same
+            // import key exists in another library the blob cannot prove which
+            // source it belongs to, so keep the saved vocabulary available only.
+            const otherIndexes = await Promise.all(configurations
+                .filter(item => (item.id || item.key) !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+            if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
+                return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
+            }
+        }
+        // Only an explicit generated-reading reference may use the built-in
+        // registry. A coincidentally identical examId is never a content link.
+        const generatedKey = exam.sourceKind === 'generated-reading' && exam.dataKey && manifestEntryFor(exam.dataKey)
+            ? exam.dataKey : null;
+        return { exam, sourceLabel, generatedKey };
+    }
+
+    async function loadImportedReadingPayload(exam) {
+        let url = '';
+        if (exam.sourceKind === 'file-picker') {
+            // File-picker resources disappear when their session ends. Do not
+            // fall back to another imported entry with the same examId.
+            url = exam.importKey && global.LibraryDiscovery?.resolveRuntimeResource({ importKey: exam.importKey }, 'html');
+        } else if (exam.filename) {
+            const base = global.location.pathname.includes('/reading-exams/')
+                ? new URL('../../../', global.location.href) : new URL('./', global.location.href);
+            const filename = String(exam.filename).replace(/\\/g, '/');
+            const path = String(exam.path || '').replace(/\\/g, '/');
+            url = new URL(/^[a-z][a-z\d+.-]*:/i.test(filename) || filename.startsWith('/')
+                ? filename : `${path.replace(/\/?$/, '/')}${filename}`.replace(/^\//, ''), base).href;
+        }
+        if (!url || !/^(?:https?:|file:|blob:)/i.test(url)) {
+            throw new Error('原题库文件不可用，请重新载入原题库；已保存的生词仍可查看或导出');
+        }
+        const response = await global.fetch(url);
+        if (!response.ok) throw new Error('原题库文件无法读取，已保存的生词仍可查看或导出');
+        // Parse and sanitize before the content normalizer creates any regular
+        // DOM nodes: even detached images can dispatch load/error handlers.
+        const template = document.createElement('template');
+        template.innerHTML = await response.text();
+        const passage = template.content.querySelector('#passage, #reading-passage, .reading-passage, #left, .passage');
+        const questions = template.content.querySelector('#questions, #question-panel, .questions-container, #right');
+        if (!passage || !passage.textContent.trim()) {
+            throw new Error('原题库文章结构已更改或不支持，已保存的生词仍可查看或导出');
+        }
+        const assetBase = response.url || url;
+        return { meta: { title: exam.title || template.content.querySelector('title')?.textContent || '', category: exam.category },
+            passage: { blocks: [{ html: sanitizeImportedReadingHtml(passage.innerHTML, assetBase, 'imported-passage') }] },
+            questionGroups: questions ? [{ bodyHtml: sanitizeImportedReadingHtml(questions.innerHTML, assetBase, 'imported-questions') }] : [] };
+    }
+
+    function sanitizeImportedReadingHtml(html, baseUrl, namespace) {
+        const template = document.createElement('template');
+        template.content.appendChild(createReadOnlyQuestionContent(html, namespace));
+        template.content.querySelectorAll('base, meta').forEach(node => node.remove());
+        const resolveAsset = value => {
+            try {
+                const url = new URL(value, baseUrl);
+                if (/^(?:https?:|file:|blob:)$/.test(url.protocol)
+                    || (url.protocol === 'data:' && /^data:image\/(?:png|gif|jpe?g|webp|avif|svg\+xml)[;,]/i.test(url.href))) return url.href;
+            } catch (_) {}
+            return '';
+        };
+        const resolveSrcset = value => {
+            const candidates = [];
+            let remaining = value.trim();
+            while (remaining) {
+                remaining = remaining.replace(/^[\s,]+/, '');
+                const match = remaining.match(/^\S+/);
+                if (!match) break;
+                const token = match[0];
+                remaining = remaining.slice(token.length);
+                let descriptor = '';
+                if (!token.endsWith(',')) {
+                    const end = remaining.indexOf(',');
+                    descriptor = (end < 0 ? remaining : remaining.slice(0, end)).trim();
+                    remaining = end < 0 ? '' : remaining.slice(end + 1);
+                }
+                const url = resolveAsset(token.replace(/,+$/, ''));
+                if (url && (!descriptor || /^(?:\d+w|(?:\d+(?:\.\d+)?|\.\d+)x)$/.test(descriptor))) {
+                    candidates.push(url + (descriptor ? ` ${descriptor}` : ''));
+                }
+            }
+            return candidates.join(', ');
+        };
+        template.content.querySelectorAll('[src], [srcset], [poster]').forEach(node => {
+            for (const name of ['src', 'srcset', 'poster']) {
+                if (!node.hasAttribute(name)) continue;
+                const value = name === 'srcset' ? resolveSrcset(node.getAttribute(name)) : resolveAsset(node.getAttribute(name));
+                if (value) node.setAttribute(name, value);
+                else node.removeAttribute(name);
+            }
+        });
+        return template.innerHTML;
+    }
+
     async function loadReadingExplanationPayload(examId) {
         if (!examId) return null;
 
@@ -16520,6 +16681,10 @@ if (typeof module !== 'undefined' && module.exports) {
     const ReadingVocabReader = {
         currentExamId: null,
         currentSource: DEFAULT_SOURCE,
+        currentSourceLabel: '内置题库',
+        currentContentRef: null,
+        _sourceReady: false,
+        _openOptions: null,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -16753,13 +16918,15 @@ if (typeof module !== 'undefined' && module.exports) {
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                on(bookshelfBtn, 'click', () => {
+                on(bookshelfBtn, 'click', async () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
                         try {
-                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
-                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            if (typeof global.opener.AppActions?.openBookshelf === 'function') {
+                                await global.opener.AppActions.openBookshelf({ fromView: global.opener.app?.currentView || 'browse' });
+                                global.opener.focus();
+                                return;
                             }
                             if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
                                 global.opener.app.navigateToView('bookshelf');
@@ -16772,10 +16939,9 @@ if (typeof module !== 'undefined' && module.exports) {
                             }
                         } catch (_) {}
                     }
-                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
-                        global.BookshelfView.mount('#bookshelf-view');
-                    }
-                    if (global.app && typeof global.app.navigateToView === 'function') {
+                    if (typeof global.AppActions?.openBookshelf === 'function') {
+                        await global.AppActions.openBookshelf({ fromView: global.app?.currentView || 'browse' });
+                    } else if (global.app && typeof global.app.navigateToView === 'function') {
                         global.app.navigateToView('bookshelf');
                     } else if (typeof global.switchView === 'function') {
                         global.switchView('bookshelf');
@@ -16859,7 +17025,7 @@ if (typeof module !== 'undefined' && module.exports) {
                         val,
                         this.currentExamId,
                         this.currentExam?.title || '',
-                        '', null, this.currentSource
+                        '', null, this.currentSource, this.currentContentRef
                     );
                     if (requestId !== this._openRequestId) return;
                     if (result.added) {
@@ -16985,7 +17151,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 } else if (button.dataset.action === 'undo-occurrence') {
                     this.undoOccurrence();
                 } else if (button.dataset.action === 'retry-anchors') {
-                    this.open(this.currentExamId, { source: this.currentSource });
+                    this.open(this.currentExamId, { ...this._openOptions, source: this.currentSource });
                 }
             });
 
@@ -17004,23 +17170,32 @@ if (typeof module !== 'undefined' && module.exports) {
         },
 
         async open(examId, options = {}) {
-            if (!examId) return;
+            if (!examId && !options.notebook) return;
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            this._openOptions = { ...options };
             const initiatingElement = options.returnFocus || document.activeElement;
             if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
             this.unbindEvents();
             this.bindEvents(overlay);
             this.clearPendingWork(overlay);
             this.currentExamId = examId;
+            this.currentSource = options.source ? { ...options.source } : { ...DEFAULT_SOURCE };
+            this.currentSourceLabel = options.source?.kind === 'imported' ? `导入题库 · ${options.source.id}` : '内置题库';
+            this._sourceReady = false;
             this.currentExam = null;
+            this.currentContentRef = null;
             this.currentPayload = null;
             this.currentExplanation = null;
             this.closeModal(false);
             this.modalTab = 'current';
             overlay.querySelector('#v-tab-current')?.classList.add('active');
             overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            overlay.querySelector('#v-tab-current').disabled = !examId;
+            ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                overlay.querySelector(selector).disabled = true;
+            });
             const manualInput = overlay.querySelector('#vocab-manual-input');
             if (manualInput) manualInput.value = '';
 
@@ -17030,6 +17205,9 @@ if (typeof module !== 'undefined' && module.exports) {
             if (options && options.fromPractice) {
                 if (backBtnText) backBtnText.textContent = '返回练习';
                 if (backBtn) backBtn.title = '返回练习试卷';
+            } else if (options.fromView === 'bookshelf') {
+                if (backBtnText) backBtnText.textContent = '返回书架';
+                if (backBtn) backBtn.title = '返回阅读书架';
             } else {
                 if (backBtnText) backBtnText.textContent = '返回题库';
                 if (backBtn) backBtn.title = '返回题库浏览';
@@ -17055,53 +17233,98 @@ if (typeof module !== 'undefined' && module.exports) {
                 if (element) element.textContent = '';
             });
             this.switchViewTab('all');
+            this.updateCounts();
 
             try {
+                if (options.notebook) {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    this._sourceReady = true;
+                    this.currentExam = { title: '全部精读生词' };
+                    titleEl.textContent = '全部精读生词';
+                    passageContent.textContent = '查看、删除或导出全部文章的精读生词。';
+                    this.modalTab = 'all';
+                    overlay.querySelector('#v-tab-current').classList.remove('active');
+                    overlay.querySelector('#v-tab-all').classList.add('active');
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                    this.openModal();
+                    return;
+                }
                 // 加载试卷数据
                 const source = await ReadingVocabStore.resolveSource(options);
                 if (requestId !== this._openRequestId) return;
                 this.currentSource = source;
-                const payload = await loadReadingExamPayload(examId);
+                this.currentSourceLabel = source.kind === 'imported' ? `导入题库 · ${source.id}` : '内置题库';
+                const articleId = global.AppData.vocab.readingModel.articleId(source, String(examId));
+                if (options.articleId && options.articleId !== articleId) {
+                    throw new Error('文章与题库来源不匹配，请从原书架条目重新打开');
+                }
+                this._sourceReady = true;
+                this.currentExam = { title: options.title || examId };
+                await ReadingVocabStore.init();
+                if (requestId !== this._openRequestId) return;
+                const storedArticle = ReadingVocabStore._state.snapshot.reading.articles.find(article => article.id === articleId);
+                const resolved = await resolveReadingArticle(examId, source);
+                if (requestId !== this._openRequestId) return;
+                this.currentSourceLabel = resolved.sourceLabel;
+                this.currentExam = { ...this.currentExam, ...(resolved.exam || {}) };
+                this.renderIdentity();
+                if (!resolved.exam) throw new Error(resolved.unavailableReason || '原题库或文章已移除，已保存的生词仍可查看或导出');
+                const contentRef = global.AppData.vocab.readingModel.contentRef(source.kind === 'builtin'
+                    ? { sourceKind: 'generated-reading', dataKey: resolved.generatedKey } : resolved.exam);
+                const storedRefs = storedArticle?.contentRefs || [];
+                if (storedRefs.length > 1 || (storedRefs.length === 1 && storedRefs[0] !== contentRef)
+                    || (options.contentRef && options.contentRef !== contentRef)) {
+                    throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
+                }
+                this.currentContentRef = contentRef;
+                const expectedTitle = options.title || storedArticle?.title;
+                const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
+                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                    throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
+                }
+                const payload = resolved.generatedKey
+                    ? await loadReadingExamPayload(resolved.generatedKey)
+                    : await loadImportedReadingPayload(resolved.exam);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
-                }
-                // The current payload registry contains only built-in generated
-                // content. Never attach that content to a different library.
-                if (source.kind !== 'builtin' || source.id !== 'default') {
-                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
                 }
                 this.currentPayload = payload;
                 this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
-                loadReadingExplanationPayload(examId).then(exp => {
+                if (resolved.generatedKey) loadReadingExplanationPayload(resolved.generatedKey).then(exp => {
                     if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
 
                 // 获取 Exam Meta
-                const manifest = global.__READING_EXAM_MANIFEST__ || {};
-                const manifestEntry = manifest[examId] || {};
-                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+                this.currentExam = Object.assign({}, payload.meta || {}, resolved.exam);
 
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
                 let saveError = null;
                 try {
-                    await ReadingVocabStore.init();
-                    if (requestId !== this._openRequestId) return;
-                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source, contentRef);
                 } catch (error) {
                     saveError = error;
                 }
                 if (requestId !== this._openRequestId) return;
+                const committedRefs = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId)?.contentRefs || [];
+                if (committedRefs.length > 1 || (committedRefs.length === 1 && committedRefs[0] !== contentRef)) {
+                    throw new Error('原题库的来源记录已更改，已保存的生词仍可查看或导出');
+                }
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                    overlay.querySelector(selector).disabled = false;
+                });
                 if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
@@ -17109,12 +17332,22 @@ if (typeof module !== 'undefined' && module.exports) {
                 this.currentPayload = null;
                 await ReadingVocabStore.init().catch(() => {});
                 if (requestId !== this._openRequestId) return;
+                if (this._sourceReady) {
+                    const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
+                    const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
+                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                }
+                this.renderIdentity();
                 this.applyVocabHighlights();
                 this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
                     const message = document.createElement('p');
+                    errorState.setAttribute('role', 'status');
+                    errorState.dataset.sourceUnavailable = 'true';
                     message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
                     const retry = document.createElement('button');
                     retry.type = 'button';
@@ -17128,16 +17361,25 @@ if (typeof module !== 'undefined' && module.exports) {
                     retry.addEventListener('click', handleRetry);
                     this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
+                    const review = document.createElement('button');
+                    review.type = 'button';
+                    review.textContent = '查看已保存生词';
+                    const handleReview = () => this.openModal();
+                    review.addEventListener('click', handleReview);
+                    this._eventCleanups.push(() => review.removeEventListener('click', handleReview));
+                    errorState.append(review);
                     passageContent.replaceChildren(errorState);
                 }
             }
         },
 
-        renderContent() {
-            const overlay = this.ensureOverlay();
-            const exam = this.currentExam;
-            const payload = this.currentPayload;
+        openNotebook(options = {}) {
+            return this.open(null, { ...options, notebook: true });
+        },
 
+        renderIdentity() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam || {};
             // 标题与标签（紧凑精致）
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -17149,9 +17391,17 @@ if (typeof module !== 'undefined' && module.exports) {
             if (badgesEl) {
                 badgesEl.innerHTML = `
                     <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    <span class="vocab-badge vocab-badge--source">${escapeHtml(this.currentSourceLabel)}</span>
                     ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+            this.renderIdentity();
 
             // 解析文章大标题、考试指导语与真实段落
             const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
@@ -17348,7 +17598,7 @@ if (typeof module !== 'undefined' && module.exports) {
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
-                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource, this.currentContentRef);
                 if (requestId !== this._openRequestId) return;
                 if (!result.added) throw new Error('Selection was not saved');
                 selection.removeAllRanges();
@@ -17458,7 +17708,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 // Keep the acknowledged deletion fence: a later clear/replace must
                 // reject this undo instead of resurrecting deleted relationships.
                 const committedRevision = result.revisions?.['vocab.readingState'];
-                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                this._undoOccurrence = !owner.contentAmbiguous && result.changed !== false && Number.isInteger(committedRevision)
                     ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
                 this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
                 this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
@@ -17593,7 +17843,7 @@ if (typeof module !== 'undefined' && module.exports) {
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
+            const currentList = this._sourceReady ? ReadingVocabStore.getByExam(examId, this.currentSource) : [];
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -17615,7 +17865,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -17678,7 +17928,8 @@ if (typeof module !== 'undefined' && module.exports) {
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
-                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
+                const input = modal.querySelector('#vocab-manual-input');
+                (input && !input.disabled ? input : modal.querySelector('#vocab-modal-close'))?.focus({ preventScroll: true });
             }
         },
 
@@ -17729,6 +17980,12 @@ if (typeof module !== 'undefined' && module.exports) {
             }
             document.body.classList.remove('vocab-reader-open');
             if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            else if (this._openOptions?.fromView === 'bookshelf') {
+                const card = [...document.querySelectorAll('[data-article-id]')]
+                    .find(element => element.dataset.articleId === this._openOptions.articleId);
+                (card?.querySelector('button[data-action="open-reading-vocab"]')
+                    || document.querySelector('[data-action="open-global-notebook"]'))?.focus({ preventScroll: true });
+            }
             this._returnFocus = null;
         }
     };
@@ -17736,7 +17993,7 @@ if (typeof module !== 'undefined' && module.exports) {
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.currentExamId) {
+            if (ReadingVocabReader._sourceReady && !document.getElementById('reading-vocab-reader-overlay')?.classList.contains('is-hidden')) {
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
                 if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
@@ -24209,15 +24466,43 @@ function createFallbackExamCard(exam, options = {}) {
             vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
             vocabBtn.type = 'button';
             vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
             vocabBtn.dataset.examId = exam.id;
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && window.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = window.AppData.vocab.readingModel.contentRef(exam);
+                }
+            }
             vocabBtn.textContent = '精读';
             vocabBtn.title = '打开该题全文精读与生词本';
-            vocabBtn.addEventListener('click', function (e) {
+            vocabBtn.addEventListener('click', async function (e) {
                 e.preventDefault();
-                if (window.ReadingVocabReader && typeof window.ReadingVocabReader.open === 'function') {
-                    window.ReadingVocabReader.open(exam.id);
-                } else if (typeof window.openReadingVocabReader === 'function') {
-                    window.openReadingVocabReader(exam.id);
+                e.stopPropagation();
+                const navigation = window.__getAppNavigationIntentGeneration?.();
+                try {
+                    if (!Object.prototype.hasOwnProperty.call(vocabBtn.dataset, 'libraryConfigurationId')) {
+                        vocabBtn.dataset.libraryConfigurationId = await window.AppData.library.getActive() || '';
+                    }
+                    if (typeof window.launchBrowseReadingVocab !== 'function'
+                        && window.AppLazyLoader?.ensureGroup) {
+                        await window.AppLazyLoader.ensureGroup('browse-runtime');
+                    }
+                    if (navigation != null && navigation !== window.__getAppNavigationIntentGeneration()) return;
+                    if (typeof window.launchBrowseReadingVocab === 'function') {
+                        await window.launchBrowseReadingVocab(exam.id, vocabBtn);
+                    } else if (typeof window.ReadingVocabReader?.open === 'function') {
+                        await window.ReadingVocabReader.open(exam.id, {
+                            returnFocus: vocabBtn, fromView: 'browse', title: exam.title || exam.name || '',
+                            contentRef: vocabBtn.dataset.contentRef || '',
+                            libraryConfigurationId: vocabBtn.dataset.libraryConfigurationId || null
+                        });
+                    } else {
+                        throw new Error('Reading vocabulary reader is unavailable');
+                    }
+                } catch (error) {
+                    console.warn('[Browse] Opening intensive reading failed:', error);
+                    if (typeof window.showMessage === 'function') window.showMessage('未能打开精读，请重试。', 'warning');
                 }
             });
             actions.appendChild(vocabBtn);

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -16422,11 +16422,16 @@ if (typeof module !== 'undefined' && module.exports) {
             return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
         }
         if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
-        const [index, configurations] = await Promise.all([
+        const [index, storedConfigurations] = await Promise.all([
             global.AppData.library.getIndex(source.id),
             global.AppData.library.listConfigurations()
         ]);
-        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const configurations = storedConfigurations.map(item => {
+            const id = typeof item === 'string' ? item
+                : [item?.id, item?.key, item?.configId].find(value => value != null && value !== '');
+            return { ...(typeof item === 'object' && item ? item : {}), id: id == null ? '' : String(id) };
+        }).filter(item => item.id);
+        const configuration = configurations.find(item => item.id === source.id);
         const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
         const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
         if (!configuration || matches.length !== 1) {
@@ -16438,8 +16443,8 @@ if (typeof module !== 'undefined' && module.exports) {
             // import key exists in another library the blob cannot prove which
             // source it belongs to, so keep the saved vocabulary available only.
             const otherIndexes = await Promise.all(configurations
-                .filter(item => (item.id || item.key) !== source.id)
-                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+                .filter(item => item.id !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id)));
             if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
                 return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
             }
@@ -17279,9 +17284,10 @@ if (typeof module !== 'undefined' && module.exports) {
                     throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
                 }
                 this.currentContentRef = contentRef;
-                const expectedTitle = options.title || storedArticle?.title;
                 const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
-                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                const resolvedTitle = normalizeTitle(resolved.exam.title);
+                if (resolvedTitle && [storedArticle?.title, options.title].some(title =>
+                    normalizeTitle(title) && normalizeTitle(title) !== resolvedTitle)) {
                     throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
                 }
                 const payload = resolved.generatedKey
@@ -17335,7 +17341,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 if (this._sourceReady) {
                     const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
                     const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
-                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    this.currentExam = { ...(this.currentExam || {}), title: stored?.title || options.title || this.currentExam?.title || examId };
                     overlay.querySelector('#vocab-export-btn').disabled = false;
                     overlay.querySelector('#vocab-clear-btn').disabled = false;
                 }

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -2662,6 +2662,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -2750,6 +2757,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -2825,10 +2844,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -2845,6 +2869,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -3156,6 +3181,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -3200,7 +3232,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
@@ -16147,7 +16179,7 @@
             }
             return this.normalizeIndexForCustomConfig(
                 this.getDefaultReadingIndex().concat(this.resolveDefaultTypeIndex('listening'))
-            );
+            ).map((exam) => ({ ...exam, libraryConfigurationId: null }));
         }
 
         async resolveIndexForConfiguration(configurationId) {
@@ -16156,7 +16188,8 @@
                 ? configurationId.trim()
                 : null;
             if (id === null) return this.resolveDefaultIndex();
-            return this.normalizeIndexForCustomConfig(await global.AppData.library.getIndex(id));
+            return this.normalizeIndexForCustomConfig(await global.AppData.library.getIndex(id))
+                .map((exam) => ({ ...exam, libraryConfigurationId: id }));
         }
 
         getRecordLibraryProvenance(record) {
@@ -16240,7 +16273,8 @@
             }
 
             if (!isDefaultConfig && Array.isArray(cachedData) && cachedData.length > 0) {
-                const updatedIndex = this.normalizeIndexForCustomConfig(cachedData);
+                const updatedIndex = this.normalizeIndexForCustomConfig(cachedData)
+                    .map((exam) => ({ ...exam, libraryConfigurationId: activeConfigKey }));
                 if (typeof global.assignExamSequenceNumbers === 'function') global.assignExamSequenceNumbers(updatedIndex);
                 await this.savePathMapForConfiguration(activeConfigKey, updatedIndex, { setActive: true });
                 this.finishLibraryLoading(startTime, updatedIndex);
@@ -16278,7 +16312,8 @@
                     return [];
                 }
 
-                const combined = cloneArray(readingExams).concat(listeningExams);
+                const combined = cloneArray(readingExams).concat(listeningExams)
+                    .map((exam) => ({ ...exam, libraryConfigurationId: null }));
                 if (typeof global.assignExamSequenceNumbers === 'function') {
                     global.assignExamSequenceNumbers(combined);
                 }
@@ -16567,7 +16602,10 @@
         }
 
         async applyLibraryConfiguration(key, dataset, options = {}) {
-            const exams = Array.isArray(dataset) ? dataset.slice() : await this.fetchLibraryDataset(key);
+            const configurationId = typeof key === 'string' && key.trim() ? key.trim() : null;
+            const rawExams = Array.isArray(dataset) ? dataset : await this.fetchLibraryDataset(key);
+            const exams = Array.isArray(rawExams)
+                ? rawExams.map((exam) => ({ ...exam, libraryConfigurationId: configurationId })) : [];
             if (!Array.isArray(exams) || exams.length === 0) {
                 if (typeof global.showMessage === 'function') {
                     global.showMessage('目标题库没有题目，请先加载数据', 'warning');

--- a/js/bundles/legacy-app.bundle.js
+++ b/js/bundles/legacy-app.bundle.js
@@ -2746,6 +2746,11 @@ class ExamSystemApp {
                             return null;
                         })
                         .then(() => {
+                            if (this.currentView !== 'bookshelf'
+                                || navigationIntentGeneration !== this._navigationIntentGeneration
+                                || (sharedNavigationIntentGeneration != null
+                                    && typeof window.__getAppNavigationIntentGeneration === 'function'
+                                    && sharedNavigationIntentGeneration !== window.__getAppNavigationIntentGeneration())) return;
                             const bookshelfView = document.getElementById('bookshelf-view');
                             if (bookshelfView) {
                                 bookshelfView.removeAttribute('hidden');

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -2331,6 +2331,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -2419,6 +2426,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -2494,10 +2513,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -2514,6 +2538,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -2825,6 +2850,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -2869,7 +2901,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -2331,6 +2331,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -2419,6 +2426,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -2494,10 +2513,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -2514,6 +2538,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -2825,6 +2850,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -2869,7 +2901,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -5205,6 +5205,8 @@
         _commitBound: false,
         _loadSequence: 0,
         _loadError: null,
+        _loading: false,
+        _sourceMetadata: new Map(),
 
         getRawRecords() {
             return this.getBookshelfExams().map((exam) => ({
@@ -5225,11 +5227,12 @@
 
         _adopt(result) {
             if (!result || !result.snapshot) throw new Error('Reading snapshot is unavailable');
-            if (this._revision !== null && result.revision < this._revision) return;
+            if (this._generation === result.generation && this._revision !== null && result.revision < this._revision) return false;
             this._snapshot = result.snapshot;
             this._revision = result.revision;
             this._generation = result.generation;
             this._loadError = null;
+            return true;
         },
 
         _notify(detail = {}) {
@@ -5238,6 +5241,8 @@
 
         async init() {
             const sequence = ++this._loadSequence;
+            this._loading = true;
+            this._notify({ action: 'loading' });
             try {
                 if (global.AppData && global.AppData.ready) await global.AppData.ready;
                 this.bindCommitListener();
@@ -5246,13 +5251,16 @@
                     throw new Error('Reading persistence is unavailable');
                 }
                 const result = await vocab.getReadingSnapshot();
+                const metadata = await this._readSourceMetadata(result.snapshot);
                 if (sequence === this._loadSequence) {
-                    this._adopt(result);
+                    if (this._adopt(result)) this._sourceMetadata = metadata;
+                    this._loading = false;
                     this._notify({ action: 'reload' });
                 }
                 return result;
             } catch (error) {
                 if (sequence === this._loadSequence) {
+                    this._loading = false;
                     this._loadError = error;
                     this._notify({ action: 'load-failed' });
                 }
@@ -5263,6 +5271,28 @@
         // Compatibility flush callers wait for a fresh durable snapshot.
         async flushToAppData() { return this.init(); },
 
+        async _readSourceMetadata(snapshot) {
+            const library = global.AppData && global.AppData.library;
+            const metadata = new Map();
+            if (!library) return metadata;
+            try {
+                const configurations = typeof library.listConfigurations === 'function'
+                    ? await library.listConfigurations() : [];
+                await Promise.all(snapshot.reading.sources.filter((row) => row.kind === 'imported').map(async (source) => {
+                    const config = configurations.find((row) => String(row.id || row.key || row.configId) === source.libraryId);
+                    const index = typeof library.getIndex === 'function' ? await library.getIndex(source.libraryId) : null;
+                    metadata.set(source.id, {
+                        name: config && (config.name || config.title) || source.libraryId,
+                        index: Array.isArray(index) ? index : null
+                    });
+                }));
+            } catch (error) {
+                // Stored vocabulary remains usable when source metadata cannot be read.
+                console.warn('[ReadingBookshelfStore] Source metadata unavailable:', error);
+            }
+            return metadata;
+        },
+
         bindCommitListener() {
             if (this._commitBound) return;
             const backups = global.AppData && global.AppData.backups;
@@ -5270,7 +5300,7 @@
                 this._commitBound = true;
                 backups.onDataCommitted((event) => {
                     const targets = event && event.targets;
-                    if (Array.isArray(targets) && targets.some((target) => String(target.logicalKey || '').startsWith('vocab.'))) {
+                    if (Array.isArray(targets) && targets.some((target) => /^(vocab|library)\./.test(String(target.logicalKey || '')))) {
                         this.init().catch((error) => console.warn('[ReadingBookshelfStore] Reload failed:', error));
                     }
                 });
@@ -5294,6 +5324,7 @@
             // An in-flight reload may predate this acknowledgement.
             ++this._loadSequence;
             this._adopt(result);
+            this._loading = false;
             this._notify({ action: type, articleId: command.articleId });
             return result;
         },
@@ -5324,8 +5355,11 @@
                 const source = { kind: sourceRow.kind, id: sourceRow.libraryId };
                 const related = associations.get(article.id) || [];
                 const visit = visitMap.get(article.id);
-                const meta = source.kind === 'builtin' ? manifest[article.examId] || {} : {};
-                const words = related.map((association) => this._wordForTerm(termMap.get(association.termId))).filter(Boolean);
+                const sourceMeta = this._sourceMetadata.get(article.sourceId);
+                const meta = source.kind === 'builtin' ? manifest[article.examId] || {}
+                    : sourceMeta?.index?.find((row) => String(row.id || row.examId) === article.examId) || {};
+                const termIds = Array.from(new Set(related.map((association) => association.termId)));
+                const words = termIds.map((id) => this._wordForTerm(termMap.get(id))).filter(Boolean);
                 const lastActivityAt = Math.max(
                     visit ? Date.parse(visit.lastVisitedAt) : 0,
                     ...related.map((association) => Date.parse(association.updatedAt)),
@@ -5333,9 +5367,14 @@
                 );
                 return {
                     articleId: article.id, source, examId: article.examId,
+                    sourceLabel: source.kind === 'builtin' ? '内置题库'
+                        : `导入题库 · ${sourceMeta?.name && sourceMeta.name !== source.id ? `${sourceMeta.name} (${source.id})` : source.id}`,
+                    sourceUnavailable: source.kind === 'imported' && Array.isArray(sourceMeta?.index)
+                        && !sourceMeta.index.some((row) => String(row.id || row.examId) === article.examId),
                     title: article.title || meta.title || meta.name || article.examId,
                     category: meta.category || meta.type || '雅思阅读',
-                    wordCount: words.length, sampleWords: words.slice(0, 6).map((word) => word.word),
+                    wordCount: termIds.length, allWords: words.map((word) => word.word),
+                    sampleWords: words.slice(0, 6).map((word) => word.word),
                     lastActivityAt, hasPdf: Boolean(meta.pdfPath || meta.pdf)
                 };
             }).sort((a, b) => b.lastActivityAt - a.lastActivityAt);
@@ -5354,6 +5393,11 @@
             const reading = this._snapshot.reading;
             const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
             return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
+        },
+
+        getDistinctWordCount() {
+            if (!this._snapshot) return 0;
+            return new Set(this._snapshot.reading.associations.map((row) => row.termId)).size;
         },
 
         async _articleId(examId, source, articleId) {
@@ -5468,8 +5512,13 @@
             sortBy: 'recent', // 'recent' | 'words' | 'title'
             filterMode: 'all', // 'all' | 'has-words'
             fromView: null,
-            toastTimer: null
+            toastTimer: null,
+            readerLoading: false,
+            readerError: null
         },
+        _readerRequestId: 0,
+        _readerLoadPromise: null,
+        _lastReaderRequest: null,
 
         mount(targetSelector = '#bookshelf-view', options = {}) {
             if (options && options.fromView) {
@@ -5496,7 +5545,7 @@
             if (!root) return;
 
             const allExams = ReadingBookshelfStore.getBookshelfExams();
-            const totalWords = allExams.reduce((sum, item) => sum + item.wordCount, 0);
+            const totalWords = ReadingBookshelfStore.getDistinctWordCount();
 
             // 过滤与搜索
             let filtered = allExams.slice();
@@ -5505,8 +5554,9 @@
                 filtered = filtered.filter(item => {
                     const matchTitle = (item.title || '').toLowerCase().includes(q);
                     const matchCategory = (item.category || '').toLowerCase().includes(q);
-                    const matchWords = (item.sampleWords || []).some(w => w.toLowerCase().includes(q));
-                    return matchTitle || matchCategory || matchWords;
+                    const matchSource = `${item.sourceLabel || ''} ${item.source.kind} ${item.source.id}`.toLowerCase().includes(q);
+                    const matchWords = (item.allWords || []).some(w => w.toLowerCase().includes(q));
+                    return matchTitle || matchCategory || matchSource || matchWords;
                 });
             }
 
@@ -5532,6 +5582,11 @@
                     ${ReadingBookshelfStore._loadError ? (needsPageReload(ReadingBookshelfStore._loadError)
                         ? '<p role="alert">书架加载失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
                         : '<p role="alert">书架加载失败，已显示的数据保持不变。<button type="button" class="btn btn-secondary" data-action="retry-load">重试加载</button></p>') : ''}
+                    ${this.state.readerLoading ? '<p role="status">正在打开生词本…</p>' : ''}
+                    ${this.state.readerError ? (needsPageReload(this.state.readerError)
+                        ? '<p role="alert">生词本打开失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
+                        : '<p role="alert">生词本打开失败，请重试。<button type="button" class="btn btn-secondary" data-action="retry-reader">重试打开</button></p>') : ''}
+                    ${ReadingBookshelfStore._snapshot && ReadingBookshelfStore._loading ? '<p role="status">正在更新书架…</p>' : ''}
                     <!-- 顶部标题栏与导航 -->
                     <div class="bookshelf-topbar">
                         <div class="bookshelf-topbar__left">
@@ -5541,7 +5596,7 @@
                             </button>
                             <div class="bookshelf-heading-group">
                                 <h2 class="bookshelf-title">📚 阅读书架</h2>
-                                <p class="bookshelf-subtitle">收录使用过生词本的精读篇目，温故知新，查缺补漏</p>
+                                <p class="bookshelf-subtitle">收录打开过的精读篇目与生词，随时继续阅读与复习</p>
                             </div>
                         </div>
                         <div class="bookshelf-topbar__right">
@@ -5567,7 +5622,7 @@
                             <span class="bookshelf-stat-icon">🔤</span>
                             <div class="bookshelf-stat-content">
                                 <span class="bookshelf-stat-value">${totalWords}</span>
-                                <span class="bookshelf-stat-label">积累生词</span>
+                                <span class="bookshelf-stat-label">不重复生词</span>
                             </div>
                         </div>
                         <div class="bookshelf-stat-card">
@@ -5586,7 +5641,7 @@
                             <input
                                 type="text"
                                 class="bookshelf-search-input"
-                                placeholder="搜索篇目名称、分类或单词..."
+                                placeholder="搜索篇目名称、分类、来源或单词..."
                                 value="${this.escapeHtml(this.state.searchQuery)}"
                                 data-action="search-input"
                             />
@@ -5659,6 +5714,8 @@
                         </h3>
                         <div class="bookshelf-card__meta">
                             <span class="bookshelf-card__time">🕒 ${formattedTime}</span>
+                            <span class="bookshelf-card__source">${this.escapeHtml(exam.sourceLabel)}</span>
+                            ${exam.sourceUnavailable ? '<span class="bookshelf-card__source-state">原题库内容不可用 · 可查看与导出生词</span>' : ''}
                         </div>
 
                         <!-- 生词预览药丸标签 -->
@@ -5809,11 +5866,7 @@
             const globalNotebookBtn = root.querySelector('[data-action="open-global-notebook"]');
             if (globalNotebookBtn) {
                 globalNotebookBtn.addEventListener('click', () => {
-                    if (global.ReadingVocabReader && typeof global.ReadingVocabReader.openModal === 'function') {
-                        global.ReadingVocabReader.openModal();
-                    } else {
-                        this.showToast('⚠️ 生词本组件正在加载...');
-                    }
+                    this.launchGlobalNotebook(globalNotebookBtn);
                 });
             }
 
@@ -5840,6 +5893,12 @@
                     await ReadingBookshelfStore.init().catch(() => {});
                     return;
                 }
+                if (e.target.closest('[data-action="retry-reader"]')) {
+                    const request = this._lastReaderRequest;
+                    if (request?.examId) await this.launchExamVocabReader(request.examId, request.source, request.articleId);
+                    else await this.launchGlobalNotebook();
+                    return;
+                }
                 const card = e.target.closest('[data-article-id]');
                 const articleId = card && card.dataset.articleId;
                 const article = ReadingBookshelfStore.getBookshelfExams().find((exam) => exam.articleId === articleId);
@@ -5847,7 +5906,7 @@
                 const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
                 if (openVocabTrigger) {
                     const examId = openVocabTrigger.dataset.examId;
-                    await this.launchExamVocabReader(examId, article && article.source, articleId);
+                    await this.launchExamVocabReader(examId, article && article.source, articleId, openVocabTrigger);
                     return;
                 }
 
@@ -5855,6 +5914,7 @@
                 const openPracticeTrigger = e.target.closest('[data-action="open-exam-practice"]');
                 if (openPracticeTrigger) {
                     const examId = openPracticeTrigger.dataset.examId;
+                    if (!await this.canOpenOriginalSource(article)) return;
                     if (global.app && typeof global.app.openExam === 'function') {
                         global.app.openExam(examId);
                     } else if (typeof global.openExam === 'function') {
@@ -5867,6 +5927,7 @@
                 const openPdfTrigger = e.target.closest('[data-action="open-exam-pdf"]');
                 if (openPdfTrigger) {
                     const examId = openPdfTrigger.dataset.examId;
+                    if (!await this.canOpenOriginalSource(article)) return;
                     if (typeof global.viewPDF === 'function') {
                         global.viewPDF(examId);
                     }
@@ -6001,24 +6062,94 @@
             overlay.classList.remove('is-hidden');
         },
 
-        async launchExamVocabReader(examId, source, articleId) {
-            if (!examId) return;
+        async ensureReader() {
+            if (this._readerLoadPromise) return this._readerLoadPromise;
+            this._readerLoadPromise = (async () => {
+                const loader = global.AppLazyLoader;
+                if (loader && typeof loader.ensureGroup === 'function') {
+                    await Promise.all(['exam-data', 'browse-runtime'].map((group) => loader.ensureGroup(group)));
+                }
+                if (!global.ReadingVocabReader || typeof global.ReadingVocabReader.open !== 'function') {
+                    throw new Error('Reading reader is unavailable');
+                }
+                return global.ReadingVocabReader;
+            })();
+            try { return await this._readerLoadPromise; }
+            finally { this._readerLoadPromise = null; }
+        },
 
-            // 确保 ReadingVocabReader 依赖加载
-            if (!global.ReadingVocabReader && global.lazyLoader && typeof global.lazyLoader.ensureGroup === 'function') {
-                try {
-                    await global.lazyLoader.ensureGroup('browse-runtime');
-                } catch (e) {
-                    console.warn('[BookshelfView] 加载 browse-runtime 失败:', e);
+        async launchExamVocabReader(examId, source, articleId, returnFocus) {
+            if (!examId) return;
+            const article = ReadingBookshelfStore.getBookshelfExams().find((row) => row.articleId === articleId);
+            return this.launchReader({ examId, source, articleId, title: article?.title }, returnFocus);
+        },
+
+        async launchGlobalNotebook(returnFocus) {
+            return this.launchReader({}, returnFocus);
+        },
+
+        async launchReader(request, returnFocus) {
+            const requestId = ++this._readerRequestId;
+            const navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+                ? global.__getAppNavigationIntentGeneration() : null;
+            const isCurrent = () => requestId === this._readerRequestId && (navigation == null
+                || navigation === global.__getAppNavigationIntentGeneration());
+            this._lastReaderRequest = request;
+            this.state.readerLoading = true;
+            this.state.readerError = null;
+            this.render();
+            try {
+                const reader = await this.ensureReader();
+                if (!isCurrent()) return;
+                const options = { ...request, fromView: 'bookshelf', returnFocus };
+                if (request.examId) await reader.open(request.examId, options);
+                else if (typeof reader.openNotebook === 'function') await reader.openNotebook(options);
+                else throw new Error('Reading notebook is unavailable');
+            } catch (error) {
+                if (isCurrent()) {
+                    this.state.readerError = error;
+                    console.warn('[BookshelfView] Reader loading failed:', error);
+                }
+            } finally {
+                if (requestId === this._readerRequestId) {
+                    this.state.readerLoading = false;
+                    this.render();
                 }
             }
+        },
 
-            if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                await global.ReadingVocabReader.open(examId, { source, articleId });
-            } else if (typeof global.openReadingVocabReader === 'function') {
-                await global.openReadingVocabReader(examId, { source, articleId });
-            } else {
-                this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
+        async canOpenOriginalSource(article) {
+            if (!article) return false;
+            try {
+                const activeSource = await ReadingBookshelfStore.resolveSource();
+                if (activeSource.kind !== article.source.kind || activeSource.id !== article.source.id) {
+                    this.showToast(`请先切换至原题库「${article.sourceLabel}」，或打开本篇精读查看生词`);
+                    return false;
+                }
+                if (article.source.kind === 'imported') {
+                    const index = await global.AppData.library.getIndex(article.source.id);
+                    if (!index.some((row) => String(row.id || row.examId) === article.examId)) {
+                        this.showToast('⚠️ 原题库内容已不可用，已保存的生词仍可在精读中查看或导出');
+                        return false;
+                    }
+                }
+                await this.ensureReader();
+                const currentSource = await ReadingBookshelfStore.resolveSource();
+                const currentExam = Array.isArray(global.examIndex)
+                    ? global.examIndex.find((row) => String(row.id || row.examId) === article.examId) : null;
+                const indexSource = currentExam && Object.prototype.hasOwnProperty.call(currentExam, 'libraryConfigurationId')
+                    ? (currentExam.libraryConfigurationId == null || currentExam.libraryConfigurationId === ''
+                        ? { kind: 'builtin', id: 'default' }
+                        : { kind: 'imported', id: String(currentExam.libraryConfigurationId) }) : null;
+                if (currentSource.kind !== article.source.kind || currentSource.id !== article.source.id
+                    || (indexSource && (indexSource.kind !== article.source.kind || indexSource.id !== article.source.id))) {
+                    this.showToast('题库已切换或正在更新，请等待原题库加载完成后重试');
+                    return false;
+                }
+                return true;
+            } catch (error) {
+                this.showToast('⚠️ 原题库加载失败，请重试');
+                return false;
             }
         },
 
@@ -6037,8 +6168,11 @@
             }
         },
 
-        navigateToMoreView() {
+        async navigateToMoreView() {
             const returnTarget = this.state.fromView || 'more';
+            ++this._readerRequestId;
+            this.state.readerLoading = false;
+            this.state.readerError = null;
             this.state.fromView = null;
             const bookshelfView = document.getElementById('bookshelf-view');
             const targetView = document.getElementById(`${returnTarget}-view`);
@@ -6050,11 +6184,16 @@
 
             if (global.app && typeof global.app.navigateToView === 'function') {
                 try {
-                    global.app.navigateToView(returnTarget);
+                    await global.app.navigateToView(returnTarget);
                     return;
                 } catch (err) {
                     console.warn('[BookshelfView] navigateToView 异常:', err);
                 }
+            }
+
+            if (typeof global.switchView === 'function') {
+                await global.switchView(returnTarget);
+                return;
             }
 
             if (targetView) {
@@ -6131,6 +6270,18 @@
             }
         });
         window.addEventListener('reading-vocab-store-updated', () => {
+            const state = global.ReadingVocabStore && global.ReadingVocabStore._state;
+            if (state && ReadingBookshelfStore._adopt(state)) {
+                const sequence = ++ReadingBookshelfStore._loadSequence;
+                ReadingBookshelfStore._loading = false;
+                // Reader acknowledgements can supersede the commit-triggered
+                // reload; still refresh source names and indexes after restores.
+                ReadingBookshelfStore._readSourceMetadata(state.snapshot).then((metadata) => {
+                    if (sequence !== ReadingBookshelfStore._loadSequence) return;
+                    ReadingBookshelfStore._sourceMetadata = metadata;
+                    ReadingBookshelfStore._notify({ action: 'sources-reloaded' });
+                });
+            }
             const root = document.querySelector(BookshelfView.containerSelector);
             if (root && root.offsetParent !== null) {
                 BookshelfView.render();
@@ -6301,9 +6452,12 @@
         if (event && typeof event.preventDefault === 'function') {
             event.preventDefault();
         }
+        if (typeof global.AppActions?.openBookshelf === 'function') {
+            return global.AppActions.openBookshelf({ fromView: 'more' });
+        }
         var mountView = function () {
             if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
-                global.BookshelfView.mount('#bookshelf-view');
+                global.BookshelfView.mount('#bookshelf-view', { fromView: 'more' });
             }
         };
 

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -2331,6 +2331,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -2419,6 +2426,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -2494,10 +2513,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -2514,6 +2538,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -2825,6 +2850,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -2869,7 +2901,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -2331,6 +2331,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -2419,6 +2426,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -2494,10 +2513,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -2514,6 +2538,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -2825,6 +2850,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -2869,7 +2901,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });
@@ -8796,10 +8828,10 @@
             .replace(/'/g, '&#39;');
     }
 
-    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE, contentRef = null) {
         if (!examId) return;
         return ReadingVocabStore.mutate('recordVisit', {
-            source, article: { examId: String(examId), title: examTitle },
+            source, article: { examId: String(examId), title: examTitle, category, ...(contentRef ? { contentRef } : {}) },
             at: new Date().toISOString()
         });
     }
@@ -8853,8 +8885,10 @@
             const source = reading?.sources.find(row => row.id === article?.sourceId);
             if (!article || !source) return null;
             return { articleId: article.id,
+                contentAmbiguous: (article.contentRefs || []).length > 1,
                 source: { kind: source.kind, id: source.libraryId },
-                article: { examId: article.examId, title: article.title } };
+                article: { examId: article.examId, title: article.title,
+                    ...(article.contentRefs?.length === 1 ? { contentRef: article.contentRefs[0] } : {}) } };
         },
 
         adopt(state) {
@@ -8896,7 +8930,7 @@
         async syncToAppData() { return this.reload(); },
         async flushToAppData() { return this.reload(); },
 
-        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE, contentRef = null) {
             const word = this.cleanWord(rawWord);
             if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
             if (!this._state) await this.init();
@@ -8908,7 +8942,7 @@
                 quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
-                source, article: { examId: String(examId), title: examTitle || '' },
+                source, article: { examId: String(examId), title: examTitle || '', ...(contentRef ? { contentRef } : {}) },
                 word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
                 ...(occurrence ? { occurrence } : { manual: true }),
                 at: new Date().toISOString()
@@ -9137,6 +9171,125 @@
         return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
     }
 
+    function manifestEntryFor(examId) {
+        const manifest = global.__READING_EXAM_MANIFEST__ || {};
+        return manifest[examId] || Object.values(manifest).find(entry => entry &&
+            [entry.examId, entry.id, entry.dataKey].some(id => String(id) === String(examId))) || null;
+    }
+
+    async function resolveReadingArticle(examId, source) {
+        if (source.kind === 'builtin' && source.id === 'default') {
+            return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
+        }
+        if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
+        const [index, configurations] = await Promise.all([
+            global.AppData.library.getIndex(source.id),
+            global.AppData.library.listConfigurations()
+        ]);
+        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
+        const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
+        if (!configuration || matches.length !== 1) {
+            return { exam: null, sourceLabel };
+        }
+        const exam = matches[0];
+        if (exam.sourceKind === 'file-picker' && exam.importKey) {
+            // Session blobs predate library-scoped identities. When the same
+            // import key exists in another library the blob cannot prove which
+            // source it belongs to, so keep the saved vocabulary available only.
+            const otherIndexes = await Promise.all(configurations
+                .filter(item => (item.id || item.key) !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+            if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
+                return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
+            }
+        }
+        // Only an explicit generated-reading reference may use the built-in
+        // registry. A coincidentally identical examId is never a content link.
+        const generatedKey = exam.sourceKind === 'generated-reading' && exam.dataKey && manifestEntryFor(exam.dataKey)
+            ? exam.dataKey : null;
+        return { exam, sourceLabel, generatedKey };
+    }
+
+    async function loadImportedReadingPayload(exam) {
+        let url = '';
+        if (exam.sourceKind === 'file-picker') {
+            // File-picker resources disappear when their session ends. Do not
+            // fall back to another imported entry with the same examId.
+            url = exam.importKey && global.LibraryDiscovery?.resolveRuntimeResource({ importKey: exam.importKey }, 'html');
+        } else if (exam.filename) {
+            const base = global.location.pathname.includes('/reading-exams/')
+                ? new URL('../../../', global.location.href) : new URL('./', global.location.href);
+            const filename = String(exam.filename).replace(/\\/g, '/');
+            const path = String(exam.path || '').replace(/\\/g, '/');
+            url = new URL(/^[a-z][a-z\d+.-]*:/i.test(filename) || filename.startsWith('/')
+                ? filename : `${path.replace(/\/?$/, '/')}${filename}`.replace(/^\//, ''), base).href;
+        }
+        if (!url || !/^(?:https?:|file:|blob:)/i.test(url)) {
+            throw new Error('原题库文件不可用，请重新载入原题库；已保存的生词仍可查看或导出');
+        }
+        const response = await global.fetch(url);
+        if (!response.ok) throw new Error('原题库文件无法读取，已保存的生词仍可查看或导出');
+        // Parse and sanitize before the content normalizer creates any regular
+        // DOM nodes: even detached images can dispatch load/error handlers.
+        const template = document.createElement('template');
+        template.innerHTML = await response.text();
+        const passage = template.content.querySelector('#passage, #reading-passage, .reading-passage, #left, .passage');
+        const questions = template.content.querySelector('#questions, #question-panel, .questions-container, #right');
+        if (!passage || !passage.textContent.trim()) {
+            throw new Error('原题库文章结构已更改或不支持，已保存的生词仍可查看或导出');
+        }
+        const assetBase = response.url || url;
+        return { meta: { title: exam.title || template.content.querySelector('title')?.textContent || '', category: exam.category },
+            passage: { blocks: [{ html: sanitizeImportedReadingHtml(passage.innerHTML, assetBase, 'imported-passage') }] },
+            questionGroups: questions ? [{ bodyHtml: sanitizeImportedReadingHtml(questions.innerHTML, assetBase, 'imported-questions') }] : [] };
+    }
+
+    function sanitizeImportedReadingHtml(html, baseUrl, namespace) {
+        const template = document.createElement('template');
+        template.content.appendChild(createReadOnlyQuestionContent(html, namespace));
+        template.content.querySelectorAll('base, meta').forEach(node => node.remove());
+        const resolveAsset = value => {
+            try {
+                const url = new URL(value, baseUrl);
+                if (/^(?:https?:|file:|blob:)$/.test(url.protocol)
+                    || (url.protocol === 'data:' && /^data:image\/(?:png|gif|jpe?g|webp|avif|svg\+xml)[;,]/i.test(url.href))) return url.href;
+            } catch (_) {}
+            return '';
+        };
+        const resolveSrcset = value => {
+            const candidates = [];
+            let remaining = value.trim();
+            while (remaining) {
+                remaining = remaining.replace(/^[\s,]+/, '');
+                const match = remaining.match(/^\S+/);
+                if (!match) break;
+                const token = match[0];
+                remaining = remaining.slice(token.length);
+                let descriptor = '';
+                if (!token.endsWith(',')) {
+                    const end = remaining.indexOf(',');
+                    descriptor = (end < 0 ? remaining : remaining.slice(0, end)).trim();
+                    remaining = end < 0 ? '' : remaining.slice(end + 1);
+                }
+                const url = resolveAsset(token.replace(/,+$/, ''));
+                if (url && (!descriptor || /^(?:\d+w|(?:\d+(?:\.\d+)?|\.\d+)x)$/.test(descriptor))) {
+                    candidates.push(url + (descriptor ? ` ${descriptor}` : ''));
+                }
+            }
+            return candidates.join(', ');
+        };
+        template.content.querySelectorAll('[src], [srcset], [poster]').forEach(node => {
+            for (const name of ['src', 'srcset', 'poster']) {
+                if (!node.hasAttribute(name)) continue;
+                const value = name === 'srcset' ? resolveSrcset(node.getAttribute(name)) : resolveAsset(node.getAttribute(name));
+                if (value) node.setAttribute(name, value);
+                else node.removeAttribute(name);
+            }
+        });
+        return template.innerHTML;
+    }
+
     async function loadReadingExplanationPayload(examId) {
         if (!examId) return null;
 
@@ -9288,6 +9441,10 @@
     const ReadingVocabReader = {
         currentExamId: null,
         currentSource: DEFAULT_SOURCE,
+        currentSourceLabel: '内置题库',
+        currentContentRef: null,
+        _sourceReady: false,
+        _openOptions: null,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -9521,13 +9678,15 @@
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                on(bookshelfBtn, 'click', () => {
+                on(bookshelfBtn, 'click', async () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
                         try {
-                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
-                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            if (typeof global.opener.AppActions?.openBookshelf === 'function') {
+                                await global.opener.AppActions.openBookshelf({ fromView: global.opener.app?.currentView || 'browse' });
+                                global.opener.focus();
+                                return;
                             }
                             if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
                                 global.opener.app.navigateToView('bookshelf');
@@ -9540,10 +9699,9 @@
                             }
                         } catch (_) {}
                     }
-                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
-                        global.BookshelfView.mount('#bookshelf-view');
-                    }
-                    if (global.app && typeof global.app.navigateToView === 'function') {
+                    if (typeof global.AppActions?.openBookshelf === 'function') {
+                        await global.AppActions.openBookshelf({ fromView: global.app?.currentView || 'browse' });
+                    } else if (global.app && typeof global.app.navigateToView === 'function') {
                         global.app.navigateToView('bookshelf');
                     } else if (typeof global.switchView === 'function') {
                         global.switchView('bookshelf');
@@ -9627,7 +9785,7 @@
                         val,
                         this.currentExamId,
                         this.currentExam?.title || '',
-                        '', null, this.currentSource
+                        '', null, this.currentSource, this.currentContentRef
                     );
                     if (requestId !== this._openRequestId) return;
                     if (result.added) {
@@ -9753,7 +9911,7 @@
                 } else if (button.dataset.action === 'undo-occurrence') {
                     this.undoOccurrence();
                 } else if (button.dataset.action === 'retry-anchors') {
-                    this.open(this.currentExamId, { source: this.currentSource });
+                    this.open(this.currentExamId, { ...this._openOptions, source: this.currentSource });
                 }
             });
 
@@ -9772,23 +9930,32 @@
         },
 
         async open(examId, options = {}) {
-            if (!examId) return;
+            if (!examId && !options.notebook) return;
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            this._openOptions = { ...options };
             const initiatingElement = options.returnFocus || document.activeElement;
             if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
             this.unbindEvents();
             this.bindEvents(overlay);
             this.clearPendingWork(overlay);
             this.currentExamId = examId;
+            this.currentSource = options.source ? { ...options.source } : { ...DEFAULT_SOURCE };
+            this.currentSourceLabel = options.source?.kind === 'imported' ? `导入题库 · ${options.source.id}` : '内置题库';
+            this._sourceReady = false;
             this.currentExam = null;
+            this.currentContentRef = null;
             this.currentPayload = null;
             this.currentExplanation = null;
             this.closeModal(false);
             this.modalTab = 'current';
             overlay.querySelector('#v-tab-current')?.classList.add('active');
             overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            overlay.querySelector('#v-tab-current').disabled = !examId;
+            ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                overlay.querySelector(selector).disabled = true;
+            });
             const manualInput = overlay.querySelector('#vocab-manual-input');
             if (manualInput) manualInput.value = '';
 
@@ -9798,6 +9965,9 @@
             if (options && options.fromPractice) {
                 if (backBtnText) backBtnText.textContent = '返回练习';
                 if (backBtn) backBtn.title = '返回练习试卷';
+            } else if (options.fromView === 'bookshelf') {
+                if (backBtnText) backBtnText.textContent = '返回书架';
+                if (backBtn) backBtn.title = '返回阅读书架';
             } else {
                 if (backBtnText) backBtnText.textContent = '返回题库';
                 if (backBtn) backBtn.title = '返回题库浏览';
@@ -9823,53 +9993,98 @@
                 if (element) element.textContent = '';
             });
             this.switchViewTab('all');
+            this.updateCounts();
 
             try {
+                if (options.notebook) {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    this._sourceReady = true;
+                    this.currentExam = { title: '全部精读生词' };
+                    titleEl.textContent = '全部精读生词';
+                    passageContent.textContent = '查看、删除或导出全部文章的精读生词。';
+                    this.modalTab = 'all';
+                    overlay.querySelector('#v-tab-current').classList.remove('active');
+                    overlay.querySelector('#v-tab-all').classList.add('active');
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                    this.openModal();
+                    return;
+                }
                 // 加载试卷数据
                 const source = await ReadingVocabStore.resolveSource(options);
                 if (requestId !== this._openRequestId) return;
                 this.currentSource = source;
-                const payload = await loadReadingExamPayload(examId);
+                this.currentSourceLabel = source.kind === 'imported' ? `导入题库 · ${source.id}` : '内置题库';
+                const articleId = global.AppData.vocab.readingModel.articleId(source, String(examId));
+                if (options.articleId && options.articleId !== articleId) {
+                    throw new Error('文章与题库来源不匹配，请从原书架条目重新打开');
+                }
+                this._sourceReady = true;
+                this.currentExam = { title: options.title || examId };
+                await ReadingVocabStore.init();
+                if (requestId !== this._openRequestId) return;
+                const storedArticle = ReadingVocabStore._state.snapshot.reading.articles.find(article => article.id === articleId);
+                const resolved = await resolveReadingArticle(examId, source);
+                if (requestId !== this._openRequestId) return;
+                this.currentSourceLabel = resolved.sourceLabel;
+                this.currentExam = { ...this.currentExam, ...(resolved.exam || {}) };
+                this.renderIdentity();
+                if (!resolved.exam) throw new Error(resolved.unavailableReason || '原题库或文章已移除，已保存的生词仍可查看或导出');
+                const contentRef = global.AppData.vocab.readingModel.contentRef(source.kind === 'builtin'
+                    ? { sourceKind: 'generated-reading', dataKey: resolved.generatedKey } : resolved.exam);
+                const storedRefs = storedArticle?.contentRefs || [];
+                if (storedRefs.length > 1 || (storedRefs.length === 1 && storedRefs[0] !== contentRef)
+                    || (options.contentRef && options.contentRef !== contentRef)) {
+                    throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
+                }
+                this.currentContentRef = contentRef;
+                const expectedTitle = options.title || storedArticle?.title;
+                const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
+                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                    throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
+                }
+                const payload = resolved.generatedKey
+                    ? await loadReadingExamPayload(resolved.generatedKey)
+                    : await loadImportedReadingPayload(resolved.exam);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
-                }
-                // The current payload registry contains only built-in generated
-                // content. Never attach that content to a different library.
-                if (source.kind !== 'builtin' || source.id !== 'default') {
-                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
                 }
                 this.currentPayload = payload;
                 this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
-                loadReadingExplanationPayload(examId).then(exp => {
+                if (resolved.generatedKey) loadReadingExplanationPayload(resolved.generatedKey).then(exp => {
                     if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
 
                 // 获取 Exam Meta
-                const manifest = global.__READING_EXAM_MANIFEST__ || {};
-                const manifestEntry = manifest[examId] || {};
-                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+                this.currentExam = Object.assign({}, payload.meta || {}, resolved.exam);
 
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
                 let saveError = null;
                 try {
-                    await ReadingVocabStore.init();
-                    if (requestId !== this._openRequestId) return;
-                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source, contentRef);
                 } catch (error) {
                     saveError = error;
                 }
                 if (requestId !== this._openRequestId) return;
+                const committedRefs = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId)?.contentRefs || [];
+                if (committedRefs.length > 1 || (committedRefs.length === 1 && committedRefs[0] !== contentRef)) {
+                    throw new Error('原题库的来源记录已更改，已保存的生词仍可查看或导出');
+                }
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                    overlay.querySelector(selector).disabled = false;
+                });
                 if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
@@ -9877,12 +10092,22 @@
                 this.currentPayload = null;
                 await ReadingVocabStore.init().catch(() => {});
                 if (requestId !== this._openRequestId) return;
+                if (this._sourceReady) {
+                    const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
+                    const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
+                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                }
+                this.renderIdentity();
                 this.applyVocabHighlights();
                 this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
                     const message = document.createElement('p');
+                    errorState.setAttribute('role', 'status');
+                    errorState.dataset.sourceUnavailable = 'true';
                     message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
                     const retry = document.createElement('button');
                     retry.type = 'button';
@@ -9896,16 +10121,25 @@
                     retry.addEventListener('click', handleRetry);
                     this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
+                    const review = document.createElement('button');
+                    review.type = 'button';
+                    review.textContent = '查看已保存生词';
+                    const handleReview = () => this.openModal();
+                    review.addEventListener('click', handleReview);
+                    this._eventCleanups.push(() => review.removeEventListener('click', handleReview));
+                    errorState.append(review);
                     passageContent.replaceChildren(errorState);
                 }
             }
         },
 
-        renderContent() {
-            const overlay = this.ensureOverlay();
-            const exam = this.currentExam;
-            const payload = this.currentPayload;
+        openNotebook(options = {}) {
+            return this.open(null, { ...options, notebook: true });
+        },
 
+        renderIdentity() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam || {};
             // 标题与标签（紧凑精致）
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -9917,9 +10151,17 @@
             if (badgesEl) {
                 badgesEl.innerHTML = `
                     <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    <span class="vocab-badge vocab-badge--source">${escapeHtml(this.currentSourceLabel)}</span>
                     ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+            this.renderIdentity();
 
             // 解析文章大标题、考试指导语与真实段落
             const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
@@ -10116,7 +10358,7 @@
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
-                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource, this.currentContentRef);
                 if (requestId !== this._openRequestId) return;
                 if (!result.added) throw new Error('Selection was not saved');
                 selection.removeAllRanges();
@@ -10226,7 +10468,7 @@
                 // Keep the acknowledged deletion fence: a later clear/replace must
                 // reject this undo instead of resurrecting deleted relationships.
                 const committedRevision = result.revisions?.['vocab.readingState'];
-                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                this._undoOccurrence = !owner.contentAmbiguous && result.changed !== false && Number.isInteger(committedRevision)
                     ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
                 this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
                 this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
@@ -10361,7 +10603,7 @@
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
+            const currentList = this._sourceReady ? ReadingVocabStore.getByExam(examId, this.currentSource) : [];
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -10383,7 +10625,7 @@
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -10446,7 +10688,8 @@
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
-                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
+                const input = modal.querySelector('#vocab-manual-input');
+                (input && !input.disabled ? input : modal.querySelector('#vocab-modal-close'))?.focus({ preventScroll: true });
             }
         },
 
@@ -10497,6 +10740,12 @@
             }
             document.body.classList.remove('vocab-reader-open');
             if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            else if (this._openOptions?.fromView === 'bookshelf') {
+                const card = [...document.querySelectorAll('[data-article-id]')]
+                    .find(element => element.dataset.articleId === this._openOptions.articleId);
+                (card?.querySelector('button[data-action="open-reading-vocab"]')
+                    || document.querySelector('[data-action="open-global-notebook"]'))?.focus({ preventScroll: true });
+            }
             this._returnFocus = null;
         }
     };
@@ -10504,7 +10753,7 @@
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.currentExamId) {
+            if (ReadingVocabReader._sourceReady && !document.getElementById('reading-vocab-reader-overlay')?.classList.contains('is-hidden')) {
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
                 if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();
@@ -12791,20 +13040,39 @@
         }
     }
 
-    function openVocabReaderForCurrentExam() {
+    let vocabReaderOpenRequest = 0;
+    async function openVocabReaderForCurrentExam() {
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
             return;
         }
+        const requestId = ++vocabReaderOpenRequest;
+        const returnFocus = document.activeElement;
+        const options = { fromPractice: true, returnFocus,
+            title: state.dataset?.meta?.title || examId,
+            libraryConfigurationId: state.libraryConfigurationId };
         ensureVocabReaderStyles();
-
-        if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-            global.ReadingVocabReader.open(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
-        } else if (typeof global.openReadingVocabReader === 'function') {
-            global.openReadingVocabReader(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
-        } else {
-            console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
+        try {
+            if (!global.ReadingVocabReader && global.AppLazyLoader?.ensureGroup) {
+                await global.AppLazyLoader.ensureGroup('exam-data');
+                await global.AppLazyLoader.ensureGroup('browse-runtime');
+            }
+            if (requestId !== vocabReaderOpenRequest) return;
+            if (!global.ReadingVocabReader?.open) throw new Error('Reading vocabulary reader is unavailable');
+            document.getElementById('reading-vocab-load-status')?.remove();
+            await global.ReadingVocabReader.open(examId, options);
+        } catch (error) {
+            if (requestId !== vocabReaderOpenRequest) return;
+            console.warn('[UnifiedReadingPage] 生词本加载失败:', error);
+            let status = document.getElementById('reading-vocab-load-status');
+            if (!status) {
+                status = document.createElement('p');
+                status.id = 'reading-vocab-load-status';
+                status.setAttribute('role', 'status');
+                document.querySelector('.header-right')?.appendChild(status);
+            }
+            status.textContent = '生词本加载失败，请再次点击生词本重试。';
         }
     }
 

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -9182,11 +9182,16 @@
             return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
         }
         if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
-        const [index, configurations] = await Promise.all([
+        const [index, storedConfigurations] = await Promise.all([
             global.AppData.library.getIndex(source.id),
             global.AppData.library.listConfigurations()
         ]);
-        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const configurations = storedConfigurations.map(item => {
+            const id = typeof item === 'string' ? item
+                : [item?.id, item?.key, item?.configId].find(value => value != null && value !== '');
+            return { ...(typeof item === 'object' && item ? item : {}), id: id == null ? '' : String(id) };
+        }).filter(item => item.id);
+        const configuration = configurations.find(item => item.id === source.id);
         const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
         const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
         if (!configuration || matches.length !== 1) {
@@ -9198,8 +9203,8 @@
             // import key exists in another library the blob cannot prove which
             // source it belongs to, so keep the saved vocabulary available only.
             const otherIndexes = await Promise.all(configurations
-                .filter(item => (item.id || item.key) !== source.id)
-                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+                .filter(item => item.id !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id)));
             if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
                 return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
             }
@@ -10039,9 +10044,10 @@
                     throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
                 }
                 this.currentContentRef = contentRef;
-                const expectedTitle = options.title || storedArticle?.title;
                 const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
-                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                const resolvedTitle = normalizeTitle(resolved.exam.title);
+                if (resolvedTitle && [storedArticle?.title, options.title].some(title =>
+                    normalizeTitle(title) && normalizeTitle(title) !== resolvedTitle)) {
                     throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
                 }
                 const payload = resolved.generatedKey
@@ -10095,7 +10101,7 @@
                 if (this._sourceReady) {
                     const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
                     const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
-                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    this.currentExam = { ...(this.currentExam || {}), title: stored?.title || options.title || this.currentExam?.title || examId };
                     overlay.querySelector('#vocab-export-btn').disabled = false;
                     overlay.querySelector('#vocab-clear-btn').disabled = false;
                 }

--- a/js/bundles/runtime-entry.bundle.js
+++ b/js/bundles/runtime-entry.bundle.js
@@ -2392,8 +2392,17 @@
         openBookshelf: openBookshelf
     });
 
+    var bookshelfOpenSequence = 0;
+
     function openBookshelf(options) {
-        var fromView = (options && options.fromView) || 'overview';
+        var sequence = ++bookshelfOpenSequence;
+        var fromView = (options && options.fromView) || global.app?.currentView || 'overview';
+        var navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration() : null;
+        var isCurrent = function () {
+            return sequence === bookshelfOpenSequence && (navigation == null
+                || navigation === global.__getAppNavigationIntentGeneration());
+        };
         return Promise.resolve().then(function () {
             if (global.AppEntry && typeof global.AppEntry.ensureMoreToolsGroup === 'function') {
                 return global.AppEntry.ensureMoreToolsGroup();
@@ -2403,6 +2412,15 @@
             }
             return null;
         }).then(function () {
+            if (!isCurrent()) return;
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                return global.AppLazyLoader.ensureGroup('exam-data');
+            }
+        }).then(function () {
+            if (!isCurrent()) return;
+            if (!global.BookshelfView || typeof global.BookshelfView.mount !== 'function') {
+                throw new Error('Bookshelf component is unavailable');
+            }
             var bookshelfView = document.getElementById('bookshelf-view');
             if (bookshelfView) {
                 bookshelfView.removeAttribute('hidden');
@@ -2431,6 +2449,7 @@
                 moreNavBtn.classList.add('active');
             }
         }).catch(function (error) {
+            if (!isCurrent()) return;
             console.warn('[AppActions] 打开书架失败:', error);
             if (typeof global.showMessage === 'function') {
                 global.showMessage('未能打开阅读书架，请稍后重试。', 'warning');
@@ -2440,6 +2459,18 @@
 
     // 挂载到全局（向后兼容）
     global.openBookshelfView = openBookshelf;
+    // The More card is visible before more-tools has finished loading. Accept
+    // that first click in the resident runtime; the mounted handler prevents
+    // default itself, so warm clicks still have exactly one owner.
+    if (typeof document !== 'undefined') {
+        document.addEventListener('click', function (event) {
+            if (event.defaultPrevented) return;
+            var target = event.target?.closest?.('[data-action="open-bookshelf"]');
+            if (!target || !target.closest('#more-view')) return;
+            event.preventDefault();
+            openBookshelf({ fromView: 'more' });
+        });
+    }
     global.startSuitePractice = startSuitePractice;
     global.continueSuitePractice = continueSuitePractice;
     global.openExamWithFallback = openExamWithFallback;

--- a/js/components/bookshelfView.js
+++ b/js/components/bookshelfView.js
@@ -14,6 +14,8 @@
         _commitBound: false,
         _loadSequence: 0,
         _loadError: null,
+        _loading: false,
+        _sourceMetadata: new Map(),
 
         getRawRecords() {
             return this.getBookshelfExams().map((exam) => ({
@@ -34,11 +36,12 @@
 
         _adopt(result) {
             if (!result || !result.snapshot) throw new Error('Reading snapshot is unavailable');
-            if (this._revision !== null && result.revision < this._revision) return;
+            if (this._generation === result.generation && this._revision !== null && result.revision < this._revision) return false;
             this._snapshot = result.snapshot;
             this._revision = result.revision;
             this._generation = result.generation;
             this._loadError = null;
+            return true;
         },
 
         _notify(detail = {}) {
@@ -47,6 +50,8 @@
 
         async init() {
             const sequence = ++this._loadSequence;
+            this._loading = true;
+            this._notify({ action: 'loading' });
             try {
                 if (global.AppData && global.AppData.ready) await global.AppData.ready;
                 this.bindCommitListener();
@@ -55,13 +60,16 @@
                     throw new Error('Reading persistence is unavailable');
                 }
                 const result = await vocab.getReadingSnapshot();
+                const metadata = await this._readSourceMetadata(result.snapshot);
                 if (sequence === this._loadSequence) {
-                    this._adopt(result);
+                    if (this._adopt(result)) this._sourceMetadata = metadata;
+                    this._loading = false;
                     this._notify({ action: 'reload' });
                 }
                 return result;
             } catch (error) {
                 if (sequence === this._loadSequence) {
+                    this._loading = false;
                     this._loadError = error;
                     this._notify({ action: 'load-failed' });
                 }
@@ -72,6 +80,28 @@
         // Compatibility flush callers wait for a fresh durable snapshot.
         async flushToAppData() { return this.init(); },
 
+        async _readSourceMetadata(snapshot) {
+            const library = global.AppData && global.AppData.library;
+            const metadata = new Map();
+            if (!library) return metadata;
+            try {
+                const configurations = typeof library.listConfigurations === 'function'
+                    ? await library.listConfigurations() : [];
+                await Promise.all(snapshot.reading.sources.filter((row) => row.kind === 'imported').map(async (source) => {
+                    const config = configurations.find((row) => String(row.id || row.key || row.configId) === source.libraryId);
+                    const index = typeof library.getIndex === 'function' ? await library.getIndex(source.libraryId) : null;
+                    metadata.set(source.id, {
+                        name: config && (config.name || config.title) || source.libraryId,
+                        index: Array.isArray(index) ? index : null
+                    });
+                }));
+            } catch (error) {
+                // Stored vocabulary remains usable when source metadata cannot be read.
+                console.warn('[ReadingBookshelfStore] Source metadata unavailable:', error);
+            }
+            return metadata;
+        },
+
         bindCommitListener() {
             if (this._commitBound) return;
             const backups = global.AppData && global.AppData.backups;
@@ -79,7 +109,7 @@
                 this._commitBound = true;
                 backups.onDataCommitted((event) => {
                     const targets = event && event.targets;
-                    if (Array.isArray(targets) && targets.some((target) => String(target.logicalKey || '').startsWith('vocab.'))) {
+                    if (Array.isArray(targets) && targets.some((target) => /^(vocab|library)\./.test(String(target.logicalKey || '')))) {
                         this.init().catch((error) => console.warn('[ReadingBookshelfStore] Reload failed:', error));
                     }
                 });
@@ -103,6 +133,7 @@
             // An in-flight reload may predate this acknowledgement.
             ++this._loadSequence;
             this._adopt(result);
+            this._loading = false;
             this._notify({ action: type, articleId: command.articleId });
             return result;
         },
@@ -133,8 +164,11 @@
                 const source = { kind: sourceRow.kind, id: sourceRow.libraryId };
                 const related = associations.get(article.id) || [];
                 const visit = visitMap.get(article.id);
-                const meta = source.kind === 'builtin' ? manifest[article.examId] || {} : {};
-                const words = related.map((association) => this._wordForTerm(termMap.get(association.termId))).filter(Boolean);
+                const sourceMeta = this._sourceMetadata.get(article.sourceId);
+                const meta = source.kind === 'builtin' ? manifest[article.examId] || {}
+                    : sourceMeta?.index?.find((row) => String(row.id || row.examId) === article.examId) || {};
+                const termIds = Array.from(new Set(related.map((association) => association.termId)));
+                const words = termIds.map((id) => this._wordForTerm(termMap.get(id))).filter(Boolean);
                 const lastActivityAt = Math.max(
                     visit ? Date.parse(visit.lastVisitedAt) : 0,
                     ...related.map((association) => Date.parse(association.updatedAt)),
@@ -142,9 +176,14 @@
                 );
                 return {
                     articleId: article.id, source, examId: article.examId,
+                    sourceLabel: source.kind === 'builtin' ? '内置题库'
+                        : `导入题库 · ${sourceMeta?.name && sourceMeta.name !== source.id ? `${sourceMeta.name} (${source.id})` : source.id}`,
+                    sourceUnavailable: source.kind === 'imported' && Array.isArray(sourceMeta?.index)
+                        && !sourceMeta.index.some((row) => String(row.id || row.examId) === article.examId),
                     title: article.title || meta.title || meta.name || article.examId,
                     category: meta.category || meta.type || '雅思阅读',
-                    wordCount: words.length, sampleWords: words.slice(0, 6).map((word) => word.word),
+                    wordCount: termIds.length, allWords: words.map((word) => word.word),
+                    sampleWords: words.slice(0, 6).map((word) => word.word),
                     lastActivityAt, hasPdf: Boolean(meta.pdfPath || meta.pdf)
                 };
             }).sort((a, b) => b.lastActivityAt - a.lastActivityAt);
@@ -163,6 +202,11 @@
             const reading = this._snapshot.reading;
             const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
             return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
+        },
+
+        getDistinctWordCount() {
+            if (!this._snapshot) return 0;
+            return new Set(this._snapshot.reading.associations.map((row) => row.termId)).size;
         },
 
         async _articleId(examId, source, articleId) {
@@ -277,8 +321,13 @@
             sortBy: 'recent', // 'recent' | 'words' | 'title'
             filterMode: 'all', // 'all' | 'has-words'
             fromView: null,
-            toastTimer: null
+            toastTimer: null,
+            readerLoading: false,
+            readerError: null
         },
+        _readerRequestId: 0,
+        _readerLoadPromise: null,
+        _lastReaderRequest: null,
 
         mount(targetSelector = '#bookshelf-view', options = {}) {
             if (options && options.fromView) {
@@ -305,7 +354,7 @@
             if (!root) return;
 
             const allExams = ReadingBookshelfStore.getBookshelfExams();
-            const totalWords = allExams.reduce((sum, item) => sum + item.wordCount, 0);
+            const totalWords = ReadingBookshelfStore.getDistinctWordCount();
 
             // 过滤与搜索
             let filtered = allExams.slice();
@@ -314,8 +363,9 @@
                 filtered = filtered.filter(item => {
                     const matchTitle = (item.title || '').toLowerCase().includes(q);
                     const matchCategory = (item.category || '').toLowerCase().includes(q);
-                    const matchWords = (item.sampleWords || []).some(w => w.toLowerCase().includes(q));
-                    return matchTitle || matchCategory || matchWords;
+                    const matchSource = `${item.sourceLabel || ''} ${item.source.kind} ${item.source.id}`.toLowerCase().includes(q);
+                    const matchWords = (item.allWords || []).some(w => w.toLowerCase().includes(q));
+                    return matchTitle || matchCategory || matchSource || matchWords;
                 });
             }
 
@@ -341,6 +391,11 @@
                     ${ReadingBookshelfStore._loadError ? (needsPageReload(ReadingBookshelfStore._loadError)
                         ? '<p role="alert">书架加载失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
                         : '<p role="alert">书架加载失败，已显示的数据保持不变。<button type="button" class="btn btn-secondary" data-action="retry-load">重试加载</button></p>') : ''}
+                    ${this.state.readerLoading ? '<p role="status">正在打开生词本…</p>' : ''}
+                    ${this.state.readerError ? (needsPageReload(this.state.readerError)
+                        ? '<p role="alert">生词本打开失败，请刷新页面后重试。<button type="button" class="btn btn-secondary" data-action="reload-page">刷新页面</button></p>'
+                        : '<p role="alert">生词本打开失败，请重试。<button type="button" class="btn btn-secondary" data-action="retry-reader">重试打开</button></p>') : ''}
+                    ${ReadingBookshelfStore._snapshot && ReadingBookshelfStore._loading ? '<p role="status">正在更新书架…</p>' : ''}
                     <!-- 顶部标题栏与导航 -->
                     <div class="bookshelf-topbar">
                         <div class="bookshelf-topbar__left">
@@ -350,7 +405,7 @@
                             </button>
                             <div class="bookshelf-heading-group">
                                 <h2 class="bookshelf-title">📚 阅读书架</h2>
-                                <p class="bookshelf-subtitle">收录使用过生词本的精读篇目，温故知新，查缺补漏</p>
+                                <p class="bookshelf-subtitle">收录打开过的精读篇目与生词，随时继续阅读与复习</p>
                             </div>
                         </div>
                         <div class="bookshelf-topbar__right">
@@ -376,7 +431,7 @@
                             <span class="bookshelf-stat-icon">🔤</span>
                             <div class="bookshelf-stat-content">
                                 <span class="bookshelf-stat-value">${totalWords}</span>
-                                <span class="bookshelf-stat-label">积累生词</span>
+                                <span class="bookshelf-stat-label">不重复生词</span>
                             </div>
                         </div>
                         <div class="bookshelf-stat-card">
@@ -395,7 +450,7 @@
                             <input
                                 type="text"
                                 class="bookshelf-search-input"
-                                placeholder="搜索篇目名称、分类或单词..."
+                                placeholder="搜索篇目名称、分类、来源或单词..."
                                 value="${this.escapeHtml(this.state.searchQuery)}"
                                 data-action="search-input"
                             />
@@ -468,6 +523,8 @@
                         </h3>
                         <div class="bookshelf-card__meta">
                             <span class="bookshelf-card__time">🕒 ${formattedTime}</span>
+                            <span class="bookshelf-card__source">${this.escapeHtml(exam.sourceLabel)}</span>
+                            ${exam.sourceUnavailable ? '<span class="bookshelf-card__source-state">原题库内容不可用 · 可查看与导出生词</span>' : ''}
                         </div>
 
                         <!-- 生词预览药丸标签 -->
@@ -618,11 +675,7 @@
             const globalNotebookBtn = root.querySelector('[data-action="open-global-notebook"]');
             if (globalNotebookBtn) {
                 globalNotebookBtn.addEventListener('click', () => {
-                    if (global.ReadingVocabReader && typeof global.ReadingVocabReader.openModal === 'function') {
-                        global.ReadingVocabReader.openModal();
-                    } else {
-                        this.showToast('⚠️ 生词本组件正在加载...');
-                    }
+                    this.launchGlobalNotebook(globalNotebookBtn);
                 });
             }
 
@@ -649,6 +702,12 @@
                     await ReadingBookshelfStore.init().catch(() => {});
                     return;
                 }
+                if (e.target.closest('[data-action="retry-reader"]')) {
+                    const request = this._lastReaderRequest;
+                    if (request?.examId) await this.launchExamVocabReader(request.examId, request.source, request.articleId);
+                    else await this.launchGlobalNotebook();
+                    return;
+                }
                 const card = e.target.closest('[data-article-id]');
                 const articleId = card && card.dataset.articleId;
                 const article = ReadingBookshelfStore.getBookshelfExams().find((exam) => exam.articleId === articleId);
@@ -656,7 +715,7 @@
                 const openVocabTrigger = e.target.closest('[data-action="open-reading-vocab"]');
                 if (openVocabTrigger) {
                     const examId = openVocabTrigger.dataset.examId;
-                    await this.launchExamVocabReader(examId, article && article.source, articleId);
+                    await this.launchExamVocabReader(examId, article && article.source, articleId, openVocabTrigger);
                     return;
                 }
 
@@ -664,6 +723,7 @@
                 const openPracticeTrigger = e.target.closest('[data-action="open-exam-practice"]');
                 if (openPracticeTrigger) {
                     const examId = openPracticeTrigger.dataset.examId;
+                    if (!await this.canOpenOriginalSource(article)) return;
                     if (global.app && typeof global.app.openExam === 'function') {
                         global.app.openExam(examId);
                     } else if (typeof global.openExam === 'function') {
@@ -676,6 +736,7 @@
                 const openPdfTrigger = e.target.closest('[data-action="open-exam-pdf"]');
                 if (openPdfTrigger) {
                     const examId = openPdfTrigger.dataset.examId;
+                    if (!await this.canOpenOriginalSource(article)) return;
                     if (typeof global.viewPDF === 'function') {
                         global.viewPDF(examId);
                     }
@@ -810,24 +871,94 @@
             overlay.classList.remove('is-hidden');
         },
 
-        async launchExamVocabReader(examId, source, articleId) {
-            if (!examId) return;
+        async ensureReader() {
+            if (this._readerLoadPromise) return this._readerLoadPromise;
+            this._readerLoadPromise = (async () => {
+                const loader = global.AppLazyLoader;
+                if (loader && typeof loader.ensureGroup === 'function') {
+                    await Promise.all(['exam-data', 'browse-runtime'].map((group) => loader.ensureGroup(group)));
+                }
+                if (!global.ReadingVocabReader || typeof global.ReadingVocabReader.open !== 'function') {
+                    throw new Error('Reading reader is unavailable');
+                }
+                return global.ReadingVocabReader;
+            })();
+            try { return await this._readerLoadPromise; }
+            finally { this._readerLoadPromise = null; }
+        },
 
-            // 确保 ReadingVocabReader 依赖加载
-            if (!global.ReadingVocabReader && global.lazyLoader && typeof global.lazyLoader.ensureGroup === 'function') {
-                try {
-                    await global.lazyLoader.ensureGroup('browse-runtime');
-                } catch (e) {
-                    console.warn('[BookshelfView] 加载 browse-runtime 失败:', e);
+        async launchExamVocabReader(examId, source, articleId, returnFocus) {
+            if (!examId) return;
+            const article = ReadingBookshelfStore.getBookshelfExams().find((row) => row.articleId === articleId);
+            return this.launchReader({ examId, source, articleId, title: article?.title }, returnFocus);
+        },
+
+        async launchGlobalNotebook(returnFocus) {
+            return this.launchReader({}, returnFocus);
+        },
+
+        async launchReader(request, returnFocus) {
+            const requestId = ++this._readerRequestId;
+            const navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+                ? global.__getAppNavigationIntentGeneration() : null;
+            const isCurrent = () => requestId === this._readerRequestId && (navigation == null
+                || navigation === global.__getAppNavigationIntentGeneration());
+            this._lastReaderRequest = request;
+            this.state.readerLoading = true;
+            this.state.readerError = null;
+            this.render();
+            try {
+                const reader = await this.ensureReader();
+                if (!isCurrent()) return;
+                const options = { ...request, fromView: 'bookshelf', returnFocus };
+                if (request.examId) await reader.open(request.examId, options);
+                else if (typeof reader.openNotebook === 'function') await reader.openNotebook(options);
+                else throw new Error('Reading notebook is unavailable');
+            } catch (error) {
+                if (isCurrent()) {
+                    this.state.readerError = error;
+                    console.warn('[BookshelfView] Reader loading failed:', error);
+                }
+            } finally {
+                if (requestId === this._readerRequestId) {
+                    this.state.readerLoading = false;
+                    this.render();
                 }
             }
+        },
 
-            if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-                await global.ReadingVocabReader.open(examId, { source, articleId });
-            } else if (typeof global.openReadingVocabReader === 'function') {
-                await global.openReadingVocabReader(examId, { source, articleId });
-            } else {
-                this.showToast('⚠️ 生词本阅读组件尚未就绪，请稍后重试');
+        async canOpenOriginalSource(article) {
+            if (!article) return false;
+            try {
+                const activeSource = await ReadingBookshelfStore.resolveSource();
+                if (activeSource.kind !== article.source.kind || activeSource.id !== article.source.id) {
+                    this.showToast(`请先切换至原题库「${article.sourceLabel}」，或打开本篇精读查看生词`);
+                    return false;
+                }
+                if (article.source.kind === 'imported') {
+                    const index = await global.AppData.library.getIndex(article.source.id);
+                    if (!index.some((row) => String(row.id || row.examId) === article.examId)) {
+                        this.showToast('⚠️ 原题库内容已不可用，已保存的生词仍可在精读中查看或导出');
+                        return false;
+                    }
+                }
+                await this.ensureReader();
+                const currentSource = await ReadingBookshelfStore.resolveSource();
+                const currentExam = Array.isArray(global.examIndex)
+                    ? global.examIndex.find((row) => String(row.id || row.examId) === article.examId) : null;
+                const indexSource = currentExam && Object.prototype.hasOwnProperty.call(currentExam, 'libraryConfigurationId')
+                    ? (currentExam.libraryConfigurationId == null || currentExam.libraryConfigurationId === ''
+                        ? { kind: 'builtin', id: 'default' }
+                        : { kind: 'imported', id: String(currentExam.libraryConfigurationId) }) : null;
+                if (currentSource.kind !== article.source.kind || currentSource.id !== article.source.id
+                    || (indexSource && (indexSource.kind !== article.source.kind || indexSource.id !== article.source.id))) {
+                    this.showToast('题库已切换或正在更新，请等待原题库加载完成后重试');
+                    return false;
+                }
+                return true;
+            } catch (error) {
+                this.showToast('⚠️ 原题库加载失败，请重试');
+                return false;
             }
         },
 
@@ -846,8 +977,11 @@
             }
         },
 
-        navigateToMoreView() {
+        async navigateToMoreView() {
             const returnTarget = this.state.fromView || 'more';
+            ++this._readerRequestId;
+            this.state.readerLoading = false;
+            this.state.readerError = null;
             this.state.fromView = null;
             const bookshelfView = document.getElementById('bookshelf-view');
             const targetView = document.getElementById(`${returnTarget}-view`);
@@ -859,11 +993,16 @@
 
             if (global.app && typeof global.app.navigateToView === 'function') {
                 try {
-                    global.app.navigateToView(returnTarget);
+                    await global.app.navigateToView(returnTarget);
                     return;
                 } catch (err) {
                     console.warn('[BookshelfView] navigateToView 异常:', err);
                 }
+            }
+
+            if (typeof global.switchView === 'function') {
+                await global.switchView(returnTarget);
+                return;
             }
 
             if (targetView) {
@@ -940,6 +1079,18 @@
             }
         });
         window.addEventListener('reading-vocab-store-updated', () => {
+            const state = global.ReadingVocabStore && global.ReadingVocabStore._state;
+            if (state && ReadingBookshelfStore._adopt(state)) {
+                const sequence = ++ReadingBookshelfStore._loadSequence;
+                ReadingBookshelfStore._loading = false;
+                // Reader acknowledgements can supersede the commit-triggered
+                // reload; still refresh source names and indexes after restores.
+                ReadingBookshelfStore._readSourceMetadata(state.snapshot).then((metadata) => {
+                    if (sequence !== ReadingBookshelfStore._loadSequence) return;
+                    ReadingBookshelfStore._sourceMetadata = metadata;
+                    ReadingBookshelfStore._notify({ action: 'sources-reloaded' });
+                });
+            }
             const root = document.querySelector(BookshelfView.containerSelector);
             if (root && root.offsetParent !== null) {
                 BookshelfView.render();

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -366,11 +366,16 @@
             return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
         }
         if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
-        const [index, configurations] = await Promise.all([
+        const [index, storedConfigurations] = await Promise.all([
             global.AppData.library.getIndex(source.id),
             global.AppData.library.listConfigurations()
         ]);
-        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const configurations = storedConfigurations.map(item => {
+            const id = typeof item === 'string' ? item
+                : [item?.id, item?.key, item?.configId].find(value => value != null && value !== '');
+            return { ...(typeof item === 'object' && item ? item : {}), id: id == null ? '' : String(id) };
+        }).filter(item => item.id);
+        const configuration = configurations.find(item => item.id === source.id);
         const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
         const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
         if (!configuration || matches.length !== 1) {
@@ -382,8 +387,8 @@
             // import key exists in another library the blob cannot prove which
             // source it belongs to, so keep the saved vocabulary available only.
             const otherIndexes = await Promise.all(configurations
-                .filter(item => (item.id || item.key) !== source.id)
-                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+                .filter(item => item.id !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id)));
             if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
                 return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
             }
@@ -1223,9 +1228,10 @@
                     throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
                 }
                 this.currentContentRef = contentRef;
-                const expectedTitle = options.title || storedArticle?.title;
                 const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
-                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                const resolvedTitle = normalizeTitle(resolved.exam.title);
+                if (resolvedTitle && [storedArticle?.title, options.title].some(title =>
+                    normalizeTitle(title) && normalizeTitle(title) !== resolvedTitle)) {
                     throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
                 }
                 const payload = resolved.generatedKey
@@ -1279,7 +1285,7 @@
                 if (this._sourceReady) {
                     const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
                     const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
-                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    this.currentExam = { ...(this.currentExam || {}), title: stored?.title || options.title || this.currentExam?.title || examId };
                     overlay.querySelector('#vocab-export-btn').disabled = false;
                     overlay.querySelector('#vocab-clear-btn').disabled = false;
                 }

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -12,10 +12,10 @@
             .replace(/'/g, '&#39;');
     }
 
-    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE) {
+    async function recordBookshelfExamDirect(examId, examTitle = '', category = '', source = DEFAULT_SOURCE, contentRef = null) {
         if (!examId) return;
         return ReadingVocabStore.mutate('recordVisit', {
-            source, article: { examId: String(examId), title: examTitle },
+            source, article: { examId: String(examId), title: examTitle, category, ...(contentRef ? { contentRef } : {}) },
             at: new Date().toISOString()
         });
     }
@@ -69,8 +69,10 @@
             const source = reading?.sources.find(row => row.id === article?.sourceId);
             if (!article || !source) return null;
             return { articleId: article.id,
+                contentAmbiguous: (article.contentRefs || []).length > 1,
                 source: { kind: source.kind, id: source.libraryId },
-                article: { examId: article.examId, title: article.title } };
+                article: { examId: article.examId, title: article.title,
+                    ...(article.contentRefs?.length === 1 ? { contentRef: article.contentRefs[0] } : {}) } };
         },
 
         adopt(state) {
@@ -112,7 +114,7 @@
         async syncToAppData() { return this.reload(); },
         async flushToAppData() { return this.reload(); },
 
-        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE) {
+        async add(rawWord, examId, examTitle, context = '', highlight = null, source = DEFAULT_SOURCE, contentRef = null) {
             const word = this.cleanWord(rawWord);
             if (!word || word.length > 50) return { added: false, reason: 'invalid_word' };
             if (!this._state) await this.init();
@@ -124,7 +126,7 @@
                 quote: highlight.quote || highlight.text || word, before: highlight.before || '', after: highlight.after || ''
             } : undefined;
             const result = await this.mutate('collect', {
-                source, article: { examId: String(examId), title: examTitle || '' },
+                source, article: { examId: String(examId), title: examTitle || '', ...(contentRef ? { contentRef } : {}) },
                 word: { word, meaning: '待补充释义', example: String(context || '').trim().slice(0, 150) },
                 ...(occurrence ? { occurrence } : { manual: true }),
                 at: new Date().toISOString()
@@ -353,6 +355,125 @@
         return registryAfterLoad.get(examId) || (entry && (registryAfterLoad.get(entry.dataKey) || registryAfterLoad.get(entry.examId))) || null;
     }
 
+    function manifestEntryFor(examId) {
+        const manifest = global.__READING_EXAM_MANIFEST__ || {};
+        return manifest[examId] || Object.values(manifest).find(entry => entry &&
+            [entry.examId, entry.id, entry.dataKey].some(id => String(id) === String(examId))) || null;
+    }
+
+    async function resolveReadingArticle(examId, source) {
+        if (source.kind === 'builtin' && source.id === 'default') {
+            return { exam: manifestEntryFor(examId) || {}, sourceLabel: '内置题库', generatedKey: examId };
+        }
+        if (source.kind !== 'imported') throw new Error('原题库来源不可用，已保存的生词仍可查看或导出');
+        const [index, configurations] = await Promise.all([
+            global.AppData.library.getIndex(source.id),
+            global.AppData.library.listConfigurations()
+        ]);
+        const configuration = configurations.find(item => (item.id || item.key) === source.id);
+        const matches = index.filter(item => item && String(item.id || item.examId) === String(examId));
+        const sourceLabel = `${configuration?.name || configuration?.title || '导入题库'} · ${source.id}`;
+        if (!configuration || matches.length !== 1) {
+            return { exam: null, sourceLabel };
+        }
+        const exam = matches[0];
+        if (exam.sourceKind === 'file-picker' && exam.importKey) {
+            // Session blobs predate library-scoped identities. When the same
+            // import key exists in another library the blob cannot prove which
+            // source it belongs to, so keep the saved vocabulary available only.
+            const otherIndexes = await Promise.all(configurations
+                .filter(item => (item.id || item.key) !== source.id)
+                .map(item => global.AppData.library.getIndex(item.id || item.key)));
+            if (otherIndexes.some(rows => rows.some(row => row?.sourceKind === 'file-picker' && row.importKey === exam.importKey))) {
+                return { exam: null, sourceLabel, unavailableReason: '多个题库使用同名会话文件，无法确认原文来源；已保存的生词仍可查看或导出' };
+            }
+        }
+        // Only an explicit generated-reading reference may use the built-in
+        // registry. A coincidentally identical examId is never a content link.
+        const generatedKey = exam.sourceKind === 'generated-reading' && exam.dataKey && manifestEntryFor(exam.dataKey)
+            ? exam.dataKey : null;
+        return { exam, sourceLabel, generatedKey };
+    }
+
+    async function loadImportedReadingPayload(exam) {
+        let url = '';
+        if (exam.sourceKind === 'file-picker') {
+            // File-picker resources disappear when their session ends. Do not
+            // fall back to another imported entry with the same examId.
+            url = exam.importKey && global.LibraryDiscovery?.resolveRuntimeResource({ importKey: exam.importKey }, 'html');
+        } else if (exam.filename) {
+            const base = global.location.pathname.includes('/reading-exams/')
+                ? new URL('../../../', global.location.href) : new URL('./', global.location.href);
+            const filename = String(exam.filename).replace(/\\/g, '/');
+            const path = String(exam.path || '').replace(/\\/g, '/');
+            url = new URL(/^[a-z][a-z\d+.-]*:/i.test(filename) || filename.startsWith('/')
+                ? filename : `${path.replace(/\/?$/, '/')}${filename}`.replace(/^\//, ''), base).href;
+        }
+        if (!url || !/^(?:https?:|file:|blob:)/i.test(url)) {
+            throw new Error('原题库文件不可用，请重新载入原题库；已保存的生词仍可查看或导出');
+        }
+        const response = await global.fetch(url);
+        if (!response.ok) throw new Error('原题库文件无法读取，已保存的生词仍可查看或导出');
+        // Parse and sanitize before the content normalizer creates any regular
+        // DOM nodes: even detached images can dispatch load/error handlers.
+        const template = document.createElement('template');
+        template.innerHTML = await response.text();
+        const passage = template.content.querySelector('#passage, #reading-passage, .reading-passage, #left, .passage');
+        const questions = template.content.querySelector('#questions, #question-panel, .questions-container, #right');
+        if (!passage || !passage.textContent.trim()) {
+            throw new Error('原题库文章结构已更改或不支持，已保存的生词仍可查看或导出');
+        }
+        const assetBase = response.url || url;
+        return { meta: { title: exam.title || template.content.querySelector('title')?.textContent || '', category: exam.category },
+            passage: { blocks: [{ html: sanitizeImportedReadingHtml(passage.innerHTML, assetBase, 'imported-passage') }] },
+            questionGroups: questions ? [{ bodyHtml: sanitizeImportedReadingHtml(questions.innerHTML, assetBase, 'imported-questions') }] : [] };
+    }
+
+    function sanitizeImportedReadingHtml(html, baseUrl, namespace) {
+        const template = document.createElement('template');
+        template.content.appendChild(createReadOnlyQuestionContent(html, namespace));
+        template.content.querySelectorAll('base, meta').forEach(node => node.remove());
+        const resolveAsset = value => {
+            try {
+                const url = new URL(value, baseUrl);
+                if (/^(?:https?:|file:|blob:)$/.test(url.protocol)
+                    || (url.protocol === 'data:' && /^data:image\/(?:png|gif|jpe?g|webp|avif|svg\+xml)[;,]/i.test(url.href))) return url.href;
+            } catch (_) {}
+            return '';
+        };
+        const resolveSrcset = value => {
+            const candidates = [];
+            let remaining = value.trim();
+            while (remaining) {
+                remaining = remaining.replace(/^[\s,]+/, '');
+                const match = remaining.match(/^\S+/);
+                if (!match) break;
+                const token = match[0];
+                remaining = remaining.slice(token.length);
+                let descriptor = '';
+                if (!token.endsWith(',')) {
+                    const end = remaining.indexOf(',');
+                    descriptor = (end < 0 ? remaining : remaining.slice(0, end)).trim();
+                    remaining = end < 0 ? '' : remaining.slice(end + 1);
+                }
+                const url = resolveAsset(token.replace(/,+$/, ''));
+                if (url && (!descriptor || /^(?:\d+w|(?:\d+(?:\.\d+)?|\.\d+)x)$/.test(descriptor))) {
+                    candidates.push(url + (descriptor ? ` ${descriptor}` : ''));
+                }
+            }
+            return candidates.join(', ');
+        };
+        template.content.querySelectorAll('[src], [srcset], [poster]').forEach(node => {
+            for (const name of ['src', 'srcset', 'poster']) {
+                if (!node.hasAttribute(name)) continue;
+                const value = name === 'srcset' ? resolveSrcset(node.getAttribute(name)) : resolveAsset(node.getAttribute(name));
+                if (value) node.setAttribute(name, value);
+                else node.removeAttribute(name);
+            }
+        });
+        return template.innerHTML;
+    }
+
     async function loadReadingExplanationPayload(examId) {
         if (!examId) return null;
 
@@ -504,6 +625,10 @@
     const ReadingVocabReader = {
         currentExamId: null,
         currentSource: DEFAULT_SOURCE,
+        currentSourceLabel: '内置题库',
+        currentContentRef: null,
+        _sourceReady: false,
+        _openOptions: null,
         currentExam: null,
         currentPayload: null,
         currentExplanation: null,
@@ -737,13 +862,15 @@
             // 前往阅读书架
             const bookshelfBtn = overlay.querySelector('#vocab-modal-bookshelf-btn');
             if (bookshelfBtn) {
-                on(bookshelfBtn, 'click', () => {
+                on(bookshelfBtn, 'click', async () => {
                     this.closeModal();
                     this.close();
                     if (global.opener && !global.opener.closed) {
                         try {
-                            if (global.opener.BookshelfView && typeof global.opener.BookshelfView.mount === 'function') {
-                                global.opener.BookshelfView.mount('#bookshelf-view');
+                            if (typeof global.opener.AppActions?.openBookshelf === 'function') {
+                                await global.opener.AppActions.openBookshelf({ fromView: global.opener.app?.currentView || 'browse' });
+                                global.opener.focus();
+                                return;
                             }
                             if (global.opener.app && typeof global.opener.app.navigateToView === 'function') {
                                 global.opener.app.navigateToView('bookshelf');
@@ -756,10 +883,9 @@
                             }
                         } catch (_) {}
                     }
-                    if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
-                        global.BookshelfView.mount('#bookshelf-view');
-                    }
-                    if (global.app && typeof global.app.navigateToView === 'function') {
+                    if (typeof global.AppActions?.openBookshelf === 'function') {
+                        await global.AppActions.openBookshelf({ fromView: global.app?.currentView || 'browse' });
+                    } else if (global.app && typeof global.app.navigateToView === 'function') {
                         global.app.navigateToView('bookshelf');
                     } else if (typeof global.switchView === 'function') {
                         global.switchView('bookshelf');
@@ -843,7 +969,7 @@
                         val,
                         this.currentExamId,
                         this.currentExam?.title || '',
-                        '', null, this.currentSource
+                        '', null, this.currentSource, this.currentContentRef
                     );
                     if (requestId !== this._openRequestId) return;
                     if (result.added) {
@@ -969,7 +1095,7 @@
                 } else if (button.dataset.action === 'undo-occurrence') {
                     this.undoOccurrence();
                 } else if (button.dataset.action === 'retry-anchors') {
-                    this.open(this.currentExamId, { source: this.currentSource });
+                    this.open(this.currentExamId, { ...this._openOptions, source: this.currentSource });
                 }
             });
 
@@ -988,23 +1114,32 @@
         },
 
         async open(examId, options = {}) {
-            if (!examId) return;
+            if (!examId && !options.notebook) return;
 
             const overlay = this.ensureOverlay();
             const requestId = ++this._openRequestId;
+            this._openOptions = { ...options };
             const initiatingElement = options.returnFocus || document.activeElement;
             if (initiatingElement && !overlay.contains(initiatingElement)) this._returnFocus = initiatingElement;
             this.unbindEvents();
             this.bindEvents(overlay);
             this.clearPendingWork(overlay);
             this.currentExamId = examId;
+            this.currentSource = options.source ? { ...options.source } : { ...DEFAULT_SOURCE };
+            this.currentSourceLabel = options.source?.kind === 'imported' ? `导入题库 · ${options.source.id}` : '内置题库';
+            this._sourceReady = false;
             this.currentExam = null;
+            this.currentContentRef = null;
             this.currentPayload = null;
             this.currentExplanation = null;
             this.closeModal(false);
             this.modalTab = 'current';
             overlay.querySelector('#v-tab-current')?.classList.add('active');
             overlay.querySelector('#v-tab-all')?.classList.remove('active');
+            overlay.querySelector('#v-tab-current').disabled = !examId;
+            ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                overlay.querySelector(selector).disabled = true;
+            });
             const manualInput = overlay.querySelector('#vocab-manual-input');
             if (manualInput) manualInput.value = '';
 
@@ -1014,6 +1149,9 @@
             if (options && options.fromPractice) {
                 if (backBtnText) backBtnText.textContent = '返回练习';
                 if (backBtn) backBtn.title = '返回练习试卷';
+            } else if (options.fromView === 'bookshelf') {
+                if (backBtnText) backBtnText.textContent = '返回书架';
+                if (backBtn) backBtn.title = '返回阅读书架';
             } else {
                 if (backBtnText) backBtnText.textContent = '返回题库';
                 if (backBtn) backBtn.title = '返回题库浏览';
@@ -1039,53 +1177,98 @@
                 if (element) element.textContent = '';
             });
             this.switchViewTab('all');
+            this.updateCounts();
 
             try {
+                if (options.notebook) {
+                    await ReadingVocabStore.init();
+                    if (requestId !== this._openRequestId) return;
+                    this._sourceReady = true;
+                    this.currentExam = { title: '全部精读生词' };
+                    titleEl.textContent = '全部精读生词';
+                    passageContent.textContent = '查看、删除或导出全部文章的精读生词。';
+                    this.modalTab = 'all';
+                    overlay.querySelector('#v-tab-current').classList.remove('active');
+                    overlay.querySelector('#v-tab-all').classList.add('active');
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                    this.openModal();
+                    return;
+                }
                 // 加载试卷数据
                 const source = await ReadingVocabStore.resolveSource(options);
                 if (requestId !== this._openRequestId) return;
                 this.currentSource = source;
-                const payload = await loadReadingExamPayload(examId);
+                this.currentSourceLabel = source.kind === 'imported' ? `导入题库 · ${source.id}` : '内置题库';
+                const articleId = global.AppData.vocab.readingModel.articleId(source, String(examId));
+                if (options.articleId && options.articleId !== articleId) {
+                    throw new Error('文章与题库来源不匹配，请从原书架条目重新打开');
+                }
+                this._sourceReady = true;
+                this.currentExam = { title: options.title || examId };
+                await ReadingVocabStore.init();
+                if (requestId !== this._openRequestId) return;
+                const storedArticle = ReadingVocabStore._state.snapshot.reading.articles.find(article => article.id === articleId);
+                const resolved = await resolveReadingArticle(examId, source);
+                if (requestId !== this._openRequestId) return;
+                this.currentSourceLabel = resolved.sourceLabel;
+                this.currentExam = { ...this.currentExam, ...(resolved.exam || {}) };
+                this.renderIdentity();
+                if (!resolved.exam) throw new Error(resolved.unavailableReason || '原题库或文章已移除，已保存的生词仍可查看或导出');
+                const contentRef = global.AppData.vocab.readingModel.contentRef(source.kind === 'builtin'
+                    ? { sourceKind: 'generated-reading', dataKey: resolved.generatedKey } : resolved.exam);
+                const storedRefs = storedArticle?.contentRefs || [];
+                if (storedRefs.length > 1 || (storedRefs.length === 1 && storedRefs[0] !== contentRef)
+                    || (options.contentRef && options.contentRef !== contentRef)) {
+                    throw new Error('原题库的文章文件已更改或来源记录冲突，已保存的生词仍可查看或导出');
+                }
+                this.currentContentRef = contentRef;
+                const expectedTitle = options.title || storedArticle?.title;
+                const normalizeTitle = title => String(title || '').trim().replace(/\s+/g, ' ');
+                if (expectedTitle && resolved.exam.title && normalizeTitle(expectedTitle) !== normalizeTitle(resolved.exam.title)) {
+                    throw new Error('原题库中的文章已更改，已保存的生词仍可查看或导出');
+                }
+                const payload = resolved.generatedKey
+                    ? await loadReadingExamPayload(resolved.generatedKey)
+                    : await loadImportedReadingPayload(resolved.exam);
                 if (requestId !== this._openRequestId) return;
                 if (!payload) {
                     throw new Error('未找到该试卷的数据文件');
-                }
-                // The current payload registry contains only built-in generated
-                // content. Never attach that content to a different library.
-                if (source.kind !== 'builtin' || source.id !== 'default') {
-                    throw new Error('此来源的全文暂不可用，可在书架中查看或导出生词');
                 }
                 this.currentPayload = payload;
                 this.currentSource = source;
 
                 // 异步加载解析（不阻塞主内容）
-                loadReadingExplanationPayload(examId).then(exp => {
+                if (resolved.generatedKey) loadReadingExplanationPayload(resolved.generatedKey).then(exp => {
                     if (requestId !== this._openRequestId) return;
                     this.currentExplanation = exp;
                     this.enhanceWithExplanation(exp);
                 }).catch(() => {});
 
                 // 获取 Exam Meta
-                const manifest = global.__READING_EXAM_MANIFEST__ || {};
-                const manifestEntry = manifest[examId] || {};
-                this.currentExam = Object.assign({}, manifestEntry, payload.meta || {});
+                this.currentExam = Object.assign({}, payload.meta || {}, resolved.exam);
 
                 // 记录至阅读书架
                 const examTitle = this.currentExam.title || this.currentExam.name || examId;
                 const examCategory = this.currentExam.category || this.currentExam.type || '雅思阅读';
                 let saveError = null;
                 try {
-                    await ReadingVocabStore.init();
-                    if (requestId !== this._openRequestId) return;
-                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source);
+                    await recordBookshelfExamDirect(examId, examTitle, examCategory, source, contentRef);
                 } catch (error) {
                     saveError = error;
                 }
                 if (requestId !== this._openRequestId) return;
+                const committedRefs = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId)?.contentRefs || [];
+                if (committedRefs.length > 1 || (committedRefs.length === 1 && committedRefs[0] !== contentRef)) {
+                    throw new Error('原题库的来源记录已更改，已保存的生词仍可查看或导出');
+                }
 
                 // 渲染界面
                 this.renderContent();
                 this.updateCounts();
+                ['#vocab-manual-input', '#vocab-manual-add-btn', '#vocab-export-btn', '#vocab-clear-btn'].forEach(selector => {
+                    overlay.querySelector(selector).disabled = false;
+                });
                 if (saveError) this.showSaveError(saveError, '书架记录保存失败，请重新打开文章重试');
             } catch (err) {
                 if (requestId !== this._openRequestId) return;
@@ -1093,12 +1276,22 @@
                 this.currentPayload = null;
                 await ReadingVocabStore.init().catch(() => {});
                 if (requestId !== this._openRequestId) return;
+                if (this._sourceReady) {
+                    const articleId = global.AppData.vocab.readingModel.articleId(this.currentSource, String(examId));
+                    const stored = ReadingVocabStore._state?.snapshot.reading.articles.find(article => article.id === articleId);
+                    this.currentExam = { ...(this.currentExam || {}), title: options.title || stored?.title || this.currentExam?.title || examId };
+                    overlay.querySelector('#vocab-export-btn').disabled = false;
+                    overlay.querySelector('#vocab-clear-btn').disabled = false;
+                }
+                this.renderIdentity();
                 this.applyVocabHighlights();
                 this.updateCounts();
                 if (passageContent) {
                     const errorState = document.createElement('div');
                     errorState.className = 'vocab-error-state';
                     const message = document.createElement('p');
+                    errorState.setAttribute('role', 'status');
+                    errorState.dataset.sourceUnavailable = 'true';
                     message.textContent = `⚠️ 载入文章数据失败：${err.message || '请检查网络或试卷配置'}`;
                     const retry = document.createElement('button');
                     retry.type = 'button';
@@ -1112,16 +1305,25 @@
                     retry.addEventListener('click', handleRetry);
                     this._eventCleanups.push(() => retry.removeEventListener('click', handleRetry));
                     errorState.append(message, retry);
+                    const review = document.createElement('button');
+                    review.type = 'button';
+                    review.textContent = '查看已保存生词';
+                    const handleReview = () => this.openModal();
+                    review.addEventListener('click', handleReview);
+                    this._eventCleanups.push(() => review.removeEventListener('click', handleReview));
+                    errorState.append(review);
                     passageContent.replaceChildren(errorState);
                 }
             }
         },
 
-        renderContent() {
-            const overlay = this.ensureOverlay();
-            const exam = this.currentExam;
-            const payload = this.currentPayload;
+        openNotebook(options = {}) {
+            return this.open(null, { ...options, notebook: true });
+        },
 
+        renderIdentity() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam || {};
             // 标题与标签（紧凑精致）
             const titleEl = overlay.querySelector('#vocab-reader-title');
             const badgesEl = overlay.querySelector('#vocab-reader-badges');
@@ -1133,9 +1335,17 @@
             if (badgesEl) {
                 badgesEl.innerHTML = `
                     <span class="vocab-badge vocab-badge--cat">${escapeHtml(exam.category || '阅读')}</span>
+                    <span class="vocab-badge vocab-badge--source">${escapeHtml(this.currentSourceLabel)}</span>
                     ${exam.frequency ? `<span class="vocab-badge vocab-badge--freq">${escapeHtml(exam.frequency)}</span>` : ''}
                 `;
             }
+        },
+
+        renderContent() {
+            const overlay = this.ensureOverlay();
+            const exam = this.currentExam;
+            const payload = this.currentPayload;
+            this.renderIdentity();
 
             // 解析文章大标题、考试指导语与真实段落
             const passageData = global.ReadingVocabContent.normalizePassage(payload?.passage, exam.title || '');
@@ -1332,7 +1542,7 @@
             this.showToast('正在保存…');
             try {
                 const result = await ReadingVocabStore.add(captured.word, this.currentExamId,
-                    this.currentExam?.title || '', captured.context, captured, this.currentSource);
+                    this.currentExam?.title || '', captured.context, captured, this.currentSource, this.currentContentRef);
                 if (requestId !== this._openRequestId) return;
                 if (!result.added) throw new Error('Selection was not saved');
                 selection.removeAllRanges();
@@ -1442,7 +1652,7 @@
                 // Keep the acknowledged deletion fence: a later clear/replace must
                 // reject this undo instead of resurrecting deleted relationships.
                 const committedRevision = result.revisions?.['vocab.readingState'];
-                this._undoOccurrence = result.changed !== false && Number.isInteger(committedRevision)
+                this._undoOccurrence = !owner.contentAmbiguous && result.changed !== false && Number.isInteger(committedRevision)
                     ? { command: undo, observed: { revision: committedRevision, generation: observed.generation } } : null;
                 this.ensureOverlay().querySelector('#vocab-occurrence-actions').replaceChildren();
                 this.ensureOverlay().querySelector('#vocab-occurrence-undo').innerHTML =
@@ -1577,7 +1787,7 @@
         updateCounts() {
             const overlay = this.ensureOverlay();
             const examId = this.currentExamId;
-            const currentList = ReadingVocabStore.getByExam(examId, this.currentSource);
+            const currentList = this._sourceReady ? ReadingVocabStore.getByExam(examId, this.currentSource) : [];
             const allList = ReadingVocabStore.getAll();
 
             const headerCount = overlay.querySelector('#vocab-header-count');
@@ -1599,7 +1809,7 @@
 
             const isCurrent = this.modalTab === 'current';
             const list = isCurrent
-                ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource)
+                ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();
 
             if (!list || list.length === 0) {
@@ -1662,7 +1872,8 @@
                 this.renderVocabList();
                 modal.classList.add('active');
                 modal.setAttribute('aria-hidden', 'false');
-                modal.querySelector('#vocab-manual-input')?.focus({ preventScroll: true });
+                const input = modal.querySelector('#vocab-manual-input');
+                (input && !input.disabled ? input : modal.querySelector('#vocab-modal-close'))?.focus({ preventScroll: true });
             }
         },
 
@@ -1713,6 +1924,12 @@
             }
             document.body.classList.remove('vocab-reader-open');
             if (this._returnFocus?.isConnected) this._returnFocus.focus({ preventScroll: true });
+            else if (this._openOptions?.fromView === 'bookshelf') {
+                const card = [...document.querySelectorAll('[data-article-id]')]
+                    .find(element => element.dataset.articleId === this._openOptions.articleId);
+                (card?.querySelector('button[data-action="open-reading-vocab"]')
+                    || document.querySelector('[data-action="open-global-notebook"]'))?.focus({ preventScroll: true });
+            }
             this._returnFocus = null;
         }
     };
@@ -1720,7 +1937,7 @@
     // 监听生词更新事件以即时刷新打开的视图
     if (typeof window !== 'undefined') {
         window.addEventListener('reading-vocab-store-updated', () => {
-            if (ReadingVocabReader.currentExamId) {
+            if (ReadingVocabReader._sourceReady && !document.getElementById('reading-vocab-reader-overlay')?.classList.contains('is-hidden')) {
                 ReadingVocabReader.updateCounts();
                 ReadingVocabReader.applyVocabHighlights();
                 if (ReadingVocabReader.modalOpen) ReadingVocabReader.renderVocabList();

--- a/js/data/v2/readingVocabularyModel.js
+++ b/js/data/v2/readingVocabularyModel.js
@@ -65,6 +65,13 @@
     }
 
     function articleId(source, examId) { return key('article', sourceId(source), nonempty(examId, 'examId')); }
+    function contentRef(exam) {
+        object(exam, 'exam');
+        return key(...['sourceKind', 'dataKey', 'path', 'filename', 'importKey'].map((field) => {
+            const value = typeof exam[field] === 'string' ? exam[field].trim() : '';
+            return field === 'path' || field === 'filename' ? value.replace(/\\/g, '/') : value;
+        }));
+    }
     function termId(word) { return key('term', normalizeTerm(word)); }
     function associationId(article, term) { return key('association', article, term); }
 
@@ -153,6 +160,18 @@
             const source = idx.sources.get(article.sourceId);
             if (!source || article.id !== articleId({ kind: source.kind, id: source.libraryId }, article.examId)) fail('Invalid article source or identity');
             if (typeof article.title !== 'string') fail('Article title must be a string');
+            if (own(article, 'contentRefs')) {
+                if (!Array.isArray(article.contentRefs)) fail('Article contentRefs must be an array');
+                const refs = new Set();
+                for (const ref of article.contentRefs) {
+                    exactString(ref, 'article.contentRefs entry');
+                    if (refs.has(ref)) fail('Article contentRefs must be unique');
+                    refs.add(ref);
+                }
+                if (article.contentRefs.some((ref, index) => index > 0 && article.contentRefs[index - 1] > ref)) {
+                    fail('Article contentRefs must be sorted');
+                }
+            }
             timestamp(article.createdAt, 'article.createdAt');
             timestamp(article.updatedAt, 'article.updatedAt');
             if (article.createdAt > article.updatedAt) fail('Article timestamps are out of order');
@@ -228,10 +247,15 @@
         const articleKey = articleId(source, article.examId);
         const hasTitle = own(article, 'title');
         if (hasTitle && typeof article.title !== 'string') fail('article.title must be a string');
+        const ref = own(article, 'contentRef') ? exactString(article.contentRef, 'article.contentRef') : null;
         if (!snapshot.reading.sources.some((row) => row.id === sourceKey)) {
             snapshot.reading.sources.push({ id: sourceKey, kind: source.kind, libraryId: source.id.trim() });
         }
         let row = snapshot.reading.articles.find((item) => item.id === articleKey);
+        if (row && ref !== null && row.contentRefs && (row.contentRefs.length > 1
+            || (row.contentRefs.length === 1 && row.contentRefs[0] !== ref))) {
+            fail('Article content reference has changed or is ambiguous');
+        }
         if (!row) {
             row = {
                 id: articleKey, sourceId: sourceKey, examId: article.examId.trim(),
@@ -248,6 +272,7 @@
             row.createdAt = at < row.createdAt ? at : row.createdAt;
             row.updatedAt = at > row.updatedAt ? at : row.updatedAt;
         }
+        if (ref !== null) row.contentRefs = [ref];
         return row;
     }
 
@@ -559,6 +584,13 @@
                         { title: incomingRow.title, titleUpdatedAt: incomingRow.titleUpdatedAt }, 'titleUpdatedAt');
                     merged.title = title.title;
                     merged.titleUpdatedAt = title.titleUpdatedAt;
+                    if (own(existing, 'contentRefs') || own(incomingRow, 'contentRefs')) {
+                        // Conflicting backups retain every binding so a reader
+                        // cannot silently select a different content source.
+                        merged.contentRefs = [...new Set([
+                            ...(existing.contentRefs || []), ...(incomingRow.contentRefs || [])
+                        ])].sort();
+                    }
                 } else if (existing && table === 'associations') {
                     merged.manual = existing.manual || incomingRow.manual;
                 } else if (existing && table === 'visits') {
@@ -603,7 +635,7 @@
     }
 
     const model = Object.freeze({
-        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, termId, occurrenceId,
+        SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
         clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
     });

--- a/js/main.js
+++ b/js/main.js
@@ -3601,15 +3601,43 @@ function createFallbackExamCard(exam, options = {}) {
             vocabBtn.className = 'btn btn-outline exam-item-action-btn exam-item-vocab-btn';
             vocabBtn.type = 'button';
             vocabBtn.dataset.action = 'vocab-book';
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
             vocabBtn.dataset.examId = exam.id;
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && window.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = window.AppData.vocab.readingModel.contentRef(exam);
+                }
+            }
             vocabBtn.textContent = '精读';
             vocabBtn.title = '打开该题全文精读与生词本';
-            vocabBtn.addEventListener('click', function (e) {
+            vocabBtn.addEventListener('click', async function (e) {
                 e.preventDefault();
-                if (window.ReadingVocabReader && typeof window.ReadingVocabReader.open === 'function') {
-                    window.ReadingVocabReader.open(exam.id);
-                } else if (typeof window.openReadingVocabReader === 'function') {
-                    window.openReadingVocabReader(exam.id);
+                e.stopPropagation();
+                const navigation = window.__getAppNavigationIntentGeneration?.();
+                try {
+                    if (!Object.prototype.hasOwnProperty.call(vocabBtn.dataset, 'libraryConfigurationId')) {
+                        vocabBtn.dataset.libraryConfigurationId = await window.AppData.library.getActive() || '';
+                    }
+                    if (typeof window.launchBrowseReadingVocab !== 'function'
+                        && window.AppLazyLoader?.ensureGroup) {
+                        await window.AppLazyLoader.ensureGroup('browse-runtime');
+                    }
+                    if (navigation != null && navigation !== window.__getAppNavigationIntentGeneration()) return;
+                    if (typeof window.launchBrowseReadingVocab === 'function') {
+                        await window.launchBrowseReadingVocab(exam.id, vocabBtn);
+                    } else if (typeof window.ReadingVocabReader?.open === 'function') {
+                        await window.ReadingVocabReader.open(exam.id, {
+                            returnFocus: vocabBtn, fromView: 'browse', title: exam.title || exam.name || '',
+                            contentRef: vocabBtn.dataset.contentRef || '',
+                            libraryConfigurationId: vocabBtn.dataset.libraryConfigurationId || null
+                        });
+                    } else {
+                        throw new Error('Reading vocabulary reader is unavailable');
+                    }
+                } catch (error) {
+                    console.warn('[Browse] Opening intensive reading failed:', error);
+                    if (typeof window.showMessage === 'function') window.showMessage('未能打开精读，请重试。', 'warning');
                 }
             });
             actions.appendChild(vocabBtn);

--- a/js/presentation/app-actions.js
+++ b/js/presentation/app-actions.js
@@ -1044,8 +1044,17 @@
         openBookshelf: openBookshelf
     });
 
+    var bookshelfOpenSequence = 0;
+
     function openBookshelf(options) {
-        var fromView = (options && options.fromView) || 'overview';
+        var sequence = ++bookshelfOpenSequence;
+        var fromView = (options && options.fromView) || global.app?.currentView || 'overview';
+        var navigation = typeof global.__getAppNavigationIntentGeneration === 'function'
+            ? global.__getAppNavigationIntentGeneration() : null;
+        var isCurrent = function () {
+            return sequence === bookshelfOpenSequence && (navigation == null
+                || navigation === global.__getAppNavigationIntentGeneration());
+        };
         return Promise.resolve().then(function () {
             if (global.AppEntry && typeof global.AppEntry.ensureMoreToolsGroup === 'function') {
                 return global.AppEntry.ensureMoreToolsGroup();
@@ -1055,6 +1064,15 @@
             }
             return null;
         }).then(function () {
+            if (!isCurrent()) return;
+            if (global.AppLazyLoader && typeof global.AppLazyLoader.ensureGroup === 'function') {
+                return global.AppLazyLoader.ensureGroup('exam-data');
+            }
+        }).then(function () {
+            if (!isCurrent()) return;
+            if (!global.BookshelfView || typeof global.BookshelfView.mount !== 'function') {
+                throw new Error('Bookshelf component is unavailable');
+            }
             var bookshelfView = document.getElementById('bookshelf-view');
             if (bookshelfView) {
                 bookshelfView.removeAttribute('hidden');
@@ -1083,6 +1101,7 @@
                 moreNavBtn.classList.add('active');
             }
         }).catch(function (error) {
+            if (!isCurrent()) return;
             console.warn('[AppActions] 打开书架失败:', error);
             if (typeof global.showMessage === 'function') {
                 global.showMessage('未能打开阅读书架，请稍后重试。', 'warning');
@@ -1092,6 +1111,18 @@
 
     // 挂载到全局（向后兼容）
     global.openBookshelfView = openBookshelf;
+    // The More card is visible before more-tools has finished loading. Accept
+    // that first click in the resident runtime; the mounted handler prevents
+    // default itself, so warm clicks still have exactly one owner.
+    if (typeof document !== 'undefined') {
+        document.addEventListener('click', function (event) {
+            if (event.defaultPrevented) return;
+            var target = event.target?.closest?.('[data-action="open-bookshelf"]');
+            if (!target || !target.closest('#more-view')) return;
+            event.preventDefault();
+            openBookshelf({ fromView: 'more' });
+        });
+    }
     global.startSuitePractice = startSuitePractice;
     global.continueSuitePractice = continueSuitePractice;
     global.openExamWithFallback = openExamWithFallback;

--- a/js/presentation/moreView.js
+++ b/js/presentation/moreView.js
@@ -155,9 +155,12 @@
         if (event && typeof event.preventDefault === 'function') {
             event.preventDefault();
         }
+        if (typeof global.AppActions?.openBookshelf === 'function') {
+            return global.AppActions.openBookshelf({ fromView: 'more' });
+        }
         var mountView = function () {
             if (global.BookshelfView && typeof global.BookshelfView.mount === 'function') {
-                global.BookshelfView.mount('#bookshelf-view');
+                global.BookshelfView.mount('#bookshelf-view', { fromView: 'more' });
             }
         };
 

--- a/js/runtime/unifiedReadingPage.js
+++ b/js/runtime/unifiedReadingPage.js
@@ -2263,20 +2263,39 @@
         }
     }
 
-    function openVocabReaderForCurrentExam() {
+    let vocabReaderOpenRequest = 0;
+    async function openVocabReaderForCurrentExam() {
         const examId = state.suite?.activeExamId || state.examId;
         if (!examId) {
             console.warn('[UnifiedReadingPage] 无法获取当前试卷 ID');
             return;
         }
+        const requestId = ++vocabReaderOpenRequest;
+        const returnFocus = document.activeElement;
+        const options = { fromPractice: true, returnFocus,
+            title: state.dataset?.meta?.title || examId,
+            libraryConfigurationId: state.libraryConfigurationId };
         ensureVocabReaderStyles();
-
-        if (global.ReadingVocabReader && typeof global.ReadingVocabReader.open === 'function') {
-            global.ReadingVocabReader.open(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
-        } else if (typeof global.openReadingVocabReader === 'function') {
-            global.openReadingVocabReader(examId, { fromPractice: true, libraryConfigurationId: state.libraryConfigurationId });
-        } else {
-            console.warn('[UnifiedReadingPage] ReadingVocabReader 模块未加载');
+        try {
+            if (!global.ReadingVocabReader && global.AppLazyLoader?.ensureGroup) {
+                await global.AppLazyLoader.ensureGroup('exam-data');
+                await global.AppLazyLoader.ensureGroup('browse-runtime');
+            }
+            if (requestId !== vocabReaderOpenRequest) return;
+            if (!global.ReadingVocabReader?.open) throw new Error('Reading vocabulary reader is unavailable');
+            document.getElementById('reading-vocab-load-status')?.remove();
+            await global.ReadingVocabReader.open(examId, options);
+        } catch (error) {
+            if (requestId !== vocabReaderOpenRequest) return;
+            console.warn('[UnifiedReadingPage] 生词本加载失败:', error);
+            let status = document.getElementById('reading-vocab-load-status');
+            if (!status) {
+                status = document.createElement('p');
+                status.id = 'reading-vocab-load-status';
+                status.setAttribute('role', 'status');
+                document.querySelector('.header-right')?.appendChild(status);
+            }
+            status.textContent = '生词本加载失败，请再次点击生词本重试。';
         }
     }
 

--- a/js/services/libraryManager.js
+++ b/js/services/libraryManager.js
@@ -294,7 +294,7 @@
             }
             return this.normalizeIndexForCustomConfig(
                 this.getDefaultReadingIndex().concat(this.resolveDefaultTypeIndex('listening'))
-            );
+            ).map((exam) => ({ ...exam, libraryConfigurationId: null }));
         }
 
         async resolveIndexForConfiguration(configurationId) {
@@ -303,7 +303,8 @@
                 ? configurationId.trim()
                 : null;
             if (id === null) return this.resolveDefaultIndex();
-            return this.normalizeIndexForCustomConfig(await global.AppData.library.getIndex(id));
+            return this.normalizeIndexForCustomConfig(await global.AppData.library.getIndex(id))
+                .map((exam) => ({ ...exam, libraryConfigurationId: id }));
         }
 
         getRecordLibraryProvenance(record) {
@@ -387,7 +388,8 @@
             }
 
             if (!isDefaultConfig && Array.isArray(cachedData) && cachedData.length > 0) {
-                const updatedIndex = this.normalizeIndexForCustomConfig(cachedData);
+                const updatedIndex = this.normalizeIndexForCustomConfig(cachedData)
+                    .map((exam) => ({ ...exam, libraryConfigurationId: activeConfigKey }));
                 if (typeof global.assignExamSequenceNumbers === 'function') global.assignExamSequenceNumbers(updatedIndex);
                 await this.savePathMapForConfiguration(activeConfigKey, updatedIndex, { setActive: true });
                 this.finishLibraryLoading(startTime, updatedIndex);
@@ -425,7 +427,8 @@
                     return [];
                 }
 
-                const combined = cloneArray(readingExams).concat(listeningExams);
+                const combined = cloneArray(readingExams).concat(listeningExams)
+                    .map((exam) => ({ ...exam, libraryConfigurationId: null }));
                 if (typeof global.assignExamSequenceNumbers === 'function') {
                     global.assignExamSequenceNumbers(combined);
                 }
@@ -714,7 +717,10 @@
         }
 
         async applyLibraryConfiguration(key, dataset, options = {}) {
-            const exams = Array.isArray(dataset) ? dataset.slice() : await this.fetchLibraryDataset(key);
+            const configurationId = typeof key === 'string' && key.trim() ? key.trim() : null;
+            const rawExams = Array.isArray(dataset) ? dataset : await this.fetchLibraryDataset(key);
+            const exams = Array.isArray(rawExams)
+                ? rawExams.map((exam) => ({ ...exam, libraryConfigurationId: configurationId })) : [];
             if (!Array.isArray(exams) || exams.length === 0) {
                 if (typeof global.showMessage === 'function') {
                     global.showMessage('目标题库没有题目，请先加载数据', 'warning');

--- a/js/views/legacyViewBundle.js
+++ b/js/views/legacyViewBundle.js
@@ -2855,6 +2855,13 @@
                 type: 'button',
                 title: '打开该题全文精读与生词本'
             }, '精读');
+            vocabBtn.dataset.examTitle = exam.title || exam.name || '';
+            if (Object.prototype.hasOwnProperty.call(exam, 'libraryConfigurationId')) {
+                vocabBtn.dataset.libraryConfigurationId = exam.libraryConfigurationId || '';
+                if (exam.libraryConfigurationId && global.AppData?.vocab?.readingModel?.contentRef) {
+                    vocabBtn.dataset.contentRef = global.AppData.vocab.readingModel.contentRef(exam);
+                }
+            }
             if (isSelecting) {
                 vocabBtn.disabled = true;
                 vocabBtn.setAttribute('aria-disabled', 'true');


### PR DESCRIPTION
Fresh More → Bookshelf entry opens intensive reading without a prior Browse visit, including visited articles with zero words. Browse and practice entries preserve the original library, article, and return location.

- Use the lazy-loader contract, accept the first click while More tools load, and discard stale article/navigation requests.
- Derive article/global counts from distinct associated terms, search every associated word, and refresh source metadata and vocabulary after mutations, backup restore, and cross-window commits.
- Resolve original imported content and persist optional content-reference bindings. Changed or ambiguous sources remain unavailable while saved vocabulary stays reviewable/exportable. Sanitize imported fragments and preserve original image URLs.
- Validate the persisted title independently of the initiating Browse title. Normalize string, id, key, and configId configurations for both original-library selection and import-key collision detection.
- Preserve zero-word visits, article-scoped clearing, canonical review data, and entrypoint return focus. Rebuild the affected runtime bundles.
- Retain per-case logs, incremental reports, and timestamped Bookshelf substeps; clean up timed-out process trees. Use version-matched Node headless browsers and run isolated HTTP, HTTPS, and file protocol contexts concurrently. All 18 Bookshelf groups and the 180-second case/30-minute job limits remain in place.

Closes #159. References #149; #160 retains the combined release gate.

## Current revision

- Head: `73b1010ac7ed3469a97e4439422eb2e140d9522d`
- Review fixes and CI follow-ups are GPG-signed; signatures verified locally and by GitHub.

## Validation

- JavaScript unit and regression suite: 321 passed.
- Python unit suite: 32 passed, including real process-tree timeout cleanup and incremental report regressions.
- Bundle consistency: all 14 outputs current.
- Reading-data integrity: passed with only the existing allowlisted duplicate.
- Bookshelf production regression: all 18 groups passed locally with both current Chromium and the CI-matching Playwright 1.56.1 / Chromium 141.0.7390.37.
- [Complete Ubuntu CI](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34252899779): all checks passed on this head. Unified E2E: 12/12 passed in 313.08 seconds; all 18 Bookshelf groups passed within its 78.33-second case. Diagnostics were uploaded successfully. GitGuardian also passed.

The [entrypoint contract and acceptance matrix](developer/doc/Intensive-Reading-Entrypoints.md) document supported source behavior and the optional backward-compatible article binding. Actual hosted deployment, release-package qualification, TXT format/import compatibility, and aggregate v1 acceptance remain in #160; this PR does not close #149.

