### PR TITLE
feat(reading): export canonical TXT and qualify the v1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -56,6 +58,13 @@ jobs:
         timeout-minutes: 15
         run: python developer/tests/e2e/e2e_runner.py
 
+      - name: Qualify fresh intensive-reading release package
+        timeout-minutes: 6
+        env:
+          READING_RELEASE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          READING_RELEASE_REVIEWED_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: python developer/tests/ci/qualify_reading_release.py
+
       - name: Upload E2E diagnostics
         if: always()
         timeout-minutes: 3
@@ -66,5 +75,6 @@ jobs:
             developer/tests/e2e/reports/**/*.json
             developer/tests/e2e/reports/**/*.log
             developer/tests/e2e/reports/**/*.png
+            developer/tests/e2e/reports/**/*.txt
           if-no-files-found: ignore
           retention-days: 14

--- a/developer/doc/Intensive-Reading-Release.md
+++ b/developer/doc/Intensive-Reading-Release.md
@@ -1,0 +1,146 @@
+# Intensive Reading v1: TXT and release qualification
+
+This is the release contract for [#160](https://github.com/sallowayma-git/IELTS-practice/issues/160).
+It combines the [vocabulary model](Intensive-Reading-Vocabulary-Contract.md),
+[persistence](Intensive-Reading-Persistence.md),
+[selection anchors](Intensive-Reading-Anchors.md), and
+[entrypoints](Intensive-Reading-Entrypoints.md) contracts. The release PR targets
+current `opensource`, references parent [#149](https://github.com/sallowayma-git/IELTS-practice/issues/149),
+and closes #160 only when its prerequisites and the combined gate pass. Parent
+#149 remains open until its full v1 acceptance is accepted.
+
+## TXT contract
+
+Exports contain UTF-8 plain text, one term per line, with LF separators, no BOM,
+header, rich fields, or trailing newline. Each line uses the associated existing
+canonical vocabulary record's display term. All whitespace runs in that display
+term, including embedded CR/LF and Unicode line separators, become one space;
+leading and trailing whitespace is removed. A multiline term cannot inject
+another TXT entry. Export does not rewrite canonical vocabulary or review data.
+
+Current-article export selects associations for the original source and article
+identity. The explicitly labeled all-intensive-reading export selects the
+distinct union of every article association. It includes manual additions and
+selected occurrences, deduplicates by canonical term identity, and is independent
+of Bookshelf filters. Unrelated review vocabulary and terms without remaining
+reading associations are excluded. Missing-source articles retain downloadable
+vocabulary.
+
+Order is ascending by the model's `normalizedTerm`, using JavaScript UTF-16 code
+unit comparison rather than locale collation. Canonical identity normalization
+is defined in the model contract; export's whitespace formatting does not change
+that identity. Clearing A preserves shared terms associated with B and changes
+the A/global exports accordingly. Export uses acknowledged AppData state after
+migration, concurrent changes, backup merge/replace, and reload. Empty results
+produce no download or success acknowledgement; the UI explains that there are
+no intensive-reading terms to export.
+
+The tested format is plain UTF-8 TXT. No named third-party importer compatibility
+is claimed. Such a claim requires a separately recorded actual import with the
+application/version, field mapping, fixture, and observed result. Rich-field Anki
+TSV, AI analysis, and cross-device synchronization are outside this v1 gate.
+
+## Required checks
+
+Run from the repository root. CI uses Node.js 22 and Python 3, with dependencies
+installed from `developer/package-lock.json` and Python Playwright 1.56.0. Install
+the Chromium revisions required by both Playwright packages. HTTPS fixtures also
+require OpenSSL; Windows tests can use Git for Windows' bundled executable or
+`OPENSSL_EXECUTABLE_PATH`. `PLAYWRIGHT_EXECUTABLE_PATH` can select a browser; record
+its actual version in the evidence.
+
+```sh
+npm ci --prefix developer
+python -m pip install playwright==1.56.0
+python -m playwright install chromium
+node developer/node_modules/playwright/cli.js install chromium --only-shell
+
+node scripts/build-bundles.mjs
+node scripts/build-bundles.mjs --check
+npm test --prefix developer
+python -m unittest discover -s developer/tests/py -p "test_*.py"
+python developer/tests/ci/check_reading_data_integrity.py
+python developer/tests/e2e/e2e_runner.py
+```
+
+The checked-in CI workflow is authoritative for required jobs. The older static
+aggregator can additionally be run with
+`python developer/tests/ci/run_static_suite.py`; it does not replace the formal
+`npm test --prefix developer` entry point or the current CI checks.
+
+After committing source and regenerated bundles, qualify that clean revision:
+
+```sh
+python developer/tests/ci/qualify_reading_release.py
+```
+
+The qualifier records `baseSha`, the actually tested revision in `headSha`, and
+the reviewed PR revision in `reviewedHeadSha`, plus worktree cleanliness,
+commands, runtime versions, archive SHA-256, and a manifest matching every
+extracted file to the corresponding source bytes. Every packaged runtime file
+must be tracked by Git; ignored or untracked local assets cannot qualify an exact
+Git revision. Set `READING_RELEASE_BASE_SHA` to the reviewed base SHA when it
+differs from the merge base with `origin/opensource`, and set
+`READING_RELEASE_REVIEWED_HEAD_SHA` when the tested revision is a CI merge commit
+rather than the reviewed PR head. It invokes
+the platform release script, extracts into a fresh temporary directory, and runs
+`reading_txt_release.node.js` against that extracted root. Browser reports and
+logs are retained under `developer/tests/e2e/reports/reading-release-package/`.
+A changed source or bundle revision requires another qualification run.
+
+## Package contract
+
+Windows uses `powershell -NoProfile -File developer/release.ps1 <version>`;
+Linux/macOS use `bash developer/release.sh <version>`. Both rebuild and check all
+14 generated bundles before packaging. Windows uses .NET ZIP support; the shell
+builder requires `zip` and `zipinfo`. A repeated version replaces only its own
+archive, retaining other versions and existing qualification evidence in `dist`.
+
+The ZIP contains `index.html`, CSS (including `vocab-reader.css`), `js/bundles`,
+runtime `assets` (including generated reading content/media, explanations,
+dictionaries, images, and the Three.js vendor file), and local `ReadingPractice`
+content when present. Developer files and test reports are not inputs. Runtime
+JavaScript source directories, Python/Markdown development files, Python bytecode
+(`*.pyc`) and `__pycache__` directories, temporary office files, and video files
+are excluded. Locally packaged `ReadingPractice` content is optional; untracked
+local content must be absent for the exact-revision qualifier. The default redistributable omits
+local listening libraries; `INCLUDE_LOCAL_LISTENING=1` requires their generated
+manifest and compatibility index before including available P1–P4 sources.
+
+Users extract the ZIP and open `index.html`, or serve the same extracted tree
+over local HTTP or static HTTPS. Node.js and development dependencies are only
+required by the build/test process, not by the extracted application. The
+package browser flow must traverse Browse → reader → select/manual add → close
+and reopen → cold Bookshelf entry → TXT download with fresh browser storage.
+
+## Evidence matrix
+
+The following maps requirements to executable checks; it is not a pass record.
+Publish observed outcomes in the PR after the fixed revision has been tested,
+using the generated JSON/logs. Include the full reviewed base and head SHA,
+browser/version, operating system, run mode, command, fixture names, result, and
+remaining limitations. If CI tests a synthetic merge revision, record that SHA
+separately from the reviewed PR head. Keeping exact run evidence in the PR and
+reports avoids changing the tested commit merely to record its own SHA.
+
+| Requirement | Command or suite | Fixture/evidence to record |
+| --- | --- | --- |
+| F1: practice answer and session isolation | `node developer/tests/e2e/reading_reader_isolation.node.js` (also unified E2E) | `p2-low-08`; radio/text/checkbox/select answers; question selection; repeated open/close; annotation, timer, recovery and score state in file/HTTP Chromium pages. |
+| F2: canonical A/B membership and review integration | Formal npm suite: `readingVocabularyModel`, `readingVocabularyTxtExport`, `bookshelfRemoveVocabIsolation`, persistence/backup suites | Shared canonical term, different source libraries with the same exam ID, repeated occurrences, manual membership, clear A/preserve B, retained review progress. |
+| F3: actual durable concurrency and failure acknowledgement | `npm run test:reading-persistence --prefix developer` (also formal npm suite) | Real Chromium IndexedDB; two stale readers; competing additions/deletions; replacement generation fences; quota/abort rollback; one-time migration; stale backup merge; empty replace, lazy initialization and reload. |
+| F4: complete content and exact DOM restoration | `node developer/tests/e2e/reading_reader_occurrences.node.js` (also unified E2E) | Existing `bodyHtml` and repeated-label articles, ordered blocks/headings, exact split-inline Range, mouse/touch/keyboard paths, remove/undo, missing/changed/ambiguous anchors. |
+| F5: reset failure protection and baseline data | Formal npm suite: `siteDataReset`, `externalBackupServiceV2`, annotation/vocabulary/recovery/timer/score regression files | Missing backup service fails closed; locking and write failures; canonical review data and established practice behavior. |
+| F6: cold Bookshelf entry and formal working directory | `npm test --prefix developer`; `node developer/tests/e2e/reading_bookshelf_entrypoints.node.js` (also unified E2E) | Fresh More → Bookshelf without Browse preload; reader entry/return, complete search/counts, missing-source export, file/HTTP/local static HTTPS. |
+| TXT and full source flow | `node developer/tests/e2e/reading_txt_release.node.js` (also unified E2E) | Actual downloaded UTF-8 bytes, article A/B/global scope, filters, migration, merge, empty replace, reload, missing source and empty download behavior in all three modes. |
+| Fresh extracted runtime | `python developer/tests/ci/qualify_reading_release.py` | Exact archive and asset hashes; source-byte equality; clean integrated SHA; the release/TXT browser flow against extracted assets only in all three modes. |
+| Full repository regression | Bundle check, formal npm suite, Python unit/data-integrity checks, unified E2E, package qualification | Final exit codes and counts plus required CI result at the recorded revision; preserve logs for any failed attempt and its corrected rerun. |
+
+The static HTTPS fixture uses an ephemeral local certificate and isolated
+Chromium contexts that ignore certificate validation. It verifies real TLS URL
+and browser behavior, but does not establish a public host deployment or trusted
+certificate configuration. Some existing DOM regression fixtures permit file
+access to fixture HTML; the release flow must separately prove built-in generated
+content and normal downloads from `file://` without relying on external source
+access. Imported plain HTML remains subject to the browser's file restrictions;
+an unavailable source must keep its vocabulary and show recoverable source state.
+Do not generalize a recorded Chromium run to untested browser engines or devices.

--- a/developer/release.ps1
+++ b/developer/release.ps1
@@ -87,9 +87,10 @@ function Test-ZipExcluded {
         if ($name -like '~$*') { return $true }
 
         $extension = [System.IO.Path]::GetExtension($name)
-        if ($extension -in @('.MOV', '.mov', '.MP4', '.mp4', '.md', '.py')) { return $true }
+        if ($extension -in @('.MOV', '.mov', '.MP4', '.mp4', '.md', '.py', '.pyc')) { return $true }
     }
 
+    if ($entry -match '(^|/)__pycache__(/|$)') { return $true }
     if ($entry -eq '.gitignore') { return $true }
     if ($entry -eq '.git' -or $entry.StartsWith('.git/', [System.StringComparison]::Ordinal)) { return $true }
     if ($entry -eq '.claude' -or $entry.StartsWith('.claude/', [System.StringComparison]::Ordinal)) { return $true }
@@ -250,15 +251,32 @@ if (-not (Test-Path -LiteralPath $BuildScript)) {
 if ($LASTEXITCODE -ne 0) {
     throw "bundle build failed with exit code $LASTEXITCODE"
 }
+& node $BuildScript --check
+if ($LASTEXITCODE -ne 0) {
+    throw "bundle verification failed with exit code $LASTEXITCODE"
+}
 Write-Host '       Bundles generated: js/bundles/'
 
 Write-Host ''
 Write-Host '[2/2] Creating distribution zip...'
 
-if (Test-Path -LiteralPath $DistDir) {
-    Remove-Item -LiteralPath $DistDir -Recurse -Force
+[void](New-Item -ItemType Directory -Path $DistDir -Force)
+if ((Get-Item -LiteralPath $DistDir).Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+    throw 'The release output directory must not be a symbolic link or junction.'
 }
-[void](New-Item -ItemType Directory -Path $DistDir)
+$resolvedDistDir = (Resolve-Path -LiteralPath $DistDir).Path
+$resolvedZipPath = [System.IO.Path]::GetFullPath($ZipPath)
+if (-not $resolvedDistDir.Equals((Join-Path $ProjectRoot 'dist'), [System.StringComparison]::OrdinalIgnoreCase) -or
+    -not [System.IO.Path]::GetDirectoryName($resolvedZipPath).Equals($resolvedDistDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw 'The release archive must remain inside the project dist directory.'
+}
+# Keep other release versions and extracted qualification evidence intact.
+if (Test-Path -LiteralPath $resolvedZipPath) {
+    if ((Get-Item -LiteralPath $resolvedZipPath).PSIsContainer) {
+        throw "The release archive path is a directory: $resolvedZipPath"
+    }
+    Remove-Item -LiteralPath $resolvedZipPath -Force
+}
 
 $zipInputs = [System.Collections.Generic.List[string]]::new()
 @('index.html', 'css', 'js/bundles', 'assets', 'ReadingPractice') | ForEach-Object {
@@ -302,9 +320,15 @@ Require-ZipEntry $zipEntries 'css/main.css'
 Require-ZipEntry $zipEntries 'css/heroui-bridge.css'
 Require-ZipEntry $zipEntries 'css/theme-switcher-scroll.css'
 Require-ZipEntry $zipEntries 'css/onboarding.css'
+Require-ZipEntry $zipEntries 'css/vocab-reader.css'
+Require-ZipEntry $zipEntries 'assets/images/favicon.svg'
+Require-ZipEntry $zipEntries 'assets/images/logo.svg'
 Require-ZipEntry $zipEntries 'assets/vendor/three.min.js'
+Require-ZipEntry $zipEntries 'assets/wordlists/ielts_core.bundle.js'
+Require-ZipEntry $zipEntries 'assets/wordlists/ecdict_reading.bundle.js'
 Require-ZipEntry $zipEntries 'assets/generated/reading-exams/manifest.js'
 Require-ZipEntry $zipEntries 'assets/generated/reading-exams/reading-practice-unified.html'
+Require-ZipEntry $zipEntries 'assets/generated/reading-explanations/manifest.js'
 Require-ZipEntry $zipEntries 'js/bundles/runtime-entry.bundle.js'
 Require-ZipEntry $zipEntries 'js/bundles/core-foundation.bundle.js'
 Require-ZipEntry $zipEntries 'js/bundles/ui-shell.bundle.js'
@@ -336,10 +360,13 @@ if ($IncludeLocalListening -and (Test-Path -LiteralPath (Join-Path $ProjectRoot 
 }
 
 Reject-ZipEntryPrefix $zipEntries 'templates/'
+Reject-ZipEntryPrefix $zipEntries 'developer/'
 Reject-ZipEntryPrefix $zipEntries 'ListeningPractice/vip/'
 Reject-ZipEntryPattern $zipEntries '(^|/)~\$[^/]*$'
 Reject-ZipEntryPattern $zipEntries '^ListeningPractice/.*\.(MOV|mov|MP4|mp4)$'
 Reject-ZipEntryPattern $zipEntries '^assets/scripts/.*\.py$'
+Reject-ZipEntryPattern $zipEntries '(^|/)__pycache__(/|$)'
+Reject-ZipEntryPattern $zipEntries '\.pyc$'
 Reject-ZipEntryPattern $zipEntries '^js/(app|core|data|runtime|services|utils|components|presentation|views)/'
 
 $zipSize = Format-ReleaseSize (Get-Item -LiteralPath $ZipPath).Length

--- a/developer/release.sh
+++ b/developer/release.sh
@@ -62,6 +62,7 @@ echo ""
 echo "[1/2] Building bundles..."
 if [ -f "scripts/build-bundles.mjs" ]; then
     node scripts/build-bundles.mjs
+    node scripts/build-bundles.mjs --check
     echo "       Bundles generated: js/bundles/"
 else
     echo "       ERROR: scripts/build-bundles.mjs not found!"
@@ -72,9 +73,17 @@ fi
 echo ""
 echo "[2/2] Creating distribution zip..."
 
-# 清理旧的 dist 目录
-rm -rf "${DIST_DIR}"
+# Preserve other versions and extracted qualification evidence.
 mkdir -p "${DIST_DIR}"
+if [ "$(cd "${DIST_DIR}" && pwd -P)" != "$(pwd -P)/dist" ]; then
+    echo "ERROR: the release output directory must remain inside the project."
+    exit 1
+fi
+if [ -d "${ZIP_PATH}" ]; then
+    echo "ERROR: the release archive path is a directory: ${ZIP_PATH}"
+    exit 1
+fi
+rm -f "${ZIP_PATH}"
 
 LISTENING_ZIP_INPUTS=()
 LISTENING_EXCLUDE_PATTERNS=("assets/generated/listening-exams/" "assets/generated/listening-exams/*" "ListeningPractice/" "ListeningPractice/*")
@@ -98,8 +107,10 @@ ZIP_INPUTS=(
     css/
     js/bundles/
     assets/
-    ReadingPractice/
 )
+if [ -d "ReadingPractice" ]; then
+    ZIP_INPUTS+=("ReadingPractice/")
+fi
 if [ ${#LISTENING_ZIP_INPUTS[@]} -gt 0 ]; then
     ZIP_INPUTS+=("${LISTENING_ZIP_INPUTS[@]}")
 fi
@@ -114,6 +125,10 @@ zip -r "${ZIP_PATH}" \
        "*.mp4" \
        "*.md" \
        "*.py" \
+       "*.pyc" \
+       "*/__pycache__" \
+       "*/__pycache__/" \
+       "*/__pycache__/*" \
        "assets/developer/*" \
        ".git/*" \
        ".gitignore" \
@@ -158,9 +173,15 @@ require_entry "css/main.css"
 require_entry "css/heroui-bridge.css"
 require_entry "css/theme-switcher-scroll.css"
 require_entry "css/onboarding.css"
+require_entry "css/vocab-reader.css"
+require_entry "assets/images/favicon.svg"
+require_entry "assets/images/logo.svg"
 require_entry "assets/vendor/three.min.js"
+require_entry "assets/wordlists/ielts_core.bundle.js"
+require_entry "assets/wordlists/ecdict_reading.bundle.js"
 require_entry "assets/generated/reading-exams/manifest.js"
 require_entry "assets/generated/reading-exams/reading-practice-unified.html"
+require_entry "assets/generated/reading-explanations/manifest.js"
 require_entry "js/bundles/runtime-entry.bundle.js"
 require_entry "js/bundles/core-foundation.bundle.js"
 require_entry "js/bundles/ui-shell.bundle.js"
@@ -192,10 +213,13 @@ if [ "${INCLUDE_LOCAL_LISTENING:-0}" = "1" ] && [ -d "ListeningPractice" ]; then
 fi
 
 reject_entry_prefix "templates/"
+reject_entry_prefix "developer/"
 reject_entry_prefix "ListeningPractice/vip/"
 reject_entry_pattern '(^|/)~\$[^/]*$'
 reject_entry_pattern '^ListeningPractice/.*\.(MOV|mov|MP4|mp4)$'
 reject_entry_pattern '^assets/scripts/.*\.py$'
+reject_entry_pattern '(^|/)__pycache__(/|$)'
+reject_entry_pattern '\.pyc$'
 reject_entry_pattern '^js/(app|core|data|runtime|services|utils|components|presentation|views)/'
 
 rm -f "${ZIP_LIST}"

--- a/developer/tests/ci/qualify_reading_release.py
+++ b/developer/tests/ci/qualify_reading_release.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build and qualify an extracted runtime package at a recorded clean revision."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[3]
+REPORTS = ROOT / "developer/tests/e2e/reports/reading-release-package"
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+
+
+def digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def run(command: list[str], log_name: str, env: dict[str, str] | None = None) -> None:
+    print(f"Running: {subprocess.list2cmdline(command)}", flush=True)
+    with (REPORTS / log_name).open("wb") as log:
+        subprocess.run(command, cwd=ROOT, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
+
+
+def main() -> int:
+    REPORTS.mkdir(parents=True, exist_ok=True)
+    report = {"status": "running", "startedAt": datetime.now(timezone.utc).isoformat(),
+              "platform": sys.platform, "python": sys.version.split()[0]}
+    report_path = REPORTS / "qualification.json"
+    try:
+        report["headSha"] = git("rev-parse", "HEAD")
+        report["reviewedHeadSha"] = os.environ.get("READING_RELEASE_REVIEWED_HEAD_SHA") or report["headSha"]
+        report["baseSha"] = os.environ.get("READING_RELEASE_BASE_SHA") or git("merge-base", "HEAD", "origin/opensource")
+        report["workingTreeChanges"] = git("status", "--porcelain")
+        if report["workingTreeChanges"]:
+            raise RuntimeError("Commit source and test changes before qualifying a release revision.")
+        report["node"] = subprocess.check_output(["node", "--version"], text=True).strip()
+        tracked_paths = set(git("ls-files", "-z").split("\0"))
+        version = f"reading-v1-{report['headSha'][:12]}"
+        report["version"] = version
+        if os.name == "nt":
+            shell = shutil.which("pwsh") or shutil.which("powershell")
+            if not shell:
+                raise RuntimeError("PowerShell is required for Windows release packaging.")
+            build = [shell, "-NoProfile", "-File", "developer/release.ps1", version]
+        else:
+            build = ["bash", "developer/release.sh", version]
+        report["buildCommand"] = build
+        # Keep this the redistributable default package; local listening sources
+        # are not needed for the intensive-reading qualification fixture.
+        environment = dict(os.environ, INCLUDE_LOCAL_LISTENING="0")
+        run(build, "build.log", environment)
+        run(["node", "scripts/build-bundles.mjs", "--check"], "bundles.log")
+        if git("status", "--porcelain"):
+            raise RuntimeError("Release build changed tracked files; regenerate and commit bundles first.")
+        archive_path = ROOT / f"dist/ielts-practice-{version}.zip"
+        report["archive"] = archive_path.relative_to(ROOT).as_posix()
+        report["archiveSha256"] = digest(archive_path)
+        report["archiveBytes"] = archive_path.stat().st_size
+        # Every invocation starts from a fresh extraction with no development
+        # files, source fallback, pre-existing browser state, or test fixtures.
+        with tempfile.TemporaryDirectory(prefix="extracted-", dir=REPORTS) as temporary:
+            extracted = Path(temporary).resolve()
+            manifest = []
+            with zipfile.ZipFile(archive_path) as archive:
+                for entry in archive.infolist():
+                    target = (extracted / entry.filename).resolve()
+                    if not target.is_relative_to(extracted):
+                        raise RuntimeError(f"Archive entry escapes extraction root: {entry.filename}")
+                    if entry.is_dir():
+                        continue
+                    if entry.filename not in tracked_paths:
+                        raise RuntimeError(f"Untracked runtime asset cannot qualify a Git revision: {entry.filename}")
+                    archive.extract(entry, extracted)
+                    source = (ROOT / entry.filename).resolve()
+                    if not source.is_relative_to(ROOT) or not source.is_file():
+                        raise RuntimeError(f"Archive entry has no source: {entry.filename}")
+                    checksum = digest(target)
+                    if checksum != digest(source):
+                        raise RuntimeError(f"Packaged bytes differ from source: {entry.filename}")
+                    manifest.append({"path": entry.filename, "sha256": checksum, "bytes": entry.file_size})
+            report["matchedSourceFiles"] = len(manifest)
+            (REPORTS / "asset-manifest.json").write_text(
+                json.dumps(sorted(manifest, key=lambda row: row["path"]), indent=2) + "\n", encoding="utf-8")
+            report["assetManifestSha256"] = digest(REPORTS / "asset-manifest.json")
+            environment.update(READING_RELEASE_ROOT=str(extracted),
+                               READING_RELEASE_REPORT_DIR=str(REPORTS),
+                               READING_RELEASE_LABEL="package")
+            command = ["node", "developer/tests/e2e/reading_txt_release.node.js"]
+            report["browserCommand"] = command
+            run(command, "browser.log", environment)
+        if git("rev-parse", "HEAD") != report["headSha"] or git("status", "--porcelain"):
+            raise RuntimeError("The tested revision changed during release qualification.")
+        report["status"] = "pass"
+    except Exception as error:
+        report["status"] = "fail"
+        report["error"] = str(error)
+    finally:
+        report["finishedAt"] = datetime.now(timezone.utc).isoformat()
+        report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(report, indent=2), flush=True)
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/developer/tests/ci/qualify_reading_release.py
+++ b/developer/tests/ci/qualify_reading_release.py
@@ -19,7 +19,7 @@ REPORTS = ROOT / "developer/tests/e2e/reports/reading-release-package"
 
 
 def git(*args: str) -> str:
-    return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+    return subprocess.check_output(["git", *args], cwd=ROOT, encoding="utf-8").strip()
 
 
 def digest(path: Path) -> str:

--- a/developer/tests/e2e/e2e_runner.py
+++ b/developer/tests/e2e/e2e_runner.py
@@ -33,6 +33,7 @@ E2E_CASES = [
     "reading_reader_isolation.py",
     "reading_reader_occurrences.py",
     "reading_bookshelf_entrypoints.py",
+    "reading_txt_release.py",
     "interrupted_history_flow.py",
     "listening_practice_flow.py",
     "suite_practice_flow.py",

--- a/developer/tests/e2e/reading_txt_release.node.js
+++ b/developer/tests/e2e/reading_txt_release.node.js
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/** #160: qualify source or freshly extracted static assets using actual downloads and IndexedDB. */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+const repository = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const options = {};
+for (let index = 2; index < process.argv.length; index += 2) {
+    const key = process.argv[index];
+    assert.ok(['--root', '--label', '--reports'].includes(key) && process.argv[index + 1], `Unsupported argument ${key}`);
+    options[key.slice(2)] = process.argv[index + 1];
+}
+const root = path.resolve(options.root || process.env.READING_RELEASE_ROOT || repository);
+const label = options.label || process.env.READING_RELEASE_LABEL || (root === repository ? 'source' : 'package');
+assert.match(label, /^[a-zA-Z0-9_-]+$/, 'Report label must be a safe filename component');
+const reports = path.resolve(options.reports || process.env.READING_RELEASE_REPORT_DIR || path.join(repository, 'developer/tests/e2e/reports'));
+assert.ok(fs.existsSync(path.join(root, 'index.html')), `No release index.html in ${root}`);
+fs.mkdirSync(reports, { recursive: true });
+const reportFile = path.join(reports, `reading-txt-release-${label}-report.json`);
+const started = Date.now();
+const builtin = { kind: 'builtin', id: 'default' };
+const hash = bytes => createHash('sha256').update(bytes).digest('hex');
+const git = args => { try { return execFileSync('git', args, { cwd: repository, encoding: 'utf8' }).trim(); } catch { return null; } };
+const report = {
+    generatedAt: new Date().toISOString(), status: 'running', label, assetRoot: root,
+    repositoryHead: git(['rev-parse', 'HEAD']),
+    repositoryDirty: Boolean(git(['status', '--porcelain'])),
+    command: process.argv.join(' '),
+    https: 'Loopback static HTTPS with an ephemeral certificate and isolated ignoreHTTPSErrors; no public deployment tested.',
+    importer: 'UTF-8 plain-text bytes only; no named third-party application import was performed.',
+    assetHashes: Object.fromEntries(['index.html', 'js/bundles/core-foundation.bundle.js', 'js/bundles/browse.bundle.js',
+        'js/bundles/more.bundle.js', 'js/bundles/reading-page.bundle.js', 'js/data/v2/readingVocabularyModel.js'].filter(file => fs.existsSync(path.join(root, file)))
+        .map(file => [file, hash(fs.readFileSync(path.join(root, file)))])),
+    cases: [], downloads: [], checkpoints: []
+};
+function persist() {
+    report.elapsedSeconds = Number(((Date.now() - started) / 1000).toFixed(3));
+    fs.writeFileSync(reportFile, `${JSON.stringify(report, null, 2)}\n`);
+}
+async function checkpoint(name, action) {
+    const entry = { name, status: 'running' };
+    report.checkpoints.push(entry); persist();
+    console.error(`[issue160 ${label}] START ${name}`);
+    try { const value = await action(); entry.status = 'pass'; persist(); return value; }
+    catch (error) { entry.status = 'fail'; entry.error = error.stack || String(error); persist(); throw error; }
+}
+function pass(name, evidence = {}) { report.cases.push({ name, status: 'pass', ...evidence }); persist(); }
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+function serve(request, response) {
+    const relative = decodeURIComponent(new URL(request.url, 'http://localhost').pathname).replace(/^\/+/, '') || 'index.html';
+    const filename = path.resolve(root, relative);
+    if (!filename.startsWith(root + path.sep)) { response.writeHead(403).end(); return; }
+    try {
+        const body = fs.readFileSync(filename);
+        response.writeHead(200, { 'Content-Type': mime[path.extname(filename)] || 'application/octet-stream' }); response.end(body);
+    }
+    catch { response.writeHead(404).end(); }
+}
+let openssl = process.env.OPENSSL_EXECUTABLE_PATH || 'openssl';
+if (process.platform === 'win32' && !process.env.OPENSSL_EXECUTABLE_PATH) {
+    const gitPath = execFileSync('where.exe', ['git'], { encoding: 'utf8' }).trim().split(/\r?\n/)[0];
+    const bundled = path.resolve(path.dirname(gitPath), '../usr/bin/openssl.exe');
+    if (fs.existsSync(bundled)) openssl = bundled;
+}
+const certificate = path.join(reports, `issue160-${label}-localhost-cert.pem`);
+const privateKey = path.join(reports, `issue160-${label}-localhost-key.pem`);
+execFileSync(openssl, ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', privateKey,
+    '-out', certificate, '-days', '1', '-subj', '/CN=localhost', '-addext', 'subjectAltName=IP:127.0.0.1,DNS:localhost'], { stdio: 'pipe' });
+const server = http.createServer(serve);
+const secureServer = https.createServer({ key: fs.readFileSync(privateKey), cert: fs.readFileSync(certificate) }, serve);
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+await new Promise(resolve => secureServer.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const secureOrigin = `https://127.0.0.1:${secureServer.address().port}`;
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+let browser;
+
+async function poll(read, expected, message) {
+    const deadline = Date.now() + 15_000;
+    while (true) {
+        const actual = await read();
+        if (JSON.stringify(actual) === JSON.stringify(expected)) return actual;
+        if (Date.now() >= deadline) assert.deepEqual(actual, expected, message);
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+}
+async function newContext() {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    context.setDefaultTimeout(15_000); context.setDefaultNavigationTimeout(60_000);
+    context.on('page', page => page.on('dialog', dialog => dialog.accept()));
+    // AppData intentionally deletes its bootstrap channel. Observe its original
+    // definition before production startup, solely to schedule a later fault at
+    // the real transaction boundary without substituting any packaged module.
+    await context.addInitScript(() => {
+        const define = Object.defineProperty;
+        Object.defineProperty = function(target, property, descriptor) {
+            if (target === window && property === '__AppDataV2Internals') {
+                window.__txtKernelPrototype = descriptor.value.DataKernel.prototype;
+                Object.defineProperty = define;
+            }
+            return define.call(this, target, property, descriptor);
+        };
+    });
+    return context;
+}
+async function ready(page, protocol) {
+    const url = protocol === 'file' ? pathToFileURL(path.join(root, 'index.html')).href
+        : `${protocol === 'https' ? secureOrigin : origin}/index.html`;
+    await page.goto(`${url}?test_env=1`);
+    await page.waitForFunction(() => window.app?.isInitialized && window.AppData, null, { timeout: 60_000 });
+    await page.evaluate(async () => {
+        await AppData.ready; await window.LicenseModal?.accept();
+        document.querySelector('#library-loader-overlay [data-library-action="close"]')?.click();
+    });
+    assert.equal(await page.evaluate(() => AppData.status().backend), 'indexeddb-v2');
+}
+const snapshot = page => page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot);
+const state = page => page.evaluate(() => AppData.vocab.getReadingSnapshot());
+const articleId = (page, examId, source = builtin) => page.evaluate(({ examId, source }) => AppData.vocab.readingModel.articleId(source, examId), { examId, source });
+const card = (page, examId) => page.locator('.bookshelf-card').filter({ has: page.locator(`[data-action="open-reading-vocab"][data-exam-id="${examId}"]`) });
+const globalButton = page => page.locator('[data-action="export-all-bookshelf"]');
+async function shelf(page) {
+    await page.locator('nav button[data-view="more"]').click();
+    await page.locator('#bookshelf-tool-card').click();
+    await page.locator('#bookshelf-view').waitFor({ state: 'visible' });
+    await page.locator('.bookshelf-stat-value').first().waitFor();
+}
+async function shelfSettled(page) {
+    const revision = (await state(page)).revision;
+    await poll(() => page.evaluate(revision => !ReadingBookshelfStore._loading && ReadingBookshelfStore._revision === revision, revision), true, 'Shelf must project the final acknowledged revision');
+}
+async function readerReady(page, examId) {
+    await page.waitForFunction(id => window.ReadingVocabReader?.currentExamId === id && !!ReadingVocabReader.currentPayload
+        && !!document.querySelector('.vocab-paragraph-text') && window.BookshelfView?.state.readerLoading !== true, examId);
+    assert.equal(await page.locator('.vocab-error-state').count(), 0);
+}
+async function manual(page, word, count) {
+    await page.locator('#vocab-manual-input').fill(word);
+    await page.locator('#vocab-manual-add-btn').click();
+    await poll(() => page.locator('#vocab-fab-count').textContent(), String(count), `Manual add ${word}`);
+}
+async function collect(page, examId, word, options = {}, source = builtin) {
+    return page.evaluate(({ examId, word, options, source }) => AppData.vocab.mutateReading('collect', {
+        source, article: { examId, title: examId }, word: { word, meaning: 'A rich definition that must never be exported' }, manual: true
+    }, options), { examId, word, options, source });
+}
+function expectedContent(words) {
+    return [...words].sort((a, b) => a.toLowerCase() < b.toLowerCase() ? -1 : a.toLowerCase() > b.toLowerCase() ? 1 : 0)
+        .map(word => word.replace(/\s+/g, ' ').trim()).join('\n');
+}
+async function download(page, button, words, name) {
+    const promised = page.waitForEvent('download');
+    await button.click();
+    const saved = await promised;
+    assert.equal(await saved.failure(), null);
+    assert.match(saved.suggestedFilename(), /\.txt$/i);
+    const bytes = fs.readFileSync(await saved.path());
+    const expected = Buffer.from(expectedContent(words), 'utf8');
+    assert.deepEqual(bytes, expected, `${name}: exact UTF-8, canonical terms, LF only, no header/BOM/trailing LF`);
+    const artifact = `issue160-${label}-${name}.txt`;
+    fs.writeFileSync(path.join(reports, artifact), bytes);
+    report.downloads.push({ name, filename: saved.suggestedFilename(), artifact, bytes: bytes.length, sha256: hash(bytes), terms: words.length }); persist();
+}
+async function noDownload(page, action, message) {
+    const events = [];
+    const onDownload = download => events.push(download.suggestedFilename());
+    page.on('download', onDownload);
+    try { await action(); await page.waitForTimeout(250); assert.deepEqual(events, [], message); }
+    finally { page.off('download', onDownload); }
+}
+async function selectRepeated(page, quote, occurrence) {
+    await page.evaluate(({ quote, occurrence }) => {
+        const root = document.querySelector('#vocab-passage-content');
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const nodes = []; let text = '';
+        while (walker.nextNode()) { nodes.push({ node: walker.currentNode, start: text.length }); text += walker.currentNode.textContent; }
+        const matches = [...text.matchAll(new RegExp(`\\b${quote}\\b`, 'g'))];
+        const start = matches[occurrence]?.index;
+        if (start === undefined) throw new Error('Repeated real passage occurrence was not found');
+        const end = start + quote.length;
+        const from = nodes.find(item => item.start <= start && item.start + item.node.length > start);
+        const to = nodes.find(item => item.start < end && item.start + item.node.length >= end);
+        const range = document.createRange(); range.setStart(from.node, start - from.start); range.setEnd(to.node, end - to.start);
+        const selection = getSelection(); selection.removeAllRanges(); selection.addRange(range);
+        from.node.parentElement.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    }, { quote, occurrence });
+    await poll(() => page.evaluate(async () => (await AppData.vocab.getReadingSnapshot()).snapshot.reading.occurrences.length), occurrence + 1, 'DOM selection must receive a persisted occurrence');
+    await page.waitForFunction(() => ReadingVocabReader._selectionPending.size === 0);
+}
+
+async function browseFlow(page, protocol) {
+    await ready(page, protocol);
+    const emptyBackup = await page.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+    assert.equal(await page.evaluate(() => !!window.ReadingVocabReader), false, 'The first Browse entry must load production modules lazily');
+    await page.locator('nav button[data-view="browse"]').click();
+    const entries = page.locator('#exam-list-container [data-action="vocab-book"]');
+    await entries.first().waitFor();
+    const examA = await entries.nth(0).getAttribute('data-exam-id');
+    const examB = await entries.nth(1).getAttribute('data-exam-id');
+    assert.notEqual(examA, examB);
+    await entries.first().click(); await readerReady(page, examA);
+    const shared = await page.evaluate(() => {
+        const text = document.querySelector('#vocab-passage-content').textContent;
+        return [...text.matchAll(/\b[a-z]{5,}\b/g)].map(match => match[0]).find(word =>
+            [...text.matchAll(new RegExp(`\\b${word}\\b`, 'g'))].length >= 2);
+    });
+    assert.ok(shared, 'Real packaged passage must provide a repeated selectable term');
+    const display = shared[0].toUpperCase() + shared.slice(1);
+    await page.evaluate(async display => {
+        const current = (await AppData.vocab.getReadingSnapshot()).snapshot;
+        const receipt = await AppData.vocab.saveWords([...current.words,
+            { id: 'issue160-reviewed', word: display, meaning: 'Preserved definition', note: 'Preserved learner note', repetitions: 7 },
+            { id: 'issue160-unrelated', word: 'unrelatedreviewonly', meaning: 'Never an intensive reading association' }]);
+        if (!receipt.committed) throw new Error('Canonical review seed was not acknowledged');
+    }, display);
+    await selectRepeated(page, shared, 0); await selectRepeated(page, shared, 1);
+    await poll(() => page.locator('mark.vocab-highlight').evaluateAll(nodes => new Set(nodes.map(node => node.dataset.occurrenceId)).size), 2, 'Both distinct selected occurrences must be visible');
+    await page.locator('#vocab-fab').click();
+    await manual(page, 'zuluword', 2); await manual(page, 'Café', 3);
+    const wordsA = [display, 'zuluword', 'Café'];
+    await download(page, page.locator('#vocab-export-btn'), wordsA, `${protocol}-reader-A`);
+    await page.locator('#vocab-modal-close').click(); await page.locator('#vocab-reader-back-btn').click();
+    await entries.first().click(); await readerReady(page, examA);
+    await poll(() => page.locator('mark.vocab-highlight').evaluateAll(nodes => new Set(nodes.map(node => node.dataset.occurrenceId)).size), 2, 'Close/reopen restores exactly the selected occurrences');
+    await page.locator('#vocab-reader-back-btn').click();
+    await entries.nth(1).click(); await readerReady(page, examB);
+    await page.locator('#vocab-fab').click();
+    await manual(page, shared.toUpperCase(), 1); await manual(page, 'bravoword', 2); await manual(page, 'Ice   Shelf', 3);
+    const wordsB = [display, 'bravoword', 'Ice   Shelf'];
+    await download(page, page.locator('#vocab-export-btn'), wordsB, `${protocol}-reader-B`);
+    await page.locator('#v-tab-all').click();
+    assert.match(await page.locator('#v-tab-all').textContent(), /全部精读生词/);
+    await download(page, page.locator('#vocab-export-btn'), [...wordsA, 'bravoword', 'Ice   Shelf'], `${protocol}-reader-global`);
+    await page.locator('#vocab-modal-close').click(); await page.locator('#vocab-reader-back-btn').click();
+    await ready(page, protocol);
+    assert.equal(await page.evaluate(() => !!window.ReadingVocabReader), false, 'Reload gives a cold bookshelf entry');
+    await shelf(page); await shelfSettled(page);
+    await download(page, card(page, examA).locator('[data-action="export-exam-txt"]'), wordsA, `${protocol}-shelf-A`);
+    await page.locator('.bookshelf-search-input').fill('bravoword');
+    await poll(() => page.locator('.bookshelf-card').count(), 1, 'Shelf filter should hide A');
+    assert.match(await globalButton(page).textContent(), /全部精读生词/);
+    await download(page, globalButton(page), [...wordsA, 'bravoword', 'Ice   Shelf'], `${protocol}-filtered-global`);
+    await page.locator('.bookshelf-search-input').fill('');
+    await card(page, examA).locator('button[data-action="open-reading-vocab"]').click(); await readerReady(page, examA);
+    await page.locator('#vocab-fab').click(); await page.locator('#vocab-clear-btn').click();
+    await poll(() => page.locator('#vocab-fab-count').textContent(), '0', 'Clear A must acknowledge before export');
+    await noDownload(page, () => page.locator('#vocab-export-btn').click(), 'Empty article must not download');
+    assert.match(await page.locator('#vocab-toast').textContent(), /空|暂无/);
+    await page.locator('#vocab-modal-close').click(); await page.locator('#vocab-reader-back-btn').click(); await shelfSettled(page);
+    await download(page, card(page, examB).locator('[data-action="export-exam-txt"]'), wordsB, `${protocol}-B-after-clear-A`);
+    await download(page, globalButton(page), wordsB, `${protocol}-global-after-clear-A`);
+    const persisted = await snapshot(page);
+    assert.equal(persisted.words.find(word => word.id === 'issue160-reviewed').repetitions, 7);
+    assert.equal(persisted.reading.associations.filter(row => row.articleId === JSON.stringify(['article', JSON.stringify(['source', 'builtin', 'default']), examA])).length, 0);
+    assert.deepEqual(await page.evaluate(() => AppData.practice.list()), []);
+    pass(`${protocol}-browse-reopen-cold-shelf-A-B-scope-canonical-bytes-clear`, { examA, examB, shared, repeatedOccurrences: 2, globalAfterClear: wordsB.length });
+    return { examA, examB, wordsB, emptyBackup };
+}
+
+async function multiWindow(page, context, protocol, { examB, wordsB }) {
+    const other = await context.newPage();
+    try {
+        await ready(other, protocol);
+        const concurrent = await Promise.all([collect(page, 'issue160-window-A', 'windowalpha'), collect(other, 'issue160-window-B', 'windowbeta')]);
+        assert.ok(concurrent.every(receipt => receipt.committed === true && receipt.saved === true));
+        await shelfSettled(page);
+        await download(page, globalButton(page), [...wordsB, 'windowalpha', 'windowbeta'], `${protocol}-concurrent-additions`);
+        // Pause only the real kernel boundary, then let the other page delete.
+        // No fake persistence implementation or in-memory IndexedDB is used.
+        await other.evaluate(() => {
+            const proto = window.__txtKernelPrototype;
+            const mutate = proto.mutate;
+            proto.mutate = async function(changes, options) {
+                if (options?.operationId === 'issue160-delayed') {
+                    window.__txtAttempts = (window.__txtAttempts || 0) + 1;
+                    if (!window.__txtBlocked) {
+                        window.__txtBlocked = true;
+                        await new Promise(resolve => { window.__txtRelease = resolve; });
+                    }
+                }
+                return mutate.call(this, changes, options);
+            };
+            window.__txtPending = AppData.vocab.mutateReading('collect', {
+                source: { kind: 'builtin', id: 'default' }, article: { examId: 'issue160-window-A', title: 'issue160-window-A' },
+                word: { word: 'windowalpha' }, manual: true
+            }, { operationId: 'issue160-delayed' }).then(receipt => ({ receipt }), error => ({ code: error.code, committed: error.committed }));
+        });
+        await other.waitForFunction(() => window.__txtBlocked === true);
+        const id = await articleId(page, 'issue160-window-A');
+        assert.equal((await page.evaluate(articleId => AppData.vocab.mutateReading('clearArticle', { articleId }), id)).committed, true);
+        const stale = await other.evaluate(async () => { window.__txtRelease(); return window.__txtPending; });
+        assert.deepEqual(stale, { code: 'CONFLICT', committed: false });
+        await shelfSettled(page);
+        await download(page, globalButton(page), [...wordsB, 'windowbeta'], `${protocol}-deletion-fences-stale-window`);
+        // Inject an actual IndexedDB transaction failure at its put boundary.
+        await card(page, examB).locator('button[data-action="open-reading-vocab"]').click(); await readerReady(page, examB);
+        await page.locator('#vocab-fab').click();
+        const before = await snapshot(page);
+        await page.evaluate(() => {
+            const put = IDBObjectStore.prototype.put;
+            window.__txtRestorePut = () => { IDBObjectStore.prototype.put = put; };
+            IDBObjectStore.prototype.put = function(value, ...args) {
+                if (value?.logicalKey === 'vocab.readingState') {
+                    window.__txtFailedPuts = (window.__txtFailedPuts || 0) + 1;
+                    throw new DOMException('Issue 160 injected storage failure', 'QuotaExceededError');
+                }
+                return put.call(this, value, ...args);
+            };
+        });
+        await page.locator('#vocab-manual-input').fill('failedwriteword'); await page.locator('#vocab-manual-add-btn').click();
+        await page.waitForFunction(() => window.__txtFailedPuts > 0 && document.querySelector('#vocab-toast')?.textContent.includes('失败'));
+        assert.deepEqual(await snapshot(page), before, 'A failed UI write cannot acknowledge or partially persist vocabulary');
+        assert.equal(await page.locator('#vocab-fab-count').textContent(), String(wordsB.length));
+        await page.evaluate(() => window.__txtRestorePut());
+        await download(page, page.locator('#vocab-export-btn'), wordsB, `${protocol}-after-failed-acknowledgement`);
+        await page.locator('#vocab-modal-close').click(); await page.locator('#vocab-reader-back-btn').click();
+        const missingSource = { kind: 'imported', id: 'issue160-missing-library' };
+        assert.equal((await collect(page, 'issue160-missing-article', 'missingword', {}, missingSource)).committed, true);
+        await shelfSettled(page);
+        await card(page, 'issue160-missing-article').locator('button[data-action="open-reading-vocab"]').click();
+        await page.locator('.vocab-error-state').waitFor();
+        assert.equal(await page.evaluate(() => ReadingVocabReader.currentPayload), null);
+        await page.locator('#vocab-fab').click();
+        await download(page, page.locator('#vocab-export-btn'), ['missingword'], `${protocol}-missing-source-reader`);
+        await page.locator('#vocab-modal-close').click(); await page.locator('#vocab-reader-back-btn').click();
+        await download(page, card(page, 'issue160-missing-article').locator('[data-action="export-exam-txt"]'), ['missingword'], `${protocol}-missing-source-shelf`);
+        pass(`${protocol}-actual-indexeddb-concurrent-add-delete-failed-acknowledgement-missing-source`, { staleResult: stale, concurrentRevisions: concurrent.map(row => row.revision) });
+    } finally { await other.close(); }
+}
+
+async function migrationAndBackups(protocol, emptyBackup) {
+    const context = await newContext();
+    try {
+        await context.addInitScript(() => {
+            if (sessionStorage.getItem('issue160-legacy-seeded')) return;
+            sessionStorage.setItem('issue160-legacy-seeded', '1');
+            localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify([
+                { id: 'issue160-legacy', word: 'Legacyword', examId: 'issue160-legacy-article', examTitle: 'Legacy retained article',
+                    source: { kind: 'imported', id: 'issue160-legacy-library' }, createdAt: '2026-09-08T01:00:00.000Z', note: 'Never export this note' }
+            ]));
+        });
+        const page = await context.newPage(); await ready(page, protocol); await shelf(page); await shelfSettled(page);
+        await download(page, globalButton(page), ['Legacyword'], `${protocol}-after-migration`);
+        const backup = await page.evaluate(() => AppData.backups.export({ domains: ['vocab'] }));
+        const other = await context.newPage(); await ready(other, protocol);
+        assert.equal((await collect(other, 'issue160-merged', 'Line\r\nBreak')).committed, true);
+        const importBackup = (data, replace = false) => page.evaluate(async ({ data, replace }) => {
+            const plan = await AppData.backups.previewImport(data, { replace });
+            return AppData.backups.commitImport(plan.id, { confirmDestructive: replace });
+        }, { data, replace });
+        assert.equal((await importBackup(backup)).committed, true); await shelfSettled(page);
+        await download(page, globalButton(page), ['Legacyword', 'Line\r\nBreak'], `${protocol}-after-merge-newline-normalization`);
+        const id = await articleId(page, 'issue160-legacy-article', { kind: 'imported', id: 'issue160-legacy-library' });
+        assert.equal((await other.evaluate(articleId => AppData.vocab.mutateReading('clearArticle', { articleId }), id)).committed, true);
+        assert.equal((await importBackup(backup)).committed, true); await shelfSettled(page);
+        await download(page, globalButton(page), ['Line\r\nBreak'], `${protocol}-merge-retains-deletion`);
+        const stale = await state(other);
+        assert.equal((await importBackup(emptyBackup, true)).committed, true); await shelfSettled(page);
+        assert.equal((await snapshot(page)).reading.associations.length, 0);
+        const conflict = await other.evaluate(async stale => {
+            try { await AppData.vocab.mutateReading('collect', {
+                source: { kind: 'builtin', id: 'default' }, article: { examId: 'issue160-merged', title: 'issue160-merged' },
+                word: { word: 'resurrectedword' }, manual: true
+            }, { observedRevision: stale.revision, observedGeneration: stale.generation }); return null; }
+            catch (error) { return { code: error.code, committed: error.committed }; }
+        }, stale);
+        assert.deepEqual(conflict, { code: 'CONFLICT', committed: false });
+        assert.equal(await globalButton(page).isDisabled(), true, 'An empty global export has an explicitly disabled control');
+        await noDownload(page, async () => assert.equal(await page.evaluate(() => ReadingBookshelfStore.exportAllBookshelfTxt()), false), 'Empty replace must produce no download');
+        await other.evaluate(() => {
+            localStorage.setItem('ielts_reading_vocab_words_v1', JSON.stringify([{ id: 'stale', word: 'resurrectedword', examId: 'stale' }]));
+            localStorage.setItem('ielts_reading_bookshelf_exams_v1', JSON.stringify([{ examId: 'stale', firstUsedAt: 1 }]));
+        });
+        await ready(page, protocol); await shelf(page); await shelfSettled(page);
+        await ready(other, protocol);
+        assert.equal((await snapshot(page)).reading.associations.length, 0);
+        assert.deepEqual(await snapshot(other), await snapshot(page), 'Both windows must reload the empty authoritative replacement');
+        assert.equal(await globalButton(page).isDisabled(), true);
+        await noDownload(page, async () => assert.equal(await page.evaluate(() => ReadingBookshelfStore.exportAllBookshelfTxt()), false), 'Reload must not resurrect migrated mirrors');
+        pass(`${protocol}-migration-merge-deletion-empty-replace-stale-window-reload`, { emptyExport: false, staleResult: conflict });
+    } finally { await context.close(); }
+}
+
+try {
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+    report.browser = browser.version(); persist();
+    const protocols = ['http', 'https', 'file'];
+    const results = await Promise.allSettled(protocols.map(async protocol => {
+        const context = await newContext(); let fixtures;
+        try {
+            const page = await context.newPage();
+            fixtures = await checkpoint(`${protocol}-production-browse-download-flow`, () => browseFlow(page, protocol));
+            await checkpoint(`${protocol}-multi-window-indexeddb`, () => multiWindow(page, context, protocol, fixtures));
+        } finally { await context.close(); }
+        await checkpoint(`${protocol}-migration-backup-authority`, () => migrationAndBackups(protocol, fixtures.emptyBackup));
+    }));
+    report.protocols = results.map((result, index) => ({ protocol: protocols[index], status: result.status === 'fulfilled' ? 'pass' : 'fail',
+        ...(result.status === 'rejected' ? { error: result.reason?.stack || String(result.reason) } : {}) }));
+    const failures = results.filter(result => result.status === 'rejected');
+    if (failures.length) throw new AggregateError(failures.map(result => result.reason), 'TXT release qualification failed');
+    report.status = 'pass';
+} catch (error) { report.status = 'fail'; report.error = error.stack || String(error); process.exitCode = 1; }
+finally {
+    persist();
+    if (browser) await browser.close();
+    await Promise.all([new Promise(resolve => server.close(resolve)), new Promise(resolve => secureServer.close(resolve))]);
+    console.log(JSON.stringify(report, null, 2));
+}

--- a/developer/tests/e2e/reading_txt_release.py
+++ b/developer/tests/e2e/reading_txt_release.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Run TXT/release qualification; forward --root/--label/--reports to Playwright."""
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    return subprocess.run(
+        ["node", str(Path(__file__).with_suffix(".node.js")), *sys.argv[1:]],
+        check=False,
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/developer/tests/js/readingVocabularyTxtExport.test.js
+++ b/developer/tests/js/readingVocabularyTxtExport.test.js
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const source = (name) => fs.readFileSync(new URL(`../../../js/${name}`, import.meta.url), 'utf8');
+const modelCode = source('data/v2/readingVocabularyModel.js');
+const readerCode = source('components/readingVocabReader.js');
+const bookshelfCode = source('components/bookshelfView.js');
+const SOURCE_A = { kind: 'builtin', id: 'default' };
+const SOURCE_B = { kind: 'imported', id: 'missing-library' };
+const EXAM = 'same-exam';
+const AT = '2026-09-09T01:00:00.000Z';
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+async function fixture() {
+    const downloads = [];
+    const urls = new Map();
+    const pendingCleanup = [];
+    const attached = new Set();
+    const listeners = new Map();
+    const sandbox = {
+        console: { warn() {} }, Blob,
+        setTimeout(callback) { pendingCleanup.push(callback); }, clearTimeout() {},
+        URL: {
+            createObjectURL(blob) { const url = `blob:export-${urls.size}`; urls.set(url, blob); return url; },
+            revokeObjectURL(url) { urls.delete(url); }
+        },
+        CustomEvent: class { constructor(type) { this.type = type; } },
+        addEventListener(type, handler) {
+            if (!listeners.has(type)) listeners.set(type, []);
+            listeners.get(type).push(handler);
+        },
+        dispatchEvent(event) { (listeners.get(event.type) || []).forEach((handler) => handler(event)); },
+        document: {
+            body: { appendChild(node) { attached.add(node); }, removeChild(node) { attached.delete(node); } },
+            querySelector() { return null; }, getElementById() { return null; },
+            createElement(tag) {
+                assert.equal(tag, 'a');
+                return { click() {
+                    assert.ok(attached.has(this), 'download link is attached before activation');
+                    assert.ok(urls.has(this.href), 'download URL has not been revoked');
+                    downloads.push({ filename: this.download, blob: urls.get(this.href) });
+                } };
+            }
+        }
+    };
+    sandbox.window = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(modelCode, sandbox);
+    const model = sandbox.ReadingVocabularyModel;
+    let snapshot = model.createSnapshot({ words: [
+        { id: 'review-shared', word: 'Shared', meaning: 'Canonical definition', example: 'Rich\nfields stay out', note: 'No header' },
+        { id: 'unrelated-review', word: 'unrelated', meaning: 'Never collected from an article' }
+    ] });
+    const collect = (base, word, sourceIdentity, extra = {}) => model.collect(base, {
+        source: sourceIdentity, article: { examId: EXAM, title: sourceIdentity.id },
+        word: { word, meaning: 'Definition', example: 'Not exported' }, at: AT, ...extra
+    });
+    const occurrence = (startOffset) => ({
+        scopeId: 'passage', contentVersion: 'fixture-v1', startOffset,
+        endOffset: startOffset + 6, quote: 'shared', before: '', after: ''
+    });
+    snapshot = collect(snapshot, 'zebra', SOURCE_A, { manual: true });
+    snapshot = collect(snapshot, 'shared', SOURCE_A, { occurrence: occurrence(0) });
+    snapshot = collect(snapshot, 'shared', SOURCE_A, { occurrence: occurrence(15) });
+    snapshot = collect(snapshot, '  SHARED  ', SOURCE_B, { manual: true });
+    snapshot = collect(snapshot, 'Alpha', SOURCE_B, { manual: true });
+    snapshot = collect(snapshot, 'café\u00a0\r\n\t habitat\u2028zone', SOURCE_A, { manual: true });
+    let canonical = { snapshot, revision: 1, generation: 'original' };
+    let failure = null;
+    let readGate = null;
+    let reads = 0;
+    sandbox.AppData = {
+        ready: Promise.resolve(), backups: { onDataCommitted() {} },
+        library: {
+            async getActive() { return null; }, async listConfigurations() { return []; },
+            async getIndex() { return []; }
+        },
+        vocab: {
+            readingModel: model,
+            async getReadingSnapshot() {
+                reads += 1;
+                if (readGate) await readGate;
+                if (failure) throw failure;
+                return clone(canonical);
+            },
+            async mutateReading(type, command) {
+                if (failure) throw failure;
+                canonical = { ...canonical, snapshot: model[type](canonical.snapshot, command), revision: canonical.revision + 1 };
+                return { ...clone(canonical), saved: true };
+            }
+        }
+    };
+    vm.runInContext(readerCode, sandbox);
+    vm.runInContext(bookshelfCode, sandbox);
+    const reader = sandbox.ReadingVocabStore;
+    const shelf = sandbox.ReadingBookshelfStore;
+    await Promise.all([reader.init(), shelf.init()]);
+    return {
+        model, reader, shelf, sandbox, downloads, urls, attached, collect,
+        get canonical() { return canonical; }, get reads() { return reads; },
+        setSnapshot(value, generation = canonical.generation) {
+            canonical = { snapshot: value, generation, revision: canonical.revision + 1 };
+        },
+        setFailure(value) { failure = value; }, setReadGate(value) { readGate = value; },
+        cleanup() { pendingCleanup.splice(0).forEach((callback) => callback()); }
+    };
+}
+
+async function assertDownload(f, result, expected) {
+    assert.ok(result && result.filename.endsWith('.txt'));
+    assert.equal(result.count, expected.split('\n').length);
+    const download = f.downloads.at(-1);
+    assert.equal(download.filename, result.filename);
+    assert.equal(download.blob.type, 'text/plain;charset=utf-8');
+    assert.deepEqual(Buffer.from(await download.blob.arrayBuffer()), Buffer.from(expected, 'utf8'));
+    assert.equal(f.attached.size, 0, 'temporary anchor is removed');
+    f.cleanup();
+    assert.equal(f.urls.size, 0, 'object URL is released after activation');
+}
+
+test('TXT uses canonical display owners, source-scoped associations and one line per term', async () => {
+    const f = await fixture();
+    const articleA = 'café habitat zone\nShared\nzebra';
+    const articleB = 'Alpha\nShared';
+    const global = 'Alpha\ncafé habitat zone\nShared\nzebra';
+    assert.equal(f.model.query(f.canonical.snapshot).occurrenceCount, 2);
+    await assertDownload(f, await f.reader.exportTxt(EXAM, 'article-a.txt', '', SOURCE_A), articleA);
+    await assertDownload(f, await f.reader.exportTxt(EXAM, null, '', SOURCE_B), articleB);
+    await assertDownload(f, await f.reader.exportTxt(), global);
+    await assertDownload(f, await f.shelf.exportExamTxt(EXAM, 'Article A', SOURCE_A), articleA);
+    await assertDownload(f, await f.shelf.exportExamTxt(EXAM, 'Article B', SOURCE_B), articleB);
+    await assertDownload(f, await f.shelf.exportAllBookshelfTxt(), global);
+    assert.ok(f.downloads.at(-1).filename.includes('全部精读生词'));
+});
+
+test('Global TXT ignores shelf filters and preserves vocabulary for unavailable sources', async () => {
+    const f = await fixture();
+    f.sandbox.BookshelfView.state.searchQuery = 'nothing matches';
+    f.sandbox.BookshelfView.state.filterMode = 'has-words';
+    f.sandbox.BookshelfView.state.sortBy = 'title';
+    assert.equal(f.shelf.getBookshelfExams().find((row) => row.source.id === SOURCE_B.id).sourceUnavailable, true);
+    await assertDownload(f, await f.shelf.exportAllBookshelfTxt(), 'Alpha\ncafé habitat zone\nShared\nzebra');
+    f.sandbox.AppData.library.getIndex = async () => { throw new Error('Source was removed'); };
+    await assertDownload(f, await f.shelf.exportExamTxt(EXAM, 'Missing source', SOURCE_B), 'Alpha\nShared');
+});
+
+test('Clearing A preserves B and global export while empty A produces no download', async () => {
+    const f = await fixture();
+    await f.reader.clear(EXAM, SOURCE_A);
+    const before = f.downloads.length;
+    assert.equal(await f.reader.exportTxt(EXAM, null, '', SOURCE_A), false);
+    assert.equal(await f.shelf.exportExamTxt(EXAM, 'A', SOURCE_A), false);
+    assert.equal(f.downloads.length, before);
+    await assertDownload(f, await f.reader.exportTxt(EXAM, null, '', SOURCE_B), 'Alpha\nShared');
+    await assertDownload(f, await f.shelf.exportAllBookshelfTxt(), 'Alpha\nShared');
+    assert.equal(f.canonical.snapshot.words.find((word) => word.id === 'review-shared').word, 'Shared');
+});
+
+test('TXT order is independent of collection order, table order, merge and reload', async () => {
+    const f = await fixture();
+    const incoming = f.collect(f.model.createSnapshot(), 'Beta', SOURCE_B);
+    const merged = f.model.merge(f.canonical.snapshot, incoming);
+    const reverseMerged = f.model.merge(incoming, f.canonical.snapshot);
+    const expected = 'Alpha\nBeta\ncafé habitat zone\nShared\nzebra';
+    assert.equal(f.model.toPlainText(merged).content, expected);
+    assert.equal(f.model.toPlainText(reverseMerged).content, expected);
+    merged.reading.terms.reverse();
+    merged.reading.associations.reverse();
+    assert.equal(f.model.toPlainText(merged).content, expected);
+    f.setSnapshot(f.model.deserialize(f.model.serialize(merged)));
+    await assertDownload(f, await f.reader.exportTxt(), expected);
+    await assertDownload(f, await f.shelf.exportAllBookshelfTxt(), expected);
+});
+
+test('Export rereads persisted data after missed notifications and empty replacement', async () => {
+    const f = await fixture();
+    const current = f.collect(f.canonical.snapshot, 'Delta', SOURCE_B);
+    f.setSnapshot(current);
+    assert.equal(f.reader.getAll().some((word) => word.word === 'Delta'), false, 'reader starts stale');
+    const reads = f.reads;
+    await assertDownload(f, await f.reader.exportTxt(), 'Alpha\ncafé habitat zone\nDelta\nShared\nzebra');
+    assert.ok(f.reads > reads, 'export reads authoritative persistence');
+    f.setSnapshot(f.model.createSnapshot(), 'replacement');
+    const before = f.downloads.length;
+    assert.equal(await f.reader.exportTxt(), false);
+    assert.equal(await f.shelf.exportAllBookshelfTxt(), false);
+    assert.equal(f.downloads.length, before);
+    assert.equal(f.reader.getAll().length, 0);
+});
+
+test('Export waits for a snapshot and failed reads never download the cached vocabulary', async () => {
+    const f = await fixture();
+    let release;
+    f.setReadGate(new Promise((resolve) => { release = resolve; }));
+    const pending = f.reader.exportTxt();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(f.downloads.length, 0);
+    release();
+    await assertDownload(f, await pending, 'Alpha\ncafé habitat zone\nShared\nzebra');
+    f.setReadGate(null);
+    f.setFailure(new Error('Persisted snapshot read failed'));
+    const before = f.downloads.length;
+    await assert.rejects(f.reader.exportTxt(), /Persisted snapshot read failed/);
+    await assert.rejects(f.shelf.exportAllBookshelfTxt(), /Persisted snapshot read failed/);
+    assert.equal(f.downloads.length, before);
+});
+
+for (const entryPoint of ['reader', 'shelf']) {
+    test(`${entryPoint} export uses its fetched snapshot while a later refresh is still pending`, async () => {
+        const f = await fixture();
+        f.setSnapshot(f.collect(f.canonical.snapshot, 'Delta', SOURCE_B));
+        let releaseExport;
+        f.setReadGate(new Promise((resolve) => { releaseExport = resolve; }));
+        const pending = entryPoint === 'reader' ? f.reader.exportTxt() : f.shelf.exportAllBookshelfTxt();
+        await new Promise((resolve) => setImmediate(resolve));
+        let releaseRefresh;
+        f.setReadGate(new Promise((resolve) => { releaseRefresh = resolve; }));
+        const background = f[entryPoint].init();
+        await new Promise((resolve) => setImmediate(resolve));
+        try {
+            releaseExport();
+            await assertDownload(f, await pending, 'Alpha\ncafé habitat zone\nDelta\nShared\nzebra');
+        } finally {
+            releaseRefresh();
+            await background;
+        }
+    });
+}
+
+test('Download activation errors reject and still release temporary browser resources', async () => {
+    const f = await fixture();
+    f.sandbox.document.createElement = () => ({ click() { throw new Error('Download denied'); } });
+    await assert.rejects(f.reader.exportTxt(), /Download denied/);
+    await assert.rejects(f.shelf.exportAllBookshelfTxt(), /Download denied/);
+    assert.equal(f.attached.size, 0);
+    f.cleanup();
+    assert.equal(f.urls.size, 0);
+});

--- a/js/bundles/browse.bundle.js
+++ b/js/bundles/browse.bundle.js
@@ -16217,27 +16217,14 @@ if (typeof module !== 'undefined' && module.exports) {
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
-            const list = examId ? this.getByExam(examId, source) : this.getAll();
-            if (!list || list.length === 0) {
-                return false;
-            }
-
-            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
-            const words = [];
-            const seen = new Set();
-            list.forEach(item => {
-                const raw = typeof item === 'string' ? item : item?.word;
-                const w = (raw || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
+        async exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            // A later background refresh can supersede this read's cache update
+            // while still pending. Export the fetched durable snapshot itself.
+            const { snapshot } = await this.init();
+            const model = global.AppData.vocab.readingModel;
+            const articleId = examId ? model.articleId(source, String(examId)) : null;
+            const result = model.toPlainText(snapshot, articleId ? { articleId } : {});
+            if (result.count === 0) return false;
 
             let filename = customFilename;
             if (!filename) {
@@ -16247,22 +16234,26 @@ if (typeof module !== 'undefined' && module.exports) {
                 const day = String(now.getDate()).padStart(2, '0');
                 const dateStr = `${year}-${month}-${day}`;
 
-                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
-                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                const article = snapshot.reading.articles.find((row) => row.id === articleId);
+                const rawTitle = fallbackTitle || article?.title || examId || '全部精读生词';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, ' ').trim();
                 filename = `${dateStr}_${safeTitle}.txt`;
             }
 
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const blob = new Blob([result.content], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = filename;
             document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return true;
+            try {
+                a.click();
+            } finally {
+                document.body.removeChild(a);
+                // Let the browser start consuming the object URL before release.
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            }
+            return { filename, count: result.count };
         },
 
         async init() {
@@ -16837,7 +16828,7 @@ if (typeof module !== 'undefined' && module.exports) {
                                     <h3>📖 我的生词本</h3>
                                     <div class="vocab-modal-tabs">
                                         <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
-                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部精读生词 (<span id="v-count-all">0</span>)</button>
                                     </div>
                                 </div>
                                 <div class="vocab-modal-header-actions">
@@ -16860,7 +16851,7 @@ if (typeof module !== 'undefined' && module.exports) {
                             <!-- 底部操作栏 -->
                             <div class="vocab-modal-footer">
                                 <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
-                                    <span>⬇️ 导出为 TXT</span>
+                                    <span>⬇️ 导出本篇生词 TXT</span>
                                 </button>
                                 <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
                                     <span>🗑️ 清空生词</span>
@@ -17062,26 +17053,24 @@ if (typeof module !== 'undefined' && module.exports) {
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                on(exportBtn, 'click', () => {
+                on(exportBtn, 'click', async () => {
+                    if (exportBtn.disabled) return;
+                    const requestId = this._openRequestId;
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
-
-                    const now = new Date();
-                    const year = now.getFullYear();
-                    const month = String(now.getMonth() + 1).padStart(2, '0');
-                    const day = String(now.getDate()).padStart(2, '0');
-                    const dateStr = `${year}-${month}-${day}`;
-
-                    // 当前文章名字
-                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
-                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
-                    const filename = `${dateStr}_${safeArticleName}.txt`;
-
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
-                    if (success) {
-                        this.showToast(`✅ 已导出：${filename}`);
-                    } else {
-                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    const title = isCurrent ? (this.currentExam?.title || this.examData?.title || '当前文章') : '全部精读生词';
+                    exportBtn.disabled = true;
+                    try {
+                        const result = await ReadingVocabStore.exportTxt(examId, null, title, this.currentSource);
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(result ? `✅ 已导出 ${result.count} 个生词（${result.filename}）`
+                            : '⚠️ 当前生词本为空，暂无可导出内容');
+                    } catch (error) {
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                            ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
+                    } finally {
+                        if (requestId === this._openRequestId) exportBtn.disabled = false;
                     }
                 });
             }
@@ -17870,6 +17859,8 @@ if (typeof module !== 'undefined' && module.exports) {
             if (!listEl) return;
 
             const isCurrent = this.modalTab === 'current';
+            const exportLabel = overlay.querySelector('#vocab-export-btn span');
+            if (exportLabel) exportLabel.textContent = isCurrent ? '⬇️ 导出本篇生词 TXT' : '⬇️ 导出全部精读生词 TXT';
             const list = isCurrent
                 ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();

--- a/js/bundles/core-foundation.bundle.js
+++ b/js/bundles/core-foundation.bundle.js
@@ -3220,6 +3220,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -3234,7 +3249,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;

--- a/js/bundles/listening-record-bridge.bundle.js
+++ b/js/bundles/listening-record-bridge.bundle.js
@@ -2889,6 +2889,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -2903,7 +2918,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;

--- a/js/bundles/listening-wrapper.bundle.js
+++ b/js/bundles/listening-wrapper.bundle.js
@@ -2889,6 +2889,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -2903,7 +2918,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;

--- a/js/bundles/more.bundle.js
+++ b/js/bundles/more.bundle.js
@@ -5388,13 +5388,6 @@
             return words.find((word) => word.id === ref.wordId) || null;
         },
 
-        _getWords(articleId) {
-            if (!this._snapshot) return [];
-            const reading = this._snapshot.reading;
-            const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
-            return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
-        },
-
         getDistinctWordCount() {
             if (!this._snapshot) return 0;
             return new Set(this._snapshot.reading.associations.map((row) => row.termId)).size;
@@ -5413,90 +5406,42 @@
         },
 
         async exportExamTxt(examId, examTitle, source, articleId) {
-            await this.init();
             const id = await this._articleId(examId, source, articleId);
-            const examWords = this._getWords(id);
-            if (examWords.length === 0) {
-                return false;
-            }
-
-            const words = [];
-            const seen = new Set();
-            examWords.forEach(item => {
-                const w = (typeof item === 'string' ? item : item?.word || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
-
-            const now = new Date();
-            const year = now.getFullYear();
-            const month = String(now.getMonth() + 1).padStart(2, '0');
-            const day = String(now.getDate()).padStart(2, '0');
-            const dateStr = `${year}-${month}-${day}`;
-
-            const rawTitle = examTitle || examWords[0]?.examTitle || examId || '阅读生词本';
-            const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
-            const filename = `${dateStr}_${safeTitle}.txt`;
-
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = filename;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return { filename, count: words.length };
+            return this._exportTxt(id, examTitle || examId || '阅读生词本');
         },
 
         async exportAllBookshelfTxt() {
-            await this.init();
-            const vocabWords = this._getWords();
+            return this._exportTxt(null, '全部精读生词');
+        },
 
-            if (vocabWords.length === 0) {
-                return false;
-            }
-
-            const words = [];
-            const seen = new Set();
-            vocabWords.forEach(item => {
-                const w = (typeof item === 'string' ? item : item?.word || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
+        async _exportTxt(articleId, title) {
+            // init may defer cache adoption to a later pending refresh; its
+            // returned snapshot is still the durable read for this export.
+            const { snapshot } = await this.init();
+            const result = global.AppData.vocab.readingModel.toPlainText(snapshot, articleId ? { articleId } : {});
+            if (result.count === 0) return false;
 
             const now = new Date();
             const year = now.getFullYear();
             const month = String(now.getMonth() + 1).padStart(2, '0');
             const day = String(now.getDate()).padStart(2, '0');
             const dateStr = `${year}-${month}-${day}`;
-            const filename = `${dateStr}_书架全部阅读生词.txt`;
+            const safeTitle = String(title).replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, ' ').trim();
+            const filename = `${dateStr}_${safeTitle}.txt`;
 
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const blob = new Blob([result.content], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = filename;
             document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return { filename, count: words.length };
+            try {
+                a.click();
+            } finally {
+                document.body.removeChild(a);
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            }
+            return { filename, count: result.count };
         }
     };
 
@@ -5600,8 +5545,8 @@
                             </div>
                         </div>
                         <div class="bookshelf-topbar__right">
-                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="一键导出书架全部生词为 TXT">
-                                📥 导出全部生词
+                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="导出全部精读生词 TXT，包含所有文章，不受当前搜索和筛选影响">
+                                📥 导出全部精读生词
                             </button>
                             <button type="button" class="btn btn-primary bookshelf-notebook-btn" data-action="open-global-notebook" title="打开生词本总览">
                                 📖 打开生词本
@@ -5855,7 +5800,7 @@
                 exportAllBtn.addEventListener('click', async () => {
                     try {
                         const res = await ReadingBookshelfStore.exportAllBookshelfTxt();
-                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 书架暂无生词可导出');
+                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 暂无精读生词可导出');
                     } catch (error) {
                         this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }

--- a/js/bundles/practice-page-enhancer.bundle.js
+++ b/js/bundles/practice-page-enhancer.bundle.js
@@ -2889,6 +2889,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -2903,7 +2918,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;

--- a/js/bundles/reading-page.bundle.js
+++ b/js/bundles/reading-page.bundle.js
@@ -2889,6 +2889,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -2903,7 +2918,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;
@@ -8977,27 +8992,14 @@
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
-            const list = examId ? this.getByExam(examId, source) : this.getAll();
-            if (!list || list.length === 0) {
-                return false;
-            }
-
-            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
-            const words = [];
-            const seen = new Set();
-            list.forEach(item => {
-                const raw = typeof item === 'string' ? item : item?.word;
-                const w = (raw || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
+        async exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            // A later background refresh can supersede this read's cache update
+            // while still pending. Export the fetched durable snapshot itself.
+            const { snapshot } = await this.init();
+            const model = global.AppData.vocab.readingModel;
+            const articleId = examId ? model.articleId(source, String(examId)) : null;
+            const result = model.toPlainText(snapshot, articleId ? { articleId } : {});
+            if (result.count === 0) return false;
 
             let filename = customFilename;
             if (!filename) {
@@ -9007,22 +9009,26 @@
                 const day = String(now.getDate()).padStart(2, '0');
                 const dateStr = `${year}-${month}-${day}`;
 
-                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
-                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                const article = snapshot.reading.articles.find((row) => row.id === articleId);
+                const rawTitle = fallbackTitle || article?.title || examId || '全部精读生词';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, ' ').trim();
                 filename = `${dateStr}_${safeTitle}.txt`;
             }
 
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const blob = new Blob([result.content], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = filename;
             document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return true;
+            try {
+                a.click();
+            } finally {
+                document.body.removeChild(a);
+                // Let the browser start consuming the object URL before release.
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            }
+            return { filename, count: result.count };
         },
 
         async init() {
@@ -9597,7 +9603,7 @@
                                     <h3>📖 我的生词本</h3>
                                     <div class="vocab-modal-tabs">
                                         <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
-                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部精读生词 (<span id="v-count-all">0</span>)</button>
                                     </div>
                                 </div>
                                 <div class="vocab-modal-header-actions">
@@ -9620,7 +9626,7 @@
                             <!-- 底部操作栏 -->
                             <div class="vocab-modal-footer">
                                 <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
-                                    <span>⬇️ 导出为 TXT</span>
+                                    <span>⬇️ 导出本篇生词 TXT</span>
                                 </button>
                                 <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
                                     <span>🗑️ 清空生词</span>
@@ -9822,26 +9828,24 @@
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                on(exportBtn, 'click', () => {
+                on(exportBtn, 'click', async () => {
+                    if (exportBtn.disabled) return;
+                    const requestId = this._openRequestId;
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
-
-                    const now = new Date();
-                    const year = now.getFullYear();
-                    const month = String(now.getMonth() + 1).padStart(2, '0');
-                    const day = String(now.getDate()).padStart(2, '0');
-                    const dateStr = `${year}-${month}-${day}`;
-
-                    // 当前文章名字
-                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
-                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
-                    const filename = `${dateStr}_${safeArticleName}.txt`;
-
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
-                    if (success) {
-                        this.showToast(`✅ 已导出：${filename}`);
-                    } else {
-                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    const title = isCurrent ? (this.currentExam?.title || this.examData?.title || '当前文章') : '全部精读生词';
+                    exportBtn.disabled = true;
+                    try {
+                        const result = await ReadingVocabStore.exportTxt(examId, null, title, this.currentSource);
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(result ? `✅ 已导出 ${result.count} 个生词（${result.filename}）`
+                            : '⚠️ 当前生词本为空，暂无可导出内容');
+                    } catch (error) {
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                            ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
+                    } finally {
+                        if (requestId === this._openRequestId) exportBtn.disabled = false;
                     }
                 });
             }
@@ -10630,6 +10634,8 @@
             if (!listEl) return;
 
             const isCurrent = this.modalTab === 'current';
+            const exportLabel = overlay.querySelector('#vocab-export-btn span');
+            if (exportLabel) exportLabel.textContent = isCurrent ? '⬇️ 导出本篇生词 TXT' : '⬇️ 导出全部精读生词 TXT';
             const list = isCurrent
                 ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();

--- a/js/components/bookshelfView.js
+++ b/js/components/bookshelfView.js
@@ -197,13 +197,6 @@
             return words.find((word) => word.id === ref.wordId) || null;
         },
 
-        _getWords(articleId) {
-            if (!this._snapshot) return [];
-            const reading = this._snapshot.reading;
-            const termIds = new Set(reading.associations.filter((row) => !articleId || row.articleId === articleId).map((row) => row.termId));
-            return reading.terms.filter((term) => termIds.has(term.id)).map((term) => this._wordForTerm(term)).filter(Boolean);
-        },
-
         getDistinctWordCount() {
             if (!this._snapshot) return 0;
             return new Set(this._snapshot.reading.associations.map((row) => row.termId)).size;
@@ -222,90 +215,42 @@
         },
 
         async exportExamTxt(examId, examTitle, source, articleId) {
-            await this.init();
             const id = await this._articleId(examId, source, articleId);
-            const examWords = this._getWords(id);
-            if (examWords.length === 0) {
-                return false;
-            }
-
-            const words = [];
-            const seen = new Set();
-            examWords.forEach(item => {
-                const w = (typeof item === 'string' ? item : item?.word || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
-
-            const now = new Date();
-            const year = now.getFullYear();
-            const month = String(now.getMonth() + 1).padStart(2, '0');
-            const day = String(now.getDate()).padStart(2, '0');
-            const dateStr = `${year}-${month}-${day}`;
-
-            const rawTitle = examTitle || examWords[0]?.examTitle || examId || '阅读生词本';
-            const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
-            const filename = `${dateStr}_${safeTitle}.txt`;
-
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = filename;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return { filename, count: words.length };
+            return this._exportTxt(id, examTitle || examId || '阅读生词本');
         },
 
         async exportAllBookshelfTxt() {
-            await this.init();
-            const vocabWords = this._getWords();
+            return this._exportTxt(null, '全部精读生词');
+        },
 
-            if (vocabWords.length === 0) {
-                return false;
-            }
-
-            const words = [];
-            const seen = new Set();
-            vocabWords.forEach(item => {
-                const w = (typeof item === 'string' ? item : item?.word || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
+        async _exportTxt(articleId, title) {
+            // init may defer cache adoption to a later pending refresh; its
+            // returned snapshot is still the durable read for this export.
+            const { snapshot } = await this.init();
+            const result = global.AppData.vocab.readingModel.toPlainText(snapshot, articleId ? { articleId } : {});
+            if (result.count === 0) return false;
 
             const now = new Date();
             const year = now.getFullYear();
             const month = String(now.getMonth() + 1).padStart(2, '0');
             const day = String(now.getDate()).padStart(2, '0');
             const dateStr = `${year}-${month}-${day}`;
-            const filename = `${dateStr}_书架全部阅读生词.txt`;
+            const safeTitle = String(title).replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, ' ').trim();
+            const filename = `${dateStr}_${safeTitle}.txt`;
 
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const blob = new Blob([result.content], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = filename;
             document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return { filename, count: words.length };
+            try {
+                a.click();
+            } finally {
+                document.body.removeChild(a);
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            }
+            return { filename, count: result.count };
         }
     };
 
@@ -409,8 +354,8 @@
                             </div>
                         </div>
                         <div class="bookshelf-topbar__right">
-                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="一键导出书架全部生词为 TXT">
-                                📥 导出全部生词
+                            <button type="button" class="btn btn-secondary bookshelf-export-all-btn" data-action="export-all-bookshelf" ${totalWords === 0 ? 'disabled' : ''} title="导出全部精读生词 TXT，包含所有文章，不受当前搜索和筛选影响">
+                                📥 导出全部精读生词
                             </button>
                             <button type="button" class="btn btn-primary bookshelf-notebook-btn" data-action="open-global-notebook" title="打开生词本总览">
                                 📖 打开生词本
@@ -664,7 +609,7 @@
                 exportAllBtn.addEventListener('click', async () => {
                     try {
                         const res = await ReadingBookshelfStore.exportAllBookshelfTxt();
-                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 书架暂无生词可导出');
+                        this.showToast(res ? `✅ 已导出 ${res.count} 个生词（${res.filename}）` : '⚠️ 暂无精读生词可导出');
                     } catch (error) {
                         this.showToast(needsPageReload(error) ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
                     }

--- a/js/components/readingVocabReader.js
+++ b/js/components/readingVocabReader.js
@@ -161,27 +161,14 @@
                 .trim();
         },
 
-        exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
-            const list = examId ? this.getByExam(examId, source) : this.getAll();
-            if (!list || list.length === 0) {
-                return false;
-            }
-
-            // 只需要单词，不需要例句和其他内容，且每个单词一行（自动去重）
-            const words = [];
-            const seen = new Set();
-            list.forEach(item => {
-                const raw = typeof item === 'string' ? item : item?.word;
-                const w = (raw || '').trim();
-                if (w && !seen.has(w.toLowerCase())) {
-                    seen.add(w.toLowerCase());
-                    words.push(w);
-                }
-            });
-
-            if (words.length === 0) {
-                return false;
-            }
+        async exportTxt(examId = null, customFilename = null, fallbackTitle = '', source = DEFAULT_SOURCE) {
+            // A later background refresh can supersede this read's cache update
+            // while still pending. Export the fetched durable snapshot itself.
+            const { snapshot } = await this.init();
+            const model = global.AppData.vocab.readingModel;
+            const articleId = examId ? model.articleId(source, String(examId)) : null;
+            const result = model.toPlainText(snapshot, articleId ? { articleId } : {});
+            if (result.count === 0) return false;
 
             let filename = customFilename;
             if (!filename) {
@@ -191,22 +178,26 @@
                 const day = String(now.getDate()).padStart(2, '0');
                 const dateStr = `${year}-${month}-${day}`;
 
-                const rawTitle = fallbackTitle || list[0]?.examTitle || examId || '生词本';
-                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').trim();
+                const article = snapshot.reading.articles.find((row) => row.id === articleId);
+                const rawTitle = fallbackTitle || article?.title || examId || '全部精读生词';
+                const safeTitle = String(rawTitle).replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, ' ').trim();
                 filename = `${dateStr}_${safeTitle}.txt`;
             }
 
-            const content = words.join('\n');
-            const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+            const blob = new Blob([result.content], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = filename;
             document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            return true;
+            try {
+                a.click();
+            } finally {
+                document.body.removeChild(a);
+                // Let the browser start consuming the object URL before release.
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            }
+            return { filename, count: result.count };
         },
 
         async init() {
@@ -781,7 +772,7 @@
                                     <h3>📖 我的生词本</h3>
                                     <div class="vocab-modal-tabs">
                                         <button type="button" class="v-tab-btn active" id="v-tab-current">本篇 (<span id="v-count-current">0</span>)</button>
-                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部 (<span id="v-count-all">0</span>)</button>
+                                        <button type="button" class="v-tab-btn" id="v-tab-all">全部精读生词 (<span id="v-count-all">0</span>)</button>
                                     </div>
                                 </div>
                                 <div class="vocab-modal-header-actions">
@@ -804,7 +795,7 @@
                             <!-- 底部操作栏 -->
                             <div class="vocab-modal-footer">
                                 <button type="button" class="v-action-btn v-export-btn" id="vocab-export-btn">
-                                    <span>⬇️ 导出为 TXT</span>
+                                    <span>⬇️ 导出本篇生词 TXT</span>
                                 </button>
                                 <button type="button" class="v-action-btn v-clear-btn" id="vocab-clear-btn">
                                     <span>🗑️ 清空生词</span>
@@ -1006,26 +997,24 @@
             // 导出与清空
             const exportBtn = overlay.querySelector('#vocab-export-btn');
             if (exportBtn) {
-                on(exportBtn, 'click', () => {
+                on(exportBtn, 'click', async () => {
+                    if (exportBtn.disabled) return;
+                    const requestId = this._openRequestId;
                     const isCurrent = this.modalTab === 'current';
                     const examId = isCurrent ? this.currentExamId : null;
-
-                    const now = new Date();
-                    const year = now.getFullYear();
-                    const month = String(now.getMonth() + 1).padStart(2, '0');
-                    const day = String(now.getDate()).padStart(2, '0');
-                    const dateStr = `${year}-${month}-${day}`;
-
-                    // 当前文章名字
-                    const rawArticleName = (this.currentExam?.title || this.examData?.title || (isCurrent ? '当前文章' : '全部生词'));
-                    const safeArticleName = String(rawArticleName).replace(/[\\/:*?"<>|]/g, '_').trim();
-                    const filename = `${dateStr}_${safeArticleName}.txt`;
-
-                    const success = ReadingVocabStore.exportTxt(examId, filename, safeArticleName, this.currentSource);
-                    if (success) {
-                        this.showToast(`✅ 已导出：${filename}`);
-                    } else {
-                        this.showToast('⚠️ 当前生词本为空，暂无可导出内容');
+                    const title = isCurrent ? (this.currentExam?.title || this.examData?.title || '当前文章') : '全部精读生词';
+                    exportBtn.disabled = true;
+                    try {
+                        const result = await ReadingVocabStore.exportTxt(examId, null, title, this.currentSource);
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(result ? `✅ 已导出 ${result.count} 个生词（${result.filename}）`
+                            : '⚠️ 当前生词本为空，暂无可导出内容');
+                    } catch (error) {
+                        if (requestId !== this._openRequestId) return;
+                        this.showToast(error?.code === 'BACKEND_UNAVAILABLE'
+                            ? '⚠️ 生词读取失败，请刷新页面后重试导出' : '⚠️ 生词读取失败，请重试导出');
+                    } finally {
+                        if (requestId === this._openRequestId) exportBtn.disabled = false;
                     }
                 });
             }
@@ -1814,6 +1803,8 @@
             if (!listEl) return;
 
             const isCurrent = this.modalTab === 'current';
+            const exportLabel = overlay.querySelector('#vocab-export-btn span');
+            if (exportLabel) exportLabel.textContent = isCurrent ? '⬇️ 导出本篇生词 TXT' : '⬇️ 导出全部精读生词 TXT';
             const list = isCurrent
                 ? (this._sourceReady ? ReadingVocabStore.getByExam(this.currentExamId, this.currentSource) : [])
                 : ReadingVocabStore.getAll();

--- a/js/data/v2/readingVocabularyModel.js
+++ b/js/data/v2/readingVocabularyModel.js
@@ -623,6 +623,21 @@
         return copy({ terms: rows, distinctTermCount: rows.length, occurrenceCount: rows.reduce((sum, row) => sum + row.occurrences.length, 0) });
     }
 
+    function toPlainText(snapshot, options = {}) {
+        // query selects the distinct union of article associations, including
+        // missing sources, and resolves each term's canonical display owner.
+        // Order uses normalized canonical identity, compared as UTF-16 code
+        // units rather than locale collation, so every entry point agrees.
+        const entries = query(snapshot, options).terms.sort((left, right) => (
+            left.term.normalizedTerm < right.term.normalizedTerm ? -1
+                : left.term.normalizedTerm > right.term.normalizedTerm ? 1 : 0
+        ));
+        // Whitespace (including CR/LF and Unicode separators) stays inside one
+        // term. TXT has LF separators, no header, BOM, or trailing newline.
+        const words = entries.map((entry) => entry.word.word.replace(/\s+/g, ' ').trim());
+        return { content: words.join('\n'), count: words.length };
+    }
+
     function listVisits(snapshot) { validate(snapshot); return copy(snapshot.reading.visits); }
     function serialize(snapshot) { validate(snapshot); return JSON.stringify(snapshot); }
     function deserialize(value) {
@@ -637,7 +652,7 @@
     const model = Object.freeze({
         SCHEMA_VERSION, READING_LIST_ID, normalizeTerm, sourceId, articleId, contentRef, termId, occurrenceId,
         createSnapshot, validate, collect, recordVisit, removeOccurrence, removeArticleTerm,
-        clearArticle, deleteCanonicalTerm, merge, query, listVisits, serialize, deserialize
+        clearArticle, deleteCanonicalTerm, merge, query, toPlainText, listVisits, serialize, deserialize
     });
     global.ReadingVocabularyModel = model;
     if (typeof module !== 'undefined' && module.exports) module.exports = model;


### PR DESCRIPTION
## Change

Deliver UTF-8 TXT exports for the current source-scoped article and the complete intensive-reading association union. All entry points share canonical identity deduplication, canonical display terms, whitespace folding, and deterministic ordering. Export reads its own persisted snapshot even when refreshes overlap; empty or failed reads do not download cached data.

Add production browser coverage and a clean-revision release gate that builds a fresh package, verifies every tracked runtime asset, and repeats Browse → reader → select/manual add → close/reopen → cold Bookshelf → download. Both package builders verify bundles, require reader assets, exclude Python caches, and preserve other release versions.

The [release contract and F1–F6 coverage matrix](https://github.com/sallowayma-git/IELTS-practice/blob/68a416933edb4383e82bc72186e2bd5341f6f60d/developer/doc/Intensive-Reading-Release.md) documents the format, commands, fixtures, and limitations.

## Reviewed and tested revisions

- Base: `d5708aee361673e71bc1ac00dcca0a3f893d543d` (`opensource`).
- Reviewed head: `68a416933edb4383e82bc72186e2bd5341f6f60d`; both PR commits have verified GPG signatures.
- CI-tested merge: `c58ee20e7c005974ca42e9c41af0dbd92fc9c2c0`, with the same base/head recorded by the qualifier.
- Prerequisites #154–#159 are complete. [Final CI run](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34344921206) and GitGuardian both passed.

## Release evidence

CI used Ubuntu, Node.js 22.23.2, Python 3.14.7, and Chromium 141.0.7390.37 (Node Playwright 1.56.1 / Python Playwright 1.56.0). The additional Windows package qualification ran at the reviewed head with Node.js 24.19.0, Python 3.12.14, and Chromium 151.0.7922.34. Both qualification worktrees were clean.

| Command / scope | Observed outcome |
| --- | --- |
| `node scripts/build-bundles.mjs --check` | 14/14 outputs current. |
| `npm test --prefix developer` | 330 passed; no failures, skips, or cancellations. Includes production reset, annotations, vocabulary review, recovery, timing/score, actual IndexedDB/multi-page persistence, and export refresh regressions. |
| `python -m unittest discover -s developer/tests/py -p "test_*.py"` | 32 passed. |
| `python developer/tests/ci/check_reading_data_integrity.py` | 238 files passed; one existing allowlisted duplicate, no blocking findings. |
| `python developer/tests/e2e/e2e_runner.py` | 13/13 flows passed, including practice-answer isolation, real DOM selection/restoration, cold Bookshelf entry, submission, recovery, and backup behavior. |
| `reading_txt_release.node.js`, source | `file://`, local HTTP, static HTTPS all passed: 9 case groups, 45 exact-byte downloads. |
| `python developer/tests/ci/qualify_reading_release.py`, Linux and Windows | Each fresh package passed all three modes, 9 case groups, and 45 downloads; each of 515 tracked runtime files matched its checkout bytes. |

TXT fixtures use articles `p1-high-01` and `p1-low-02`, shared canonical `Began`, two selected `began` occurrences, manual `Café` and whitespace-bearing phrases, unrelated review words, filtered global export, and clear-A/preserve-B. Real IndexedDB cases cover simultaneous additions, a paused stale collection rejected after deletion, failed UI quota writes without partial acknowledgement, missing-source reader/shelf export, legacy migration, merge tombstones, and authoritative empty replace across stale windows and reload.

[Download CI diagnostics](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34344921206/artifacts/10101635701) for exact JSON results, command logs, browser versions, per-asset manifests, screenshots, and downloaded TXT fixtures.

| Package | ZIP SHA-256 | Asset-manifest SHA-256 |
| --- | --- | --- |
| Windows / reviewed head | `792e1eff9af9eaffd8513b22cda041dafd1109e86f68bda5ee8b2e8d64fdc9bf` | `fbc6bd19972375e775ebe5cdfca060d54bbfdba125451f1410b596b3ee2f1d1f` |
| Linux / tested merge | `c28bc5b64c9514ab256a073753dea6691e65ca3593a39abbd2e35b20963dfe18` | `8d405f2711816e77fee98b911edfcf1593c137f3b7d1ed0ab8a163e877275bdf` |

The four cross-platform asset differences are existing CRLF/LF checkout conversions in three SVG files and the dictionary license; all other runtime bytes match.

Static HTTPS uses loopback TLS with an ephemeral certificate and isolated certificate-validation bypass. Public-host deployment, trusted-certificate configuration, named third-party importers, non-Chromium engines, and mobile devices were not tested. Rich-field Anki TSV, AI analysis, and cross-device synchronization remain deferred.

Closes #160. References parent #149; keep the parent open until full v1 acceptance is approved.
