### PR TITLE
fix(release): validate shipping gates and Tauri 2 updater artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,28 @@
-# Tag release — Tauri 2 only (Electron packaging removed)
+# Tauri 2 release. Manual runs verify the shipping gates; v* pushes publish.
 
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
   TAURI_CLI_VERSION: 2.11.4
   TAURI_DRIVER_VERSION: 2.0.6
   PY_PLAYWRIGHT_VERSION: 1.61.0
+  PYTHONUTF8: '1'
+  PYTHONDONTWRITEBYTECODE: '1'
 
 jobs:
   shipping-gate:
     runs-on: windows-2022
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -33,6 +37,8 @@ jobs:
       - name: Install frontend deps
         run: npm --prefix apps/writing-vue ci --no-fund --no-audit
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install pinned sidecar build and runtime dependencies
         run: python -m pip install --disable-pip-version-check -r agent-runtime-python/requirements-build.lock -r agent-runtime-python/requirements.lock
       - name: Build and smoke native sidecar before static compilation
@@ -51,19 +57,21 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check "playwright==$env:PY_PLAYWRIGHT_VERSION"
           python -m playwright install chromium
+      - name: Test shared visual assertions
+        run: python developer/tests/e2e/visual_test_support_test.py
       - name: Run visual regression matrix
         run: python developer/tests/e2e/run_visual_regressions.py
       - name: Install Tauri WebDriver tooling
         shell: pwsh
         run: |
-          cargo install tauri-cli --version $env:TAURI_CLI_VERSION --locked
+          npm install --global "@tauri-apps/cli@$env:TAURI_CLI_VERSION" --no-fund --no-audit
           cargo install tauri-driver --version $env:TAURI_DRIVER_VERSION --locked
       - name: Install matching WebView2 EdgeDriver
         id: edge-driver
         shell: pwsh
         run: ./developer/tests/ci/install_edge_webdriver.ps1
       - name: Build packaged Tauri application
-        run: cargo tauri build --no-bundle
+        run: tauri build --ci --no-bundle
       - name: Packaged Tauri WebView gate
         shell: pwsh
         env:
@@ -71,7 +79,7 @@ jobs:
           TAURI_NATIVE_DRIVER: ${{ steps.edge-driver.outputs.driver-path }}
         run: |
           $env:TAURI_DRIVER = (Get-Command tauri-driver).Source
-          python developer/tests/e2e/suite_practice_flow.py
+          ./developer/tests/ci/run_native_practice_acceptance.ps1
       - name: Upload gate evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -81,13 +89,17 @@ jobs:
             developer/tests/e2e/reports/static-ci-report.json
             developer/tests/e2e/reports/suite-practice-flow-report.json
             developer/tests/e2e/reports/tauri-driver.log
+            developer/tests/e2e/reports/native-diagnostics/**
             developer/tests/e2e/reports/visual-ci-evidence/**
             developer/tests/e2e/reports/*-current.png
+            target/release/ielts-practice-tauri.exe
+            src-tauri/binaries/ielts-agent-runtime-x86_64-pc-windows-msvc*
           if-no-files-found: error
 
   rust-test:
     needs: shipping-gate
     runs-on: windows-2022
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -121,6 +133,9 @@ jobs:
 
   tauri-release:
     needs: rust-test
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -264,6 +279,9 @@ jobs:
 
   publish-release:
     needs: tauri-release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/developer/docs/phase10-release-runbook.md
+++ b/developer/docs/phase10-release-runbook.md
@@ -29,6 +29,27 @@ unconfigured and cannot download updates.
 
 ## Release
 
+Before creating a version tag, run the complete release gates on the candidate
+branch or commit's branch:
+
+```powershell
+gh workflow run release.yml --ref <candidate-branch>
+```
+
+A manual run executes the same `shipping-gate` and `rust-test` jobs as a tag
+release. Both jobs prepare a fresh Windows sidecar in their own workspace before
+Tauri compilation. The shipping job runs the static suite, shared visual assertion
+tests, all 17 visual scripts, and the packaged native practice flow; the workspace
+job then runs the complete Rust test suite. Reports, screenshots, native driver
+diagnostics, the tested host, and its matching sidecar are uploaded as evidence.
+
+Manual runs have read-only repository permissions and skip the complete signing,
+release attachment, and publication jobs, including when dispatched on a tag.
+Only a `v*` tag push can enter those jobs. Passing a manual run establishes the
+shipping and workspace gates; production signatures, notarization, signed bundle
+and updater verification, and installed update/restart acceptance still require
+their actual release evidence.
+
 1. Set the same semantic version in `src-tauri/tauri.conf.json`,
    `src-tauri/Cargo.toml`, and `apps/writing-vue/package.json`.
 2. Run the required gates in order:

--- a/developer/docs/phase10-release-runbook.md
+++ b/developer/docs/phase10-release-runbook.md
@@ -30,7 +30,7 @@ unconfigured and cannot download updates.
 ## Release
 
 Before creating a version tag, run the complete release gates on the candidate
-branch or commit's branch:
+branch:
 
 ```powershell
 gh workflow run release.yml --ref <candidate-branch>
@@ -61,8 +61,12 @@ their actual release evidence.
 
 3. Push an annotated `vX.Y.Z` tag. The tag must match all three shipping versions.
 4. The release workflow builds Windows, macOS arm64, and Linux bundles. Each job
-   verifies an installable package, updater archive, and matching `.sig` before it
-   can complete.
+   verifies an installable package and every updater artifact's matching `.sig`
+   before it can complete. With `createUpdaterArtifacts: true`, Tauri 2 signs the
+   Windows `.exe`/`.msi` and Linux `.AppImage`/`.deb`/`.rpm` files directly;
+   macOS uses `.app.tar.gz`. Windows/Linux v1-compatible wrappers are not release
+   inputs. The pinned [Tauri CLI signing implementation](https://github.com/tauri-apps/tauri/blob/tauri-cli-v2.11.4/crates/tauri-cli/src/bundle.rs)
+   defines these artifacts.
 5. Windows additionally passes `signtool verify`; macOS passes strict `codesign`
    verification and Gatekeeper `spctl` assessment after notarization.
 6. The release remains draft until `latest.json` contains signed HTTPS entries for

--- a/developer/tests/ci/release_contract_test.py
+++ b/developer/tests/ci/release_contract_test.py
@@ -203,7 +203,7 @@ class ReleaseConfigTests(unittest.TestCase):
             prepare_tauri_release.DEFAULT_ENDPOINT,
             "A" * 64,
         )
-        self.assertTrue(overlay["bundle"]["createUpdaterArtifacts"])
+        self.assertIs(overlay["bundle"]["createUpdaterArtifacts"], True)
         updater = overlay["plugins"]["updater"]
         self.assertEqual(updater["endpoints"], [prepare_tauri_release.DEFAULT_ENDPOINT])
         self.assertEqual(updater["pubkey"], "A" * 64)
@@ -294,27 +294,90 @@ class BundleVerificationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             installer = root / "IELTS Practice_0.1.0_x64-setup.exe"
-            updater = root / "IELTS Practice_0.1.0_x64-setup.nsis.zip"
-            signature = Path(f"{updater}.sig")
-            for path in (installer, updater, signature):
+            msi = root / "IELTS Practice_0.1.0_x64.msi"
+            files = [installer, msi, Path(f"{installer}.sig"), Path(f"{msi}.sig")]
+            for path in files:
                 path.write_bytes(b"artifact")
             result = verify_tauri_bundle.verify_artifacts(
-                [installer, updater, signature],
+                files,
                 "windows",
                 require_updater=True,
                 require_signatures=True,
             )
             self.assertEqual(result["status"], "passed")
+            self.assertEqual(set(result["updaterArchives"]), {str(installer), str(msi)})
+
+    def test_linux_v2_updaters_use_native_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packages = [
+                root / f"IELTS-Practice_0.1.0_amd64{suffix}"
+                for suffix in (".AppImage", ".deb", ".rpm")
+            ]
+            files = packages + [Path(f"{package}.sig") for package in packages]
+            for path in files:
+                path.write_bytes(b"artifact")
+            result = verify_tauri_bundle.verify_artifacts(files, "linux", True, True)
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(set(result["updaterArchives"]), {str(package) for package in packages})
+
+    def test_macos_still_requires_the_signed_app_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dmg = root / "IELTS Practice_0.1.0_aarch64.dmg"
+            archive = root / "IELTS Practice.app.tar.gz"
+            signature = Path(f"{archive}.sig")
+            files = [dmg, archive, signature]
+            for path in files:
+                path.write_bytes(b"artifact")
+            result = verify_tauri_bundle.verify_artifacts(files, "macos", True, True)
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["updaterArchives"], [str(archive)])
+
+    def test_every_native_updater_requires_its_own_nonempty_signature(self) -> None:
+        cases = (
+            ("windows", "setup.exe"), ("windows", "app.msi"),
+            ("linux", "app.AppImage"), ("linux", "app.deb"), ("linux", "app.rpm"),
+        )
+        for platform_name, name in cases:
+            with self.subTest(platform=platform_name, name=name), tempfile.TemporaryDirectory() as directory:
+                artifact = Path(directory) / name
+                artifact.write_bytes(b"artifact")
+                result = verify_tauri_bundle.verify_artifacts([artifact], platform_name, True, True)
+                self.assertTrue(any("missing updater signatures" in error for error in result["errors"]))
+                signature = Path(f"{artifact}.sig")
+                signature.write_bytes(b"")
+                result = verify_tauri_bundle.verify_artifacts([artifact, signature], platform_name, True, True)
+                self.assertTrue(any("missing updater signatures" in error for error in result["errors"]))
+
+    def test_legacy_archive_signature_cannot_replace_native_package_signature(self) -> None:
+        cases = (
+            ("windows", "app.nsis.zip", "app-setup.exe"),
+            ("windows", "app.msi.zip", "app.msi"),
+            ("linux", "app.AppImage.tar.gz", "app.AppImage"),
+        )
+        for platform_name, name, native_name in cases:
+            with self.subTest(platform=platform_name, name=name), tempfile.TemporaryDirectory() as directory:
+                artifact = Path(directory) / native_name
+                legacy = Path(directory) / name
+                signature = Path(f"{legacy}.sig")
+                artifact.write_bytes(b"artifact")
+                legacy.write_bytes(b"legacy archive")
+                signature.write_bytes(b"legacy signature")
+                result = verify_tauri_bundle.verify_artifacts(
+                    [artifact, legacy, signature], platform_name, True, True,
+                )
+                self.assertEqual(result["updaterArchives"], [str(artifact)])
+                self.assertEqual(result["status"], "failed")
+                self.assertTrue(any("missing updater signatures" in error for error in result["errors"]))
 
     def test_missing_signature_fails(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             installer = root / "IELTS Practice_0.1.0_amd64.AppImage"
-            updater = root / "IELTS Practice_0.1.0_amd64.AppImage.tar.gz"
-            for path in (installer, updater):
-                path.write_bytes(b"artifact")
+            installer.write_bytes(b"artifact")
             result = verify_tauri_bundle.verify_artifacts(
-                [installer, updater],
+                [installer],
                 "linux",
                 require_updater=True,
                 require_signatures=True,

--- a/developer/tests/ci/release_contract_test.py
+++ b/developer/tests/ci/release_contract_test.py
@@ -66,16 +66,52 @@ class WorkflowTriggerTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, self.branch_ci)
 
-    def test_release_is_tag_only_and_owns_desktop_packaging(self) -> None:
+    def test_release_supports_manual_gates_and_owns_desktop_packaging(self) -> None:
         trigger = workflow_block(self.release, "on")
         self.assertIn("push:", trigger)
         self.assertIn("tags:", trigger)
         self.assertIn("- 'v*'", trigger)
         self.assertNotIn("branches:", trigger)
         self.assertNotIn("pull_request:", trigger)
-        self.assertNotIn("workflow_dispatch:", trigger)
-        self.assertIn("cargo tauri build", self.release)
+        self.assertIn("workflow_dispatch:", trigger)
+        self.assertIn("tauri build --ci --no-bundle", self.release)
         self.assertIn("tauri-apps/tauri-action", self.release)
+
+    def test_manual_runs_cannot_sign_attach_or_publish_a_release(self) -> None:
+        self.assertEqual(workflow_block(self.release, "permissions"), "permissions:\n  contents: read\n")
+        tag_push_only = "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
+        for name in ("tauri-release", "publish-release"):
+            with self.subTest(job=name):
+                job = workflow_block(self.release, name, indent=2)
+                # A dispatch on a tag must also stop before certificate import,
+                # signing, or creating draft assets. Guard the complete job.
+                self.assertIn(f"\n    {tag_push_only}\n", job)
+                self.assertIn("\n    permissions:\n      contents: write\n", job)
+                self.assertNotIn("always()", job)
+                self.assertNotIn("continue-on-error", job)
+        for name in ("shipping-gate", "rust-test"):
+            job = workflow_block(self.release, name, indent=2)
+            self.assertNotIn("\n    if:", job)
+            self.assertNotIn("contents: write", job)
+            self.assertNotIn("secrets.", job)
+
+    def test_shipping_runs_all_regressions_before_workspace_acceptance(self) -> None:
+        job = workflow_block(self.release, "shipping-gate", indent=2)
+        markers = (
+            "run: python developer/tests/ci/run_static_suite.py",
+            "run: python developer/tests/e2e/visual_test_support_test.py",
+            "run: python developer/tests/e2e/run_visual_regressions.py",
+            "run: tauri build --ci --no-bundle",
+            "./developer/tests/ci/run_native_practice_acceptance.ps1",
+        )
+        positions = [job.index(marker) for marker in markers]
+        self.assertEqual(positions, sorted(positions))
+        for marker in markers:
+            step = next(step for step in job.split("\n      - ") if marker in step)
+            self.assertNotIn("\n        if:", step)
+            self.assertNotIn("continue-on-error", step)
+        self.assertIn("developer/tests/e2e/reports/native-diagnostics/**", job)
+        self.assertIn("needs: shipping-gate", workflow_block(self.release, "rust-test", indent=2))
 
     def test_release_prepares_sidecar_in_every_consuming_job(self) -> None:
         consumers = (

--- a/developer/tests/ci/verify_tauri_bundle.py
+++ b/developer/tests/ci/verify_tauri_bundle.py
@@ -51,14 +51,16 @@ def is_installable(path: Path, platform_name: str) -> bool:
     return lower_name.endswith(".dmg")
 
 
-def is_updater_archive(path: Path, platform_name: str) -> bool:
+def is_updater_artifact(path: Path, platform_name: str) -> bool:
     lower_name = path.name.lower()
     if lower_name.endswith(".sig"):
         return False
     suffixes = {
-        "windows": (".nsis.zip", ".msi.zip"),
+        # createUpdaterArtifacts=true signs native installers in Tauri 2.
+        # ZIP/tar wrappers on Windows/Linux belong to v1Compatible mode.
+        "windows": (".exe", ".msi"),
         "macos": (".app.tar.gz",),
-        "linux": (".appimage.tar.gz",),
+        "linux": (".appimage", ".deb", ".rpm"),
     }
     return lower_name.endswith(suffixes[platform_name])
 
@@ -77,11 +79,11 @@ def verify_artifacts(
     if not installables:
         errors.append(f"no installable {platform_name} bundle found")
 
-    updater_archives = [path for path in files if is_updater_archive(path, platform_name)]
-    if require_updater and not updater_archives:
-        errors.append(f"no {platform_name} updater archive found")
+    updater_artifacts = [path for path in files if is_updater_artifact(path, platform_name)]
+    if require_updater and not updater_artifacts:
+        errors.append(f"no {platform_name} updater artifact found")
 
-    publishable_artifacts = [*installables, *updater_archives]
+    publishable_artifacts = sorted(set(installables + updater_artifacts))
     empty_artifacts = [str(path) for path in publishable_artifacts if path.stat().st_size == 0]
     if empty_artifacts:
         errors.append(f"zero-byte publishable artifacts: {empty_artifacts}")
@@ -89,8 +91,8 @@ def verify_artifacts(
     signatures: list[Path] = []
     missing_signatures: list[str] = []
     file_set = {path.resolve() for path in files}
-    for archive in updater_archives:
-        signature = Path(f"{archive}.sig")
+    for artifact in updater_artifacts:
+        signature = Path(f"{artifact}.sig")
         if signature.resolve() in file_set and signature.stat().st_size > 0:
             signatures.append(signature)
         elif require_signatures:
@@ -102,7 +104,8 @@ def verify_artifacts(
         "status": "failed" if errors else "passed",
         "errors": errors,
         "installables": [str(path) for path in installables],
-        "updaterArchives": [str(path) for path in updater_archives],
+        # Preserve the report field used by existing acceptance evidence.
+        "updaterArchives": [str(path) for path in updater_artifacts],
         "signatures": [str(path) for path in signatures],
     }
 


### PR DESCRIPTION
## Problem and change

#172 could not verify the actual release shipping and Rust jobs without pushing a version tag. Its updater verifier also expected Tauri 1 wrappers, rejecting valid Tauri 2 Windows/Linux outputs.

- Allow manual runs of `release.yml` to execute the same `shipping-gate` and `rust-test` jobs with freshly prepared sidecars. Keep validation permissions read-only and restrict the complete signing, release attachment, and publication jobs to `v*` tag pushes, including when a manual run selects a tag.
- Include the shared visual assertion tests, use the pinned prebuilt Tauri CLI and native diagnostic wrapper, and retain the tested host, matching sidecar, reports, screenshots, and diagnostics.
- Validate native Tauri 2 updater artifacts: Windows EXE/MSI, Linux AppImage/DEB/RPM, and the macOS application tarball. Require each artifact's own nonempty signature, reject legacy-wrapper signature substitutions, and preserve the existing report schema.
- Document the manual verification entry point and its acceptance boundary.

## Validation

Tested signed commit: [`86ee6920`](https://github.com/sallowayma-git/IELTS-practice/commit/86ee69206633aac6e1ea3920e633e08da0a1cbb8), verified by GitHub. Its tree `eec663eb30f7b5ea97373caaaebdfe28cfbabcc2` matches the tested PR merge `d7929d447ca09a454f3b994ea96cc56df2f28540`.

| Verification | Result and evidence |
| --- | --- |
| Release contract tests | 62 passed, including native formats, absent/empty signatures, legacy substitution, trigger/permission boundaries, and preserved sidecar/bundle checks. The new format cases reproduced failures before the repair. |
| Actual release shipping gate | [Passed](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624175205): 29 static checks, 5 shared visual assertion tests, all 17 visual scripts, and all 16 native practice checks. [Reports, screenshots, tested host, and sidecar](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624175205/artifacts/10273708174). |
| Actual release Rust job | Same successful Release run: 507 passed, 0 failed/ignored, with a separately rebuilt and smoked matching sidecar. Signing and publication jobs were skipped as required for a manual run. |
| Required command sequence | [Passed on the signed head](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624179018): static suite 29/29, followed by native practice flow 16/16. [Required-sequence evidence](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624179018/artifacts/10274093610). |
| Native platform matrix | Same successful native run: Windows x64 MSI/NSIS, macOS ARM64, and Linux x64 packaging passed. Packaged host/sidecar identity, full protocol smoke, raw-byte reading-resource checks, and existing applicable budgets passed. |
| Complete PR CI | [Passed, attempt 2](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624174664): 29 static checks, 507 Rust tests, 17 visual scripts, and [113 screenshots](https://github.com/sallowayma-git/IELTS-practice/actions/runs/34624174664/artifacts/10274435608). |

The first PR CI attempt exceeded the existing 1,500 ms Windows sidecar cold-start limit. The failed job rebuilt and passed on the same commit at 762.726 ms; the limit was not changed. The complete Release run passed on its first attempt (shipping/workspace sidecars: 1,271.786 / 1,077.331 ms).

Refs #172. These results satisfy the development build, workflow, and unsigned native packaging checks for that issue; its remaining closure item is integration of this PR with the recorded evidence. Production signing credentials, notarization, and installed-updater acceptance belong to production release readiness and do not block this PR or the build-recovery issue. The production signing and verification gates remain enforced; these runs do not claim production release validation.
