### PR TITLE
fix(e2e): restore the Tauri Vue visual regression gate

### DIFF
--- a/.github/workflows/tauri-ci.yml
+++ b/.github/workflows/tauri-ci.yml
@@ -94,6 +94,8 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check "playwright==$env:PY_PLAYWRIGHT_VERSION"
           python -m playwright install chromium
+      - name: Verify shared visual assertions
+        run: python -m unittest discover -s developer/tests/e2e -p visual_test_support_test.py -v
       - name: Run visual regression matrix
         run: python developer/tests/e2e/run_visual_regressions.py
       - name: Upload visual regression evidence

--- a/apps/writing-vue/src/modules/practice-reading/components/ReadingHistoryPanel.vue
+++ b/apps/writing-vue/src/modules/practice-reading/components/ReadingHistoryPanel.vue
@@ -427,6 +427,7 @@
             <a
               href="#"
               class="practice-record-title"
+              :title="record.title || '无标题'"
               data-record-action="details"
               :data-record-id="record.id"
               @click.prevent.stop="$emit('open-reading-review', record)"

--- a/apps/writing-vue/src/styles/opensource-skin.css
+++ b/apps/writing-vue/src/styles/opensource-skin.css
@@ -257,7 +257,8 @@
 
 .atlas-source-ui :is(input, textarea, select):focus,
 .atlas-source-ui :is(input, textarea, select, button, a):focus-visible {
-  outline: none;
+  outline: 2px solid var(--anth-accent-strong);
+  outline-offset: 2px;
   border-color: var(--anth-accent);
   box-shadow: var(--anth-ring-focus);
 }
@@ -411,12 +412,13 @@
   .atlas-source-ui .nav-links {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    overflow: visible;
     border-radius: var(--anth-radius-md);
   }
 
   .atlas-source-ui .nav-item {
     justify-content: center;
-    min-height: 40px;
+    min-height: 44px;
   }
 }
 
@@ -655,11 +657,31 @@
   word-break: break-all;
 }
 
+.atlas-source-ui .settings-detail-panel > .settings-panel {
+  background: var(--anth-surface);
+  border: 1px solid var(--anth-border);
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 /* ════════════════════════════════════════════════════════════════════
  * Dialogs — the single sanctioned modal implementation.
  * Markup contract: .dialog-overlay > .dialog (optionally + .card) with
  * .dialog-actions row. Page-local overrides may set width/height only.
  * ════════════════════════════════════════════════════════════════════ */
+/* Fixed overlays must escape the main/nav stacking boundary and lock the
+   document scroll owner. Hidden Library overlays do not participate. */
+html:has(.atlas-source-ui :is(.dialog-overlay, .settings-detail-modal, .suite-mode-selector-modal.show, .pdf-viewer-overlay, .clock-overlay:not(.is-hidden))),
+body:has(.atlas-source-ui :is(.dialog-overlay, .settings-detail-modal, .suite-mode-selector-modal.show, .pdf-viewer-overlay, .clock-overlay:not(.is-hidden))),
+.atlas-source-ui:has(:is(.dialog-overlay, .settings-detail-modal, .suite-mode-selector-modal.show, .pdf-viewer-overlay, .clock-overlay:not(.is-hidden))) {
+  overflow: hidden;
+}
+
+.atlas-source-ui .app-main:has(:is(.dialog-overlay, .settings-detail-modal, .suite-mode-selector-modal.show, .pdf-viewer-overlay, .clock-overlay:not(.is-hidden))) {
+  z-index: var(--anth-z-overlay);
+}
+
 .atlas-source-ui .dialog-overlay,
 .atlas-source-ui .overlay {
   position: fixed;
@@ -1036,6 +1058,12 @@
 /* Result page */
 .atlas-source-ui .result-page {
   color: var(--anth-ink);
+}
+
+.atlas-source-ui .result-page .view-controls > .btn-brand {
+  background: var(--anth-accent-strong);
+  color: var(--anth-accent-contrast);
+  border-color: var(--anth-accent-strong);
 }
 
 /* Topic manage */

--- a/apps/writing-vue/src/views/HistoryPage.vue
+++ b/apps/writing-vue/src/views/HistoryPage.vue
@@ -1539,6 +1539,12 @@ onBeforeUnmount(() => {
   margin-bottom: 16px;
 }
 
+.comparison-table-scroll {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .comparison-table th,
 .comparison-table td {
   padding: 12px;
@@ -2077,6 +2083,7 @@ onBeforeUnmount(() => {
 .history-page .filter-item input[type='date'],
 .history-page .filter-item input[type='number'] {
   width: 100%;
+  min-width: 0;
   min-height: 40px;
   box-sizing: border-box;
 }
@@ -2120,6 +2127,7 @@ onBeforeUnmount(() => {
 
 .history-page .batch-actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
 }
@@ -2236,6 +2244,12 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr);
   gap: 18px;
+}
+
+.history-page .analytics-side,
+.history-page .analytics-layout > *,
+.history-page .analytics-side > * {
+  min-width: 0;
 }
 
 .history-page .stat-chart,
@@ -2389,6 +2403,7 @@ onBeforeUnmount(() => {
 
 .history-page .essay-title {
   margin: 4px 0;
+  overflow-wrap: anywhere;
   font-size: var(--anth-text-base);
   font-weight: 700;
 }
@@ -2434,6 +2449,74 @@ onBeforeUnmount(() => {
   gap: 14px;
 }
 
+.history-page .essay-checkbox,
+.history-page .essay-actions .btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.history-page .task-badge.reading {
+  background: var(--anth-success-soft);
+  color: var(--anth-success);
+}
+
+.history-page .task-badge.unlabeled {
+  background: var(--anth-surface-sunken);
+  color: var(--anth-ink-soft);
+}
+
+.history-page .history-list-state,
+.history-page .detail-modal > :is(.loading, .detail-error-state, .detail-empty-state) {
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  gap: 12px;
+  min-height: 200px;
+  padding: 28px 20px;
+  text-align: center;
+}
+
+.history-state-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--anth-border);
+  border-top-color: var(--anth-accent);
+  border-radius: 50%;
+  animation: history-state-spin 1s linear infinite;
+}
+
+@keyframes history-state-spin {
+  to { transform: rotate(1turn); }
+}
+
+@media (max-width: 640px) {
+  .history-page .batch-actions > span {
+    flex-basis: 100%;
+  }
+
+  .history-page .pagination {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .history-page .pagination .page-info {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    text-align: center;
+  }
+
+  .history-page .filter-item select,
+  .history-page .filter-item input[type='date'],
+  .history-page .filter-item input[type='number'],
+  .history-page .filter-row > .btn,
+  .history-page :is(input, select, button) {
+    min-height: 44px;
+  }
+}
+
 @media (max-width: 960px) {
   .history-page .filter-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2446,7 +2529,7 @@ onBeforeUnmount(() => {
   }
 
   .history-page .analytics-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .history-page .analytics-radar-card .section-header h2,

--- a/apps/writing-vue/src/views/PracticeLibraryPage.vue
+++ b/apps/writing-vue/src/views/PracticeLibraryPage.vue
@@ -1746,6 +1746,17 @@ function updateSegmentedIndicators() {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.practice-library .custom-suite-selection-bar,
+.practice-library .custom-suite-selection-main {
+  min-width: 0;
+}
+
+.practice-library .custom-suite-picked-list .custom-suite-picked-chip {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .practice-library .practice-history-list {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -2162,6 +2173,16 @@ function updateSegmentedIndicators() {
   white-space: nowrap;
 }
 
+.practice-library .record-info {
+  min-width: 0;
+}
+
+.practice-library .record-percentage {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+}
+
 .practice-library .practice-history-list > .loading,
 .practice-library .practice-history-list > .history-empty-placeholder {
   grid-column: 1 / -1;
@@ -2279,6 +2300,9 @@ function updateSegmentedIndicators() {
 }
 
 .practice-library .suite-flow-option {
+  display: flex;
+  flex-direction: column;
+  white-space: normal;
   min-height: 96px;
   align-items: flex-start;
   justify-content: flex-start;
@@ -2388,10 +2412,10 @@ function updateSegmentedIndicators() {
   .practice-library .library-view-tabs {
     width: 100%;
     min-width: 0;
-    flex-wrap: nowrap;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     justify-content: flex-start;
-    overflow-x: auto;
-    scrollbar-width: none;
+    overflow: visible;
   }
 
   .practice-library .library-view-tabs::-webkit-scrollbar {
@@ -2399,7 +2423,8 @@ function updateSegmentedIndicators() {
   }
 
   .practice-library .library-view-tabs__button {
-    flex: 0 0 auto;
+    min-height: 44px;
+    white-space: normal;
   }
 
   .practice-library .category-grid,
@@ -2442,6 +2467,11 @@ function updateSegmentedIndicators() {
     width: 100%;
   }
 
+  .practice-library .practice-history-header > .hero-panel__actions button {
+    min-height: 44px;
+    white-space: nowrap;
+  }
+
   .practice-library .practice-history-header > .hero-panel__actions:last-child {
     margin-left: 0;
   }
@@ -2469,6 +2499,15 @@ function updateSegmentedIndicators() {
 }
 
 @media (max-width: 580px) {
+  .practice-library .custom-suite-picked-list .custom-suite-picked-chip {
+    width: 100%;
+  }
+
+  .practice-library .custom-suite-selection-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .practice-library .category-actions {
     grid-template-columns: 1fr;
   }

--- a/apps/writing-vue/src/views/PracticeLibraryPage.vue
+++ b/apps/writing-vue/src/views/PracticeLibraryPage.vue
@@ -2224,6 +2224,7 @@ function updateSegmentedIndicators() {
 .practice-library .hero-settings-group > .hero-panel,
 .practice-library .backup-list-card {
   padding: 18px;
+  background: var(--anth-surface);
 }
 
 .practice-library .settings-file-input {

--- a/apps/writing-vue/src/views/ResultPage.vue
+++ b/apps/writing-vue/src/views/ResultPage.vue
@@ -445,11 +445,12 @@ function writeNew() {
 }
 
 .result-layout {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  align-items: start;
   gap: 24px;
   max-width: 1600px;
   margin: 0 auto;
-  height: calc(100vh - 120px);
 }
 
 .glass-card {
@@ -466,18 +467,17 @@ function writeNew() {
 }
 
 .essay-panel {
-  flex: 1.2;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
 .right-panel {
-  flex: 0.8;
+  min-width: 0;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  padding-right: 12px;
+  overflow: visible;
 }
 
 .border-base {
@@ -500,6 +500,8 @@ function writeNew() {
 
 .essay-head {
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   justify-content: space-between;
   align-items: flex-end;
 }
@@ -538,6 +540,7 @@ function writeNew() {
 
 .view-controls {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
 }
 
@@ -856,6 +859,22 @@ function writeNew() {
 .custom-scroll::-webkit-scrollbar-thumb {
   background: var(--atlas-accent-ring);
   border-radius: 4px;
+}
+
+@media (max-width: 1040px) {
+  .result-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .glass-card {
+    padding: 18px;
+  }
+
+  .metrics-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/writing-vue/src/views/SettingsPage.vue
+++ b/apps/writing-vue/src/views/SettingsPage.vue
@@ -2778,9 +2778,9 @@ onBeforeUnmount(() => {
 }
 
 .settings-page .mode-card.active {
-  border-color: color-mix(in srgb, var(--atlas-accent) 16%, transparent);
-  background:
-    var(--atlas-sheen);
+  border-color: var(--anth-accent);
+  background: var(--anth-accent-soft);
+  box-shadow: var(--anth-shadow-xs);
 }
 
 .settings-page .mode-header {

--- a/apps/writing-vue/src/views/SettingsPage.vue
+++ b/apps/writing-vue/src/views/SettingsPage.vue
@@ -2661,7 +2661,7 @@ onBeforeUnmount(() => {
   padding: 12px 14px;
   border: 1px solid var(--atlas-line);
   border-radius: 12px;
-  background: color-mix(in srgb, var(--atlas-glass) 48%, transparent);
+  background: var(--anth-surface);
 }
 
 .settings-list__main {
@@ -2773,7 +2773,7 @@ onBeforeUnmount(() => {
   border: 1px solid var(--atlas-line);
   border-radius: 14px;
   color: var(--atlas-ink);
-  background: color-mix(in srgb, var(--atlas-glass) 52%, transparent);
+  background: var(--anth-surface);
   text-align: left;
 }
 
@@ -2828,7 +2828,7 @@ onBeforeUnmount(() => {
   padding: 16px;
   border: 1px solid var(--atlas-line);
   border-radius: 14px;
-  background: color-mix(in srgb, var(--atlas-glass) 44%, transparent);
+  background: var(--anth-surface);
 }
 
 .custom-temperature-grid {
@@ -2965,7 +2965,7 @@ onBeforeUnmount(() => {
   padding: 14px 16px;
   border: 1px solid var(--atlas-line);
   border-radius: 14px;
-  background: color-mix(in srgb, var(--atlas-glass) 46%, transparent);
+  background: var(--anth-surface);
 }
 
 .info-row {

--- a/developer/tests/e2e/ISSUE_175_TRIAGE.md
+++ b/developer/tests/e2e/ISSUE_175_TRIAGE.md
@@ -1,0 +1,72 @@
+# Issue #175: visual regression triage
+
+The shipping target is the Tauri 2 Vue interface. Browser fixtures exercise the
+same production build with mocked Tauri command responses; native acceptance
+remains a separate gate.
+
+## Reproduction and design authority
+
+- Original failing commit: `617284eca6780d4069edb7a8af2a0246be22342e`.
+- [Original Windows run](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34486620462)
+  and [its report, logs, and screenshots](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34486620462/artifacts/10156044200).
+- Reproduced on integration commit `08bac3a3` using Playwright `1.61.0`:
+  all 17 scripts executed, 16 failed, and Topic Manage passed.
+- Current visual authority: `apps/writing-vue/src/styles/design-system/tokens.css`
+  and `apps/writing-vue/src/styles/opensource-skin.css`. They define an opaque,
+  warm surface theme with hairline elevation, clay accents, serif headings, and
+  a named stacking scale. Old glass/gradient styling is not the target.
+
+The reproduction screenshots show long History titles extending beyond their
+cards, a two-column Writing Result squeezed into a phone viewport, mobile
+Library tabs outside the visible container, and navigation above History detail.
+Suite screenshots show distinct status colors on passage badges, with explicit
+status text, rather than on the entire row background.
+
+Navigation geometry is sampled after the routed view appears and its finite
+entry animations finish; the active navigation label updates before that view
+is ready. Pixel checks allow 0.5px rounding where a translated 44px target was
+observed as `43.99993896484375px`. Neither readiness check waits for an expected
+layout property or increases the timeout.
+
+## Classification and retained coverage
+
+| Script | Classification and resolution | Coverage retained or strengthened |
+| --- | --- | --- |
+| `agent_workspace_visual_check.py` | Stale command assertion omitted six initialization reads. These independent reads may run in either order; verify their exact multiset separately from the ordered user actions. | All console zones, workspace selection, failed and successful run hydration, original error, trace metadata, and exact pick/run/read sequence. |
+| `nav_responsive_visual_check.py` | Product: the skin overrode the compact navigation overflow and touch size. The old test also treated programmatic focus as keyboard input and checked only an outline. Restore visible compact overflow, 44px targets, and a strong outline. | Actual Tab navigation and `:focus-visible`, all six entries, active-route semantics, no clipping from 320px upward. |
+| `settings_modal_visual_check.py` | Mixed: fixed z-index 60/grid assertions were stale; document scroll locking and stacking were missing. Detail sections also retained translucent, heavy glass styling. Use the named overlay layer, lock the document, and remove residual nested glass. | Onboarding, updates, nested confirmation, modal bounds and scrolling, actual overlay hit testing above navigation, scroll restoration, five settings tabs, current flat surfaces. |
+| `topic_manage_visual_check.py` | Passing baseline; no product or assertion change needed. | Existing desktop/tablet/mobile/small-screen interactions and screenshots. |
+| `history_detail_visual_check.py` | Mixed: missing scroll lock, stacking, and bounded state surfaces were product defects. Gradient score and borderless/no-shadow-only rules were stale. The current theme permits opaque hairline surfaces. | Loading/error/empty/success, retry and recovery, persisted score and essay/feedback content, four metrics, analysis sections, responsive columns, topmost overlay and restored document scrolling. |
+| `history_batch_visual_check.py` | Product: the batch bar did not wrap, and selection count did not own a narrow-screen row. | Selection count, two accessible actions, 44px targets, viewport bounds. |
+| `history_filter_analytics_visual_check.py` | Product: comparison table lacked a horizontal scroll owner; narrow filter controls fell below the target size. | Mixed/writing/reading scales, native Band and percentage units, chart geometry, reset/filter behavior, horizontal table access and 44px controls. |
+| `history_record_pagination_visual_check.py` | Product: unbroken title tokens overflowed the page, selection/icon targets were undersized, reading/unlabeled badges had no surface, and mobile pagination lost its row structure. | Full title wrapping, accessible 44px selection/actions, badge states, two-row mobile pagination, deletion on the last page and recovery to the first page. |
+| `history_page_states_visual_check.py` | Product plus misleading wait: shared bounded state styles were missing, so loading remained `display: block`. Waiting for `display: grid` hid the CSS defect behind a timeout. Restore the shared grid surface and assert layout after the semantic state appears. | All four states at four widths, live-region/busy semantics, loading spinner, disabled destructive actions, retry and filter reset. No increased timeout. |
+| `writing_result_visual_check.py` | Product plus misleading wait: the old fixed-height flex layout squeezed desktop columns into phones and the selected view had no distinct style. Waiting for `display: grid` hid the layout failure. Restore responsive grid layout, natural-height content, and selected-view contrast. Nonzero typography tracking is intentional in the current theme. | Original persisted essay, expandable/collapsible annotations, complete score/support content, nonoverlapping responsive columns, reachable content, selected-state contrast of at least 4.5:1 at rest and hover, exact history read command. No increased timeout. |
+| `reading_library_surface_visual_check.py` | Stale theme assertions: current neutral tool cards and hairline shadows are intentional; tools are actions, not selected states. Validate opaque surfaces without glass/gradient/heavy shadows. | Tool and settings panel counts, bounds, clock/config/PDF interactions and overlays; screenshots now capture each of these states. |
+| `reading_library_tabs_visual_check.py` | Product: mobile tabs used hidden horizontal scrolling. Restore three-column wrapping with 44px buttons. | All five entries remain visible from 320px, each view can be selected, active and `aria-current` agree, no page overflow. |
+| `reading_suite_selector_visual_check.py` | Mixed: exact main z-index 130 was stale, but the selector really was below navigation. Raise the containing main layer while an overlay is open. Option descriptions also needed wrapping. | Actual topmost hit testing, document lock/release, modal bounds, three options and one active state, frequency selection, keyboard focus and dismissal. |
+| `reading_custom_suite_visual_check.py` | Mixed: neutral card/shadow assertions were stale; long picked titles could escape the workflow surface. Constrain and wrap picked titles and give narrow actions stable columns. Readiness is shown by completion text and the enabled confirm button. | P1/P2/P3 progression, full long-title retention, confirm readiness and visible opacity change, mobile target geometry, cancellation. |
+| `reading_suite_visual_check.py` | Stale theme assertions: status colors belong to passage badges; loading cards may use hairline shadows. | Distinct badges plus non-color status labels, active/start, submitted/review and pending/no-action contracts, frameless layout, loading/error/empty/retry/return flows. |
+| `reading_history_widget_visual_check.py` | Product: narrow History actions were 40px high. Restore 44px targets and stable labels. | Widget front/back, heatmap/radar/priority selection, trend ranges, bulk selection, mobile action geometry. |
+| `reading_history_record_visual_check.py` | Mixed: `scrollWidth > clientWidth` is expected for ellipsis, so the old overflow assertion was incorrect. The containing grid item also lacked a shrink boundary and the score surface was undersized. Constrain the item and expose the full title as a tooltip. | Card bounds, real ellipsis and full-title fallback, score/delete targets, selection toggling, review navigation and isolated delete action. |
+
+## Validation and evidence
+
+Run `python developer/tests/e2e/run_visual_regressions.py` against the production
+Vue build. It still executes every one of the original 17 scripts. The artifact
+contains each script's log, fresh screenshots, fresh per-case JSON reports,
+and `visual-regression-report.json` with the checkout commit, dirty flag,
+platform, Python/Playwright versions, and CI run URL.
+
+The implementation PR records the tested commit and the clean Windows CI
+artifact links. Run the repository regression commands in this order:
+
+```text
+python developer/tests/ci/run_static_suite.py
+python developer/tests/e2e/suite_practice_flow.py
+```
+
+The existing Native release acceptance workflow runs this sequence against a
+fresh native Windows build. Visual and native gates retain their own results;
+a passing visual job does not imply that the aggregate CI or native gates pass.
+Issue #171's sidecar preparation is unchanged.

--- a/developer/tests/e2e/ISSUE_175_TRIAGE.md
+++ b/developer/tests/e2e/ISSUE_175_TRIAGE.md
@@ -52,6 +52,15 @@ layout property or increases the timeout.
 
 ## Validation and evidence
 
+The shared surface assertion checks computed background-color alpha as well as
+background images and shadows. It accepts opaque legacy and modern CSS colors,
+and rejects transparent, translucent, and `color-mix(..., transparent)` results.
+The Windows visual job first runs `visual_test_support_test.py` against Chromium,
+including alpha `0.999`, multiple matched surfaces, gradient, and shadow cases.
+Settings fixtures include populated lists and the custom temperature panel;
+their card backgrounds use opaque theme tokens. Reading Library configuration
+checks the painted `.backup-list-card`, whose outer container only owns layout.
+
 Run `python developer/tests/e2e/run_visual_regressions.py` against the production
 Vue build. It still executes every one of the original 17 scripts. The artifact
 contains each script's log, fresh screenshots, fresh per-case JSON reports,

--- a/developer/tests/e2e/agent_workspace_visual_check.py
+++ b/developer/tests/e2e/agent_workspace_visual_check.py
@@ -214,10 +214,16 @@ def main():
                     )
                     command_log = page.evaluate("window.__agentCommandLog")
                     commands = [item["command"] for item in command_log]
+                    expected_initialization = [
+                        "memory_catalog_list", "background_job_status", "agent_approval_list",
+                        "agent_thread_list", "study_plan_get_latest", "journal_get_daily",
+                    ]
                     expected_commands = [
                         "agent_pick_workspace", "agent_run", "agent_get_run", "agent_run", "agent_get_run"
                     ]
-                    if commands != expected_commands:
+                    # Independent mount reads may resolve in either order. User actions
+                    # must still pick once, then hydrate each failed/successful run once.
+                    if sorted(commands[:6]) != sorted(expected_initialization) or commands[6:] != expected_commands:
                         raise AssertionError(f"mobile: unexpected Agent command sequence {commands}")
                     geometry["interaction"] = {
                         "selected": page.locator(".agent-file-row").nth(0).evaluate(

--- a/developer/tests/e2e/history_detail_visual_check.py
+++ b/developer/tests/e2e/history_detail_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_document_unlocked, assert_flat_surfaces
 
 
 BASE_URL = os.environ.get("HISTORY_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -137,6 +138,7 @@ def open_detail(page):
 def close_detail(page):
     page.locator(".detail-modal .modal-header .btn-icon").click()
     page.wait_for_selector(".dialog-overlay > .detail-modal", state="detached")
+    assert_document_unlocked(page, 'History detail')
 
 
 def read_common_geometry(page):
@@ -162,6 +164,8 @@ def read_common_geometry(page):
             dialogMaxHeight: dialog ? getComputedStyle(dialog).maxHeight : '',
             dialogOverflow: dialog ? getComputedStyle(dialog).overflowY : '',
             dialogShadow: dialog ? getComputedStyle(dialog).boxShadow : '',
+            overlayAboveNav: Boolean(overlay?.contains(document.elementFromPoint(innerWidth / 2, 8))),
+            documentLocked: [document.documentElement, document.body].every(node => getComputedStyle(node).overflowY === 'hidden'),
             shellOverflow: shell ? getComputedStyle(shell).overflow : ''
           };
         }
@@ -183,8 +187,10 @@ def assert_common_geometry(name, geometry):
         raise AssertionError(f"{name}: History detail dialog is not internally scrollable")
     if geometry["dialogShadow"] in ("", "none"):
         raise AssertionError(f"{name}: History detail dialog lost its elevated surface")
-    if geometry["shellOverflow"] != "hidden":
+    if geometry["shellOverflow"] != "hidden" or not geometry['documentLocked']:
         raise AssertionError(f"{name}: app shell remains scrollable while History detail is open")
+    if not geometry['overlayAboveNav']:
+        raise AssertionError(f"{name}: navigation obscures History detail")
     if geometry["documentScrollWidth"] > width + 1 or geometry["bodyScrollWidth"] > width + 1:
         raise AssertionError(f"{name}: History detail causes page-level horizontal overflow")
 
@@ -203,6 +209,9 @@ def read_success_geometry(page):
           return {
             gridColumns: grid ? getComputedStyle(grid).gridTemplateColumns : '',
             totalBackground: total ? getComputedStyle(total).backgroundImage : '',
+            totalText: total?.textContent || '',
+            feedbackText: feedback?.textContent || '',
+            essayText: essay?.textContent || '',
             totalShadow: total ? getComputedStyle(total).boxShadow : '',
             feedbackBackground: feedback ? getComputedStyle(feedback).backgroundColor : '',
             essayBackground: essay ? getComputedStyle(essay).backgroundColor : '',
@@ -219,24 +228,14 @@ def read_success_geometry(page):
 
 
 def assert_success_geometry(name, width, geometry):
-    if "gradient" not in geometry["totalBackground"]:
-        raise AssertionError(f"{name}: total score is no longer the primary gradient surface")
-    if geometry["totalShadow"] in ("", "none"):
-        raise AssertionError(f"{name}: total score lost its visual anchor")
-    if geometry["feedbackBackground"] == geometry["essayBackground"]:
-        raise AssertionError(f"{name}: feedback and essay surfaces are visually indistinguishable")
+    if geometry["totalBackground"] != 'none' or '7.5' not in geometry['totalText']:
+        raise AssertionError(f"{name}: persisted total score lost its opaque summary surface")
+    if not geometry['feedbackText'].strip() or not geometry['essayText'].strip() or geometry['feedbackText'] == geometry['essayText']:
+        raise AssertionError(f"{name}: feedback and original essay content are incomplete")
     if geometry["scoreCount"] != 4:
         raise AssertionError(f"{name}: expected four score rows")
     if geometry["analysisCount"] < 2:
         raise AssertionError(f"{name}: expected task and rationale analysis sections")
-    if any(border != "0px" for border in geometry["infoBorders"]):
-        raise AssertionError(f"{name}: metadata items still render as nested cards")
-    if any(shadow != "none" for shadow in geometry["infoShadows"]):
-        raise AssertionError(f"{name}: metadata items still have raised shadows")
-    if any(shadow != "none" for shadow in geometry["scoreShadows"]):
-        raise AssertionError(f"{name}: score rows still have raised shadows")
-    if any(shadow != "none" for shadow in geometry["analysisShadows"]):
-        raise AssertionError(f"{name}: analysis sections still have raised shadows")
     column_count = len([value for value in geometry["gridColumns"].split(" ") if value])
     if width <= 960 and column_count != 1:
         raise AssertionError(f"{name}: mobile/tablet detail grid is not single-column")
@@ -319,6 +318,7 @@ def main():
                 success_geometry = read_success_geometry(page)
                 assert_common_geometry(f"{name}: success", success_common)
                 assert_success_geometry(f"{name}: success", width, success_geometry)
+                assert_flat_surfaces(page, '.detail-modal :is(.total-score, .info-item, .score-item, .detail-analysis-card)', f'{name}: detail')
                 page.screenshot(path=str(REPORT_DIR / f"history-detail-{name}-current.png"))
 
                 report.append(

--- a/developer/tests/e2e/history_page_states_visual_check.py
+++ b/developer/tests/e2e/history_page_states_visual_check.py
@@ -69,16 +69,7 @@ def prepare_state(page, state):
             page.wait_for_function(
                 "() => document.querySelector('.history-page > .empty-state')?.textContent.includes('当前筛选条件无结果')"
             )
-    page.wait_for_function(
-        """
-        () => {
-          const state = document.querySelector(
-            '.history-page > :is(.loading, .error-state, .empty-state)'
-          );
-          return state && getComputedStyle(state).display === 'grid';
-        }
-        """
-    )
+    # State selectors establish readiness; assert_geometry reports CSS failures directly.
 
 
 def read_geometry(page):
@@ -139,8 +130,9 @@ def assert_geometry(name, state, data):
         if data["ariaBusy"] != "true" or not data["hasSpinner"]:
             raise AssertionError(f"{name}/{state}: loading state has no busy/spinner contract")
     if state in ("error", "filtered"):
-        if len(data["buttons"]) != 1 or data["buttons"][0]["rect"]["height"] < 44:
-            raise AssertionError(f"{name}/{state}: recovery action is not a 44px target")
+        # Translated DOMRects can report 43.999938px for a 44px CSS target.
+        if len(data["buttons"]) != 1 or data["buttons"][0]["rect"]["height"] + 0.5 < 44:
+            raise AssertionError(f"{name}/{state}: recovery action is not a 44px target: {data['buttons']}")
     elif data["buttons"]:
         raise AssertionError(f"{name}/{state}: passive state unexpectedly renders an action")
     if len(data["headerDisabled"]) != 2 or not all(data["headerDisabled"]):

--- a/developer/tests/e2e/nav_responsive_visual_check.py
+++ b/developer/tests/e2e/nav_responsive_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import capture_state, wait_for_route_layout
 
 
 BASE_URL = os.environ.get("NAV_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -21,6 +22,12 @@ ROUTES = (
     ("history", "/history", "历史"),
     ("settings", "/settings", "设置"),
 )
+ROUTE_VIEWS = {
+    'reading': '.practice-library',
+    'agent': '.agent-page-header',
+    'history': '.history-page',
+    'settings': '.settings-page',
+}
 
 
 def expected_href_for(label):
@@ -115,7 +122,12 @@ def read_geometry(page):
               bottom: linksRect.bottom
             } : null,
             documentScrollWidth: document.documentElement.scrollWidth,
-            bodyScrollWidth: document.body.scrollWidth
+            bodyScrollWidth: document.body.scrollWidth,
+            overflowingElements: [...document.querySelectorAll('.app-main *')].flatMap(node => {
+              const rect = node.getBoundingClientRect();
+              return rect.width && (rect.right > innerWidth + 1 || rect.left < -1)
+                ? [{ tag: node.tagName, class: node.className, left: rect.left, right: rect.right, width: rect.width }] : [];
+            }).slice(0, 12)
           };
         }
         """
@@ -139,7 +151,7 @@ def assert_geometry(case_name, route_name, expected_active, geometry):
         if item["scrollWidth"] > item["clientWidth"] + 1:
             raise AssertionError(f"{case_name}/{route_name}: {item['label']} text is clipped")
     if geometry["documentScrollWidth"] > width + 1 or geometry["bodyScrollWidth"] > width + 1:
-        raise AssertionError(f"{case_name}/{route_name}: nav causes horizontal page overflow")
+        raise AssertionError(f"{case_name}/{route_name}: page overflows: {json.dumps(geometry, ensure_ascii=False)}")
 
     if width <= 640:
         columns = [column for column in geometry["columns"].split(" ") if column]
@@ -157,7 +169,9 @@ def assert_geometry(case_name, route_name, expected_active, geometry):
 
 def assert_focus_visible(page, case_name, route_name):
     settings = page.locator(".nav-item").filter(has_text="设置")
-    settings.focus()
+    # Exercise keyboard modality and navigation, including a genuinely visible ring.
+    page.locator('.nav-item').filter(has_text='历史').focus()
+    page.keyboard.press('Tab')
     focus = page.evaluate(
         """
         () => {
@@ -167,12 +181,13 @@ def assert_focus_visible(page, case_name, route_name):
             label: active?.textContent.trim(),
             outlineStyle: active ? getComputedStyle(active).outlineStyle : '',
             outlineWidth: active ? getComputedStyle(active).outlineWidth : '',
+            focusVisible: active?.matches(':focus-visible'),
             containerOverflow: links ? getComputedStyle(links).overflow : ''
           };
         }
         """
     )
-    if "设置" not in focus["label"] or focus["outlineStyle"] == "none" or focus["outlineWidth"] == "0px":
+    if not focus["focusVisible"] or "设置" not in focus["label"] or focus["outlineStyle"] == "none" or focus["outlineWidth"] == "0px":
         raise AssertionError(f"{case_name}/{route_name}: keyboard focus is not visible")
     if page.viewport_size["width"] <= 640 and focus["containerOverflow"] != "visible":
         raise AssertionError(f"{case_name}/{route_name}: focus ring can be clipped by compact nav")
@@ -196,6 +211,7 @@ def main():
                         "href => [...document.querySelectorAll('.nav-item[aria-current=page]')].some((item) => (item.getAttribute('href') || '').endsWith(href))",
                         arg=expected_href,
                     )
+                    wait_for_route_layout(page, ROUTE_VIEWS[route_name])
                     geometry = read_geometry(page)
                     assert_geometry(case_name, route_name, expected_active, geometry)
                     assert_focus_visible(page, case_name, route_name)
@@ -206,6 +222,9 @@ def main():
                 page.screenshot(path=str(REPORT_DIR / f"nav-{case_name}-current.png"), full_page=False)
                 report.append({"name": case_name, "routes": route_results})
                 page.close()
+        except Exception:
+            capture_state(page, f'nav-{case_name}-{route_name}-failure')
+            raise
         finally:
             browser.close()
     print(json.dumps(report, ensure_ascii=False, indent=2))

--- a/developer/tests/e2e/reading_custom_suite_visual_check.py
+++ b/developer/tests/e2e/reading_custom_suite_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_flat_surfaces
 
 from reading_suite_selector_visual_check import CASES, install_tauri_mock
 
@@ -77,6 +78,7 @@ def read_geometry(page):
               whiteSpace: style(node)?.whiteSpace || '',
             })),
             confirmDisabled: Boolean(confirm?.disabled),
+            confirmOpacity: style(confirm)?.opacity,
             confirmRect: rect(confirm),
             cancelRect: rect(cancel),
           };
@@ -92,8 +94,6 @@ def assert_geometry(name, geometry, filled_count, ready=False):
     bar = geometry["barRect"]
     if not bar or bar["left"] < -1 or bar["right"] > width + 1:
         raise AssertionError(f"{name}: custom suite bar escapes viewport width")
-    if geometry["barShadow"] not in ("none", "rgba(0, 0, 0, 0)"):
-        raise AssertionError(f"{name}: custom suite bar remains a nested raised card")
     chips = geometry["chips"]
     if len(chips) != 3 or sum(chip["filled"] for chip in chips) != filled_count:
         raise AssertionError(f"{name}: P1/P2/P3 progress state is incorrect")
@@ -139,6 +139,7 @@ def main():
 
                 selecting = read_geometry(page)
                 assert_geometry(f"{name}: selecting", selecting, 0)
+                assert_flat_surfaces(page, '.custom-suite-selection-bar', f'{name}: selection')
                 if "P1" not in selecting["currentText"]:
                     raise AssertionError(f"{name}: custom flow did not begin at P1")
 
@@ -153,8 +154,10 @@ def main():
                 choose(page, "custom-p3", 3)
                 ready = read_geometry(page)
                 assert_geometry(f"{name}: ready", ready, 3, ready=True)
-                if ready["barBackground"] == selecting["barBackground"]:
-                    raise AssertionError(f"{name}: ready workflow surface lacks state contrast")
+                # Readiness is expressed by the completion text and enabled action,
+                # while the current skin keeps the surrounding card neutral.
+                if ready['currentText'] == selecting['currentText'] or ready['confirmOpacity'] == selecting['confirmOpacity']:
+                    raise AssertionError(f"{name}: ready workflow lacks a visible completion/action state")
                 page.screenshot(path=str(REPORT_DIR / f"reading-custom-suite-ready-{name}-current.png"))
 
                 page.locator("[data-custom-suite-cancel]").click()

--- a/developer/tests/e2e/reading_history_record_visual_check.py
+++ b/developer/tests/e2e/reading_history_record_visual_check.py
@@ -36,6 +36,11 @@ def geometry(page):
             firstTitle: first?.querySelector('.practice-record-title strong')?.textContent || '',
             firstTitleWidth: rect(first?.querySelector('.practice-record-title'))?.width || 0,
             firstTitleScrollWidth: first?.querySelector('.practice-record-title')?.scrollWidth || 0,
+            titleOverflow: style(first?.querySelector('.practice-record-title'))?.overflowX,
+            titleEllipsis: style(first?.querySelector('.practice-record-title'))?.textOverflow,
+            titleTooltip: first?.querySelector('.practice-record-title')?.title,
+            recordRect: rect(first),
+            titleRect: rect(first?.querySelector('.practice-record-title')),
             scoreRect: rect(score),
             deleteRect: rect(deleteButton),
             checkboxRect: rect(checkbox),
@@ -55,8 +60,13 @@ def assert_geometry(name, data):
         raise AssertionError(f"{name}: history route overflows viewport: {json.dumps(data, ensure_ascii=False)}")
     if data["records"] != len(HISTORY):
         raise AssertionError(f"{name}: expected {len(HISTORY)} history records")
-    if data["firstTitleScrollWidth"] > data["firstTitleWidth"] + 1:
-        raise AssertionError(f"{name}: title should truncate inside the record card")
+    if data['titleRect']['right'] > data['recordRect']['right'] + 1:
+        raise AssertionError(f"{name}: title escapes the record card")
+    if data["firstTitleScrollWidth"] > data["firstTitleWidth"] + 1 and (
+        data['titleOverflow'] != 'hidden' or data['titleEllipsis'] != 'ellipsis'
+        or data['titleTooltip'] != data['firstTitle']
+    ):
+        raise AssertionError(f"{name}: truncated title has no ellipsis/full-title fallback")
     if not data["scoreRect"] or data["scoreRect"]["height"] < 44:
         raise AssertionError(f"{name}: score surface is not stable: {data['scoreRect']}")
     if not data["deleteRect"] or data["deleteRect"]["height"] < 44:

--- a/developer/tests/e2e/reading_library_surface_visual_check.py
+++ b/developer/tests/e2e/reading_library_surface_visual_check.py
@@ -207,7 +207,7 @@ def main():
                 config = config_geometry["config"]
                 if not config:
                     raise AssertionError(f"{name}: library config is missing")
-                assert_flat_surfaces(page, '[data-reading-library-config-list]', f'{name}: config')
+                assert_flat_surfaces(page, '[data-reading-library-config-list] > .backup-list-card', f'{name}: config')
                 capture_state(page, f'reading-config-{name}')
                 page.locator(".reading-library-config-list .backup-list-dismiss").click()
                 page.wait_for_selector("[data-reading-library-config-list]", state="detached")

--- a/developer/tests/e2e/reading_library_surface_visual_check.py
+++ b/developer/tests/e2e/reading_library_surface_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_flat_surfaces, capture_state
 
 
 BASE_URL = os.environ.get("READING_LIBRARY_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -149,10 +150,6 @@ def assert_tool_surface(name, geometry):
     cards = geometry["toolCards"]
     if len(cards) != 3:
         raise AssertionError(f"{name}: expected three More Tools cards")
-    if any(card["shadow"] not in ("none", "rgba(0, 0, 0, 0)") for card in cards):
-        raise AssertionError(f"{name}: More Tools cards still render as nested raised surfaces")
-    if len({card["background"] for card in cards}) < 2:
-        raise AssertionError(f"{name}: featured tool card lost selected surface contrast")
 
 
 def assert_settings_surface(name, geometry):
@@ -160,8 +157,6 @@ def assert_settings_surface(name, geometry):
     panels = geometry["settingPanels"]
     if len(panels) != 4:
         raise AssertionError(f"{name}: expected four Reading Settings panels")
-    if any(panel["shadow"] not in ("none", "rgba(0, 0, 0, 0)") for panel in panels):
-        raise AssertionError(f"{name}: Reading Settings child panels remain raised cards")
 
 
 def assert_overlay(name, geometry, key):
@@ -191,22 +186,29 @@ def main():
                 open_route(page, "/?view=more")
                 more_geometry = read_geometry(page)
                 assert_tool_surface(f"{name}: more", more_geometry)
+                assert_flat_surfaces(page, '#more-view .tool-card', f'{name}: tools')
+                capture_state(page, f'reading-tools-{name}')
                 page.locator("#more-view [data-action='open-clock']").click()
                 clock_geometry = read_geometry(page)
                 assert_overlay(f"{name}: clock", clock_geometry, "clock")
+                capture_state(page, f'reading-clock-{name}')
                 page.locator("#fullscreen-clock-overlay .clock-close-btn").click()
                 page.wait_for_function("() => document.querySelector('#fullscreen-clock-overlay')?.classList.contains('is-hidden')")
 
                 open_route(page, "/?view=settings")
                 settings_geometry = read_geometry(page)
                 assert_settings_surface(f"{name}: settings", settings_geometry)
+                assert_flat_surfaces(page, '.hero-settings-group > .hero-panel', f'{name}: settings')
+                capture_state(page, f'reading-settings-{name}')
                 page.locator("#library-config-btn").click()
                 page.wait_for_selector("[data-reading-library-config-list]")
                 config_geometry = read_geometry(page)
                 assert_settings_surface(f"{name}: config", config_geometry)
                 config = config_geometry["config"]
-                if not config or config["cardShadow"] not in ("none", "rgba(0, 0, 0, 0)"):
-                    raise AssertionError(f"{name}: library config remains a nested raised card")
+                if not config:
+                    raise AssertionError(f"{name}: library config is missing")
+                assert_flat_surfaces(page, '[data-reading-library-config-list]', f'{name}: config')
+                capture_state(page, f'reading-config-{name}')
                 page.locator(".reading-library-config-list .backup-list-dismiss").click()
                 page.wait_for_selector("[data-reading-library-config-list]", state="detached")
 
@@ -216,6 +218,7 @@ def main():
                 page.wait_for_selector(".pdf-viewer-overlay")
                 pdf_geometry = read_geometry(page)
                 assert_overlay(f"{name}: pdf", pdf_geometry, "pdf")
+                capture_state(page, f'reading-pdf-{name}')
                 page.locator(".pdf-viewer-overlay .pdf-viewer-header .btn-text").click()
                 page.wait_for_selector(".pdf-viewer-overlay", state="detached")
 

--- a/developer/tests/e2e/reading_suite_selector_visual_check.py
+++ b/developer/tests/e2e/reading_suite_selector_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_document_unlocked
 
 
 BASE_URL = os.environ.get("READING_SUITE_SELECTOR_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -109,6 +110,8 @@ def read_geometry(page):
             bodyScrollWidth: document.body.scrollWidth,
             appMainZ: style(document.querySelector('.app-main'))?.zIndex || '',
             navZ: style(document.querySelector('.nav-shell'))?.zIndex || '',
+            modalAboveNav: Boolean(modal?.contains(document.elementFromPoint(innerWidth / 2, 8))),
+            documentLocked: [document.documentElement, document.body].every(node => getComputedStyle(node).overflowY === 'hidden'),
           };
         }
         """
@@ -125,10 +128,10 @@ def assert_bounded(name, geometry):
     body = geometry["bodyRect"]
     if not body:
         raise AssertionError(f"{name}: modal body is not bounded")
-    if geometry["appMainZ"] != "130":
-        raise AssertionError(f"{name}: app-main stacking context was not raised above navigation")
-    if geometry["navZ"] != "120":
-        raise AssertionError(f"{name}: navigation stacking contract changed")
+    if int(geometry["appMainZ"]) <= int(geometry["navZ"]) or not geometry['modalAboveNav']:
+        raise AssertionError(f"{name}: suite selector is obscured by navigation")
+    if not geometry['documentLocked']:
+        raise AssertionError(f"{name}: suite selector leaves the background scrollable")
 
 
 def assert_options(name, geometry):
@@ -190,6 +193,7 @@ def main():
                 page.wait_for_function("() => document.querySelector('#suite-mode-selector-modal')?.classList.contains('show')")
                 page.mouse.click(2, 2)
                 page.wait_for_function("() => !document.querySelector('#suite-mode-selector-modal')?.classList.contains('show')")
+                assert_document_unlocked(page, name)
 
                 report.append({"name": name, "geometry": geometry})
                 page.close()

--- a/developer/tests/e2e/reading_suite_visual_check.py
+++ b/developer/tests/e2e/reading_suite_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_flat_surfaces
 
 
 BASE_URL = os.environ.get("READING_SUITE_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -157,11 +158,14 @@ def assert_success(name, width, geometry):
     if len(geometry["rows"]) != 3:
         raise AssertionError(f"{name}: expected active/submitted/locked passage rows")
     rows = geometry["rows"]
-    if len({row["background"] for row in rows}) != 3:
-        raise AssertionError(f"{name}: passage row state surfaces are not visually distinct")
+    # The current theme puts state color on P1/P2/P3 badges, with explicit status text.
+    if len({row["indexBackground"] for row in rows}) != 3:
+        raise AssertionError(f"{name}: passage state badges are not visually distinct")
     active = next(row for row in rows if "passage-row--active" in row["status"])
     submitted = next(row for row in rows if "passage-row--submitted" in row["status"])
     locked = next(row for row in rows if "passage-row--pending" in row["status"])
+    if '当前篇' not in active['text'] or '已提交' not in submitted['text'] or '等待前一篇' not in locked['text']:
+        raise AssertionError(f"{name}: passage states lost their non-color labels")
     if submitted["shadow"] not in ("none", "rgba(0, 0, 0, 0)") or locked["shadow"] not in ("none", "rgba(0, 0, 0, 0)"):
         raise AssertionError(f"{name}: passive passage rows still behave as nested raised cards")
     if active["actionText"] != "开始":
@@ -196,9 +200,7 @@ def main():
                 page.wait_for_selector(".reading-suite-page > .loading")
                 loading = read_geometry(page)
                 assert_no_overflow(f"{name}: loading", loading)
-                loading_surface = page.locator(".reading-suite-page > .loading")
-                if loading_surface.evaluate("node => getComputedStyle(node).boxShadow") not in ("none", "rgba(0, 0, 0, 0)"):
-                    raise AssertionError(f"{name}: loading state is still a raised card")
+                assert_flat_surfaces(page, '.reading-suite-page > .loading', f'{name}: loading')
                 page.wait_for_function("() => typeof window.__resolveSuite === 'function'")
                 page.evaluate("() => window.__resolveSuite()")
                 page.wait_for_selector("[data-reading-suite-summary]")

--- a/developer/tests/e2e/run_visual_regressions.py
+++ b/developer/tests/e2e/run_visual_regressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
 import socket
 import subprocess
@@ -12,6 +13,7 @@ import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
+from importlib.metadata import version
 from pathlib import Path
 
 
@@ -138,6 +140,25 @@ def current_artifacts(started_ns: int) -> list[Path]:
     )
 
 
+def source_metadata() -> dict[str, object]:
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ['git', *args], cwd=ROOT, capture_output=True, text=True,
+            check=True, timeout=10,
+        ).stdout.strip()
+
+    run_id = os.environ.get('GITHUB_RUN_ID')
+    repository = os.environ.get('GITHUB_REPOSITORY')
+    return {
+        'gitCommit': git('rev-parse', 'HEAD'),
+        'gitDirty': bool(git('status', '--porcelain', '--untracked-files=normal')),
+        'platform': platform.platform(),
+        'pythonVersion': platform.python_version(),
+        'playwrightVersion': version('playwright'),
+        'runUrl': f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/{repository}/actions/runs/{run_id}" if run_id and repository else None,
+    }
+
+
 def main() -> int:
     if not (DIST / "index.html").is_file():
         raise SystemExit("dist/writing is missing; run the Vue production build first")
@@ -153,9 +174,11 @@ def main() -> int:
     process: subprocess.Popen[bytes] | None = None
     results: list[dict[str, object]] = []
     startup_error: str | None = None
+    metadata: dict[str, object] = {}
 
     with server_log_path.open("wb") as server_log:
         try:
+            metadata = source_metadata()
             process = subprocess.Popen(
                 [
                     sys.executable,
@@ -223,6 +246,13 @@ def main() -> int:
     for screenshot in screenshots:
         shutil.copy2(screenshot, EVIDENCE / screenshot.name)
 
+    case_reports = sorted(
+        path for path in REPORTS.glob('*-report.json')
+        if path != REPORT and path.stat().st_mtime_ns >= started_ns
+    )
+    for case_report in case_reports:
+        shutil.copy2(case_report, EVIDENCE / case_report.name)
+
     expected_count = sum(len(scripts) for _, scripts in SCRIPT_GROUPS)
     passed = (
         startup_error is None
@@ -235,12 +265,14 @@ def main() -> int:
         "status": "passed" if passed else "failed",
         "exitCode": 0 if passed else 1,
         "target": "vue-u1-u25-visual-state-regressions",
+        "metadata": metadata,
         "baseUrl": base_url,
         "expectedScripts": expected_count,
         "executedScripts": len(results),
         "startupError": startup_error,
         "scripts": results,
         "screenshots": [str((EVIDENCE / path.name).relative_to(ROOT)) for path in screenshots],
+        "caseReports": [str((EVIDENCE / path.name).relative_to(ROOT)) for path in case_reports],
     }
     serialized = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
     REPORT.write_text(serialized, encoding="utf-8")

--- a/developer/tests/e2e/settings_modal_visual_check.py
+++ b/developer/tests/e2e/settings_modal_visual_check.py
@@ -20,8 +20,13 @@ def install_tauri_mock(page):
         invoke: async (command) => {
           if (command === 'list_settings') return { ok: true, data: [] };
           if (command === 'history_get_retention_policy') return { ok: true, data: { maxTerminalAttempts: 100 } };
-          if (command === 'ai_list_configs') return { ok: true, data: [] };
-          if (command === 'writing_prompt_list') return { ok: true, data: [] };
+          if (command === 'ai_list_configs') return { ok: true, data: [{
+            id: 1, config_name: 'Visual fixture', provider: 'openai', default_model: 'fixture-model',
+            is_enabled: true, is_default: true, has_secret: true,
+          }] };
+          if (command === 'writing_prompt_list') return { ok: true, data: [{
+            id: 1, task_type: 'task2', version: 'visual-fixture', is_active: true,
+          }] };
           if (command === 'writing_topic_statistics') return { ok: true, data: { total: 0, byTaskType: [] } };
           if (command === 'get_app_info') return { host: 'Tauri', tauriVersion: '2', version: '0.1.0' };
           if (command === 'get_app_data_paths') return { appData: 'C:/atlas/data', backups: 'C:/atlas/backups' };
@@ -148,6 +153,11 @@ def main():
                 for tab_name in ("模型参数", "数据管理", "关于", "提示词", "API 配置"):
                     page.locator(".settings-tabs .settings-tab").filter(has_text=tab_name).click()
                     page.wait_for_timeout(30)
+                    if tab_name == '模型参数':
+                        page.locator('.mode-card').filter(has_text='自定义模式').click()
+                        page.wait_for_selector('.custom-temperature-panel')
+                    if tab_name in ('提示词', 'API 配置'):
+                        page.wait_for_selector('.settings-detail-panel .settings-list__row')
                     detail_surfaces[tab_name] = read_detail_surface_geometry(page)
                     assert_detail_surfaces(f"{name}: {tab_name}", detail_surfaces[tab_name])
                     assert_flat_surfaces(

--- a/developer/tests/e2e/settings_modal_visual_check.py
+++ b/developer/tests/e2e/settings_modal_visual_check.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
+from visual_test_support import assert_document_unlocked, assert_flat_surfaces
 
 
 BASE_URL = os.environ.get("SETTINGS_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -53,6 +54,8 @@ def read_geometry(page):
             dialogOverflow: dialog ? getComputedStyle(dialog).overflowY : '',
             dialogWithinViewport: Boolean(dialogRect && dialogRect.top >= 0 && dialogRect.bottom <= innerHeight + 1),
             overlayCoversViewport: Boolean(overlayRect && overlayRect.width >= innerWidth && overlayRect.height >= innerHeight),
+            overlayAboveNav: Boolean(overlay?.contains(document.elementFromPoint(innerWidth / 2, 8))),
+            documentLocked: [document.documentElement, document.body].every(node => getComputedStyle(node).overflowY === 'hidden'),
             detailZIndex: detail ? getComputedStyle(detail).zIndex : '',
             shellOverflow: shell ? getComputedStyle(shell).overflow : ''
           };
@@ -73,7 +76,11 @@ def read_detail_surface_geometry(page):
             sectionCount: sections.length,
             sectionShadows: sections.map((section) => getComputedStyle(section).boxShadow),
             nestedShadows: nested.map((section) => getComputedStyle(section).boxShadow),
-            detailOverflow: panel ? getComputedStyle(panel).overflowY : ''
+            detailOverflow: panel ? getComputedStyle(panel).overflowY : '',
+            modes: [...document.querySelectorAll('.settings-detail-panel .mode-card')].map(node => ({
+              active: node.classList.contains('active'),
+              background: getComputedStyle(node).backgroundColor,
+            }))
           };
         }
         """
@@ -85,19 +92,18 @@ def assert_detail_surfaces(name, geometry):
         raise AssertionError(f"{name}: detail tab has no content section")
     if geometry["panelShadow"] in ("", "none"):
         raise AssertionError(f"{name}: detail panel lost its elevated surface")
-    if any(shadow != "none" for shadow in geometry["sectionShadows"]):
-        raise AssertionError(f"{name}: nested settings section still has raised shadow")
-    if any(shadow != "none" for shadow in geometry["nestedShadows"]):
-        raise AssertionError(f"{name}: nested settings content still has raised shadow")
+    modes = geometry['modes']
+    if modes and (sum(mode['active'] for mode in modes) != 1 or len({mode['background'] for mode in modes}) < 2):
+        raise AssertionError(f"{name}: selected temperature mode is not visually distinct: {modes}")
 
 
 def assert_geometry(name, geometry):
     if geometry["overlayPosition"] != "fixed":
         raise AssertionError(f"{name}: settings overlay is not fixed")
-    if geometry["overlayZIndex"] != "60":
-        raise AssertionError(f"{name}: expected secondary overlay z-index 60, got {geometry['overlayZIndex']}")
-    if geometry["overlayDisplay"] != "grid":
-        raise AssertionError(f"{name}: settings overlay is not a grid viewport")
+    if int(geometry["overlayZIndex"]) <= int(geometry["detailZIndex"] or '0') or not geometry['overlayAboveNav']:
+        raise AssertionError(f"{name}: secondary overlay is obscured by the settings detail or navigation")
+    if geometry["overlayDisplay"] not in ("grid", "flex"):
+        raise AssertionError(f"{name}: settings overlay has no centered layout")
     if geometry["dialogMaxHeight"] in ("", "none", "auto"):
         raise AssertionError(f"{name}: dialog has no bounded max-height")
     if geometry["dialogOverflow"] not in ("auto", "scroll"):
@@ -106,7 +112,7 @@ def assert_geometry(name, geometry):
         raise AssertionError(f"{name}: overlay does not cover the viewport")
     if not geometry["dialogWithinViewport"]:
         raise AssertionError(f"{name}: dialog escapes the viewport")
-    if geometry["shellOverflow"] != "hidden":
+    if geometry["shellOverflow"] != "hidden" or not geometry['documentLocked']:
         raise AssertionError(f"{name}: app shell remains scrollable while dialog is open")
 
 
@@ -128,6 +134,7 @@ def main():
                 assert_geometry(f"{name}: onboarding", onboarding)
                 page.locator(".settings-page > .dialog-overlay").click(position={"x": 4, "y": 4})
                 page.wait_for_selector(".settings-page > .dialog-overlay", state="detached")
+                assert_document_unlocked(page, name)
 
                 page.locator("#check-updates-btn").click()
                 page.wait_for_selector(".settings-page > .dialog-overlay")
@@ -143,14 +150,16 @@ def main():
                     page.wait_for_timeout(30)
                     detail_surfaces[tab_name] = read_detail_surface_geometry(page)
                     assert_detail_surfaces(f"{name}: {tab_name}", detail_surfaces[tab_name])
+                    assert_flat_surfaces(
+                        page, '.settings-detail-panel > .settings-panel, .settings-detail-panel :is(.settings-list__row, .mode-card, .custom-temperature-panel, .about-info, .about-features)',
+                        f'{name}: {tab_name}',
+                    )
 
                 page.locator(".settings-tabs .settings-tab").filter(has_text="数据管理").click()
                 page.locator(".danger-zone .btn-danger").click()
                 page.wait_for_selector(".settings-page > .dialog-overlay")
                 confirm = read_geometry(page)
                 assert_geometry(f"{name}: confirmation", confirm)
-                if confirm["detailZIndex"] != "40":
-                    raise AssertionError(f"{name}: detail modal z-index changed unexpectedly")
                 page.screenshot(path=str(REPORT_DIR / f"settings-{name}-current.png"), full_page=True)
                 report.append({"name": name, "onboarding": onboarding, "update": update, "detailSurfaces": detail_surfaces, "confirmation": confirm})
                 page.close()

--- a/developer/tests/e2e/visual_test_support.py
+++ b/developer/tests/e2e/visual_test_support.py
@@ -1,0 +1,59 @@
+"""Shared behavioral and current-theme checks for the Vue visual fixtures."""
+
+from pathlib import Path
+
+
+def capture_state(page, name):
+    destination = Path(__file__).parent / 'reports' / f'{name}-current.png'
+    page.screenshot(path=str(destination), full_page=True)
+
+
+def wait_for_route_layout(page, selector):
+    """Wait for the routed view and finite entry motion, never for a CSS value."""
+    page.wait_for_selector(selector)
+    page.evaluate(
+        """async () => {
+          const finite = document.getAnimations().filter(animation =>
+            Number.isFinite(animation.effect?.getComputedTiming().endTime));
+          await Promise.all(finite.map(animation => animation.finished.catch(() => {})));
+          await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        }"""
+    )
+
+
+def assert_flat_surfaces(page, selector, name):
+    """The shipping skin permits hairline elevation, not the retired glass layers."""
+    surfaces = page.evaluate(
+        """selector => {
+          const probe = document.createElement('span');
+          document.body.append(probe);
+          const subtleShadows = ['--anth-shadow-xs', '--anth-shadow-sm'].map(token => {
+            probe.style.boxShadow = `var(${token})`;
+            return getComputedStyle(probe).boxShadow;
+          });
+          probe.remove();
+          return [...document.querySelectorAll(selector)].map(node => {
+            const style = getComputedStyle(node);
+            return {
+              background: style.backgroundImage,
+              shadow: style.boxShadow,
+              subtleShadows,
+              width: node.getBoundingClientRect().width,
+            };
+          });
+        }""",
+        selector,
+    )
+    if not surfaces:
+        raise AssertionError(f"{name}: no surfaces matched {selector}")
+    for surface in surfaces:
+        if surface["background"] != "none" or surface["shadow"] not in ("none", *surface["subtleShadows"]):
+            raise AssertionError(f"{name}: surface violates the opaque, hairline-elevation theme: {surface}")
+        if surface["width"] <= 0:
+            raise AssertionError(f"{name}: surface collapsed: {surface}")
+
+
+def assert_document_unlocked(page, name):
+    overflow = page.evaluate("() => [document.documentElement, document.body].map(node => getComputedStyle(node).overflowY)")
+    if "hidden" in overflow:
+        raise AssertionError(f"{name}: closing the overlay did not release document scrolling: {overflow}")

--- a/developer/tests/e2e/visual_test_support.py
+++ b/developer/tests/e2e/visual_test_support.py
@@ -1,5 +1,6 @@
 """Shared behavioral and current-theme checks for the Vue visual fixtures."""
 
+import re
 from pathlib import Path
 
 
@@ -21,6 +22,23 @@ def wait_for_route_layout(page, selector):
     )
 
 
+def _computed_color_alpha(color):
+    """Read alpha from legacy and modern CSSOM color serializations."""
+    if color == 'transparent':
+        return 0.0
+    match = re.fullmatch(r'(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\(([^()]*)\)', color)
+    if not match:
+        raise AssertionError(f'Unsupported computed background color: {color}')
+    components = match.group(1)
+    if '/' in components:
+        alpha = components.rsplit('/', 1)[1].strip()
+    elif color.startswith(('rgba(', 'hsla(')) and ',' in components:
+        alpha = components.rsplit(',', 1)[1].strip()
+    else:
+        return 1.0
+    return float(alpha.rstrip('%')) / (100 if alpha.endswith('%') else 1)
+
+
 def assert_flat_surfaces(page, selector, name):
     """The shipping skin permits hairline elevation, not the retired glass layers."""
     surfaces = page.evaluate(
@@ -35,7 +53,9 @@ def assert_flat_surfaces(page, selector, name):
           return [...document.querySelectorAll(selector)].map(node => {
             const style = getComputedStyle(node);
             return {
-              background: style.backgroundImage,
+              classes: node.className,
+              backgroundImage: style.backgroundImage,
+              backgroundColor: style.backgroundColor,
               shadow: style.boxShadow,
               subtleShadows,
               width: node.getBoundingClientRect().width,
@@ -47,7 +67,12 @@ def assert_flat_surfaces(page, selector, name):
     if not surfaces:
         raise AssertionError(f"{name}: no surfaces matched {selector}")
     for surface in surfaces:
-        if surface["background"] != "none" or surface["shadow"] not in ("none", *surface["subtleShadows"]):
+        surface['backgroundAlpha'] = _computed_color_alpha(surface['backgroundColor'])
+        if (
+            surface['backgroundImage'] != 'none'
+            or surface['backgroundAlpha'] != 1.0
+            or surface['shadow'] not in ('none', *surface['subtleShadows'])
+        ):
             raise AssertionError(f"{name}: surface violates the opaque, hairline-elevation theme: {surface}")
         if surface["width"] <= 0:
             raise AssertionError(f"{name}: surface collapsed: {surface}")

--- a/developer/tests/e2e/visual_test_support_test.py
+++ b/developer/tests/e2e/visual_test_support_test.py
@@ -1,0 +1,91 @@
+"""Browser-backed regression tests for the shared visual assertions."""
+
+import unittest
+
+from playwright.sync_api import sync_playwright
+
+from visual_test_support import assert_flat_surfaces
+
+
+class VisualSurfaceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.playwright = sync_playwright().start()
+        cls.browser = cls.playwright.chromium.launch()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.close()
+        cls.playwright.stop()
+
+    def setUp(self):
+        self.page = self.browser.new_page()
+        self.page.set_content("""
+            <style>
+              :root { --anth-shadow-xs: 0 1px 1px rgb(0 0 0 / 10%); --anth-shadow-sm: none; }
+              .surface { width: 120px; height: 40px; background: white; }
+            </style>
+            <div class="surface">Surface</div>
+        """)
+
+    def tearDown(self):
+        self.page.close()
+
+    def set_background(self, color):
+        self.page.locator('.surface').evaluate(
+            '(node, color) => { node.style.backgroundColor = color; }', color,
+        )
+
+    def test_opaque_colors_are_accepted(self):
+        for color in (
+            'white', 'rgba(255, 255, 255, 1)', 'rgb(255 255 255 / 100%)',
+            'color(srgb 1 1 1)', 'color(display-p3 1 1 1 / 1)',
+            'oklch(100% 0 0 / 100%)', 'color-mix(in srgb, white 52%, black)',
+        ):
+            with self.subTest(color=color):
+                self.set_background(color)
+                assert_flat_surfaces(self.page, '.surface', color)
+
+    def test_non_opaque_colors_are_rejected(self):
+        for color in (
+            'transparent', 'rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 0.5)',
+            'rgba(255, 255, 255, 0.99)', 'rgb(255 255 255 / 50%)',
+            'color(srgb 1 1 1 / 0.5)', 'color(display-p3 1 1 1 / 50%)',
+            'oklch(100% 0 0 / 50%)', 'color-mix(in srgb, white 52%, transparent)',
+            'color(srgb 1 1 1 / 0.999)', 'color-mix(in srgb, white 99.9%, transparent)',
+        ):
+            with self.subTest(color=color):
+                self.set_background(color)
+                with self.assertRaisesRegex(AssertionError, 'opaque'):
+                    assert_flat_surfaces(self.page, '.surface', color)
+
+    def test_every_matched_surface_must_be_opaque(self):
+        self.page.locator('.surface').evaluate("""node => {
+            const transparentSibling = node.cloneNode(true);
+            transparentSibling.style.backgroundColor = 'transparent';
+            node.after(transparentSibling);
+        }""")
+        with self.assertRaisesRegex(AssertionError, 'opaque'):
+            assert_flat_surfaces(self.page, '.surface', 'mixed surfaces')
+
+    def test_gradients_remain_rejected(self):
+        self.page.locator('.surface').evaluate(
+            "node => { node.style.backgroundImage = 'linear-gradient(white, black)'; }",
+        )
+        with self.assertRaises(AssertionError):
+            assert_flat_surfaces(self.page, '.surface', 'gradient')
+
+    def test_only_theme_shadows_are_accepted(self):
+        self.page.locator('.surface').evaluate(
+            "node => { node.style.boxShadow = 'var(--anth-shadow-xs)'; }",
+        )
+        assert_flat_surfaces(self.page, '.surface', 'hairline shadow')
+        self.page.locator('.surface').evaluate(
+            "node => { node.style.boxShadow = '0 12px 24px black'; }",
+        )
+        with self.assertRaises(AssertionError):
+            assert_flat_surfaces(self.page, '.surface', 'heavy shadow')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/developer/tests/e2e/writing_result_visual_check.py
+++ b/developer/tests/e2e/writing_result_visual_check.py
@@ -396,14 +396,6 @@ def assert_geometry(name, width, data):
         if data["sidebarScrollHeight"] > data["sidebarClientHeight"] + 1:
             raise AssertionError(f"{name}: stacked Result sidebar clips its content")
 
-    letter_spacing = (
-        data["headingLetterSpacing"],
-        data["scoreLabelLetterSpacing"],
-        data["metricLabelLetterSpacing"],
-    )
-    if any(value not in ("0px", "normal") for value in letter_spacing):
-        raise AssertionError(f"{name}: Result still uses non-zero letter spacing: {letter_spacing}")
-
     if data["calls"] != [
         {"command": "get_history_detail", "args": {"attemptId": "writing-result-visual"}}
     ]:
@@ -532,9 +524,7 @@ def main():
                 page.on("pageerror", lambda error: page_errors.append(getattr(error, "stack", str(error))))
                 page.goto(f"{BASE_URL}/#/result/writing-result-visual", wait_until="domcontentloaded")
                 page.wait_for_selector(".result-page .score-total")
-                page.wait_for_function(
-                    "() => document.querySelector('.result-layout') && getComputedStyle(document.querySelector('.result-layout')).display === 'grid'"
-                )
+                # Persisted score content establishes readiness; layout is asserted below.
                 geometry = read_geometry(page)
                 assert_geometry(name, width, geometry)
                 original = verify_original_view(page, name, geometry)


### PR DESCRIPTION
## Problem and behavior

Fixes #175.

The Windows visual gate executed all 17 scripts but failed 16. Reproduction on integration commit `08bac3a3` confirmed a mixture of product defects and assertions tied to the retired glass theme. This change restores responsive History, Library, and Writing Result layouts, keyboard focus and mobile targets, modal stacking and document scroll locking, and distinct selected states.

The two 30-second state waits were waiting for missing CSS layouts. The affected layouts are restored, and the checks now wait for the semantic state before asserting geometry. No script is skipped and no timeout is increased. Stale theme and initialization-order assertions are replaced with current-theme, content, accessibility, and state checks.

The shared surface assertion now checks computed background-color alpha as well as background images and theme shadows. It rejects transparent and translucent colors, including `color-mix` results and alpha `0.999`. Browser-backed regression tests run before the 17-script matrix. Settings fixtures cover populated lists and custom temperature controls, affected cards use opaque theme tokens, and the Library configuration check targets its actual painted card.

See [the complete 17-script classification and retained coverage](developer/tests/e2e/ISSUE_175_TRIAGE.md). Sidecar preparation tracked in #171 is unchanged.

## Validation

- Signed head commit: [`2a892d0f87934a776c4b08e9fc45760aa8fc73ef`](https://github.com/sallowayma-git/IELTS-practice/commit/2a892d0f87934a776c4b08e9fc45760aa8fc73ef), verified by GitHub.
- Local production Vue build, `vue-tsc --noEmit`, and all five browser-backed assertion tests: passed.
- [Windows visual job](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611723638/job/103303599058): **5/5 shared assertion tests and 17/17 visual scripts passed**, with **113 screenshots** and `gitDirty: false`. The report identifies PR merge checkout `efcf463eb010050dab9e4568a17dbbf48534c742` (head above, base `08bac3a3e3a4327149a66f7f17029d6185b07163`), Python 3.12.10, and Playwright 1.61.0. [Report, script logs, per-case reports, and all screenshots](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611723638/artifacts/10268792546).
- [Complete tauri-ci](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611723638): **passed**, including static **29/29**, Rust workspace tests, visual checks, and the aggregate CI result. [Static report](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611723638/artifacts/10269067418).
- [Required static and native practice sequence](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611758475/job/103303730270): **passed** on signed head `2a892d0f87934a776c4b08e9fc45760aa8fc73ef`. `python developer/tests/ci/run_static_suite.py` passed **29/29** checks and completed at **14:47:01 UTC**, followed by `python developer/tests/e2e/suite_practice_flow.py` at **14:50:00–14:50:18 UTC**, which passed **16/16** checks on 2026-09-11. [Static/native reports, screenshots, diagnostics, and tested executable](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611758475/artifacts/10268588689).

The visual report records `gitDirty: false`. The native report separately records the build-time modified-file list (`gitDirty: true`) and executable SHA-256 `7f6d615db4ec2822e69c29fb3b5d1a16fe5e838d687184ceac4067d03bd20e45`; the downloaded executable matches that hash. The [complete Native release acceptance workflow](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34611758475) has passed, including the required static/native sequence and the Windows x86_64, macOS ARM64, and Linux x86_64 native packaging jobs. These are native build and package-verification results; production release signing, notarization, updater acceptance, and the complete release shipping gate remain tracked in #172.

