### PR TITLE
fix(reading): paint and verify suite selector modal surfaces

### DIFF
--- a/apps/writing-vue/src/styles/opensource-skin.css
+++ b/apps/writing-vue/src/styles/opensource-skin.css
@@ -691,6 +691,11 @@ body:has(.atlas-source-ui :is(.dialog-overlay, .settings-detail-modal, .suite-mo
   align-items: center;
   justify-content: center;
   padding: var(--anth-space-5);
+}
+
+.atlas-source-ui .dialog-overlay,
+.atlas-source-ui .overlay,
+.atlas-source-ui .suite-mode-selector-modal.show {
   background: var(--lg-bg-scrim);
 }
 
@@ -700,10 +705,14 @@ body:has(.atlas-source-ui :is(.dialog-overlay, .settings-detail-modal, .suite-mo
   max-height: min(86vh, 860px);
   overflow-y: auto;
   padding: var(--anth-space-6);
+  box-shadow: var(--anth-shadow-lg);
+}
+
+.atlas-source-ui .dialog,
+.atlas-source-ui .suite-mode-selector-content {
   background: var(--anth-surface);
   border: 1px solid var(--anth-border-strong);
   border-radius: var(--anth-radius-xl);
-  box-shadow: var(--anth-shadow-lg);
 }
 
 .atlas-source-ui .dialog h3 {

--- a/developer/tests/e2e/reading_suite_selector_visual_check.py
+++ b/developer/tests/e2e/reading_suite_selector_visual_check.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
-from visual_test_support import assert_document_unlocked
+from visual_test_support import _computed_color_alpha, assert_document_unlocked, assert_flat_surfaces
 
 
 BASE_URL = os.environ.get("READING_SUITE_SELECTOR_VISUAL_BASE_URL", "http://127.0.0.1:4175")
@@ -86,9 +86,18 @@ def read_geometry(page):
           const style = (node) => node ? getComputedStyle(node) : null;
           const content = modal?.querySelector('.suite-mode-selector-content');
           const body = modal?.querySelector('.suite-mode-selector-body');
+          const probe = document.createElement('span');
+          probe.style.backgroundColor = 'var(--lg-bg-scrim)';
+          modal.append(probe);
+          const themeScrim = style(probe).backgroundColor;
+          probe.remove();
           return {
             viewport: [innerWidth, innerHeight],
             modalDisplay: style(modal)?.display || '',
+            modalBackgroundColor: style(modal)?.backgroundColor || '',
+            modalBackgroundImage: style(modal)?.backgroundImage || '',
+            contentBackgroundColor: style(content)?.backgroundColor || '',
+            themeScrim,
             contentRect: rect(content),
             headerRect: rect(modal?.querySelector('.theme-modal-header')),
             bodyRect: rect(body),
@@ -151,6 +160,17 @@ def assert_options(name, geometry):
             raise AssertionError(f"{name}: option description is not rendered")
 
 
+def assert_painted_surfaces(page, name, geometry):
+    assert_flat_surfaces(page, '.suite-mode-selector-content', name)
+    scrim = geometry['modalBackgroundColor']
+    if (
+        geometry['modalBackgroundImage'] != 'none'
+        or scrim != geometry['themeScrim']
+        or not 0 < _computed_color_alpha(scrim) < 1
+    ):
+        raise AssertionError(f"{name}: selector overlay must paint the translucent theme scrim: {scrim}")
+
+
 def main():
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report = []
@@ -165,12 +185,14 @@ def main():
                 closed = read_geometry(page)
                 if closed["modalDisplay"] != "none":
                     raise AssertionError(f"{name}: selector modal is not closed on initial route")
+                assert_document_unlocked(page, name)
 
                 page.locator("[data-action='start-suite-mode']").click()
                 page.wait_for_function("() => document.querySelector('#suite-mode-selector-modal')?.classList.contains('show')")
                 geometry = read_geometry(page)
                 assert_bounded(name, geometry)
                 assert_options(name, geometry)
+                assert_painted_surfaces(page, name, geometry)
                 page.screenshot(path=str(REPORT_DIR / f"reading-suite-selector-{name}-current.png"))
 
                 frequency = page.locator("#suite-frequency-scope")
@@ -188,6 +210,7 @@ def main():
 
                 page.locator("#suite-mode-selector-modal [data-suite-flow-cancel='1']").last.click()
                 page.wait_for_function("() => !document.querySelector('#suite-mode-selector-modal')?.classList.contains('show')")
+                assert_document_unlocked(page, name)
 
                 page.locator("[data-action='start-suite-mode']").click()
                 page.wait_for_function("() => document.querySelector('#suite-mode-selector-modal')?.classList.contains('show')")


### PR DESCRIPTION
Opening Reading overview → Suite mode currently paints neither the selector dialog nor its overlay, allowing selector text to overlap the overview and navigation. This follows up on the [post-merge review of #180](https://github.com/sallowayma-git/IELTS-practice/pull/180#discussion_r3990636908).

The selector now shares the modal surface, border, radius, and scrim declarations in the shipping skin. Its existing layout and visibility behavior are retained. The four-viewport regression now checks the inner surface with `assert_flat_surfaces`, requires the overlay to paint the translucent theme scrim without a background image, and verifies that the initially hidden and cancelled selector leave document scrolling unlocked. Stacking, viewport bounds, option layout, frequency selection, focus, and dismissal checks remain in place.

Fixes #175.

Validation:

- The strengthened regression fails on the previous build with computed background alpha `0.0`.
- All four selector viewports pass after the fix: 1440×900, 1024×768, 390×844, and 360×800. Computed surface: `rgb(255, 255, 255)`; computed scrim: `rgba(31, 31, 31, 0.42)`. Screenshots inspected for all four.
- Vue production build and TypeScript check pass; shared visual assertion tests pass (5/5).
- All 17 visual/state scripts pass locally. All 28 negative controls reject transparent/translucent surfaces and missing, incorrect, opaque, or gradient scrims across the four viewports.
- [Complete tauri-ci](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326551): **passed**, including Rust workspace tests and [29/29 static checks](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326551/artifacts/10271930405).
- [Clean Windows visual job](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326551/job/103325707069): **5/5 assertion tests and 17/17 visual scripts passed**, `gitDirty: false`, with [113 screenshots, logs, and reports](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326551/artifacts/10270783369). Tested merge `fac224689831686d61c1694cc140bebe0a19987e` and signed head `5da7feae39a24b57af2e5b49187bce3f83bf5f34` share tree `0b9805f169490c804ee8e29ad568462d492e9ce0`.
- The [required static-then-native sequence](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326186/job/103325710433) **passed** on signed head `5da7feae39a24b57af2e5b49187bce3f83bf5f34`: `python developer/tests/ci/run_static_suite.py` completed **29/29**, then `python developer/tests/e2e/suite_practice_flow.py` completed **16/16** native practice checks. [Reports, screenshots, and tested binary](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34618326186/artifacts/10272590073) include binary SHA-256 `76fed5c8b83f9b7763db6b98e31a113f03d4245bac3366be733774f29abfa3b7`, verified against the uploaded executable. The complete workflow also passed all three native packaging jobs: Windows x64, macOS ARM64, and Linux x64.

The [original review thread](https://github.com/sallowayma-git/IELTS-practice/pull/180#discussion_r3990950307) has been replied to and resolved. This PR was merged into `IELTS-WRITING-FEAT` as [`e06ad21dc2e3850c07a0c9b6216f929f5f64410a`](https://github.com/sallowayma-git/IELTS-practice/commit/e06ad21dc2e3850c07a0c9b6216f929f5f64410a), preserving the signed implementation commit. The final merge has the same tree as the tested head and PR merge. [Issue #175 is closed as completed](https://github.com/sallowayma-git/IELTS-practice/issues/175#issuecomment-5637496063), with all six acceptance items satisfied.

